### PR TITLE
Use the same port settings for up and run.

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -319,10 +319,10 @@ class TopLevelCommand(Command):
             **container_options
         )
         if options['-d']:
-            service.start_container(container, ports=None, one_off=True)
+            service.start_container(container, one_off=True)
             print(container.name)
         else:
-            service.start_container(container, ports=None, one_off=True)
+            service.start_container(container, one_off=True)
             dockerpty.start(project.client, container.id, interactive=not options['-T'])
             exit_code = container.wait()
             if options['--rm']:


### PR DESCRIPTION
Don't remove the port settings when starting an individual service via
`fig up <service>`. Closes #653.

Signed-off-by: Markus Hubig mhubig@gmail.com
