### PR TITLE
Fix cli for python 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info
 *.pyc
+.tox
 /build
 /dist
 /docs/_site

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -24,16 +24,7 @@ log = logging.getLogger(__name__)
 
 
 def main():
-    console_handler = logging.StreamHandler(stream=sys.stderr)
-    console_handler.setFormatter(logging.Formatter())
-    console_handler.setLevel(logging.INFO)
-    root_logger = logging.getLogger()
-    root_logger.addHandler(console_handler)
-    root_logger.setLevel(logging.DEBUG)
-
-    # Disable requests logging
-    logging.getLogger("requests").propagate = False
-
+    setup_logging()
     try:
         command = TopLevelCommand()
         command.sys_dispatch()
@@ -54,6 +45,18 @@ def main():
     except BuildError as e:
         log.error("Service '%s' failed to build: %s" % (e.service.name, e.reason))
         sys.exit(1)
+
+
+def setup_logging():
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(logging.Formatter())
+    console_handler.setLevel(logging.INFO)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(console_handler)
+    root_logger.setLevel(logging.DEBUG)
+
+    # Disable requests logging
+    logging.getLogger("requests").propagate = False
 
 
 # stolen from docopt master

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
+import logging
+import os
 from .. import unittest
+
+from fig.cli import main
 from fig.cli.main import TopLevelCommand
 from fig.packages.six import StringIO
-import os
+
 
 class CLITestCase(unittest.TestCase):
     def test_default_project_name(self):
@@ -35,3 +39,8 @@ class CLITestCase(unittest.TestCase):
         command = TopLevelCommand()
         with self.assertRaises(SystemExit):
             command.dispatch(['-h'], None)
+
+    def test_setup_logging(self):
+        main.setup_logging()
+        self.assertEqual(logging.getLogger().level, logging.DEBUG)
+        self.assertEqual(logging.getLogger('requests').propagate, False)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist = py26,py27,py32,py33,pypy
 
 [testenv]
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
 commands =
-	pip install -e {toxinidir}
-	pip install -e {toxinidir}[test]
-	python setup.py test
+    nosetests {posargs}


### PR DESCRIPTION
Right now fig is unusable on python 2.6.

Error:

```
$ fig
Traceback (most recent call last):
  File ".../.tox/py26/bin/fig", line 9, in <module>
    load_entry_point('fig==0.5.0', 'console_scripts', 'fig')()
  File ".../.tox/py26/lib/python2.6/site-packages/fig/cli/main.py", line 27, in main
    console_handler = logging.StreamHandler(stream=sys.stderr)
TypeError: __init__() got an unexpected keyword argument 'stream'
```

This fixes the issue, adds a test, and cleans up the tox.ini to install dependencies properly.

As a side question, why does `CONTRIBUTING.md` suggest using `scripts/test` instead of `tox -e py27` or something like that?
