### PR TITLE
Speed up fig up

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -425,6 +425,7 @@ class TopLevelCommand(Command):
             --no-color            Produce monochrome output.
             --no-deps             Don't start linked services.
             --no-recreate         If containers already exist, don't recreate them.
+            --no-build            Don't build an image, even if it's missing
         """
         insecure_registry = options['--allow-insecure-ssl']
         detached = options['-d']
@@ -440,7 +441,8 @@ class TopLevelCommand(Command):
             start_links=start_links,
             recreate=recreate,
             insecure_registry=insecure_registry,
-            detach=options['-d']
+            detach=options['-d'],
+            do_build=not options['--no-build'],
         )
 
         to_attach = [c for s in project.get_services(service_names) for c in s.containers()]

--- a/fig/project.py
+++ b/fig/project.py
@@ -167,14 +167,26 @@ class Project(object):
             else:
                 log.info('%s uses an image, skipping' % service.name)
 
-    def up(self, service_names=None, start_links=True, recreate=True, insecure_registry=False, detach=False):
+    def up(self,
+           service_names=None,
+           start_links=True,
+           recreate=True,
+           insecure_registry=False,
+           detach=False,
+           do_build=True):
         running_containers = []
         for service in self.get_services(service_names, include_links=start_links):
             if recreate:
-                for (_, container) in service.recreate_containers(insecure_registry=insecure_registry, detach=detach):
+                for (_, container) in service.recreate_containers(
+                        insecure_registry=insecure_registry,
+                        detach=detach,
+                        do_build=do_build):
                     running_containers.append(container)
             else:
-                for container in service.start_or_create_containers(insecure_registry=insecure_registry, detach=detach):
+                for container in service.start_or_create_containers(
+                        insecure_registry=insecure_registry,
+                        detach=detach,
+                        do_build=do_build):
                     running_containers.append(container)
 
         return running_containers

--- a/fig/service.py
+++ b/fig/service.py
@@ -54,7 +54,7 @@ DOCKER_START_KEYS = [
     'cap_add',
     'cap_drop',
     'dns',
-    'dns_search', 
+    'dns_search',
     'env_file',
     'net',
     'privileged',
@@ -236,7 +236,7 @@ class Service(object):
                 return Container.create(self.client, **container_options)
             raise
 
-    def recreate_containers(self, insecure_registry=False, **override_options):
+    def recreate_containers(self, insecure_registry=False, do_build=True, **override_options):
         """
         If a container for this service doesn't exist, create and start one. If there are
         any, stop them, create+start new ones, and remove the old containers.
@@ -244,7 +244,10 @@ class Service(object):
         containers = self.containers(stopped=True)
         if not containers:
             log.info("Creating %s..." % self._next_container_name(containers))
-            container = self.create_container(insecure_registry=insecure_registry, **override_options)
+            container = self.create_container(
+                insecure_registry=insecure_registry,
+                do_build=do_build,
+                **override_options)
             self.start_container(container)
             return [(None, container)]
         else:
@@ -283,7 +286,7 @@ class Service(object):
         container.remove()
 
         options = dict(override_options)
-        new_container = self.create_container(**options)
+        new_container = self.create_container(do_build=False, **options)
         self.start_container(new_container, intermediate_container=intermediate_container)
 
         intermediate_container.remove()
@@ -330,14 +333,19 @@ class Service(object):
         )
         return container
 
-    def start_or_create_containers(self, insecure_registry=False, detach=False):
+    def start_or_create_containers(
+            self,
+            insecure_registry=False,
+            detach=False,
+            do_build=True):
         containers = self.containers(stopped=True)
 
         if not containers:
             log.info("Creating %s..." % self._next_container_name(containers))
             new_container = self.create_container(
                 insecure_registry=insecure_registry,
-                detach=detach
+                detach=detach,
+                do_build=do_build,
             )
             return [self.start_container(new_container)]
         else:

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -391,34 +391,34 @@ class ServiceTest(DockerClientTestCase):
 
     def test_restart_always_value(self):
         service = self.create_service('web', restart='always')
-        container = service.start_container().inspect()
-        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'always')
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.RestartPolicy.Name'), 'always')
 
     def test_restart_on_failure_value(self):
         service = self.create_service('web', restart='on-failure:5')
-        container = service.start_container().inspect()
-        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'on-failure')
-        self.assertEqual(container['HostConfig']['RestartPolicy']['MaximumRetryCount'], 5)
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.RestartPolicy.Name'), 'on-failure')
+        self.assertEqual(container.get('HostConfig.RestartPolicy.MaximumRetryCount'), 5)
 
     def test_cap_add_list(self):
         service = self.create_service('web', cap_add=['SYS_ADMIN', 'NET_ADMIN'])
-        container = service.start_container().inspect()
-        self.assertEqual(container['HostConfig']['CapAdd'], ['SYS_ADMIN', 'NET_ADMIN'])
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.CapAdd'), ['SYS_ADMIN', 'NET_ADMIN'])
 
     def test_cap_drop_list(self):
         service = self.create_service('web', cap_drop=['SYS_ADMIN', 'NET_ADMIN'])
-        container = service.start_container().inspect()
-        self.assertEqual(container['HostConfig']['CapDrop'], ['SYS_ADMIN', 'NET_ADMIN'])
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.CapDrop'), ['SYS_ADMIN', 'NET_ADMIN'])
 
     def test_dns_search_single_value(self):
         service = self.create_service('web', dns_search='example.com')
