### PR TITLE
Faster integration testing

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from collections import namedtuple
-from docker.errors import APIError
 import logging
 import re
 import os
 import sys
+
+from docker.errors import APIError
+
 from .container import Container
 from .progress_stream import stream_output, StreamOutputError
 
@@ -41,6 +43,9 @@ class ConfigError(ValueError):
 
 
 VolumeSpec = namedtuple('VolumeSpec', 'external internal mode')
+
+
+ServiceName = namedtuple('ServiceName', 'project service number')
 
 
 class Service(object):
@@ -185,8 +190,8 @@ class Service(object):
         """
         containers = self.containers(stopped=True)
 
-        if len(containers) == 0:
-            log.info("Creating %s..." % self.next_container_name())
+        if not containers:
+            log.info("Creating %s..." % self._next_container_name(containers))
             container = self.create_container(**override_options)
             self.start_container(container)
             return [(None, container)]
@@ -264,7 +269,7 @@ class Service(object):
         containers = self.containers(stopped=True)
 
         if not containers:
-            log.info("Creating %s..." % self.next_container_name())
+            log.info("Creating %s..." % self._next_container_name(containers))
             new_container = self.create_container()
             return [self.start_container(new_container)]
         else:
@@ -273,19 +278,15 @@ class Service(object):
     def get_linked_names(self):
         return [s.name for (s, _) in self.links]
 
-    def next_container_name(self, one_off=False):
+    def _next_container_name(self, all_containers, one_off=False):
         bits = [self.project, self.name]
         if one_off:
             bits.append('run')
-        return '_'.join(bits + [str(self.next_container_number(one_off=one_off))])
+        return '_'.join(bits + [str(self._next_container_number(all_containers))])
 
-    def next_container_number(self, one_off=False):
-        numbers = [parse_name(c.name)[2] for c in self.containers(stopped=True, one_off=one_off)]
-
-        if len(numbers) == 0:
-            return 1
-        else:
-            return max(numbers) + 1
+    def _next_container_number(self, all_containers):
+        numbers = [parse_name(c.name).number for c in all_containers]
+        return 1 if not numbers else max(numbers) + 1
 
     def _get_links(self, link_to_self):
         links = []
@@ -319,7 +320,9 @@ class Service(object):
         container_options = dict((k, self.options[k]) for k in DOCKER_CONFIG_KEYS if k in self.options)
         container_options.update(override_options)
 
-        container_options['name'] = self.next_container_name(one_off)
+        container_options['name'] = self._next_container_name(
+            self.containers(stopped=True, one_off=one_off),
+            one_off)
 
         # If a qualified hostname was given, split it into an
         # unqualified hostname and a domainname unless domainname
@@ -424,10 +427,10 @@ def is_valid_name(name, one_off=False):
         return match.group(3) is None
 
 
-def parse_name(name, one_off=False):
+def parse_name(name):
     match = NAME_RE.match(name)
     (project, service_name, _, suffix) = match.groups()
-    return (project, service_name, int(suffix))
+    return ServiceName(project, service_name, int(suffix))
 
 
 def get_container_name(container):

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -10,7 +10,6 @@ class DockerClientTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = Client(docker_url())
-        cls.client.pull('busybox', tag='latest')
 
     def setUp(self):
         for c in self.client.containers(all=True):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -17,6 +17,10 @@ from fig.service import (
 
 
 class ServiceTest(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_client = mock.create_autospec(docker.Client)
+
     def test_name_validations(self):
         self.assertRaises(ConfigError, lambda: Service(name=''))
 
@@ -70,29 +74,27 @@ class ServiceTest(unittest.TestCase):
             split_port("0.0.0.0:1000:2000:tcp")
 
     def test_split_domainname_none(self):
-        service = Service('foo',
-                hostname = 'name',
-            )
-        service.next_container_name = lambda x: 'foo'
+        service = Service('foo', hostname='name', client=self.mock_client)
+        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({})
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertFalse('domainname' in opts, 'domainname')
 
     def test_split_domainname_fqdn(self):
         service = Service('foo',
-                hostname = 'name.domain.tld',
-            )
-        service.next_container_name = lambda x: 'foo'
+                hostname='name.domain.tld',
+                client=self.mock_client)
+        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({})
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
 
     def test_split_domainname_both(self):
         service = Service('foo',
-                hostname = 'name',
-                domainname = 'domain.tld',
-            )
-        service.next_container_name = lambda x: 'foo'
+                hostname='name',
+                domainname='domain.tld',
+                client=self.mock_client)
+        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({})
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
@@ -101,8 +103,8 @@ class ServiceTest(unittest.TestCase):
         service = Service('foo',
                 hostname='name.sub',
                 domainname='domain.tld',
-            )
-        service.next_container_name = lambda x: 'foo'
+                client=self.mock_client)
+        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({})
         self.assertEqual(opts['hostname'], 'name.sub', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')


### PR DESCRIPTION
After running the integration test suite many times it seemed unusually slow. Running it on a jenkins host takes close to an hour, (on my desktop it's just over 2min).

I ran the suite with profiling enabled and noticed a few things that seemed like low hanging fruit.  After these changes the test suite ran on my desktop in ~112s, so it's almost 10% off.  I believe the savings on the jenkins host may actually be a lot greater because the time spent doing `Service.containers` and filtering them actually increases as the number of containers increases. So a host with lots of containers will see a lot faster test runs.

Primary changes:
- Don't `docker pull busybox` on every integration test class. At most this only has to be done once as part of the `tox.ini`/`.travis.yml`. fig already does this pull for us, so I think it's somewhat unnecessary (unless we really care about updates, but it seems like we shouldn't).
- `Service._next_container_name` calls `self.containers()` on every call, but most of the time this is duplicated work (it was just called and all the containers were already filtered).  Since this is only called from inside the `Service` class itself, it seems safe enough to modify the interface and make it private. This will actually improve the performance of `fig` itself as well on any host with many containers.

Secondary changes:
- Don't modify the class under test in the `Service` unit test suite. Instead mock out a dependency
- use a namedtuple for the service name tuple, which lets us remove some indexing into tuples with a more readable attribute
