### PR TITLE
Let tox.ini run coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/_site
 /venv
 fig.spec
+cover

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ nose
 git+https://github.com/pyinstaller/pyinstaller.git@12e40471c77f588ea5be352f7219c873ddaae056#egg=pyinstaller
 unittest2
 flake8
+coverage

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,14 @@ commands =
     nosetests {posargs}
     flake8 fig
 
+[testenv:coverage]
+setenv = VIRTUAL_ENV={envdir}
+         NOSE_WITH_COVERAGE=1
+         NOSE_COVER_BRANCHES=1
+         NOSE_COVER_HTML=1
+         NOSE_COVER_HTML_DIR={toxinidir}/cover
+         NOSE_COVER_PACKAGE=fig
+
 [flake8]
 # ignore line-length for now
 ignore = E501,E203


### PR DESCRIPTION
Give tox.ini a target to run the coverage report, which get generated
in the top directory under cover and can be viewed nicely in a web
browser.