### PR TITLE
Add support for .dockerignore

### DIFF
--- a/fig/packages/docker/client.py
+++ b/fig/packages/docker/client.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import json
+import os
 import re
 import shlex
 import struct
@@ -351,7 +352,12 @@ class Client(requests.Session):
                               'git://', 'github.com/')):
             remote = path
         else:
-            context = utils.tar(path)
+            dockerignore = os.path.join(path, '.dockerignore')
+            exclude = None
+            if os.path.exists(dockerignore):
+                with open(dockerignore, 'r') as f:
+                    exclude = list(filter(bool, f.read().split('\n')))
+            context = utils.tar(path, exclude=exclude)
 
         if utils.compare_version('1.8', self._version) >= 0:
             stream = True


### PR DESCRIPTION
Implementation is a bit more elaborate than docker's implementation and matches with the one proposed in https://github.com/dotcloud/docker/pull/6869 to handle permission issues when running e.g. a mysql container next to a local container.

I'm getting test failures locally so I haven't looked at writing a proper test yet.
