### PR TITLE
Ensure that `pwd`/dist exists and is writeable

### DIFF
--- a/script/build-linux
+++ b/script/build-linux
@@ -1,3 +1,5 @@
 #!/bin/sh
+mkdir -p `pwd`/dist
+chmod 777 `pwd`/dist
 docker build -t fig .
 docker run -v `pwd`/dist:/code/dist fig pyinstaller -F bin/fig


### PR DESCRIPTION
This fixes the problem that was reported in #192

The chmod maybe extreme; but as I built this as a non-root user I got the feeling it might be required.

Signed-off-by: Scott M. Likens scott@likens.us
