### PR TITLE
Exclude tests package from installation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     url='http://www.fig.sh/',
     author='Docker, Inc.',
     license='Apache License 2.0',
-    packages=find_packages(),
+    packages=find_packages(exclude=[ 'tests.*', 'tests' ]),
     include_package_data=True,
     test_suite='nose.collector',
     install_requires=install_requires,


### PR DESCRIPTION
Installing the top-level tests package is asking for conflicts with
other python packages and isn't required to run fig.  This simply lets
find_packages know to ignore tests and any sub-packages.
