### PR TITLE
Project name support '-' and '_'

### DIFF
--- a/fig/cli/command.py
+++ b/fig/cli/command.py
@@ -81,7 +81,7 @@ class Command(DocoptCommand):
 
     def get_project_name(self, config_path, project_name=None):
         def normalize_name(name):
-            return re.sub(r'[^a-zA-Z0-9]', '', name)
+            return re.sub(r'[^a-zA-Z0-9-_]', '', name)
 
         project_name = project_name or os.environ.get('FIG_PROJECT_NAME')
         if project_name is not None:

--- a/fig/service.py
+++ b/fig/service.py
@@ -26,7 +26,7 @@ DOCKER_CONFIG_HINTS = {
     'workdir'   : 'working_dir',
 }
 
-VALID_NAME_CHARS = '[a-zA-Z0-9]'
+VALID_NAME_CHARS = '[a-zA-Z0-9-_]'
 
 
 class BuildError(Exception):


### PR DESCRIPTION
Any reason to disable '-' and '_' for project name?
