### PR TITLE
Use busybox in fixtures, instead of ubuntu

### DIFF
--- a/tests/fixtures/longer-filename-figfile/fig.yaml
+++ b/tests/fixtures/longer-filename-figfile/fig.yaml
@@ -1,3 +1,3 @@
 definedinyamlnotyml:
-  image: ubuntu
+  image: busybox:latest
   command: /bin/sleep 300

--- a/tests/fixtures/multiple-figfiles/fig.yml
+++ b/tests/fixtures/multiple-figfiles/fig.yml
@@ -1,6 +1,6 @@
 simple:
-  image: ubuntu
+  image: busybox:latest
   command: /bin/sleep 300
 another:
-  image: ubuntu
+  image: busybox:latest
   command: /bin/sleep 300

--- a/tests/fixtures/multiple-figfiles/fig2.yml
+++ b/tests/fixtures/multiple-figfiles/fig2.yml
@@ -1,3 +1,3 @@
 yetanother:
-  image: ubuntu
+  image: busybox:latest
   command: /bin/sleep 300

--- a/tests/fixtures/simple-dockerfile/Dockerfile
+++ b/tests/fixtures/simple-dockerfile/Dockerfile
@@ -1,2 +1,2 @@
-FROM ubuntu
+FROM busybox:latest
 CMD echo "success"

--- a/tests/fixtures/simple-figfile/fig.yml
+++ b/tests/fixtures/simple-figfile/fig.yml
@@ -1,6 +1,6 @@
 simple:
-  image: ubuntu
+  image: busybox:latest
   command: /bin/sleep 300
 another:
-  image: ubuntu
+  image: busybox:latest
   command: /bin/sleep 300

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -10,7 +10,7 @@ class DockerClientTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = Client(docker_url())
-        cls.client.pull('ubuntu', tag='latest')
+        cls.client.pull('busybox', tag='latest')
 
     def setUp(self):
         for c in self.client.containers(all=True):
@@ -28,7 +28,7 @@ class DockerClientTestCase(unittest.TestCase):
             project='figtest',
             name=name,
             client=self.client,
-            image="ubuntu",
+            image="busybox:latest",
             **kwargs
         )
 

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -6,7 +6,7 @@ class ContainerTest(unittest.TestCase):
     def test_from_ps(self):
         container = Container.from_ps(None, {
             "Id":"abc",
-            "Image":"ubuntu:12.04",
+            "Image":"busybox:latest",
             "Command":"sleep 300",
             "Created":1387384730,
             "Status":"Up 8 seconds",
@@ -17,7 +17,7 @@ class ContainerTest(unittest.TestCase):
         }, has_been_inspected=True)
         self.assertEqual(container.dictionary, {
             "ID": "abc",
-            "Image":"ubuntu:12.04",
+            "Image":"busybox:latest",
             "Name": "/figtest_db_1",
         })
 
@@ -39,7 +39,7 @@ class ContainerTest(unittest.TestCase):
     def test_number(self):
         container = Container.from_ps(None, {
             "Id":"abc",
-            "Image":"ubuntu:12.04",
+            "Image":"busybox:latest",
             "Command":"sleep 300",
             "Created":1387384730,
             "Status":"Up 8 seconds",
@@ -53,7 +53,7 @@ class ContainerTest(unittest.TestCase):
     def test_name(self):
         container = Container.from_ps(None, {
             "Id":"abc",
-            "Image":"ubuntu:12.04",
+            "Image":"busybox:latest",
             "Command":"sleep 300",
             "Names":["/figtest_db_1"]
         }, has_been_inspected=True)
@@ -62,7 +62,7 @@ class ContainerTest(unittest.TestCase):
     def test_name_without_project(self):
         container = Container.from_ps(None, {
             "Id":"abc",
-            "Image":"ubuntu:12.04",
+            "Image":"busybox:latest",
             "Command":"sleep 300",
             "Names":["/figtest_db_1"]
         }, has_been_inspected=True)

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -8,29 +8,29 @@ class ProjectTest(unittest.TestCase):
         project = Project.from_dicts('figtest', [
             {
                 'name': 'web',
-                'image': 'ubuntu'
+                'image': 'busybox:latest'
             },
             {
                 'name': 'db',
-                'image': 'ubuntu'
-            }
+                'image': 'busybox:latest'
+            },
         ], None)
         self.assertEqual(len(project.services), 2)
         self.assertEqual(project.get_service('web').name, 'web')
-        self.assertEqual(project.get_service('web').options['image'], 'ubuntu')
+        self.assertEqual(project.get_service('web').options['image'], 'busybox:latest')
         self.assertEqual(project.get_service('db').name, 'db')
-        self.assertEqual(project.get_service('db').options['image'], 'ubuntu')
+        self.assertEqual(project.get_service('db').options['image'], 'busybox:latest')
 
     def test_from_dict_sorts_in_dependency_order(self):
         project = Project.from_dicts('figtest', [
             {
                 'name': 'web',
-                'image': 'ubuntu',
+                'image': 'busybox:latest',
                 'links': ['db'],
             },
             {
                 'name': 'db',
-                'image': 'ubuntu'
+                'image': 'busybox:latest'
             }
         ], None)
 
@@ -40,22 +40,22 @@ class ProjectTest(unittest.TestCase):
     def test_from_config(self):
         project = Project.from_config('figtest', {
             'web': {
-                'image': 'ubuntu',
+                'image': 'busybox:latest',
             },
             'db': {
-                'image': 'ubuntu',
+                'image': 'busybox:latest',
             },
         }, None)
         self.assertEqual(len(project.services), 2)
         self.assertEqual(project.get_service('web').name, 'web')
-        self.assertEqual(project.get_service('web').options['image'], 'ubuntu')
+        self.assertEqual(project.get_service('web').options['image'], 'busybox:latest')
         self.assertEqual(project.get_service('db').name, 'db')
-        self.assertEqual(project.get_service('db').options['image'], 'ubuntu')
+        self.assertEqual(project.get_service('db').options['image'], 'busybox:latest')
 
     def test_from_config_throws_error_when_not_dict(self):
         with self.assertRaises(ConfigurationError):
             project = Project.from_config('figtest', {
-                'web': 'ubuntu',
+                'web': 'busybox:latest',
             }, None)
 
     def test_get_service(self):
@@ -63,7 +63,7 @@ class ProjectTest(unittest.TestCase):
             project='figtest',
             name='web',
             client=None,
-            image="ubuntu",
+            image="busybox:latest",
         )
         project = Project('test', [web], None)
         self.assertEqual(project.get_service('web'), web)


### PR DESCRIPTION
I develop exclusively inside docker containers, because I like to make sure my development environments are both disposable and reproducible. This includes hacking on fig, by running [docker inside docker](https://github.com/d11wtq/fig-dev-docker).

Because my dev environment begins with a clean slate (i.e. no docker images), using ubuntu as a text fixture is a bit heavyweight. Quite often I'm limited to using a 3G connection tethering on my phone too. Switching to busybox reduces the bandwidth overhead to all of 2.5MB instead of 200MB. Given you only need /bin/sleep, this should be sufficient. It also speeds up the tests, as the initial pull has way less work to do.
