### PR TITLE
BUGFIX: Handle WINCH to set the pseudo-tty size (fixes #97 and #253).

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -14,6 +14,7 @@ from .command import Command
 from .formatter import Formatter
 from .log_printer import LogPrinter
 from .utils import yesno
+from .ttysizer import TTYSizer
 
 from ..packages.docker.errors import APIError
 from .errors import UserError
@@ -231,9 +232,15 @@ class TopLevelCommand(Command):
             service.start_container(container, ports=None, one_off=True)
             print(container.name)
         else:
-            with self._attach_to_container(container.id, raw=tty) as c:
+            with self._attach_to_container(container, raw=tty) as c:
                 service.start_container(container, ports=None, one_off=True)
+
+                if tty:
+                    tty_sizer = TTYSizer(container)
+                    tty_sizer.start()
+
                 c.run()
+
             exit_code = container.wait()
             if options['--rm']:
                 log.info("Removing %s..." % container.name)
@@ -320,10 +327,10 @@ class TopLevelCommand(Command):
                 print("Gracefully stopping... (press Ctrl+C again to force)")
                 self.project.stop(service_names=options['SERVICE'])
 
-    def _attach_to_container(self, container_id, raw=False):
-        socket_in = self.client.attach_socket(container_id, params={'stdin': 1, 'stream': 1})
-        socket_out = self.client.attach_socket(container_id, params={'stdout': 1, 'logs': 1, 'stream': 1})
-        socket_err = self.client.attach_socket(container_id, params={'stderr': 1, 'logs': 1, 'stream': 1})
+    def _attach_to_container(self, container, raw=False):
+        socket_in = self.client.attach_socket(container.id, params={'stdin': 1, 'stream': 1})
+        socket_out = self.client.attach_socket(container.id, params={'stdout': 1, 'logs': 1, 'stream': 1})
+        socket_err = self.client.attach_socket(container.id, params={'stderr': 1, 'logs': 1, 'stream': 1})
 
         return SocketClient(
             socket_in=socket_in,

--- a/fig/cli/ttysizer.py
+++ b/fig/cli/ttysizer.py
@@ -1,0 +1,73 @@
+import sys
+import os
+import fcntl
+import termios
+import struct
+import signal
+
+class TTYSizer:
+    """
+    Keeps the pseudo-tty of a container sized the same as the real tty.
+
+    Pseudo-TTYs need to be resized when a SIGWINCH signal is received on the
+    real TTY, so that the number of rows and columns matches that of the host.
+    """
+
+    def __init__(self, container):
+        """
+        Initialize a TTYSizer that monitors `container`.
+
+        When the TTYSizer is started, it will run in a sub-process so that the
+        received signals can be processed immediately and are not blocked on
+        the main process running the pseudo-tty.
+        """
+        self.container = container
+        self.client = container.client
+
+    def start(self):
+        """
+        Spawn the child process that will keep the pseudo-tty correctly sized.
+
+        This method returns immediately in the main process.
+        """
+        if os.fork() > 0:
+            return
+
+        def handler(signum, frame):
+            if signum == signal.SIGWINCH:
+                self.resize_tty()
+
+        signal.signal(signal.SIGWINCH, handler)
+
+        self.resize_tty()
+        self.container.wait()
+        sys.exit(0)
+
+    def resize_tty(self):
+        """
+        Set the size of the pseudo-tty in the container to match the real tty.
+        """
+        size = self._get_tty_size()
+
+        if size is not None:
+            h, w = size
+            url = self.client._url(
+                "/containers/{0}/resize".format(self.container.id)
+            )
+
+            self.client._post(url, params={'h': h, 'w': w})
+
+    # http://blog.taz.net.au/2012/04/09/getting-the-terminal-size-in-python/
+    def _get_tty_size(self):
+        try:
+            hw = struct.unpack(
+                'hh',
+                fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, '1234')
+            )
+        except:
+            try:
+                hw = (os.environ['LINES'], os.environ['COLUMNS'])
+            except:
+                return
+
+        return hw


### PR DESCRIPTION
This fixes #97 and #253.

The TTY needs to be resized when the container first starts, and then on each WINCH signal received by the real TTY. I have no idea how to unit test this in practice, but it does work.

This solution uses a forked child to handle the signals, since without it, the signals were just being queued on the main process and then run once the container had exited. I'm not sure if that is an issue with the threading  in SocketClient (threads and POSIX signals doesn't play well together sometimes), or if it's due to the way the SocketClient works. Forking is a good POSIX solution anyway and from reading up on Pseudo-TTYs, it's a common approach to use multi-processes.
