### PR TITLE
BUGFIX: Update dockerpty for non-TTY multiplexing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ PyYAML==3.10
 requests==2.2.1
 texttable==0.8.1
 websocket-client==0.11.0
-dockerpty==0.1.1
+dockerpty==0.2.1


### PR DESCRIPTION
If you don't allocate a pseudo-TTY in a container, then you attach to the container, docker does something magic with the streams and multiplexes stdout and stderr together, with 8-byte headers indicating the stream and the packet size. This update to dockerpty implements that behaviour (*) and is also the second release to have full test coverage.

Users affected would have been those using `docker run -T ...`.
- Note that fig also had this bug with the old threaded SocketClient.
