### PR TITLE
add support for domainname, qualified hostname

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -304,6 +304,17 @@ class Service(object):
 
         container_options['name'] = self.next_container_name(one_off)
 
+        # If a qualified hostname was given, split it into an
+        # unqualified hostname and a domainname unless domainname
+        # was also given explicitly. This matches the behavior of
+        # the official Docker CLI in that scenario.
+        if ('hostname' in container_options
+                and 'domainname' not in container_options
+                and '.' in container_options['hostname']):
+            parts = container_options['hostname'].partition('.')
+            container_options['hostname'] = parts[0]
+            container_options['domainname'] = parts[2]
+
         if 'ports' in container_options or 'expose' in self.options:
             ports = []
             all_ports = container_options.get('ports', []) + self.options.get('expose', [])

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -41,4 +41,40 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(internal_port, "2000")
         self.assertEqual(external_port, "1000")
 
+    def test_split_domainname_none(self):
+        service = Service('foo',
+                hostname = 'name',
+            )
+        service.next_container_name = lambda x: 'foo'
+        opts = service._get_container_create_options({})
+        self.assertEqual(opts['hostname'], 'name', 'hostname')
+        self.assertFalse('domainname' in opts, 'domainname')
 
+    def test_split_domainname_fqdn(self):
+        service = Service('foo',
+                hostname = 'name.domain.tld',
+            )
+        service.next_container_name = lambda x: 'foo'
+        opts = service._get_container_create_options({})
+        self.assertEqual(opts['hostname'], 'name', 'hostname')
+        self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
+
+    def test_split_domainname_both(self):
+        service = Service('foo',
+                hostname = 'name',
+                domainname = 'domain.tld',
+            )
+        service.next_container_name = lambda x: 'foo'
+        opts = service._get_container_create_options({})
+        self.assertEqual(opts['hostname'], 'name', 'hostname')
+        self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
+
+    def test_split_domainname_weird(self):
+        service = Service('foo',
+                hostname = 'name.sub',
+                domainname = 'domain.tld',
+            )
+        service.next_container_name = lambda x: 'foo'
+        opts = service._get_container_create_options({})
+        self.assertEqual(opts['hostname'], 'name.sub', 'hostname')
+        self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')


### PR DESCRIPTION
Docker doesn't like it when a fully qualified hostname is passed in the `hostname` parameter. When an FQDN is provided with `-h` the official CLI puts the first component in `hostname` and the rest in `domainname`. This change replicates that behavior when the user specifies an FQDN in `hostname` in their `fig.yml`. It also adds support for passing the `domainname` parameter directly.
