### PR TITLE
Add TLS support to fig

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -51,8 +51,8 @@ class Command(DocoptCommand):
         handler(project, command_options)
 
     def get_client(self, verbose=False):
-        if os.environ.get('FIG_TLS_PATH') is not None:
-            tls_path = os.environ.get('FIG_TLS_PATH')
+        if os.environ.get('DOCKER_CERT_PATH') is not None:
+            tls_path = os.environ.get('DOCKER_CERT_PATH')
             tls_config = tls.TLSConfig(
                 ssl_version=ssl.PROTOCOL_TLSv1,
                 verify=True,


### PR DESCRIPTION
Take advantage of docker-py TLS support by passing in TLS configuration via the standard docker environment variables for doing so. Unfortunately this doesn't work 100% yet. I think dockerpty needs to support SSL-based python sockets because the library throws an error when you try to attach a virtual tty stream. I filed an issue for it here https://github.com/d11wtq/dockerpty/issues/13
