### PR TITLE
Multiple external ports bound to a single internal port

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -241,7 +241,7 @@ class Service(object):
         ports = {}
         for port in options.get('ports') or []:
             if not split_port(port)[0] in ports.keys():
-                  ports[split_port(port)[0]] = []
+                ports[split_port(port)[0]] = []
             ports[split_port(port)[0]].append(split_port(port)[1])
 
         volume_bindings = dict(


### PR DESCRIPTION
Hi !

As I tested fig for my containers I realized that when using for ports declaration the following configuration :

```
  ports:
    - "80:80"
    - "5000:80"
```

Only the last binding was used.
It it due to the way the port_bindings dict is filled.
I changed that to allow this kind of configuration to work.
