### PR TITLE
Fix a couple bugs with 1.0 release and Docker 1.3

### DIFF
--- a/fig/cli/docker_client.py
+++ b/fig/cli/docker_client.py
@@ -11,7 +11,7 @@ def docker_client():
     """
     cert_path = os.environ.get('DOCKER_CERT_PATH', '')
     if cert_path == '':
-        cert_path = os.path.join(os.environ.get('HOME'), '.docker')
+        cert_path = os.path.join(os.environ.get('HOME', ''), '.docker')
 
     base_url = os.environ.get('DOCKER_HOST')
     tls_config = None

--- a/fig/progress_stream.py
+++ b/fig/progress_stream.py
@@ -19,7 +19,9 @@ def stream_output(output, stream):
         all_events.append(event)
 
         if 'progress' in event or 'progressDetail' in event:
-            image_id = event['id']
+            image_id = event.get('id')
+            if not image_id:
+                continue
 
             if image_id in lines:
                 diff = len(lines) - lines[image_id]

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+from __future__ import absolute_import
+import os
+
+import mock
+from tests import unittest
+
+from fig.cli import docker_client 
+
+
+class DockerClientTestCase(unittest.TestCase):
+
+    def test_docker_client_no_home(self):
+        with mock.patch.dict(os.environ):
+            del os.environ['HOME']
+            docker_client.docker_client()

--- a/tests/unit/cli/verbose_proxy_test.py
+++ b/tests/unit/cli/verbose_proxy_test.py
@@ -5,7 +5,7 @@ from tests import unittest
 from fig.cli import verbose_proxy
 
 
-class VerboseProxy(unittest.TestCase):
+class VerboseProxyTestCase(unittest.TestCase):
 
     def test_format_call(self):
         expected = "(u'arg1', True, key=u'value')"

--- a/tests/unit/progress_stream_test.py
+++ b/tests/unit/progress_stream_test.py
@@ -1,0 +1,20 @@
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from tests import unittest
+
+import mock
+from six import StringIO
+
+from fig import progress_stream 
+
+
+class ProgressStreamTestCase(unittest.TestCase):
+
+    def test_stream_output(self):
+        output = [
+            '{"status": "Downloading", "progressDetail": {"current": '
+            '31019763, "start": 1413653874, "total": 62763875}, '
+            '"progress": "..."}',
+        ]
+        events = progress_stream.stream_output(output, StringIO())
+        self.assertEqual(len(events), 1)

--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,4 @@ commands =
 [flake8]
 # ignore line-length for now
 ignore = E501,E203
+exclude = fig/packages


### PR DESCRIPTION
Resolves #553 - do not require `$HOME` to be set
Resolves #546 - be more defensive about the expected stream  from the docker remote api

Also adds the exclude to `tox.ini` for the new vendored package.
