### PR TITLE
Update Twitter button URL

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -52,7 +52,7 @@
 
         <div class="badges">
           <iframe src="http://ghbtns.com/github-btn.html?user=docker&amp;repo=fig&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100" height="20"></iframe>
-          <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://orchardup.github.io/fig/">Tweet</a>
+          <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://www.fig.sh/">Tweet</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I originally left it as orchardup.github.io so the number wouldn't roll
back to 0, but people have been tweeting about fig.sh now.

Signed-off-by: Ben Firshman ben@firshman.co.uk
