### PR TITLE
Support setting project name from the environment

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -81,6 +81,7 @@ class Command(DocoptCommand):
         def normalize_name(name):
             return re.sub(r'[^a-zA-Z0-9]', '', name)
 
+        project_name = project_name or os.environ.get('FIG_PROJECT_NAME')
         if project_name is not None:
             return normalize_name(project_name)
 

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -35,6 +35,14 @@ class CLITestCase(unittest.TestCase):
         project_name = command.get_project_name(None, project_name=name)
         self.assertEquals('explicitprojectname', project_name)
 
+    def test_project_name_from_environment(self):
+        command = TopLevelCommand()
+        name = 'namefromenv'
+        with mock.patch.dict(os.environ):
+            os.environ['FIG_PROJECT_NAME'] = name
+            project_name = command.get_project_name(None)
+        self.assertEquals(project_name, name)
+
     def test_yaml_filename_check(self):
         command = TopLevelCommand()
         command.base_dir = 'tests/fixtures/longer-filename-figfile'


### PR DESCRIPTION
Another possible resolution for #45. I still like #463 but I think this is compatible, and this one is probably less contentious.

My use of fig includes some calls directly into `get_project()`, so I'd like this support behind that interface so I don't have to repeat the project name all over.  Currently I have to specify it for every command, and again as a parameter to `get_project()`
