### PR TITLE
Add tests to sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include requirements.txt
 include requirements-dev.txt
 include tox.ini
 include *.md
-recursive-exclude tests *
+recursive-include tests *
 global-exclude *.pyc
 global-exclude *.pyo
 global-exclude *.un~


### PR DESCRIPTION
In order to validate installation it's very convenient to have the tests
as part of the source distribution.  This greatly assists native
packaging that might occur (i.e. Gentoo ebuilds).
