### PR TITLE
fix issue with utf8 encoding in logger stdout

### DIFF
--- a/fig/cli/log_printer.py
+++ b/fig/cli/log_printer.py
@@ -18,7 +18,7 @@ class LogPrinter(object):
     def run(self):
         mux = Multiplexer(self.generators)
         for line in mux.loop():
-            sys.stdout.write(line.encode(sys.__stdout__.encoding or 'utf8'))
+            sys.stdout.write(line.encode(sys.__stdout__.encoding or 'utf-8'))
 
     def _make_log_generators(self):
         color_fns = cycle(colors.rainbow())

--- a/fig/cli/socketclient.py
+++ b/fig/cli/socketclient.py
@@ -81,7 +81,7 @@ class SocketClient:
                 chunk = socket.recv(4096)
 
                 if chunk:
-                    stream.write(chunk.encode(stream.encoding or 'utf8'))
+                    stream.write(chunk.encode(stream.encoding or 'utf-8'))
                     stream.flush()
                 else:
                     break

--- a/fig/service.py
+++ b/fig/service.py
@@ -306,7 +306,7 @@ class Service(object):
                 match = re.search(r'Successfully built ([0-9a-f]+)', line)
                 if match:
                     image_id = match.group(1)
-            sys.stdout.write(line.encode(sys.__stdout__.encoding or 'utf8'))
+            sys.stdout.write(line.encode(sys.__stdout__.encoding or 'utf-8'))
 
         if image_id is None:
             raise BuildError(self)


### PR DESCRIPTION
this fixes a bug with the logger and utf8:

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2713'   ordinal not in range(128)
```

heres a link to docs referencing `utf-8` instead of `utf8`: 

https://docs.python.org/2/howto/unicode.html#the-unicode-type
