### PR TITLE
Fix UnicodeEncodeErrors in output of 'build', 'run' and 'up'

### DIFF
--- a/fig/cli/log_printer.py
+++ b/fig/cli/log_printer.py
@@ -18,7 +18,7 @@ class LogPrinter(object):
     def run(self):
         mux = Multiplexer(self.generators)
         for line in mux.loop():
-            sys.stdout.write(line)
+            sys.stdout.write(line.encode(sys.__stdout__.encoding or 'utf8'))
 
     def _make_log_generators(self):
         color_fns = cycle(colors.rainbow())

--- a/fig/cli/socketclient.py
+++ b/fig/cli/socketclient.py
@@ -81,7 +81,7 @@ class SocketClient:
                 chunk = socket.recv(4096)
 
                 if chunk:
-                    stream.write(chunk)
+                    stream.write(chunk.encode(stream.encoding or 'utf8'))
                     stream.flush()
                 else:
                     break

--- a/fig/service.py
+++ b/fig/service.py
@@ -295,7 +295,7 @@ class Service(object):
                 match = re.search(r'Successfully built ([0-9a-f]+)', line)
                 if match:
                     image_id = match.group(1)
-            sys.stdout.write(line)
+            sys.stdout.write(line.encode(sys.__stdout__.encoding or 'utf8'))
 
         if image_id is None:
             raise BuildError()


### PR DESCRIPTION
Squashed version of #125.
Closes #112.
