### PR TITLE
fig patch for docker v1.4 volume management

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -393,9 +393,8 @@ class Service(object):
             container_options['ports'] = ports
 
         if 'volumes' in container_options:
-            container_options['volumes'] = dict(
-                (parse_volume_spec(v).internal, {})
-                for v in container_options['volumes'])
+            vols = (parse_volume_spec(v) for v in container_options['volumes'])
+            container_options['volumes'] = [v.internal for v in vols if not v.external]
 
         container_options['environment'] = merge_environment(container_options)
 


### PR DESCRIPTION
Related to issues #723 and #622. 

Seems that docker 1.4 breaks the way docker-py binds volumes.
But as stated by @cpuguy83 on opened issue on docker-py: https://github.com/docker/docker-py/issues/419, seems that it should be fixed on docker or docker-py. 
(On https://github.com/docker/docker-py/issues/419 is explained why fig does not bind-mount volumes on docker >=1.4)

This patch works for me, and seems backwards compatible with docker (tested 1.3.2 and 1.3.0).

As short description, it only pass `volumes` parameter to `create_container()` if it's not a bind volume, because otherwise docker >=1.4 and docker-py <=0.6.0 wouldn't bind-mount the volume. 
The `binds` parameter to `start()` includes the correct `binds` parameter.

But I don't know if fig has to be patched like this.
Other option is waiting for a docker or docker-py patch, and then update fig if still needed. Seems at least dependencies will have to be updated.

Signed-off-by: Bernardo Cabezas Serra <bcabezas@apsl.net>