### PR TITLE
Fix port syntax

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -172,9 +172,10 @@ class Service(object):
                 port = str(port)
                 if ':' in port:
                     external_port, internal_port = port.split(':', 1)
-                    port_bindings[int(internal_port)] = int(external_port)
                 else:
-                    port_bindings[int(port)] = None
+                    external_port, internal_port = (None, port)
+
+                port_bindings[internal_port] = external_port
 
         volume_bindings = {}
 
@@ -225,6 +226,8 @@ class Service(object):
                 port = str(port)
                 if ':' in port:
                     port = port.split(':')[-1]
+                if '/' in port:
+                    port = tuple(port.split('/'))
                 ports.append(port)
             container_options['ports'] = ports
 

--- a/tests/service_test.py
+++ b/tests/service_test.py
@@ -187,6 +187,11 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(container['HostConfig']['PortBindings'].keys(), ['8000/tcp'])
         self.assertNotEqual(container['HostConfig']['PortBindings']['8000/tcp'][0]['HostPort'], '8000')
 
+    def test_start_container_creates_port_with_explicit_protocol(self):
+        service = self.create_service('web', ports=['8000/udp'])
+        container = service.start_container().inspect()
+        self.assertEqual(container['HostConfig']['PortBindings'].keys(), ['8000/udp'])
+
     def test_start_container_creates_fixed_external_ports(self):
         service = self.create_service('web', ports=['8000:8000'])
         container = service.start_container().inspect()


### PR DESCRIPTION
- Fix bug where too many `/tcp` suffixes were added to port config
- Allow ports to be specified in `1234/tcp` format
