### PR TITLE
Feature/interface bind

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -37,7 +37,7 @@ If it's at a non-standard location, specify the URL with the DOCKER_HOST environ
     def project(self):
         try:
             yaml_path = self.check_yaml_filename()
-            config = yaml.load(os.path.expandvars(open(yaml_path).read()))
+            config = yaml.load(open(yaml_path))
 
         except IOError as e:
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
Add the interface binding to the port forwarding, case like:

```
        - 172.17.42.1:4245
        - 172.17.42.1:4246:4246
        - 172.17.42.1:4247/udp
        - 172.17.42.1:4258:4248/udp
```

are now working.

TODO : add some unit tests.

I tested and checked by hand, reading docker ps ouput, with the following fig.yml:

```
test:
    image: ubuntu
    ports:
        - 4243
        - 4244:4244
        - 172.17.42.1:4245
        - 172.17.42.1:4246:4246

        - 4247/udp 
        - 4248:4248/udp
        - 172.17.42.1:4249/udp
        - 172.17.42.1:4250:4250/udp
    command: sh -c "echo 'Launched'; sleep 6000"
```
