### PR TITLE
Respect --allow-insecure-ssl option for dependencies

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -293,6 +293,7 @@ class TopLevelCommand(Command):
                     service_names=deps,
                     start_links=True,
                     recreate=False,
+                    insecure_registry=insecure_registry,
                 )
 
         tty = True


### PR DESCRIPTION
Hi,

When using run --allow-insecure-ssl, the insecure-registry is not passed to dependencies. This requires manual workaround to run depencies with insecure-ssl allowed too.

Regards,
Étienne BERSAC
