### PR TITLE
Documentation: Include notes on mapping ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ web:
   links:
    - db
   ports:
-   - 8000:8000
+   - "8000:8000"
+   - "49100:22"
 db:
   image: orchardup/postgresql
 ```
+
+**Note** When mapping ports in the format HOST:CONTAINER you may experience erroneous results when using a container port lower than 60. This is due to YAML parsing numbers in the format "xx:yy" as sexagesimal (base 60) for this reason it is recommended to define your port mappings as strings.
 
 (No more installing Postgres on your laptop!)
 

--- a/docs/django.md
+++ b/docs/django.md
@@ -29,14 +29,14 @@ Simple enough. Finally, this is all tied together with a file called `fig.yml`. 
     db:
       image: orchardup/postgresql
       ports:
-        - 5432
+        - "5432"
     web:
       build: .
       command: python manage.py runserver 0.0.0.0:8000
       volumes:
         - .:/code
       ports:
-        - 8000:8000
+        - "8000:8000"
       links:
         - db
 

--- a/docs/fig.yml
+++ b/docs/fig.yml
@@ -1,7 +1,7 @@
 jekyll:
   build: .
   ports:
-   - 4000:4000
+   - "4000:4000"
   volumes:
    - .:/code
   environment:

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ web:
   links:
    - db
   ports:
-   - 8000:8000
+   - "8000:8000"
 db:
   image: orchardup/postgresql
 ```
@@ -107,7 +107,7 @@ We then define a set of services using `fig.yml`:
       build: .
       command: python app.py
       ports:
-       - 5000:5000
+       - "5000:5000"
       volumes:
        - .:/code
       links:

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -30,14 +30,14 @@ Finally, `fig.yml` is where the magic happens. It describes what services our ap
     db:
       image: orchardup/postgresql
       ports:
-        - 5432
+        - "5432"
     web:
       build: .
       command: bundle exec rackup -p 3000
       volumes:
         - .:/myapp
       ports:
-        - 3000:3000
+        - "3000:3000"
       links:
         - db
 

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -26,7 +26,7 @@ web:
   build: .
   command: php -S 0.0.0.0:8000 -t /code
   ports:
-    - 8000:8000
+    - "8000:8000"
   links:
     - db
   volumes:
@@ -34,7 +34,7 @@ web:
 db:
   image: orchardup/mysql
   ports:
-    - 3306:3306
+    - "3306:3306"
   environment:
     MYSQL_DATABASE: wordpress
 ```

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -28,9 +28,11 @@ links:
  - redis
 
 -- Expose ports. Either specify both ports (HOST:CONTAINER), or just the container port (a random host port will be chosen).
+-- Note When mapping ports in the format HOST:CONTAINER you may experience erroneous results when using a container port lower than 60. This is due to YAML parsing numbers in the format "xx:yy" as sexagesimal (base 60) for this reason it is recommended to define your port mappings as strings.
 ports:
- - 3000
- - 8000:8000
+ - "3000"
+ - "8000:8000"
+ - "49100:22"
 
 -- Map volumes from the host machine (HOST:CONTAINER).
 volumes:


### PR DESCRIPTION
When mapping ports as strings there is an issue with the way YAML parses
numbers in the format "xx:yy" where yy is less than 60 - this issue is
now included in the documentation.

This fixes #103
