### PR TITLE
Respect --allow-insecure-ssl option for dependencies

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -293,6 +293,7 @@ class TopLevelCommand(Command):
                     service_names=deps,
                     start_links=True,
                     recreate=False,
+                    insecure_registry=insecure_registry,
                 )
 
         tty = True


### PR DESCRIPTION
If a dependencies depends on an insecure hub, fig fails.

Signed-off-by: Étienne Bersac etienne.bersac@novapost.fr
