### PR TITLE
Added support for restart_policy parameter

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -157,3 +157,14 @@ domainname: foo.com
 mem_limit: 1000000000
 privileged: true
 ```
+
+### restart_policy
+
+Specify the container restart policy using the same syntax as the Docker CLI.
+Supported values are "no", "always" and "on-failure[:max-retry]". The default
+is to have no restart policy.
+
+```
+restart_policy: "always"
+restart_policy: "on-failure:3"
+```

--- a/tests/fixtures/restart-policy-figfile/fig.yml
+++ b/tests/fixtures/restart-policy-figfile/fig.yml
@@ -1,0 +1,4 @@
+service:
+  image: busybox:latest
+  command: sleep 5
+  restart_policy: on-failure:3

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -237,6 +237,16 @@ class CLITestCase(DockerClientTestCase):
         # make sure a value with a = don't crash out
         self.assertEqual('moto=bobo', container.environment['allo'])
 
+    @patch('dockerpty.start')
+    def test_run_service_with_restart_policy(self, __):
+        self.command.base_dir = 'tests/fixtures/restart-policy-figfile'
+        self.command.dispatch(['up', '-d', 'service'], None)
+        service = self.project.get_service('service')
+        containers = service.containers(stopped=True)
+        container = service.containers(stopped=True)[0].inspect()
+        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'on-failure')
+        self.assertEqual(container['HostConfig']['RestartPolicy']['MaximumRetryCount'], 3)
+
     def test_rm(self):
         service = self.project.get_service('simple')
         service.create_container()

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -389,3 +389,25 @@ class ServiceTest(DockerClientTestCase):
             del os.environ['FILE_DEF']
             del os.environ['FILE_DEF_EMPTY']
             del os.environ['ENV_DEF']
+
+    def test_restart_policy_default(self):
+        service = self.create_service('container')
+        container = service.start_container().inspect()
+        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], '')
+
+    def test_restart_policy_always(self):
+        service = self.create_service('container')
+        container = service.start_container(restart_policy='always').inspect()
+        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'always')
+
+    def test_restart_policy_on_failure(self):
+        service = self.create_service('container')
+        container = service.start_container(restart_policy='on-failure').inspect()
+        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'on-failure')
+        self.assertEqual(container['HostConfig']['RestartPolicy']['MaximumRetryCount'], 0)
+
+    def test_restart_policy_on_failure_retry_count(self):
+        service = self.create_service('container')
+        container = service.start_container(restart_policy='on-failure:3').inspect()
+        self.assertEqual(container['HostConfig']['RestartPolicy']['Name'], 'on-failure')
+        self.assertEqual(container['HostConfig']['RestartPolicy']['MaximumRetryCount'], 3)

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -17,6 +17,7 @@ from fig.service import (
     parse_volume_spec,
     build_volume_binding,
     APIError,
+    parse_restart_policy,
 )
 
 
@@ -204,6 +205,18 @@ class ServiceTest(unittest.TestCase):
             pass
         self.mock_client.pull.assert_called_once_with('someimage:sometag', insecure_registry=True, stream=True)
         mock_log.info.assert_called_once_with('Pulling image someimage:sometag...')
+
+    def test_parse_restart_policy(self):
+        test_args = {
+            None: None,
+            '': None,
+            'no': None,
+            'always': {'Name':'always'},
+            'on-failure': {'Name':'on-failure'},
+            'on-failure:3': {'Name':'on-failure', 'MaximumRetryCount':3},
+        }
+        for k, v in test_args.items():
+            self.assertEqual(parse_restart_policy(k), v)
 
 
 class ServiceVolumesTest(unittest.TestCase):


### PR DESCRIPTION
This patch adds the restart_policy parameter to services. The parameter
is passed to the Docker API when starting containers. Its recognized
values are the same as in the Docker CLI ("always" and "on-failure[:max-retry]").

For future compatibility, the policy can also be specified as a
dictionary, which is passed directly to the Docker API (after converting
the keys to CamelCase).

This feature seems to have been requested at least in issue #478.

Signed-off-by: Kenneth Falck kennu@iki.fi
