### PR TITLE
Use DOCKER_HOST environment variable to find Docker daemon

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from ..packages.docker import Client
+from requests.exceptions import ConnectionError
 import errno
 import logging
 import os
@@ -11,11 +12,22 @@ from ..project import Project
 from .docopt_command import DocoptCommand
 from .formatter import Formatter
 from .utils import cached_property, docker_url
+from .errors import UserError
 
 log = logging.getLogger(__name__)
 
 class Command(DocoptCommand):
     base_dir = '.'
+
+    def dispatch(self, *args, **kwargs):
+        try:
+            super(Command, self).dispatch(*args, **kwargs)
+        except ConnectionError:
+            raise UserError("""
+Couldn't connect to Docker daemon at %s - is it running?
+
+If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.
+""" % self.client.base_url)
 
     @cached_property
     def client(self):

--- a/fig/cli/utils.py
+++ b/fig/cli/utils.py
@@ -82,33 +82,4 @@ def mkdir(path, permissions=0o700):
 
 
 def docker_url():
-    if os.environ.get('DOCKER_URL'):
-        return os.environ['DOCKER_URL']
-
-    socket_path = '/var/run/docker.sock'
-    tcp_hosts = [
-        ('localdocker', 4243),
-        ('127.0.0.1', 4243),
-    ]
-    tcp_host = '127.0.0.1'
-    tcp_port = 4243
-
-    for host, port in tcp_hosts:
-        try:
-            s = socket.create_connection((host, port), timeout=1)
-            s.close()
-            return 'http://%s:%s' % (host, port)
-        except:
-            pass
-
-    if os.path.exists(socket_path):
-        return 'unix://%s' % socket_path
-
-    raise UserError("""
-Couldn't find Docker daemon - tried:
-
-unix://%s
-%s
-
-If it's running elsewhere, specify a url with DOCKER_URL.
-    """ % (socket_path, '\n'.join('tcp://%s:%s' % h for h in tcp_hosts)))
+    return os.environ.get('DOCKER_HOST')


### PR DESCRIPTION
Removed all "smart" connection logic. Fig either uses the `DOCKER_HOST` environment variable if it's present, or passes `None` to docker-py, which does the "right thing" (i.e. falls back to the Unix socket).

This means we no longer know at URL-deciding time whether we can connect to the Docker daemon, so we wrap `dispatch` in a `try/except` which catches `requests.exceptions.ConnectionError`.
