### PR TITLE
Stop `fig run` starting everything when a service has no links

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -220,11 +220,14 @@ class TopLevelCommand(Command):
         service = self.project.get_service(options['SERVICE'])
 
         if not options['--no-deps']:
-            self.project.up(
-                service_names=service.get_linked_names(),
-                start_links=True,
-                recreate=False
-            )
+            deps = service.get_linked_names()
+
+            if len(deps) > 0:
+                self.project.up(
+                    service_names=deps,
+                    start_links=True,
+                    recreate=False,
+                )
 
         tty = True
         if options['-d'] or options['-T'] or not sys.stdin.isatty():

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -103,9 +103,13 @@ class CLITestCase(DockerClientTestCase):
 
 
     @patch('dockerpty.start')
-    def test_run_with_links(self, mock_stdout):
-        mock_stdout.fileno = lambda: 1
+    def test_run_service_without_links(self, mock_stdout):
+        self.command.base_dir = 'tests/fixtures/links-figfile'
+        self.command.dispatch(['run', 'console', '/bin/true'], None)
+        self.assertEqual(len(self.command.project.containers()), 0)
 
+    @patch('dockerpty.start')
+    def test_run_service_with_links(self, mock_stdout):
         self.command.base_dir = 'tests/fixtures/links-figfile'
         self.command.dispatch(['run', 'web', '/bin/true'], None)
         db = self.command.project.get_service('db')


### PR DESCRIPTION
This was thanks to the semantics of project.up(), which starts everything if you pass it an empty list of service names. (That logic should probably be moved out to main.py.)
