### PR TITLE
Set default project name to dir name of fig.yml

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -23,7 +23,7 @@ class Command(DocoptCommand):
     base_dir = '.'
 
     def __init__(self):
-        self.yaml_path = os.environ.get('FIG_FILE', None)
+        self._yaml_path = os.environ.get('FIG_FILE', None)
         self.explicit_project_name = None
 
     def dispatch(self, *args, **kwargs):
@@ -56,10 +56,7 @@ class Command(DocoptCommand):
     @cached_property
     def project(self):
         try:
-            yaml_path = self.yaml_path
-            if yaml_path is None:
-                yaml_path = self.check_yaml_filename()
-            config = yaml.safe_load(open(yaml_path))
+            config = yaml.safe_load(open(self.yaml_path))
         except IOError as e:
             if e.errno == errno.ENOENT:
                 raise errors.FigFileNotFound(os.path.basename(e.filename))
@@ -72,7 +69,7 @@ class Command(DocoptCommand):
 
     @cached_property
     def project_name(self):
-        project = os.path.basename(os.getcwd())
+        project = os.path.basename(os.path.dirname(self.yaml_path))
         if self.explicit_project_name is not None:
             project = self.explicit_project_name
         project = re.sub(r'[^a-zA-Z0-9]', '', project)
@@ -84,8 +81,11 @@ class Command(DocoptCommand):
     def formatter(self):
         return Formatter()
 
-    def check_yaml_filename(self):
-        if os.path.exists(os.path.join(self.base_dir, 'fig.yaml')):
+    @cached_property
+    def yaml_path(self):
+        if self._yaml_path is not None:
+            return self._yaml_path
+        elif os.path.exists(os.path.join(self.base_dir, 'fig.yaml')):
 
             log.warning("Fig just read the file 'fig.yaml' on startup, rather than 'fig.yml'")
             log.warning("Please be aware that fig.yml the expected extension in most cases, and using .yaml can cause compatibility issues in future")
@@ -93,3 +93,7 @@ class Command(DocoptCommand):
             return os.path.join(self.base_dir, 'fig.yaml')
         else:
             return os.path.join(self.base_dir, 'fig.yml')
+
+    @yaml_path.setter
+    def yaml_path(self, value):
+        self._yaml_path = value

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -22,7 +22,7 @@ class CLITestCase(DockerClientTestCase):
     def test_ps(self, mock_stdout):
         self.command.project.get_service('simple').create_container()
         self.command.dispatch(['ps'], None)
-        self.assertIn('fig_simple_1', mock_stdout.getvalue())
+        self.assertIn('simplefigfile_simple_1', mock_stdout.getvalue())
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ps_default_figfile(self, mock_stdout):
@@ -31,9 +31,9 @@ class CLITestCase(DockerClientTestCase):
         self.command.dispatch(['ps'], None)
 
         output = mock_stdout.getvalue()
-        self.assertIn('fig_simple_1', output)
-        self.assertIn('fig_another_1', output)
-        self.assertNotIn('fig_yetanother_1', output)
+        self.assertIn('multiplefigfiles_simple_1', output)
+        self.assertIn('multiplefigfiles_another_1', output)
+        self.assertNotIn('multiplefigfiles_yetanother_1', output)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ps_alternate_figfile(self, mock_stdout):
@@ -42,9 +42,9 @@ class CLITestCase(DockerClientTestCase):
         self.command.dispatch(['-f', 'fig2.yml', 'ps'], None)
 
         output = mock_stdout.getvalue()
-        self.assertNotIn('fig_simple_1', output)
-        self.assertNotIn('fig_another_1', output)
-        self.assertIn('fig_yetanother_1', output)
+        self.assertNotIn('multiplefigfiles_simple_1', output)
+        self.assertNotIn('multiplefigfiles_another_1', output)
+        self.assertIn('multiplefigfiles_yetanother_1', output)
 
     def test_up(self):
         self.command.dispatch(['up', '-d'], None)

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -5,6 +5,11 @@ from fig.cli.main import TopLevelCommand
 from fig.packages.six import StringIO
 
 class CLITestCase(unittest.TestCase):
+    def test_project_name_defaults_to_dirname(self):
+        command = TopLevelCommand()
+        command.base_dir = 'tests/fixtures/simple-figfile'
+        self.assertEquals('simplefigfile', command.project_name)
+
     def test_yaml_filename_check(self):
         command = TopLevelCommand()
         command.base_dir = 'tests/fixtures/longer-filename-figfile'


### PR DESCRIPTION
This behavior already happens under normal circumstances, but when running Fig from a different directory than that of the `fig.yml`, the project name is the `cwd` instead of where the `fig.yml` is actually located. This means that if you change directories, you'll get a different project name even if you are pointing to the same `fig.yml` file. This fixes it so that the project name stays consistent for a given `fig.yml` file.

Because the `check_yaml_filename()` was not happening until `project()` was called and this behavior would have been duplicated in `project_name()`, I extracted out the `yaml_path` resolution into a property (just doing it in the initializer wouldn't work because the tests mutate the `base_dir` after initialization). I'm pretty new to Python, so please let me know if this could have been done in a better way.