-        container = service.start_container().inspect()
-        self.assertEqual(container['HostConfig']['DnsSearch'], ['example.com'])
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.DnsSearch'), ['example.com'])
 
     def test_dns_search_list(self):
         service = self.create_service('web', dns_search=['dc1.example.com', 'dc2.example.com'])
-        container = service.start_container().inspect()
-        self.assertEqual(container['HostConfig']['DnsSearch'], ['dc1.example.com', 'dc2.example.com'])
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.DnsSearch'), ['dc1.example.com', 'dc2.example.com'])
 
     def test_working_dir_param(self):
         service = self.create_service('container', working_dir='/working/dir/sample')
@@ -433,7 +433,7 @@ class ServiceTest(DockerClientTestCase):
 
     def test_env_from_file_combined_with_env(self):
         service = self.create_service('web', environment=['ONE=1', 'TWO=2', 'THREE=3'], env_file=['tests/fixtures/env/one.env', 'tests/fixtures/env/two.env'])
-        env = service.start_container().environment
+        env = create_and_start_container(service).environment
         for k,v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.iteritems():
             self.assertEqual(env[k], v)
 

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -228,6 +228,23 @@ class ServiceTest(unittest.TestCase):
         service.create_container()
         self.assertEqual(Container.create.call_args[1]['image'], 'someimage:latest')
 
+    def test_create_container_with_build(self):
+        self.mock_client.images.return_value = []
+        service = Service('foo', client=self.mock_client, build='.')
+        service.build = mock.create_autospec(service.build)
+        service.create_container(do_build=True)
+
+        self.mock_client.images.assert_called_once_with(name=service.full_name)
+        service.build.assert_called_once_with()
+
+    def test_create_container_no_build(self):
+        self.mock_client.images.return_value = []
+        service = Service('foo', client=self.mock_client, build='.')
+        service.create_container(do_build=False)
+
+        self.assertFalse(self.mock_client.images.called)
+        self.assertFalse(self.mock_client.build.called)
+
 
 class ServiceVolumesTest(unittest.TestCase):
 


### PR DESCRIPTION
I did some profiling of one of our larger fig setups. I noticed a lot of time wasted on an unnecessary `build()`. This branch adds a flag to disable the `build()` that was called during `fig up`. The slowdown wasn't on the `build()` itself, but the conditional `if not client.images()`, because it requires hitting the docker remote again, and filtering through the images.

In almost every use of fig I perform a `fig build` before a `fig up` already, to ensure that `fig up` is actually running the latest code/containers, so this extra check is completely wasted (and is actually slower than the build itself).

This branch also includes a few cleanup and bug fixes. Some from an earlier `fig tag` branch that probably wont get merged, and some new ones I found while working on the tests.  I'll comment on the specifics inline.
### Background

On this host:

```
$ docker images | wc -l 
1335
$ docker ps -a  | wc -l
104
```

I suspect this issue is less noticeable when there are fewer images, but 1335 doesn't seem like a lot. We actually cleanup images that are greater than 30 days old, so there shouldn't be anything terribly old here.

Total time: 30s
Number of fig services: 8 (2 image, 6 build)
This setup basically does 3 things: 

```
fig pull
fig build
fig up
```
### fig 1.0 profile

This is heavily cleaned up, but shows the relevant lines.

```
    399922 function calls (394317 primitive calls) in 30.741 CPU seconds
    Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   16.916   16.916 fig/project.py:170(up)
        6    0.000    0.000   12.334    2.056 docker/client.py:552(images)
        1    0.000    0.000   10.536   10.536 fig/project.py:163(build)
        4    0.000    0.000    2.692    0.673 docker/client.py:716(pull)
```

Tracing the `project.up()` call through the stack:

```
Function                         called...                                                         
                                 ncalls  tottime  cumtime
fig/project.py:170(up)  ->       1    0.000    0.000  fig/project.py:86(get_services)
                                 8    0.000   16.916  fig/service.py:187(recreate_containers)

Function                                          called...                                                         
                                                  ncalls  tottime  cumtime                                              
fig/service.py:187(recreate_containers)  ->       8    0.001    0.277  fig/service.py:77(containers)
                                                  8    0.000   14.839  fig/service.py:171(create_container)
                                                  8    0.000    1.798  fig/service.py:248(start_container)

Function                                       called...                                                         
                                               ncalls  tottime  cumtime                                              
fig/service.py:171(create_container)  ->       8    0.000    1.929  fig/container.py:35(create)
                                               8    0.000   12.910  fig/service.py:329(_get_container_create_options)


Function                                                    called...                                                         
                                                            ncalls  tottime  cumtime                                              
fig/service.py:329(_get_container_create_options)  ->       6    0.000   12.334  docker/client.py:552(images)
```

We see that 12 seconds out of 30 seconds are spent on an operation that we already know to be a no-op
### this branch profile

```
    398171 function calls (392402 primitive calls) in 18.330 CPU seconds
    Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   10.927   10.927 fig/project.py:163(build)
        1    0.000    0.000    4.843    4.843 fig/project.py:170(up)
        4    0.000    0.000    1.997    0.499 docker/client.py:728(pull)
```

Time is down to 18 seconds, and `fig up` is now 4 seconds instead of 16.
