### PR TITLE
Make fig run COMMAND parameter optional.

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -206,7 +206,7 @@ class TopLevelCommand(Command):
         running. If you do not want to start linked services, use
         `fig run --no-deps SERVICE COMMAND [ARGS...]`.
 
-        Usage: run [options] SERVICE COMMAND [ARGS...]
+        Usage: run [options] SERVICE [COMMAND] [ARGS...]
 
         Options:
             -d         Detached mode: Run container in the background, print
@@ -233,8 +233,13 @@ class TopLevelCommand(Command):
         if options['-d'] or options['-T'] or not sys.stdin.isatty():
             tty = False
 
+        if options['COMMAND']:
+            command = [options['COMMAND']] + options['ARGS']
+        else:
+            command = service.options.get('command')
+
         container_options = {
-            'command': [options['COMMAND']] + options['ARGS'],
+            'command': command,
             'tty': tty,
             'stdin_open': not options['-d'],
         }

--- a/tests/fixtures/commands-figfile/fig.yml
+++ b/tests/fixtures/commands-figfile/fig.yml
@@ -1,0 +1,5 @@
+implicit:
+  image: figtest_test
+explicit:
+  image: figtest_test
+  command: [ "/bin/true" ]


### PR DESCRIPTION
The new behaviour:

Same as previously:

```
fig run SERVICE COMMAND
```

If there's a `command` defined for the service in the fig.yml, runs `command` (i.e. basically behaves like `fig up`, but with a TTY and `--rm` options:

```
fig run SERVICE
```

If there's no `command` defined in the fig.yml, acts like the native client and runs `CMD` from the Dockerfile:

```
fig run SERVICE
```

This cuts down my keystrokes considerably, as I'm almost exclusively using `fig run` to launch into dev environments in a console :)
