### PR TITLE
Allow Dockerfiles in Build Field

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -365,7 +365,8 @@ class Service(object):
     # If path is a file use it as the active Dockerfile
     #   by copying it to <context path>/Dockerfile, and if a Dockerfile
     #   already exists, then temporarily copy it to Dockerfile.bk.
-    # Otherwise, return the context directory unmodified.
+    # Otherwise, return the context directory unmodified, to be used
+    #   in maintaining previous functionality
     def create_temp_dockerfile(self, path):
         bk_made = False
         temp_created = False


### PR DESCRIPTION
A potential stop-gap solution for this: docker/docker#2112. While a proper solution is being developed, to allow one Dockerfile to handle multiple targets ( or whatever solution in decided upon ), this code simply copies the Dockerfile that is being built to a file named Dockerfile, then deletes it after the build is done. If there is already a Dockerfile in that directory, it is copied to a backup location and restored after the build. If a path is specified, then the behavior is the same as previously.

Allows for a fig.yml that looks like this:

<pre>db:
  image: postgres
  ports:
    - "5432"
dev:
  build: dev.Dockerfile
  command: bundle exec rails server
  ports:
    - "3000:3000"
  links:
    - db
prod:
  build: prod.Dockerfile
  command: bundle exec rails server
  ports:
    - "3001:3000"
  links:
    - db
test:
  build: test.Dockerfile
  command: bundle exec rails server
  ports:
    - "3002:3000"
  links:
    - db</pre>
