### PR TITLE
Link services to themselves

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,10 @@ Note that this will not start any services that the command's service links to. 
 
 One-off commands are started in new containers with the same config as a normal container for that service, so volumes, links, etc will all be created as expected. The only thing different to a normal container is the command will be overridden with the one specified and no ports will be created in case they collide.
 
+Links are also created between one-off commands and the other containers for that service so you can do stuff like this:
+
+    $ fig run db /bin/sh -c "psql -h \$DB_1_PORT_5432_TCP_ADDR -U docker"
+
 ## scale
 
 Set number of containers to run for a service.

--- a/fig/service.py
+++ b/fig/service.py
@@ -212,6 +212,9 @@ class Service(object):
             for container in service.containers():
                 links.append((container.name, container.name))
                 links.append((container.name, container.name_without_project))
+        for container in self.containers():
+            links.append((container.name, container.name))
+            links.append((container.name, container.name_without_project))
         return links
 
     def _get_container_options(self, override_options, one_off=False):

--- a/tests/service_test.py
+++ b/tests/service_test.py
@@ -155,8 +155,13 @@ class ServiceTest(DockerClientTestCase):
         web.start_container()
         self.assertIn('figtest_db_1', web.containers()[0].links())
         self.assertIn('db_1', web.containers()[0].links())
-        db.stop(timeout=1)
-        web.stop(timeout=1)
+
+    def test_start_container_creates_links_to_its_own_service(self):
+        db1 = self.create_service('db')
+        db2 = self.create_service('db')
+        db1.start_container()
+        db2.start_container()
+        self.assertIn('db_1', db2.containers()[0].links())
 
     def test_start_container_builds_images(self):
         service = Service(


### PR DESCRIPTION
E.g. `fig run db ...` will be able to access the db service.
