### PR TITLE
Add restart option to Fig.

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -142,7 +142,7 @@ dns:
   - 9.9.9.9
 ```
 
-### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged
+### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged, restart
 
 Each of these is a single value, analogous to its [docker run](https://docs.docker.com/reference/run/) counterpart.
 
@@ -156,4 +156,6 @@ domainname: foo.com
 
 mem_limit: 1000000000
 privileged: true
+
+restart: always
 ```

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -365,6 +365,17 @@ class ServiceTest(DockerClientTestCase):
         container = service.start_container().inspect()
         self.assertEqual(container['HostConfig']['Dns'], ['8.8.8.8', '9.9.9.9'])
 
+    def test_restart_always_value(self):
+        service = self.create_service('web', restart='always')
+        container = service.start_container().inspect()
+        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'always')
+
+    def test_restart_on_failure_value(self):
+        service = self.create_service('web', restart='on-failure:5')
+        container = service.start_container().inspect()
+        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'on-failure')
+        self.assertEqual(container['HostConfig']['RestartPolicy']['MaximumRetryCount'], 5)
+
     def test_working_dir_param(self):
         service = self.create_service('container', working_dir='/working/dir/sample')
         container = service.create_container().inspect()


### PR DESCRIPTION
**Hello!**

I simply find this project really good, and ended up needing the `restart` option (Related to #478).

Since Docker 1.2 there is a `restart` option on `docker run`ning containers to add restart policies. I think fig options should be able to set restart policies to it's orchestrated containers.
This PR adds the option in Fig.

Let me know if there it's all ok?
