### PR TITLE
implementation of initial_scale service option (issue #116)

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -199,3 +199,12 @@ privileged: true
 
 restart: always
 ```
+
+### initial_scale
+
+Specify inital scale for container. Upon service creation or recreation, `initial_scale`
+instances of the service container will be created (and started).
+
+```
+initial_scale: 3
+```


### PR DESCRIPTION
Implementation of the initial_scale service option discussed in option (issue #116). Initial scale is applied whenever the containers for a service are newly created, ie. on "fig up" or "fig up --no-recreate".

Signed-off-by: Emil Kroymann <emil.kroymann@gmail.com>