### PR TITLE
Update dockerpty to fix discovered race condition.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ PyYAML==3.10
 requests==2.2.1
 texttable==0.8.1
 websocket-client==0.11.0
-dockerpty==0.0.8
+dockerpty==0.1.0


### PR DESCRIPTION
This resolves the build errors https://travis-ci.org/orchardup/fig/jobs/28421853

It was previously possible to start a container that runs a very quick
command (like /bin/true) and thus exits fast. In this case, when trying
to start the pseudo-terminal and resize it, docker would complain that
the file descriptor does not exist.
