### PR TITLE
Fixed additional links being made when a custom link name is made. 

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -286,8 +286,9 @@ class Service(object):
             for container in service.containers():
                 if link_name:
                     links.append((container.name, link_name))
-                links.append((container.name, container.name))
-                links.append((container.name, container.name_without_project))
+                else:
+                    links.append((container.name, container.name))
+                    links.append((container.name, container.name_without_project))
         if link_to_self:
             for container in self.containers():
                 links.append((container.name, container.name))

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -187,6 +187,15 @@ class ServiceTest(DockerClientTestCase):
         web.start_container()
         self.assertIn('custom_link_name', web.containers()[0].links())
 
+    def test_start_container_creates_links_with_names_without_extra_links(self):
+        db = self.create_service('db')
+        web = self.create_service('web', links=[(db, 'custom_link_name')])
+        db.start_container()
+        web.start_container()
+        self.assertIn('custom_link_name', web.containers()[0].links())
+        self.assertNotIn('figtest_db_1', web.containers()[0].links())
+        self.assertNotIn('db_1', web.containers()[0].links())
+
     def test_start_normal_container_does_not_create_links_to_its_own_service(self):
         db = self.create_service('db')
         c1 = db.start_container()


### PR DESCRIPTION
Signed-off-by: Connor Humphries <humphries.40s@chemistry.ohio-state.edu>

 Changes to be committed:
	modified:   fig/service.py
	modified:   tests/integration/service_test.py

Fixes use where a custom link name is declared and deprecated link names are still added.