### PR TITLE
Do not encode chunk, just write as is.

### DIFF
--- a/fig/cli/socketclient.py
+++ b/fig/cli/socketclient.py
@@ -81,7 +81,7 @@ class SocketClient:
                 chunk = socket.recv(4096)
 
                 if chunk:
-                    stream.write(chunk.encode(stream.encoding or 'utf-8'))
+                    stream.write(chunk)
                     stream.flush()
                 else:
                     break


### PR DESCRIPTION
Encoding as 'utf-8' does not work well on `chunk` as it is a fixed stream of bytes. Maybe see also this article about [Python, terminals and encoding](http://lucumr.pocoo.org/2014/5/12/everything-about-unicode/).

I get errors like this, when starting a bash with `fig run` and pressing `ö` for example:

```
DEBUG:fig.cli.socketclient:'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

Without encoding it works fine.
