### PR TITLE
POC run command aliases

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -210,8 +210,13 @@ class TopLevelCommand(Command):
         if options['-d'] or options['-T'] or not sys.stdin.isatty():
             tty = False
 
+        if 'commands' in service.options and options['COMMAND'] in service.options['commands']:
+            command = service.options['commands'][options['COMMAND']]
+        else:
+            command = [options['COMMAND']] + options['ARGS']
+
         container_options = {
-            'command': [options['COMMAND']] + options['ARGS'],
+            'command': command,
             'tty': tty,
             'stdin_open': not options['-d'],
         }

--- a/tests/fixtures/commands-figfile/fig.yml
+++ b/tests/fixtures/commands-figfile/fig.yml
@@ -1,0 +1,5 @@
+web:
+  build: .
+  commands:
+   r: runner
+   l: cowsay hello world!


### PR DESCRIPTION
I want to be able to alias often run commands in the fig.yml file. This is a POC for being able to set these up with an example test file. If an alias if found, use it instead of passing the command through.

``` bash
$ fig run web r
```

Thoughts on the idea? There are some edge cases I'm not taking in to consideration, but will if people are interested.
