### PR TITLE
Enable monochrome output in the 'up' and 'logs' commands

### DIFF
--- a/fig/cli/log_printer.py
+++ b/fig/cli/log_printer.py
@@ -10,11 +10,11 @@ from .utils import split_buffer
 
 
 class LogPrinter(object):
-    def __init__(self, containers, attach_params=None, output=sys.stdout):
+    def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False):
         self.containers = containers
         self.attach_params = attach_params or {}
         self.prefix_width = self._calculate_prefix_width(containers)
-        self.generators = self._make_log_generators()
+        self.generators = self._make_log_generators(monochrome)
         self.output = output
 
     def run(self):
@@ -35,12 +35,15 @@ class LogPrinter(object):
             prefix_width = max(prefix_width, len(container.name_without_project))
         return prefix_width
 
-    def _make_log_generators(self):
+    def _make_log_generators(self, monochrome):
         color_fns = cycle(colors.rainbow())
         generators = []
 
         for container in self.containers:
-            color_fn = color_fns.next()
+            if monochrome:
+                color_fn = lambda s: s
+            else:
+                color_fn = color_fns.next()
             generators.append(self._make_log_generator(container, color_fn))
 
         return generators

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -137,11 +137,17 @@ class TopLevelCommand(Command):
         """
         View output from containers.
 
-        Usage: logs [SERVICE...]
+        Usage: logs [options] [SERVICE...]
+
+        Options:
+            --no-color  Produce monochrome output.
         """
         containers = self.project.containers(service_names=options['SERVICE'], stopped=True)
+
+        monochrome = options['--no-color']
+
         print("Attaching to", list_containers(containers))
-        LogPrinter(containers, attach_params={'logs': True}).run()
+        LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome).run()
 
     def ps(self, options):
         """
@@ -325,10 +331,13 @@ class TopLevelCommand(Command):
         Options:
             -d             Detached mode: Run containers in the background,
                            print new container names.
+            --no-color     Produce monochrome output.
             --no-deps      Don't start linked services.
             --no-recreate  If containers already exist, don't recreate them.
         """
         detached = options['-d']
+
+        monochrome = options['--no-color']
 
         start_links = not options['--no-deps']
         recreate = not options['--no-recreate']
@@ -344,7 +353,7 @@ class TopLevelCommand(Command):
 
         if not detached:
             print("Attaching to", list_containers(to_attach))
-            log_printer = LogPrinter(to_attach, attach_params={"logs": True})
+            log_printer = LogPrinter(to_attach, attach_params={"logs": True}, monochrome=monochrome)
 
             try:
                 log_printer.run()


### PR DESCRIPTION
Some systems, like Jenkins or other build servers, cannot correctly render ANSI color codes.  The '-m' option enable monochrome output in the 'up' and 'logs' commands to improve readability in those systems.

Let me know if you have any concerns.  I'm happy to make revisions.

Signed-off-by: Tim Freund tim@freunds.net
