### PR TITLE
Update wordpress url on wordpress example

### DIFF
--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -8,7 +8,7 @@ Getting started with Fig and Wordpress
 
 Fig makes it nice and easy to run Wordpress in an isolated environment. [Install Fig](install.html), then download Wordpress into the current directory:
 
-    $ curl http://wordpress.org/wordpress-3.8.1.tar.gz | tar -xvzf -
+    $ curl https://wordpress.org/latest.tar.gz | tar -xvzf -
 
 This will create a directory called `wordpress`, which you can rename to the name of your project if you wish. Inside that directory, we create `Dockerfile`, a file that defines what environment your app is going to run in:
 


### PR DESCRIPTION
The old url gave a 302 and wordpress 4.0 has also been released.
