### PR TITLE
Add a CLI command to view volumes

### DIFF
--- a/fig/cli/utils.py
+++ b/fig/cli/utils.py
@@ -53,6 +53,12 @@ def prettydate(d):
         return '{0} hours ago'.format(s / 3600)
 
 
+def trim(source, length, extra=' ...'):
+    if len(source) > length:
+        return '%s%s' % (source[:length - len(extra)], extra)
+    return source
+
+
 def mkdir(path, permissions=0o700):
     if not os.path.exists(path):
         os.mkdir(path)

--- a/fig/container.py
+++ b/fig/container.py
@@ -1,7 +1,11 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
+from collections import namedtuple
 
 import six
+
+
+Volume = namedtuple('Volume', 'path mode host')
 
 
 class Container(object):
@@ -66,7 +70,6 @@ class Container(object):
 
     @property
     def ports(self):
-        self.inspect_if_not_inspected()
         return self.get('NetworkSettings.Ports') or {}
 
     @property
@@ -100,6 +103,19 @@ class Container(object):
     @property
     def is_running(self):
         return self.get('State.Running')
+
+    @property
+    def volumes(self):
+        def get_mode(is_rw):
+            if is_rw is None:
+                return ''
+            return 'rw' if is_rw else 'ro'
+
+        def get_volume(volume_item):
+            path, host = volume_item
+            return Volume(path, get_mode(self.get('VolumesRW').get(path)), host)
+
+        return map(get_volume, six.iteritems(self.get('Volumes')))
 
     def get(self, key):
         """Return a value from the container or None if the value is not set.

--- a/tests/fixtures/volumes-figfile/fig.yml
+++ b/tests/fixtures/volumes-figfile/fig.yml
@@ -1,0 +1,11 @@
+
+one:
+    image: busybox
+    volumes:
+        - '/etc'
+        - '/home:/home:ro'
+
+two:
+    image: busybox
+    volumes_from:
+        - one

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -63,6 +63,16 @@ class CLITestCase(DockerClientTestCase):
         self.assertNotIn('multiplefigfiles_another_1', output)
         self.assertIn('multiplefigfiles_yetanother_1', output)
 
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_volumes(self, mock_stdout):
+        self.command.base_dir = 'tests/fixtures/volumes-figfile'
+        self.command.dispatch(['up', '-d'], None)
+        self.command.dispatch(['volumes'], None)
+
+        output = mock_stdout.getvalue()
+        self.assertIn('/etc', output)
+        self.assertIn('/home', output)
+
     @patch('fig.service.log')
     def test_pull(self, mock_logging):
         self.command.dispatch(['pull'], None)

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -4,11 +4,10 @@ from .. import unittest
 import mock
 import docker
 
-from fig.container import Container
+from fig.container import Container, Volume
 
 
 class ContainerTest(unittest.TestCase):
-
 
     def setUp(self):
         self.container_dict = {
@@ -105,6 +104,27 @@ class ContainerTest(unittest.TestCase):
         self.assertEqual(
             container.get_local_port(45454, protocol='tcp'),
             '0.0.0.0:49197')
+
+    def test_volumes(self):
+        container = Container(None, {
+            "Volumes": {
+                "/sys": "/sys",
+                "/var/lib/docker": "/var/lib/docker",
+                "/etc": "/var/lib/docker/vfs/dir/531d0515",
+            },
+            "VolumesRW": {
+                "/sys": False,
+                "/var/lib/docker": True,
+                "/etc": True,
+            }
+        }, has_been_inspected=True)
+        self.assertEqual(
+            sorted(container.volumes),
+            [
+                Volume('/etc', 'rw', '/var/lib/docker/vfs/dir/531d0515'),
+                Volume('/sys', 'ro', '/sys'),
+                Volume('/var/lib/docker', 'rw', '/var/lib/docker'),
+            ])
 
     def test_get(self):
         container = Container(None, {


### PR DESCRIPTION
Related: #707, #706, #691, #447, #613, #637, #622, #461, #674, #579, #465, ...

Many users have reported issues with volumes, and docker likes to silently ignore volumes when the host path doesn't exist.

To help debug these issues, and to help developers better understand the volumes being used by their containers, this PR adds a new cli command `fig volumes`.

It will display a table like this, with all the volumes the containers are using:

```
         Name                 Path         Mode                                             Host                                           
------------------------------------------------------------------------------------------------------------------------------------------
examples_cadvisor_1      /var/lib/docker   rw     /var/lib/docker                                                                          
examples_cadvisor_1      /var/run          rw     /run                                                                                     
examples_cadvisor_1      /sys              ro     /sys                                                                                     
examples_longestname_1   /etc              rw     /var/lib/docker/vfs/dir/531d0515d0fefc1a485e83f933810677d8d6132092387cc1ef8029960585135a
```
