### PR TITLE
Multiple external ports bound to a single internal port

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -238,7 +238,12 @@ class Service(object):
     def start_container(self, container=None, intermediate_container=None, **override_options):
         container = container or self.create_container(**override_options)
         options = dict(self.options, **override_options)
-        ports = dict(split_port(port) for port in options.get('ports') or [])
+        ports = {}
+        for port in options.get('ports') or []:
+            internal, external = split_port(port)
+            if not internal in ports.keys():
+                ports[internal] = []
+            ports[internal].append(external)
 
         volume_bindings = dict(
             build_volume_binding(parse_volume_spec(volume))

--- a/fig/service.py
+++ b/fig/service.py
@@ -241,7 +241,7 @@ class Service(object):
         ports = {}
         for port in options.get('ports') or []:
             internal, external = split_port(port)
-            if not internal in ports.keys():
+            if internal not in ports.keys():
                 ports[internal] = []
             ports[internal].append(external)
 


### PR DESCRIPTION
Hi !

As I tested fig for my containers I realized that when using for ports declaration the following configuration :
```
  ports:
    - "80:80"
    - "5000:80"
```

Only the last binding was used.
It it due to the way the port_bindings dict is filled.
I changed that to allow this kind of configuration to work.

This is a resubmit of my previous PR ... hopefully cleaner for travis ;)