### PR TITLE
Fix regression of default behaviour in Command.project_name

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -69,7 +69,7 @@ class Command(DocoptCommand):
 
     @cached_property
     def project_name(self):
-        project = os.path.basename(os.path.dirname(self.yaml_path))
+        project = os.path.basename(os.path.dirname(os.path.abspath(self.yaml_path)))
         if self.explicit_project_name is not None:
             project = self.explicit_project_name
         project = re.sub(r'[^a-zA-Z0-9]', '', project)

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -3,12 +3,28 @@ from __future__ import absolute_import
 from .. import unittest
 from fig.cli.main import TopLevelCommand
 from fig.packages.six import StringIO
+import os
 
 class CLITestCase(unittest.TestCase):
-    def test_project_name_defaults_to_dirname(self):
+    def test_default_project_name(self):
+        cwd = os.getcwd()
+
+        try:
+            os.chdir('tests/fixtures/simple-figfile')
+            command = TopLevelCommand()
+            self.assertEquals('simplefigfile', command.project_name)
+        finally:
+            os.chdir(cwd)
+
+    def test_project_name_with_explicit_base_dir(self):
         command = TopLevelCommand()
         command.base_dir = 'tests/fixtures/simple-figfile'
         self.assertEquals('simplefigfile', command.project_name)
+
+    def test_project_name_with_explicit_project_name(self):
+        command = TopLevelCommand()
+        command.explicit_project_name = 'explicit-project-name'
+        self.assertEquals('explicitprojectname', command.project_name)
 
     def test_yaml_filename_check(self):
         command = TopLevelCommand()


### PR DESCRIPTION
Needed an `os.abspath` in there. Added more tests, too.
