### PR TITLE
Feature/env

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -33,11 +33,18 @@ If it's at a non-standard location, specify the URL with the DOCKER_HOST environ
     def client(self):
         return Client(docker_url())
 
+    def __expand_env_variables(self, yaml_path):
+        file_content = open(yaml_path).read()
+        for k, v in os.environ.iteritems():
+            if file_content.find('$' + k) != -1:
+                file_content = file_content.replace('$' + k, v)
+        return file_content
+
     @cached_property
     def project(self):
         try:
             yaml_path = self.check_yaml_filename()
-            config = yaml.load(open(yaml_path))
+            config = yaml.load(self.__expand_env_variables(yaml_path))
 
         except IOError as e:
             if e.errno == errno.ENOENT:

--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -33,18 +33,11 @@ If it's at a non-standard location, specify the URL with the DOCKER_HOST environ
     def client(self):
         return Client(docker_url())
 
-    def __expand_env_variables(self, yaml_path):
-        file_content = open(yaml_path).read()
-        for k, v in os.environ.iteritems():
-            if file_content.find('$' + k) != -1:
-                file_content = file_content.replace('$' + k, v)
-        return file_content
-
     @cached_property
     def project(self):
         try:
             yaml_path = self.check_yaml_filename()
-            config = yaml.load(self.__expand_env_variables(yaml_path))
+            config = yaml.load(os.path.expandvars(open(yaml_path).read()))
 
         except IOError as e:
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
This feature allow you to use environment variables in the fig.yml file.
It simply expand any found environment variable (ex: $HOST) to the value defined in the environment running fig.

useful example : 

I'm using Skydock (https://github.com/crosbymichael/skydock) along with skydns.

When i launch a skydns container by hand I need to specify the ip of the docker0 interface so that docker inject a new nameserver into /etc/resolv.conf:

ex:

Here the ip is "172.17.42.1"

`docker run -d -dns 172.17.42.1 -p 172.17.42.1:53:53/udp -name skydns crosbymichael/skydns -nameserver 8.8.8.8:53 -domain docker`

A nice way to be more flexible, compute what is the address automatically for example, is to add an environment variable in the equation : 

`env DNS_IP=172.17.42.1 docker run -d -dns $DNS_IP -p $DNS_IP:53:53/udp -name skydns crosbymichael/skydns -nameserver 8.8.8.8:53 -domain docker`

Wouldn't it be nice to be able to do the same thing in a fig.yml file? 

ex:

`env DNS_IP=172.17.42.1 fig up`

with this fig.yml:

```
skydns:
    image: crosbymichael/skydns
    ports:
        - $DNS_IP:53:53/udp
        - 8080:8080
    dns:
        - $DNS_IP
    command: "-nameserver 8.8.8.8:53 -domain docker"
```

I wanted to add a flag to make this expansion optional, just in case. What do you think?