### PR TITLE
onStart, onStop events for containers

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -54,6 +54,16 @@ class Service(object):
         for c in self.containers():
             log.info("Stopping %s..." % c.name)
             c.stop(**options)
+            if self.options.get('events', None) is not None:
+                d = c.flat_dictionary
+                onStop = self.options.get('events', {}).get('onStop', [])
+                if not isinstance(onStop, list):
+                    onStop = list(onStop)
+                for cmd in onStop:
+                    log.info(cmd % d)
+                    os.system(cmd % d)
+
+
 
     def kill(self, **options):
         for c in self.containers():
@@ -190,6 +200,14 @@ class Service(object):
             port_bindings=port_bindings,
             binds=volume_bindings,
         )
+        if options.get('events', None) is not None:
+            d = container.flat_dictionary
+            onStart = options.get('events', {}).get('onStart', [])
+            if not isinstance(onStart, list):
+                onStart = list(onStart)
+            for cmd in onStart:
+                log.info(cmd % d)
+                os.system(cmd % d)
         return container
 
     def next_container_name(self, one_off=False):


### PR DESCRIPTION
I use fig for running local development environment (django projects). All works fine, but after each restarting of services I need manually reconfigure hipache (because ip address of www container changed).  I try to add some functionality (it's dirty, untested, just idea implementations) for run some commands on start/stop of services.

For example (fig.yml): 

```yaml
www:
    build: .
    command: python manage.py runserver 0.0.0.0:8000
    events:
        onStart:
            - redis-cli del frontend:project.dev
            - redis-cli rpush frontend:project.dev project
            - redis-cli rpush frontend:project.dev http://%(.NetworkSettings.IPAddress)s:8000
        onStop:
            - redis-cli del frontend:project.dev
```

This options should be configure hipache on ```fig up``` with ```www``` container ip address. Commands executed on host machine. Commands executed in order (as in options). Commands can use container options (for example ```.NetworkSettings.IPAddress```) as in ```docker inspect``.   It's work good for me. But there is a question, do *fig* need this option, or not. I saw those problems:

* Broke *fig run* functionality, for example if I want to start django shell I can't start it with command ```fig run www python manage.py shell```, because onStart event will be executed (that broke http access to project via hipache). So I must create copy of www services (called shell) and run commands with those service.
* Broke *fig scale* functionality. I didn't use it, but someone do. Those events binding on containers, for supporting scale functionality they are must bind to service.

Any thoughts, need or not *events* option?