### PR TITLE
Project name mismatch

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -32,7 +32,7 @@ class Command(DocoptCommand):
             if e.errno == errno.ENOENT:
                 raise errors.FigFileNotFound(os.path.basename(e.filename))
             raise errors.UserError(six.text_type(e))
-        self.yaml_path = yaml_path
+        self.yaml_path = os.path.abspath(yaml_path)
         self.explicit_project_name = None
 
     def dispatch(self, *args, **kwargs):


### PR DESCRIPTION
Here's my upstart config file (/etc/init/fig.conf) I use to run fig after docker starts and stop fig before docker stops.

```
description "Fig daemon"

start on started docker
stop on stopping docker

kill signal SIGINT  # upstart uses SIGTERM as default, critical for graceful shutdown
chdir /path/to/dir/containing/config # avoid project name bug
exec /usr/local/bin/fig -f /path/to/dir/containing/config/fig.yml up 2>&1  # redirect stderr to the log file (/var/log/upstart/fig.log)
```

The `chdir` is only necessary so that the project name is set correctly as the `-f` arg isn't taken into account. Without it the project name defaults to `default` and then `fig` commands don't work as the project name mismatch means that no containers are found, even though containers can be seen with `docker ps`.

This patch creates the project name from the directory that fig.yml is in, whether provided via `-f` or implicit.
