### PR TITLE
removing _1 suffix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@ Thanks @ryanbrainard and @d11wtq!
 ------------------
 
  - Fig now starts links when you run `fig run` or `fig up`.
-   
+
    For example, if you have a `web` service which depends on a `db` service, `fig run web ...` will start the `db` service.
 
  - Environment variables can now be resolved from the environment that Fig is running in. Just specify it as a blank variable in your `fig.yml` and, if set, it'll be resolved:
@@ -187,5 +187,3 @@ Big thanks to @tomstuart, @EnTeQuAk, @schickling, @aronasorman and @GeoffreyPlit
 ------------------
 
 Initial release.
-
-

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,7 +51,7 @@ One-off commands are started in new containers with the same config as a normal 
 
 Links are also created between one-off commands and the other containers for that service so you can do stuff like this:
 
-    $ fig run db /bin/sh -c "psql -h \$DB_1_PORT_5432_TCP_ADDR -U docker"
+    $ fig run db /bin/sh -c "psql -h \$DB_PORT_5432_TCP_ADDR -U docker"
 
 If you do not want linked containers to be started when running the one-off command, specify the `--no-deps` flag:
 

--- a/docs/django.md
+++ b/docs/django.md
@@ -60,8 +60,8 @@ First thing we need to do is set up the database connection. Replace the `DATABA
             'NAME': 'docker',
             'USER': 'docker',
             'PASSWORD': 'docker',
-            'HOST': os.environ.get('DB_1_PORT_5432_TCP_ADDR'),
-            'PORT': os.environ.get('DB_1_PORT_5432_TCP_PORT'),
+            'HOST': os.environ.get('DB_PORT_5432_TCP_ADDR'),
+            'PORT': os.environ.get('DB_PORT_5432_TCP_PORT'),
         }
     }
 
@@ -69,24 +69,23 @@ These settings are determined by the [orchardup/postgresql](https://github.com/o
 
 Then, run `fig up`:
 
-    Recreating myapp_db_1...
-    Recreating myapp_web_1...
-    Attaching to myapp_db_1, myapp_web_1
-    myapp_db_1 |
-    myapp_db_1 | PostgreSQL stand-alone backend 9.1.11
-    myapp_db_1 | 2014-01-27 12:17:03 UTC LOG:  database system is ready to accept connections
-    myapp_db_1 | 2014-01-27 12:17:03 UTC LOG:  autovacuum launcher started
-    myapp_web_1 | Validating models...
-    myapp_web_1 |
-    myapp_web_1 | 0 errors found
-    myapp_web_1 | January 27, 2014 - 12:12:40
-    myapp_web_1 | Django version 1.6.1, using settings 'figexample.settings'
-    myapp_web_1 | Starting development server at http://0.0.0.0:8000/
-    myapp_web_1 | Quit the server with CONTROL-C.
+    Recreating myapp_db...
+    Recreating myapp_web...
+    Attaching to myapp_db, myapp_web
+    myapp_db |
+    myapp_db | PostgreSQL stand-alone backend 9.1.11
+    myapp_db | 2014-01-27 12:17:03 UTC LOG:  database system is ready to accept connections
+    myapp_db | 2014-01-27 12:17:03 UTC LOG:  autovacuum launcher started
+    myapp_web | Validating models...
+    myapp_web |
+    myapp_web | 0 errors found
+    myapp_web | January 27, 2014 - 12:12:40
+    myapp_web | Django version 1.6.1, using settings 'figexample.settings'
+    myapp_web | Starting development server at http://0.0.0.0:8000/
+    myapp_web | Quit the server with CONTROL-C.
 
 And your Django app should be running at [localhost:8000](http://localhost:8000) (or [localdocker:8000](http://localdocker:8000) if you're using docker-osx).
 
 You can also run management commands with Docker. To set up your database, for example, run `fig up` and in another terminal run:
 
     $ fig run web python manage.py syncdb
-

--- a/docs/env.md
+++ b/docs/env.md
@@ -11,21 +11,21 @@ Fig uses [Docker links] to expose services' containers to one another. Each link
 To see what environment variables are available to a service, run `fig run SERVICE env`.
 
 <b><i>name</i>\_PORT</b><br>
-Full URL, e.g. `DB_1_PORT=tcp://172.17.0.5:5432`
+Full URL, e.g. `DB_PORT=tcp://172.17.0.5:5432`
 
 <b><i>name</i>\_PORT\_<i>num</i>\_<i>protocol</i></b><br>
