### PR TITLE
Fixed error where Django can't connect to Postgres because psycopg2 is not installed

### DIFF
--- a/docs/django.md
+++ b/docs/django.md
@@ -11,6 +11,7 @@ Let's use Fig to set up and run a Django/PostgreSQL app. Before starting, you'll
 Let's set up the three files that'll get us started. First, our app is going to be running inside a Docker container which contains all of its dependencies. We can define what goes inside that Docker container using a file called `Dockerfile`. It'll contain this to start with:
 
     FROM orchardup/python:2.7
+    RUN apt-get update -qq && apt-get install -y python-psycopg2
     RUN mkdir /code
     WORKDIR /code
     ADD requirements.txt /code/


### PR DESCRIPTION
I was following the 'Get started with Django' guide and stumbled across an error when Django tries to run for the first time. It cannot connect to the Postgres instance as Psycopg Python library is not installed. The alternative is to install the libpq-dev package then pip install psycopg2 but this is cleaner and quicker.
