### PR TITLE
Fix external port config

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -224,6 +224,8 @@ class Service(object):
                 port = str(port)
                 if ':' in port:
                     port = port.split(':')[-1]
+                if '/' not in port:
+                    port = "%s/tcp" % port
                 ports.append(port)
             container_options['ports'] = ports
 


### PR DESCRIPTION
When exposing a port externally, it seems Docker only actually exposes it
if you specify the _internal_ port as `xxxx/tcp`. So add that on if it's
not there.