-Full URL, e.g. `DB_1_PORT_5432_TCP=tcp://172.17.0.5:5432`
+Full URL, e.g. `DB_PORT_5432_TCP=tcp://172.17.0.5:5432`
 
 <b><i>name</i>\_PORT\_<i>num</i>\_<i>protocol</i>\_ADDR</b><br>
-Container's IP address, e.g. `DB_1_PORT_5432_TCP_ADDR=172.17.0.5`
+Container's IP address, e.g. `DB_PORT_5432_TCP_ADDR=172.17.0.5`
 
 <b><i>name</i>\_PORT\_<i>num</i>\_<i>protocol</i>\_PORT</b><br>
-Exposed port number, e.g. `DB_1_PORT_5432_TCP_PORT=5432`
+Exposed port number, e.g. `DB_PORT_5432_TCP_PORT=5432`
 
 <b><i>name</i>\_PORT\_<i>num</i>\_<i>protocol</i>\_PROTO</b><br>
-Protocol (tcp or udp), e.g. `DB_1_PORT_5432_TCP_PROTO=tcp`
+Protocol (tcp or udp), e.g. `DB_PORT_5432_TCP_PROTO=tcp`
 
 <b><i>name</i>\_NAME</b><br>
-Fully qualified container name, e.g. `DB_1_NAME=/myapp_web_1/myapp_db_1`
+Fully qualified container name, e.g. `DB_NAME=/myapp_web/myapp_db`
 
 [Docker links]: http://docs.docker.io/en/latest/use/port_redirection/#linking-a-container

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,8 +60,8 @@ from redis import Redis
 import os
 app = Flask(__name__)
 redis = Redis(
-    host=os.environ.get('REDIS_1_PORT_6379_TCP_ADDR'),
-    port=int(os.environ.get('REDIS_1_PORT_6379_TCP_PORT'))
+    host=os.environ.get('REDIS_PORT_6379_TCP_ADDR'),
+    port=int(os.environ.get('REDIS_PORT_6379_TCP_PORT'))
 )
 
 @app.route('/')
@@ -104,30 +104,30 @@ We then define a set of services using `fig.yml`:
 This defines two services:
 
  - `web`, which is built from `Dockerfile` in the current directory. It also says to run the command `python app.py` inside the image, forward the exposed port 5000 on the container to port 5000 on the host machine, connect up the Redis service, and mount the current directory inside the container so we can work on code without having to rebuild the image.
