### PR TITLE
Upgrade to docker-py 0.6.0

### DIFF
--- a/fig/cli/docker_client.py
+++ b/fig/cli/docker_client.py
@@ -31,4 +31,4 @@ def docker_client():
             ca_cert=ca_cert,
         )
 
-    return Client(base_url=base_url, tls=tls_config)
+    return Client(base_url=base_url, tls=tls_config, version='1.14')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==0.5.3
+docker-py==0.6.0
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 0.12',
-    'docker-py >= 0.5.3, < 0.6',
+    'docker-py >= 0.6.0, < 0.7',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]


### PR DESCRIPTION
Force using remote API version 1.14 so Fig is still compatible with
Docker 1.2.

Signed-off-by: Ben Firshman ben@firshman.co.uk
