### PR TITLE
Fix docker-py requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 0.12',
-    'docker-py >= 0.5, < 0.6',
+    'docker-py >= 0.5.3, < 0.6',
     'six >= 1.3.0, < 2',
 ]
 


### PR DESCRIPTION
I updated requirements.txt but forgot about setup.py, so the version on pypi is broken for people who already have docker-py 0.5.0 installed.

Closes #547.