- - `redis`, which uses the public image [orchardup/redis](https://index.docker.io/u/orchardup/redis/). 
+ - `redis`, which uses the public image [orchardup/redis](https://index.docker.io/u/orchardup/redis/).
 
 Now if we run `fig up`, it'll pull a Redis image, build an image for our own code, and start everything up:
 
     $ fig up
     Pulling image orchardup/redis...
     Building web...
-    Starting figtest_redis_1...
-    Starting figtest_web_1...
-    redis_1 | [8] 02 Jan 18:43:35.576 # Server started, Redis version 2.8.3
-    web_1   |  * Running on http://0.0.0.0:5000/
+    Starting figtest_redis...
+    Starting figtest_web...
+    redis | [8] 02 Jan 18:43:35.576 # Server started, Redis version 2.8.3
+    web   |  * Running on http://0.0.0.0:5000/
 
 Open up [http://localhost:5000](http://localhost:5000) in your browser (or [http://localdocker:5000](http://localdocker:5000) if you're using [docker-osx](https://github.com/noplay/docker-osx)) and you should see it running!
 
 If you want to run your services in the background, you can pass the `-d` flag to `fig up` and use `fig ps` to see what is currently running:
 
     $ fig up -d
-    Starting figtest_redis_1...
-    Starting figtest_web_1...
+    Starting figtest_redis...
+    Starting figtest_web...
     $ fig ps
             Name                 Command            State       Ports
     -------------------------------------------------------------------
-    figtest_redis_1   /usr/local/bin/run         Up
-    figtest_web_1     /bin/sh -c python app.py   Up      5000->5000/tcp
+    figtest_redis   /usr/local/bin/run         Up
+    figtest_web     /bin/sh -c python app.py   Up      5000->5000/tcp
 
 `fig run` allows you to run one-off commands for your services. For example, to see what environment variables are available to the `web` service:
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -73,8 +73,8 @@ Open up your newly-generated `database.yml`. Replace its contents with the follo
       pool: 5
       username: docker
       password: docker
-      host: <%= ENV.fetch('DB_1_PORT_5432_TCP_ADDR', 'localhost') %>
-      port: <%= ENV.fetch('DB_1_PORT_5432_TCP_PORT', '5432') %>
+      host: <%= ENV.fetch('DB_PORT_5432_TCP_ADDR', 'localhost') %>
+      port: <%= ENV.fetch('DB_PORT_5432_TCP_PORT', '5432') %>
 
     test:
       <<: *default
@@ -86,9 +86,9 @@ We can now boot the app.
 
 If all's well, you should see some PostgreSQL output, and then—after a few seconds—the familiar refrain:
 
-    myapp_web_1 | [2014-01-17 17:16:29] INFO  WEBrick 1.3.1
-    myapp_web_1 | [2014-01-17 17:16:29] INFO  ruby 2.0.0 (2013-11-22) [x86_64-linux-gnu]
-    myapp_web_1 | [2014-01-17 17:16:29] INFO  WEBrick::HTTPServer#start: pid=1 port=3000
+    myapp_web | [2014-01-17 17:16:29] INFO  WEBrick 1.3.1
+    myapp_web | [2014-01-17 17:16:29] INFO  ruby 2.0.0 (2013-11-22) [x86_64-linux-gnu]
+    myapp_web | [2014-01-17 17:16:29] INFO  WEBrick::HTTPServer#start: pid=1 port=3000
 
 Finally, we just need to create the database. In another terminal, run:
 

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -44,7 +44,7 @@ Two supporting files are needed to get this working - first up, `wp-config.php` 
 define('DB_NAME', 'wordpress');
 define('DB_USER', 'root');
 define('DB_PASSWORD', '');
-define('DB_HOST', getenv("DB_1_PORT_3306_TCP_ADDR") . ":" . getenv("DB_1_PORT_3306_TCP_PORT"));
+define('DB_HOST', getenv("DB_PORT_3306_TCP_ADDR") . ":" . getenv("DB_PORT_3306_TCP_PORT"));
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -39,7 +39,7 @@ command: bundle exec thin -p 3000
 ### links
 
 
-Link to containers in another service. Optionally specify an alternate name for the link, which will determine how environment variables are prefixed, e.g. `db` -> `DB_1_PORT`, `db:database` -> `DATABASE_1_PORT`
+Link to containers in another service. Optionally specify an alternate name for the link, which will determine how environment variables are prefixed, e.g. `db` -> `DB_PORT`, `db:database` -> `DATABASE_PORT`
 
 ```
 links:

--- a/fig/cli/log_printer.py
+++ b/fig/cli/log_printer.py
@@ -27,8 +27,8 @@ class LogPrinter(object):
         Calculate the maximum width of container names so we can make the log
         prefixes line up like so:
 
-        db_1  | Listening
-        web_1 | Listening
+        db  | Listening
+        web | Listening
         """
         prefix_width = 0
         for container in containers:

--- a/fig/container.py
+++ b/fig/container.py
@@ -60,7 +60,7 @@ class Container(object):
         try:
             return int(self.name.split('_')[-1])
         except ValueError:
-            return None
+            return 1
 
     @property
     def human_readable_ports(self):

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -22,7 +22,7 @@ class CLITestCase(DockerClientTestCase):
     def test_ps(self, mock_stdout):
         self.command.project.get_service('simple').create_container()
         self.command.dispatch(['ps'], None)
-        self.assertIn('simplefigfile_simple_1', mock_stdout.getvalue())
+        self.assertIn('simplefigfile_simple', mock_stdout.getvalue())
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ps_default_figfile(self, mock_stdout):
@@ -31,9 +31,9 @@ class CLITestCase(DockerClientTestCase):
         self.command.dispatch(['ps'], None)
 
         output = mock_stdout.getvalue()
-        self.assertIn('multiplefigfiles_simple_1', output)
-        self.assertIn('multiplefigfiles_another_1', output)
-        self.assertNotIn('multiplefigfiles_yetanother_1', output)
+        self.assertIn('multiplefigfiles_simple', output)
+        self.assertIn('multiplefigfiles_another', output)
+        self.assertNotIn('multiplefigfiles_yetanother', output)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ps_alternate_figfile(self, mock_stdout):
@@ -42,9 +42,9 @@ class CLITestCase(DockerClientTestCase):
         self.command.dispatch(['-f', 'fig2.yml', 'ps'], None)
 
         output = mock_stdout.getvalue()
-        self.assertNotIn('multiplefigfiles_simple_1', output)
-        self.assertNotIn('multiplefigfiles_another_1', output)
-        self.assertIn('multiplefigfiles_yetanother_1', output)
+        self.assertNotIn('multiplefigfiles_simple', output)
+        self.assertNotIn('multiplefigfiles_another', output)
+        self.assertIn('multiplefigfiles_yetanother', output)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_build_no_cache(self, mock_stdout):

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -54,15 +54,15 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(web.containers()), 0)
         self.assertEqual(len(db.containers()), 0)
 
-        web_container_1 = web.create_container()
+        web_container = web.create_container()
         web_container_2 = web.create_container()
         db_container = db.create_container()
 
         project.start(service_names=['web'])
-        self.assertEqual(set(c.name for c in project.containers()), set([web_container_1.name, web_container_2.name]))
+        self.assertEqual(set(c.name for c in project.containers()), set([web_container.name, web_container_2.name]))
 
         project.start()
-        self.assertEqual(set(c.name for c in project.containers()), set([web_container_1.name, web_container_2.name, db_container.name]))
+        self.assertEqual(set(c.name for c in project.containers()), set([web_container.name, web_container_2.name, db_container.name]))
 
         project.stop(service_names=['web'], timeout=1)
         self.assertEqual(set(c.name for c in project.containers()), set([db_container.name]))

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -15,7 +15,7 @@ class ServiceTest(DockerClientTestCase):
         foo.start_container()
 
         self.assertEqual(len(foo.containers()), 1)
-        self.assertEqual(foo.containers()[0].name, 'figtest_foo_1')
+        self.assertEqual(foo.containers()[0].name, 'figtest_foo')
         self.assertEqual(len(bar.containers()), 0)
 
         bar.start_container()
@@ -25,7 +25,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(len(bar.containers()), 2)
 
         names = [c.name for c in bar.containers()]
-        self.assertIn('figtest_bar_1', names)
+        self.assertIn('figtest_bar', names)
         self.assertIn('figtest_bar_2', names)
 
     def test_containers_one_off(self):
@@ -37,7 +37,7 @@ class ServiceTest(DockerClientTestCase):
     def test_project_is_added_to_container_name(self):
         service = self.create_service('web')
         service.start_container()
-        self.assertEqual(service.containers()[0].name, 'figtest_web_1')
+        self.assertEqual(service.containers()[0].name, 'figtest_web')
 
     def test_start_stop(self):
         service = self.create_service('scalingtest')
@@ -78,13 +78,13 @@ class ServiceTest(DockerClientTestCase):
     def test_create_container_with_one_off(self):
         db = self.create_service('db')
         container = db.create_container(one_off=True)
-        self.assertEqual(container.name, 'figtest_db_run_1')
+        self.assertEqual(container.name, 'figtest_db_run')
 
     def test_create_container_with_one_off_when_existing_container_is_running(self):
         db = self.create_service('db')
         db.start()
         container = db.create_container(one_off=True)
-        self.assertEqual(container.name, 'figtest_db_run_1')
+        self.assertEqual(container.name, 'figtest_db_run')
 
     def test_create_container_with_unspecified_volume(self):
         service = self.create_service('db', volumes=['/var/db'])
@@ -100,12 +100,12 @@ class ServiceTest(DockerClientTestCase):
 
     def test_create_container_with_volumes_from(self):
         volume_service = self.create_service('data')
-        volume_container_1 = volume_service.create_container()
+        volume_container = volume_service.create_container()
         volume_container_2 = Container.create(self.client, image='busybox:latest', command=["/bin/sleep", "300"])
         host_service = self.create_service('host', volumes_from=[volume_service, volume_container_2])
         host_container = host_service.create_container()
         host_service.start_container(host_container)
-        self.assertIn(volume_container_1.id, host_container.inspect()['HostConfig']['VolumesFrom'])
+        self.assertIn(volume_container.id, host_container.inspect()['HostConfig']['VolumesFrom'])
         self.assertIn(volume_container_2.id, host_container.inspect()['HostConfig']['VolumesFrom'])
 
     def test_recreate_containers(self):
@@ -120,7 +120,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(old_container.dictionary['Config']['Entrypoint'], ['sleep'])
         self.assertEqual(old_container.dictionary['Config']['Cmd'], ['300'])
         self.assertIn('FOO=1', old_container.dictionary['Config']['Env'])
-        self.assertEqual(old_container.name, 'figtest_db_1')
+        self.assertEqual(old_container.name, 'figtest_db')
         service.start_container(old_container)
         volume_path = old_container.inspect()['Volumes']['/var/db']
 
@@ -137,7 +137,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(new_container.dictionary['Config']['Entrypoint'], ['sleep'])
         self.assertEqual(new_container.dictionary['Config']['Cmd'], ['300'])
         self.assertIn('FOO=2', new_container.dictionary['Config']['Env'])
-        self.assertEqual(new_container.name, 'figtest_db_1')
+        self.assertEqual(new_container.name, 'figtest_db')
         self.assertEqual(new_container.inspect()['Volumes']['/var/db'], volume_path)
         self.assertIn(intermediate_container.id, new_container.dictionary['HostConfig']['VolumesFrom'])
 
@@ -173,8 +173,8 @@ class ServiceTest(DockerClientTestCase):
         web = self.create_service('web', links=[(db, None)])
         db.start_container()
         web.start_container()
-        self.assertIn('figtest_db_1', web.containers()[0].links())
-        self.assertIn('db_1', web.containers()[0].links())
+        self.assertIn('figtest_db', web.containers()[0].links())
+        self.assertIn('db', web.containers()[0].links())
 
     def test_start_container_creates_links_with_names(self):
         db = self.create_service('db')

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -13,12 +13,12 @@ class ContainerTest(unittest.TestCase):
             "Ports":None,
             "SizeRw":0,
             "SizeRootFs":0,
-            "Names":["/figtest_db_1"]
+            "Names":["/figtest_db"]
         }, has_been_inspected=True)
         self.assertEqual(container.dictionary, {
             "Id": "abc",
             "Image":"busybox:latest",
-            "Name": "/figtest_db_1",
+            "Name": "/figtest_db",
         })
 
     def test_environment(self):
@@ -46,7 +46,7 @@ class ContainerTest(unittest.TestCase):
             "Ports":None,
             "SizeRw":0,
             "SizeRootFs":0,
-            "Names":["/figtest_db_1"]
+            "Names":["/figtest_db"]
         }, has_been_inspected=True)
         self.assertEqual(container.number, 1)
 
@@ -55,15 +55,15 @@ class ContainerTest(unittest.TestCase):
             "Id":"abc",
             "Image":"busybox:latest",
             "Command":"sleep 300",
-            "Names":["/figtest_db_1"]
+            "Names":["/figtest_db"]
         }, has_been_inspected=True)
-        self.assertEqual(container.name, "figtest_db_1")
+        self.assertEqual(container.name, "figtest_db")
 
     def test_name_without_project(self):
         container = Container.from_ps(None, {
             "Id":"abc",
             "Image":"busybox:latest",
             "Command":"sleep 300",
-            "Names":["/figtest_db_1"]
+            "Names":["/figtest_db"]
         }, has_been_inspected=True)
-        self.assertEqual(container.name_without_project, "db_1")
+        self.assertEqual(container.name_without_project, "db")

--- a/tests/unit/log_printer_test.py
+++ b/tests/unit/log_printer_test.py
@@ -44,11 +44,11 @@ class MockContainer(object):
 
     @property
     def name(self):
-        return 'myapp_web_1'
+        return 'myapp_web'
 
     @property
     def name_without_project(self):
-        return 'web_1'
+        return 'web'
 
     def attach(self, *args, **kwargs):
         return self._reader()

--- a/tests/unit/sort_service_test.py
+++ b/tests/unit/sort_service_test.py
@@ -3,7 +3,7 @@ from .. import unittest
 
 
 class SortServiceTest(unittest.TestCase):
-    def test_sort_service_dicts_1(self):
+    def test_sort_service_dicts(self):
         services = [
             {
                 'links': ['redis'],


### PR DESCRIPTION
coming from #342,
this will change container naming to avoid the `_1` suffix, the change will be:

```
container_1 => container
container_2 => container_2
container_3 => container_3
...
```

I updated all docs I found to reflect this. test

Signed-off-by: Benjamin Eidelman beneidel@gmail.com
