### PR TITLE
Catch a UnicodeEncode Exception and retry with a utf-8 encoding

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -418,7 +418,7 @@ def print_output_event(event, stream, is_terminal):
     elif 'stream' in event:
         try:
             stream.write("%s%s" % (event['stream'], terminator))
-        except UnicodeEncodeError as uee:
+        except UnicodeEncodeError:
             stream.write("%s%s" % (event['stream'].encode('utf-8'), terminator))
     else:
         stream.write("%s%s\n" % (status, terminator))


### PR DESCRIPTION
I found this issue while I was using fig to build an app that needs bower install ran to pull down the required JS files. The output from bower is not valid ascii and stream.write assumes that it is ascii. I added a try except UnicodeEncodeError block and retry the stream.write with the stream default encoded to utf-8. Verified that this fixed my issue and reran the tests and didn't receive any failures. 
