### PR TITLE
Change database host

### DIFF
--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -44,7 +44,7 @@ Two supporting files are needed to get this working - first up, `wp-config.php` 
 define('DB_NAME', 'wordpress');
 define('DB_USER', 'root');
 define('DB_PASSWORD', '');
-define('DB_HOST', "db:3306");
+define('DB_HOST', "wordpress_db_1:3306");
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 


### PR DESCRIPTION
I've been struggling with this setting for a long time and I realized if I changed the DB_HOST to wordpress_db_1 (which is container name) from db, it worked. Is it something I've done wrongly or is it a mistake on this document?
