### PR TITLE
Fig port command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,10 @@ Force stop service containers.
 
 View output from services.
 
+## port
+
+Print the public port for a port binding
+
 ## ps
 
 List containers.

--- a/fig/cli/errors.py
+++ b/fig/cli/errors.py
@@ -9,6 +9,8 @@ class UserError(Exception):
     def __unicode__(self):
         return self.msg
 
+    __str__ = __unicode__
+
 
 class DockerNotFoundMac(UserError):
     def __init__(self):

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -84,6 +84,7 @@ class TopLevelCommand(Command):
       help      Get help on a command
       kill      Kill containers
       logs      View output from containers
+      port      Print the public port for a port binding
       ps        List containers
       rm        Remove stopped containers
       run       Run a one-off command
@@ -147,6 +148,26 @@ class TopLevelCommand(Command):
         monochrome = options['--no-color']
         print("Attaching to", list_containers(containers))
         LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome).run()
+
+    def port(self, project, options):
+        """
+        Print the public port for a port binding.
+
+        Usage: port [options] SERVICE PRIVATE_PORT
+
+        Options:
+            --protocol=proto  tcp or udp (defaults to tcp)
+            --index=index     index of the container if there are multiple
+                              instances of a service (defaults to 1)
+        """
+        service = project.get_service(options['SERVICE'])
+        try:
+            container = service.get_container(number=options.get('--index') or 1)
+        except ValueError as e:
+            raise UserError(str(e))
+        print(container.get_local_port(
+            options['PRIVATE_PORT'],
+            protocol=options.get('--protocol') or 'tcp') or '')
 
     def ps(self, project, options):
         """

--- a/fig/service.py
+++ b/fig/service.py
@@ -78,8 +78,21 @@ class Service(object):
         name = get_container_name(container)
         if not name or not is_valid_name(name, one_off):
             return False
-        project, name, number = parse_name(name)
+        project, name, _number = parse_name(name)
         return project == self.project and name == self.name
+
+    def get_container(self, number=1):
+        """Return a :class:`fig.container.Container` for this service. The
+        container must be active, and match `number`.
+        """
+        for container in self.client.containers():
+            if not self.has_container(container):
+                continue
+            _, _, container_number = parse_name(get_container_name(container))
+            if container_number == number:
+                return Container.from_ps(self.client, container)
+
+        raise ValueError("No container found for %s_%s" % (self.name, number))
 
     def start(self, **options):
         for c in self.containers(stopped=True):

--- a/tests/fixtures/ports-figfile/fig.yml
+++ b/tests/fixtures/ports-figfile/fig.yml
@@ -1,0 +1,7 @@
+
+simple:
+  image: busybox:latest
+  command: /bin/sleep 300
+  ports:
+    - '3000'
+    - '9999:3001'

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -5,6 +5,8 @@ import os
 from .. import unittest
 import mock
 
+from fig.packages import docker
+
 from fig import Service
 from fig.service import (
     ConfigError,
@@ -97,13 +99,32 @@ class ServiceTest(unittest.TestCase):
 
     def test_split_domainname_weird(self):
         service = Service('foo',
-                hostname = 'name.sub',
-                domainname = 'domain.tld',
+                hostname='name.sub',
+                domainname='domain.tld',
             )
         service.next_container_name = lambda x: 'foo'
         opts = service._get_container_create_options({})
         self.assertEqual(opts['hostname'], 'name.sub', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
+
+    def test_get_container_not_found(self):
+        mock_client = mock.create_autospec(docker.Client)
+        mock_client.containers.return_value = []
+        service = Service('foo', client=mock_client)
+
+        self.assertRaises(ValueError, service.get_container)
+
+    @mock.patch('fig.service.Container', autospec=True)
+    def test_get_container(self, mock_container_class):
+        mock_client = mock.create_autospec(docker.Client)
+        container_dict = dict(Name='default_foo_2')
+        mock_client.containers.return_value = [container_dict]
+        service = Service('foo', client=mock_client)
+
+        container = service.get_container(number=2)
+        self.assertEqual(container, mock_container_class.from_ps.return_value)
+        mock_container_class.from_ps.assert_called_once_with(
+            mock_client, container_dict)
 
 
 class ServiceVolumesTest(unittest.TestCase):


### PR DESCRIPTION
This branch adds a new fig command, which returns the local port binding of a service.

It's used when you want to run a test suite (or something else) outside of a docker image, so you can connect to one of your containers easily.

I will be using it mostly programatically, but I thought I'd add a command at the same time.
