### PR TITLE
Fix typo in script dir name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ that should get you started.
 1. Clone your forked repository locally `git clone git@github.com:kvz/fig.git`.
 1. Enter the local directory `cd fig`.
 1. Set up a development environment `python setup.py develop`. That will install the dependencies and set up a symlink from your `fig` executable to the checkout of the repo. So from any of your fig projects, `fig` now refers to your development project. Time to start hacking : )
-1. Works for you? Run the test suite via `./scripts/test` to verify it won't break other usecases.
+1. Works for you? Run the test suite via `./script/test` to verify it won't break other usecases.
 1. All good? Commit and push to GitHub, and submit a pull request.
 
 ## Running the test suite


### PR DESCRIPTION
The directory is called `script`, not `scripts`.

Signed-off-by: Ryan Brainard brainard@heroku.com
