### PR TITLE
Use /bin/echo for intermediate container

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -223,7 +223,7 @@ class Service(object):
         intermediate_container = Container.create(
             self.client,
             image=container.image,
-            entrypoint=['echo'],
+            entrypoint=['/bin/echo'],
             command=[],
         )
         intermediate_container.start(volumes_from=container.id)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -136,7 +136,7 @@ class ServiceTest(DockerClientTestCase):
 
         intermediate_container = tuples[0][0]
         new_container = tuples[0][1]
-        self.assertEqual(intermediate_container.dictionary['Config']['Entrypoint'], ['echo'])
+        self.assertEqual(intermediate_container.dictionary['Config']['Entrypoint'], ['/bin/echo'])
 
         self.assertEqual(new_container.dictionary['Config']['Entrypoint'], ['sleep'])
         self.assertEqual(new_container.dictionary['Config']['Cmd'], ['300'])


### PR DESCRIPTION
In cases where the service is using a minimal container,
/bin/echo can be created but echo cannot.

See #517

Signed-off-by: Ben Firshman ben@firshman.co.uk
