### PR TITLE
Fixes the mac build script so it wont fail when the venv folder doesn't exist

### DIFF
--- a/script/build-osx
+++ b/script/build-osx
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-rm -r venv
+rm -rf venv
 virtualenv venv
 venv/bin/pip install pyinstaller==2.1
 venv/bin/pip install .


### PR DESCRIPTION
This will happen if you haven't done a build before and haven't already run virtualenv venv yourself.
