### PR TITLE
Fix lag when using cursor keys in an interactive 'fig run'

### DIFF
--- a/fig/cli/socketclient.py
+++ b/fig/cli/socketclient.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 # Adapted from https://github.com/benthor/remotty/blob/master/socketclient.py
 
-from select import select
 import sys
 import tty
 import fcntl


### PR DESCRIPTION
Turns out `select()` was not only extraneous, it was resulting in buffering of ANSI control sequences.
