### PR TITLE
Avoid rebuilding the same image

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -386,6 +386,13 @@ class Service(object):
 
         return image_id
 
+    def tag(self, image_id):
+        self.client.tag(image_id, self._build_tag_name())
+
+    @property
+    def build_path(self):
+        return self.options.get('build')
+
     def can_be_built(self):
         return 'build' in self.options
 

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -82,3 +82,10 @@ class ServiceTest(unittest.TestCase):
         opts = service._get_container_create_options({})
         self.assertEqual(opts['hostname'], 'name.sub', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
+
+    def test_build_path(self):
+        service = Service('foo', build='.')
+        self.assertEqual(service.build_path, '.')
+
+        service = Service('foo', image='test')
+        self.assertEqual(service.build_path, None)


### PR DESCRIPTION
Since there can be only one Dockerfile in a build context, we often
end up reusing one image in our project for multiple purposes.

In that case, the `fig.yml` would look like:

``` yaml
service1:
    build: .
    command: aaa
service2:
    build: .
    command: bbb
service3:
    build: .
    command: ccc
test:
    build: .
    entrypoint: make
    command: test
    link:
        - service1:service1
        - service2:service2
        - service3:service3
```

Now when we use `fig build`, `fig` tries to build all three of them.

This commit aims to avoid unnecessary `docker build`s, if an image for
the build path has already been built, we just skip that service.
