### PR TITLE
Added map service ports option for run command.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,7 +77,7 @@ For example:
 
 By default, linked services will be started, unless they are already running.
 
-One-off commands are started in new containers with the same config as a normal container for that service, so volumes, links, etc will all be created as expected. The only thing different to a normal container is the command will be overridden with the one specified and no ports will be created in case they collide.
+One-off commands are started in new containers with the same config as a normal container for that service, so volumes, links, etc will all be created as expected. The only thing different to a normal container is the command will be overridden with the one specified and by default no ports will be created in case they collide.
 
 Links are also created between one-off commands and the other containers for that service so you can do stuff like this:
 
@@ -86,6 +86,9 @@ Links are also created between one-off commands and the other containers for tha
 If you do not want linked containers to be started when running the one-off command, specify the `--no-deps` flag:
 
     $ fig run --no-deps web python manage.py shell
+
+If you want the service's ports to be created and mapped to the host, specify the `--service-ports` flag:
+	$ fig run --service-ports web python manage.py shell
 
 ### scale
 

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -278,6 +278,8 @@ class TopLevelCommand(Command):
             -e KEY=VAL            Set an environment variable (can be used multiple times)
             --no-deps             Don't start linked services.
             --rm                  Remove container after run. Ignored in detached mode.
+            --service-ports       Run command with the service's ports enabled and mapped
+                                  to the host.
             -T                    Disable pseudo-tty allocation. By default `fig run`
                                   allocates a TTY.
         """
@@ -325,11 +327,15 @@ class TopLevelCommand(Command):
             insecure_registry=insecure_registry,
             **container_options
         )
+
+        service_ports = None
+        if options['--service-ports']:
+            service_ports = service.options['ports']
         if options['-d']:
-            service.start_container(container, ports=None, one_off=True)
+            service.start_container(container, ports=service_ports, one_off=True)
             print(container.name)
         else:
-            service.start_container(container, ports=None, one_off=True)
+            service.start_container(container, ports=service_ports, one_off=True)
             dockerpty.start(project.client, container.id, interactive=not options['-T'])
             exit_code = container.wait()
             if options['--rm']:


### PR DESCRIPTION
When using the fig run command, ports defined in fig.yml can be mapped
to the host computer using the -m or --map-ports option.  Resolves #163.

Signed-off-by: Stephen Quebe squebe@gmail.com
