### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -59,7 +59,7 @@ class Command(DocoptCommand):
             yaml_path = self.yaml_path
             if yaml_path is None:
                 yaml_path = self.check_yaml_filename()
-            config = yaml.load(open(yaml_path))
+            config = yaml.safe_load(open(yaml_path))
         except IOError as e:
             if e.errno == errno.ENOENT:
                 raise errors.FigFileNotFound(os.path.basename(e.filename))


### PR DESCRIPTION
See my comment in https://github.com/orchardup/fig/pull/76#issuecomment-48610330

Fig maybe should use `yaml.safe_load` not `yaml.load`.  It's kinda powerful, but in a way that makes me think it's probably insecure.

http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML
Signed-off-by: Richard Morrison richard@rmorrison.net
