### PR TITLE
Regardless of dependencies, `fig up` only attaches to what you specify

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -322,11 +322,13 @@ class TopLevelCommand(Command):
         recreate = not options['--no-recreate']
         service_names = options['SERVICE']
 
-        to_attach = self.project.up(
+        self.project.up(
             service_names=service_names,
             start_links=start_links,
             recreate=recreate
         )
+
+        to_attach = [c for s in self.project.get_services(service_names) for c in s.containers()]
 
         if not detached:
             print("Attaching to", list_containers(to_attach))


### PR DESCRIPTION
Without this, if you go:

```
$ fig up -d db
$ fig up web
```

you'll get output for both db and web, and Ctrl-C will kill them both, because we now automatically include dependent services.
