### PR TITLE
Support a timeout on docker client

### DIFF
--- a/fig/cli/docker_client.py
+++ b/fig/cli/docker_client.py
@@ -31,4 +31,5 @@ def docker_client():
             ca_cert=ca_cert,
         )
 
-    return Client(base_url=base_url, tls=tls_config, version='1.14')
+    timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
+    return Client(base_url=base_url, tls=tls_config, version='1.14', timeout=timeout)

--- a/fig/service.py
+++ b/fig/service.py
@@ -15,7 +15,30 @@ from .progress_stream import stream_output, StreamOutputError
 log = logging.getLogger(__name__)
 
 
-DOCKER_CONFIG_KEYS = ['image', 'command', 'hostname', 'domainname', 'user', 'detach', 'stdin_open', 'tty', 'mem_limit', 'ports', 'environment', 'env_file', 'dns', 'volumes', 'entrypoint', 'privileged', 'volumes_from', 'net', 'working_dir', 'restart', 'cap_add', 'cap_drop']
+DOCKER_CONFIG_KEYS = [
+    'cap_add',
+    'cap_drop',
+    'command',
+    'detach',
+    'dns',
+    'domainname',
+    'entrypoint',
+    'env_file',
+    'environment',
+    'hostname',
+    'image',
+    'mem_limit',
+    'net',
+    'ports',
+    'privileged',
+    'restart',
+    'stdin_open',
+    'tty',
+    'user',
+    'volumes',
+    'volumes_from',
+    'working_dir',
+]
 DOCKER_CONFIG_HINTS = {
     'link'      : 'links',
     'port'      : 'ports',
@@ -337,7 +360,9 @@ class Service(object):
         return volumes_from
 
     def _get_container_create_options(self, override_options, one_off=False):
-        container_options = dict((k, self.options[k]) for k in DOCKER_CONFIG_KEYS if k in self.options)
+        container_options = dict(
+            (k, self.options[k])
+            for k in DOCKER_CONFIG_KEYS if k in self.options)
         container_options.update(override_options)
 
         container_options['name'] = self._next_container_name(

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -14,3 +14,9 @@ class DockerClientTestCase(unittest.TestCase):
         with mock.patch.dict(os.environ):
             del os.environ['HOME']
             docker_client.docker_client()
+
+    def test_docker_client_with_custom_timeout(self):
+        with mock.patch.dict(os.environ):
+            os.environ['DOCKER_CLIENT_TIMEOUT'] = timeout = "300"
+            client = docker_client.docker_client()
+        self.assertEqual(client._timeout, int(timeout))

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -165,23 +165,21 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
 
     def test_get_container_not_found(self):
-        mock_client = mock.create_autospec(docker.Client)
-        mock_client.containers.return_value = []
-        service = Service('foo', client=mock_client)
+        self.mock_client.containers.return_value = []
+        service = Service('foo', client=self.mock_client)
 
         self.assertRaises(ValueError, service.get_container)
 
     @mock.patch('fig.service.Container', autospec=True)
     def test_get_container(self, mock_container_class):
-        mock_client = mock.create_autospec(docker.Client)
         container_dict = dict(Name='default_foo_2')
-        mock_client.containers.return_value = [container_dict]
-        service = Service('foo', client=mock_client)
+        self.mock_client.containers.return_value = [container_dict]
+        service = Service('foo', client=self.mock_client)
 
         container = service.get_container(number=2)
         self.assertEqual(container, mock_container_class.from_ps.return_value)
         mock_container_class.from_ps.assert_called_once_with(
-            mock_client, container_dict)
+            self.mock_client, container_dict)
 
     @mock.patch('fig.service.log', autospec=True)
     def test_pull_image(self, mock_log):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,pypy
+envlist = py26,py27
 
 [testenv]
 usedevelop=True
@@ -7,7 +7,7 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    nosetests {posargs}
+    nosetests -v {posargs}
     flake8 fig
 
 [flake8]


### PR DESCRIPTION
This gets us slightly closer to being able to remove E501 (ignore line length) from flake8 ignore list
- support a timeout environment variable for the docker-py client
- sort `DOCKER_CONFIG_KEYS` and make them one-per-line (helps avoid merge conflicts when new keys are added, also just easier to read)
- only include python versions in tox that actually work with the current version
