### PR TITLE
Use ubuntu:13.10 image to build docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackbrew/ubuntu:13.10
+FROM ubuntu:13.10
 RUN apt-get -qq update && apt-get install -y ruby1.8 bundler python
 RUN locale-gen en_US.UTF-8
 ADD Gemfile /code/


### PR DESCRIPTION
stackbrew/ubuntu and ubuntu are the same thing now.

Signed-off-by: Ben Firshman ben@firshman.co.uk
