### PR TITLE
Add support for the --entrypoint option of docker run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/_site
 /venv
 fig.spec
+*.sw[op]

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -221,12 +221,11 @@ class TopLevelCommand(Command):
         Usage: run [options] SERVICE [COMMAND] [ARGS...]
 
         Options:
-            -d         Detached mode: Run container in the background, print
-                       new container name.
-            -T         Disable pseudo-tty allocation. By default `fig run`
-                       allocates a TTY.
-            --rm       Remove container after run. Ignored in detached mode.
-            --no-deps  Don't start linked services.
+            -d                  Detached mode: Run container in the background, print new container name.
+            -T                  Disable pseudo-tty allocation. By default `fig run` allocates a TTY.
+            --rm                Remove container after run. Ignored in detached mode.
+            --no-deps           Don't start linked services.
+            --entrypoint=<cmd>  Override entrypoint of the image.
         """
         service = project.get_service(options['SERVICE'])
 
@@ -254,6 +253,10 @@ class TopLevelCommand(Command):
             'tty': tty,
             'stdin_open': not options['-d'],
         }
+
+        if options['--entrypoint']:
+            container_options['entrypoint'] = options.get('--entrypoint')
+
         container = service.create_container(one_off=True, **container_options)
         if options['-d']:
             service.start_container(container, ports=None, one_off=True)

--- a/fig/container.py
+++ b/fig/container.py
@@ -89,8 +89,12 @@ class Container(object):
     @property
     def human_readable_command(self):
         self.inspect_if_not_inspected()
-        if self.dictionary['Config']['Cmd']:
-            return ' '.join(self.dictionary['Config']['Cmd'])
+        config = self.dictionary['Config']
+        entrypoint = config['Entrypoint'] or []
+        cmd = config['Cmd'] or []
+        whole_cmd = entrypoint + cmd
+        if whole_cmd:
+            return ' '.join(whole_cmd)
         else:
             return ''
 

--- a/tests/fixtures/dockerfile_with_entrypoint/Dockerfile
+++ b/tests/fixtures/dockerfile_with_entrypoint/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox:latest
+ENTRYPOINT echo "From prebuilt entrypoint"

--- a/tests/fixtures/dockerfile_with_entrypoint/fig.yml
+++ b/tests/fixtures/dockerfile_with_entrypoint/fig.yml
@@ -1,0 +1,2 @@
+service:
+  build: tests/fixtures/dockerfile_with_entrypoint

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -184,6 +184,21 @@ class CLITestCase(DockerClientTestCase):
             [u'/bin/true'],
         )
 
+    @patch('dockerpty.start')
+    def test_run_service_with_entrypoint_overridden(self, _):
+        self.command.base_dir = 'tests/fixtures/dockerfile_with_entrypoint'
+        name = 'service'
+        self.command.dispatch(
+            ['run', '--entrypoint', '/bin/echo', name, 'helloworld'],
+            None
+        )
+        service = self.project.get_service(name)
+        container = service.containers(stopped=True, one_off=True)[0]
+        self.assertEqual(
+            container.human_readable_command,
+            u'/bin/echo helloworld'
+        )
+
     def test_rm(self):
         service = self.project.get_service('simple')
         service.create_container()


### PR DESCRIPTION
We can use `command` in `fig.yml` to override the default command, but this won't work if the docker image we are working with specifies a `ENTRYPOINT` for its containers.

In my case, the Dockerfile of the main service has specified something like `["gunicorn", "-c", "config.py"]` as its `ENTRYPOINT`, so I can't do things like `python manage.py syncdb` if I can't override the `ENTRYPOINT`.

Entrypoints can be overrdden by the `--entrypoint` option, this PR attempts to solve the problem by exposing this option in `fig`.
