### PR TITLE
Jekyll errors out with utf8 input

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,3 @@
 markdown: redcarpet
+encoding: utf-8
+


### PR DESCRIPTION
Jekyll seems to not want to build these docs unless the utf-8 option is supplied
