### PR TITLE
Add option to configure devices in yaml file

### DIFF
--- a/fig/packages/docker/utils/utils.py
+++ b/fig/packages/docker/utils/utils.py
@@ -134,6 +134,20 @@ def convert_volume_binds(binds):
             result.append('%s:%s:rw' % (k, v))
     return result
 
+def convert_device_binds(device_binds):
+    result = []
+    for k, v in device_binds.items():
+        device = {}
+        if isinstance(v, dict):
+            device['CgroupPermissions'] = 'rom' if v.get('rom', False) else 'rwm'
+            device['PathOnHost'] = v['bind']
+        else:
+            device['CgroupPermissions'] = 'rwm'
+            device['PathOnHost'] = v
+        device['PathInContainer'] = k
+        result.append(device)
+    return result
+
 
 def parse_repository_tag(repo):
     column_index = repo.rfind(':')


### PR DESCRIPTION
Example:
tvheadend:
  image: tvheadend
  devices:
  - "/dev/dvb/adapter0/dvr0:/dev/dvb/adapter0/dvr0"

Format for each entry is HOST:CONTAINER.
If only HOST is given then the file will be the same
inside the container.