### PR TITLE
Remove extra calls, test bug fixes

### DIFF
--- a/fig/container.py
+++ b/fig/container.py
@@ -97,11 +97,8 @@ class Container(object):
     @property
     def environment(self):
         self.inspect_if_not_inspected()
-        out = {}
-        for var in self.dictionary.get('Config', {}).get('Env', []):
-            k, v = var.split('=', 1)
-            out[k] = v
-        return out
+        return dict(var.split("=", 1)
+                    for var in self.dictionary.get('Config', {}).get('Env', []))
 
     @property
     def is_running(self):
@@ -132,6 +129,7 @@ class Container(object):
 
     def inspect(self):
         self.dictionary = self.client.inspect_container(self.id)
+        self.has_been_inspected = True
         return self.dictionary
 
     def links(self):

--- a/fig/project.py
+++ b/fig/project.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 import logging
+
 from .service import Service
 from .container import Container
 from .packages.docker.errors import APIError
@@ -179,12 +180,11 @@ class Project(object):
         for service in self.get_services(service_names):
             service.remove_stopped(**options)
 
-    def containers(self, service_names=None, *args, **kwargs):
-        l = []
-        for service in self.get_services(service_names):
-            for container in service.containers(*args, **kwargs):
-                l.append(container)
-        return l
+    def containers(self, service_names=None, stopped=False, one_off=False):
+        return [Container.from_ps(self.client, container)
+                for container in self.client.containers(all=stopped)
+                for service in self.get_services(service_names)
+                if service.has_container(container, one_off=one_off)]
 
     def _inject_links(self, acc, service):
         linked_names = service.get_linked_names()

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -108,8 +108,9 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(project.containers()), 2)
 
         db_container = [c for c in project.containers() if 'db' in c.name][0]
-        self.assertNotEqual(c.id, old_db_id)
-        self.assertEqual(c.inspect()['Volumes']['/var/db'], db_volume_path)
+        self.assertNotEqual(db_container.id, old_db_id)
+        self.assertEqual(db_container.inspect()['Volumes']['/var/db'],
+                         db_volume_path)
 
         project.kill()
         project.remove_stopped()
@@ -130,8 +131,9 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(project.containers()), 2)
 
         db_container = [c for c in project.containers() if 'db' in c.name][0]
-        self.assertEqual(c.id, old_db_id)
-        self.assertEqual(c.inspect()['Volumes']['/var/db'], db_volume_path)
+        self.assertEqual(db_container.id, old_db_id)
+        self.assertEqual(db_container.inspect()['Volumes']['/var/db'],
+                         db_volume_path)
 
         project.kill()
         project.remove_stopped()
@@ -158,8 +160,9 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(new_containers), 2)
 
         db_container = [c for c in new_containers if 'db' in c.name][0]
-        self.assertEqual(c.id, old_db_id)
-        self.assertEqual(c.inspect()['Volumes']['/var/db'], db_volume_path)
+        self.assertEqual(db_container.id, old_db_id)
+        self.assertEqual(db_container.inspect()['Volumes']['/var/db'],
+                         db_volume_path)
 
         project.kill()
         project.remove_stopped()

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
+import os
+
 from fig import Service
 from fig.service import CannotBeScaledError
 from fig.container import Container
 from fig.packages.docker.errors import APIError
 from .testcases import DockerClientTestCase
-import os
+
 
 class ServiceTest(DockerClientTestCase):
     def test_containers(self):
@@ -143,7 +145,9 @@ class ServiceTest(DockerClientTestCase):
 
         self.assertEqual(len(self.client.containers(all=True)), num_containers_before)
         self.assertNotEqual(old_container.id, new_container.id)
-        self.assertRaises(APIError, lambda: self.client.inspect_container(intermediate_container.id))
+        self.assertRaises(APIError,
+                          self.client.inspect_container,
+                          intermediate_container.id)
 
     def test_recreate_containers_when_containers_are_stopped(self):
         service = self.create_service(

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -1,6 +1,11 @@
 from __future__ import unicode_literals
 from .. import unittest
+
+import mock
+from fig.packages import docker
+
 from fig.container import Container
+
 
 class ContainerTest(unittest.TestCase):
     def test_from_ps(self):
@@ -67,3 +72,16 @@ class ContainerTest(unittest.TestCase):
             "Names":["/figtest_db_1"]
         }, has_been_inspected=True)
         self.assertEqual(container.name_without_project, "db_1")
+
+    def test_inspect_if_not_inspected(self):
+        mock_client = mock.create_autospec(docker.Client)
+        container = Container(mock_client, dict(Id="the_id"))
+
+        container.inspect_if_not_inspected()
+        mock_client.inspect_container.assert_called_once_with("the_id")
+        self.assertEqual(container.dictionary,
+                         mock_client.inspect_container.return_value)
+        self.assertTrue(container.has_been_inspected)
+
+        container.inspect_if_not_inspected()
+        self.assertEqual(mock_client.inspect_container.call_count, 1)


### PR DESCRIPTION
When I ran `fig --verbose ps` I noticed a lot of repeated calls to the docker server (with the same args). I believe these extra calls are unnecessary.

There were two causes for these repeated calls:
- `project.containers()` calls `service.containers()` in a loop, and each call requires a full list from `client.containers()` again
- `container.inspect()` was not setting `has_been_inspected` to True, causing each iteration to re-inspect a container that was already inspected.

To remove these extra calls I moved the `client.containers()` call up into project, and split out a filter (`has_container()`) in service. This allows both `containers()` implementations to be just a single for-comprehension.

Set `has_been_inspected = True` in `inspect()`.

While working on these changes I noticed that some tests in `tests/integration/project_test.py` where actually using the wrong variable (a local from the comprehension scope, instead of the result of the comprehension). This passes in most cases, but can actually fail if you have more copies of these containers.
