### PR TITLE
Fix language in Wordpress guide

### DIFF
--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -37,7 +37,7 @@ db:
     MYSQL_DATABASE: wordpress
 ```
 
-Two supporting files are needed to get this working - first up, `wp-config.php` is the standard Wordpress config file with a single change to make it read the MySQL host and port from the environment variables passed in by Fig:
+Two supporting files are needed to get this working - first up, `wp-config.php` is the standard Wordpress config file with a single change to point the database configuration at the `db` container:
 
 ```
 <?php


### PR DESCRIPTION
Was still talking about 'environment variables'.
