### PR TITLE
Configure project name from the config file

### DIFF
--- a/fig/project.py
+++ b/fig/project.py
@@ -64,13 +64,19 @@ class Project(object):
 
     @classmethod
     def from_config(cls, name, config, client):
-        dicts = []
+        services = []
+        project_config = config.pop('project-config', {})
+        name = project_config.get('name', name)
+
         for service_name, service in list(config.items()):
             if not isinstance(service, dict):
-                raise ConfigurationError('Service "%s" doesn\'t have any configuration options. All top level keys in your fig.yml must map to a dictionary of configuration options.')
+                raise ConfigurationError(
+                    'Service "%s" doesn\'t have any configuration options. '
+                    'All top level keys in your fig.yml must map to a '
+                    'dictionary of configuration options.')
             service['name'] = service_name
-            dicts.append(service)
-        return cls.from_dicts(name, dicts, client)
+            services.append(service)
+        return cls.from_dicts(name, services, client)
 
     def get_service(self, name):
         """

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -3,6 +3,7 @@ from .. import unittest
 from fig.service import Service
 from fig.project import Project, ConfigurationError
 
+
 class ProjectTest(unittest.TestCase):
     def test_from_dict(self):
         project = Project.from_dicts('figtest', [
@@ -64,6 +65,15 @@ class ProjectTest(unittest.TestCase):
             project = Project.from_config('figtest', {
                 'web': 'busybox:latest',
             }, None)
+
+    def test_from_config_with_project_config(self):
+        project_name = 'theprojectnamefromconfig'
+        project = Project.from_config('default_name_not_used', {
+            'project-config': {'name': project_name},
+            'web': {'image': 'busybox:latest'}
+        }, None)
+
+        self.assertEqual(project.name, project_name)
 
     def test_get_service(self):
         web = Service(


### PR DESCRIPTION
Resolve #45 and adds `.project` required for #318 and #210 

Still needs documentation, opening PR for discussion regarding the top level key to use for this config (currently `.project`).