### PR TITLE
Remove intermediate build containers

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -305,7 +305,8 @@ class Service(object):
         build_output = self.client.build(
             self.options['build'],
             tag=self._build_tag_name(),
-            stream=True
+            stream=True,
+            rm=True
         )
 
         try:


### PR DESCRIPTION
Docker does this by default now.
