### PR TITLE
ability to set custom tag, somewhat addresses #213

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -11,7 +11,7 @@ from .progress_stream import stream_output, StreamOutputError
 log = logging.getLogger(__name__)
 
 
-DOCKER_CONFIG_KEYS = ['image', 'command', 'hostname', 'domainname', 'user', 'detach', 'stdin_open', 'tty', 'mem_limit', 'ports', 'environment', 'dns', 'volumes', 'entrypoint', 'privileged', 'volumes_from', 'net', 'working_dir']
+DOCKER_CONFIG_KEYS = ['image', 'command', 'tag', 'hostname', 'domainname', 'user', 'detach', 'stdin_open', 'tty', 'mem_limit', 'ports', 'environment', 'dns', 'volumes', 'entrypoint', 'privileged', 'volumes_from', 'net', 'working_dir']
 DOCKER_CONFIG_HINTS = {
     'link'      : 'links',
     'port'      : 'ports',
@@ -393,6 +393,9 @@ class Service(object):
         """
         The tag to give to images built for this service.
         """
+        if 'tag' in self.options:
+            return self.options['tag']
+            
         return '%s_%s' % (self.project, self.name)
 
     def can_be_scaled(self):


### PR DESCRIPTION
I have a repo that has all my docker images, prefer not to have to push them to a repo in order to reference images by name. I use fig.yml to build all images locally, which can than be reused through DockerFiles, etc.