### PR TITLE
Add warning for mapping local volumes

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -75,6 +75,8 @@ expose:
 ### volumes
 
 Mount paths as volumes, optionally specifying a path on the host machine (`HOST:CONTAINER`).
+Note: Mapping local volumes is currently unsuported on boot2docker. We
+recommend you use docker-osx if want to map local volumes.
 
 ```
 volumes:


### PR DESCRIPTION
Mapping local volumes is not currently supported in boot2docker

https://github.com/boot2docker/boot2docker/issues/413
https://github.com/dotcloud/docker/issues/4023
