### PR TITLE
Only `fig run` containers link back to the service they're part of

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -207,7 +207,7 @@ class Service(object):
                     volume_bindings[os.path.abspath(external_dir)] = internal_dir
 
         container.start(
-            links=self._get_links(),
+            links=self._get_links(link_to_self=override_options.get('one_off', False)),
             port_bindings=port_bindings,
             binds=volume_bindings,
         )
@@ -227,7 +227,7 @@ class Service(object):
         else:
             return max(numbers) + 1
 
-    def _get_links(self):
+    def _get_links(self, link_to_self):
         links = []
         for service, link_name in self.links:
             for container in service.containers():
@@ -235,9 +235,10 @@ class Service(object):
                     links.append((container.name, link_name))
                 links.append((container.name, container.name))
                 links.append((container.name, container.name_without_project))
-        for container in self.containers():
-            links.append((container.name, container.name))
-            links.append((container.name, container.name_without_project))
+        if link_to_self:
+            for container in self.containers():
+                links.append((container.name, container.name))
+                links.append((container.name, container.name_without_project))
         return links
 
     def _get_container_options(self, override_options, one_off=False):

--- a/tests/service_test.py
+++ b/tests/service_test.py
@@ -175,12 +175,17 @@ class ServiceTest(DockerClientTestCase):
         web.start_container()
         self.assertIn('custom_link_name', web.containers()[0].links())
 
-    def test_start_container_creates_links_to_its_own_service(self):
-        db1 = self.create_service('db')
-        db2 = self.create_service('db')
-        db1.start_container()
-        db2.start_container()
-        self.assertIn('db_1', db2.containers()[0].links())
+    def test_start_normal_container_does_not_create_links_to_its_own_service(self):
+        db = self.create_service('db')
+        c1 = db.start_container()
+        c2 = db.start_container()
+        self.assertNotIn(c1.name, c2.links())
+
+    def test_start_one_off_container_creates_links_to_its_own_service(self):
+        db = self.create_service('db')
+        c1 = db.start_container()
+        c2 = db.start_container(one_off=True)
+        self.assertIn(c1.name, c2.links())
 
     def test_start_container_builds_images(self):
         service = Service(


### PR DESCRIPTION
Fixes #107.
