### PR TITLE
Tell fig up to print logs before attaching

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -292,7 +292,7 @@ class TopLevelCommand(Command):
         if not detached:
             to_attach = [c for (s, c) in new]
             print("Attaching to", list_containers(to_attach))
-            log_printer = LogPrinter(to_attach)
+            log_printer = LogPrinter(to_attach, attach_params={"logs": True})
 
         for (service, container) in new:
             service.start_container(container)


### PR DESCRIPTION
@aanand | Basically we can add `attach_params={'logs': True}` to the LogPrinter() line in up().                                                        @aanand | Feel free to try and submit a PR if it works!                                                
