### PR TITLE
Allow overriding environements on command line

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -261,12 +261,13 @@ class TopLevelCommand(Command):
         running. If you do not want to start linked services, use
         `fig run --no-deps SERVICE COMMAND [ARGS...]`.
 
-        Usage: run [options] SERVICE [COMMAND] [ARGS...]
+        Usage: run [options] [-e KEY=VAL...] SERVICE [COMMAND] [ARGS...]
 
         Options:
             -d                Detached mode: Run container in the background, print
                               new container name.
             --entrypoint CMD  Override the entrypoint of the image.
+            -e KEY=VAL        Set an environment variable (can be used multiple times)
             --no-deps         Don't start linked services.
             --rm              Remove container after run. Ignored in detached mode.
             -T                Disable pseudo-tty allocation. By default `fig run`
@@ -298,6 +299,13 @@ class TopLevelCommand(Command):
             'tty': tty,
             'stdin_open': not options['-d'],
         }
+
+        if options['-e']:
+            for option in options['-e']:
+                if 'environment' not in service.options:
+                    service.options['environment'] = {}
+                k, v = option.split('=', 1)
+                service.options['environment'][k] = v
 
         if options['--entrypoint']:
             container_options['entrypoint'] = options.get('--entrypoint')

--- a/tests/fixtures/environment-figfile/fig.yml
+++ b/tests/fixtures/environment-figfile/fig.yml
@@ -1,0 +1,7 @@
+service:
+  image: busybox:latest
+  command: sleep 5
+
+  environment:
+    foo: bar
+    hello: world


### PR DESCRIPTION
Add a new command line option -e to override environement variables when
running a service. Syntax is -e option1:value1,option2:value2 which is
not ideal but it does not seem that docopt support repeatable options.

Signed-off-by: Chmouel Boudjnah chmouel@chmouel.com
