### PR TITLE
Updated docker-py to 0.6.0 to fix issues with directories and symlinks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==0.5.3
+docker-py==0.6.0
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 0.12',
-    'docker-py >= 0.5.3, < 0.6',
+    'docker-py >= 0.6.0, < 0.7',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]


### PR DESCRIPTION
By updating docker-py to version 0.6.0 an issue is resolved where symlinks and empty directories were not properly passed to docker when building an image. See https://github.com/docker/fig/issues/651. This issue resulted in images that were different from images built with the default docker client.

I successfully ran all the tests. 

Output:

```
Ran 156 tests in 206.877s

OK
```
