### PR TITLE
Exclude tests from MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include requirements.txt
 include requirements-dev.txt
 include tox.ini
 include *.md
-recursive-include tests *
+recursive-exclude tests *
 global-exclude *.pyc
 global-exclude *.pyo
 global-exclude *.un~


### PR DESCRIPTION
Currently tests are included in distribution builds (`bdist_*`, `sdist`). This clutters the user's filesystem and causes pointless conflicts (with Sphinx for example). Tox still seems to pick up the tests fine.
