### PR TITLE
docker build --pull 

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -117,7 +117,7 @@ class TopLevelCommand(Command):
             --pull      Attempt to pull the image even if an older image exists locally
         """
         no_cache = bool(options.get('--no-cache', False))
-        pull = bool(options.get('--pul', False))
+        pull = bool(options.get('--pull', False))
         project.build(service_names=options['SERVICE'], no_cache=no_cache, pull=pull)
 
     def help(self, project, options):

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -114,9 +114,11 @@ class TopLevelCommand(Command):
 
         Options:
             --no-cache  Do not use cache when building the image.
+            --pull      Attempt to pull the image even if an older image exists locally
         """
         no_cache = bool(options.get('--no-cache', False))
-        project.build(service_names=options['SERVICE'], no_cache=no_cache)
+        pull = bool(options.get('--pul', False))
+        project.build(service_names=options['SERVICE'], no_cache=no_cache, pull=pull)
 
     def help(self, project, options):
         """

--- a/fig/project.py
+++ b/fig/project.py
@@ -160,10 +160,10 @@ class Project(object):
         for service in self.get_services(service_names):
             service.restart(**options)
 
-    def build(self, service_names=None, no_cache=False):
+    def build(self, service_names=None, no_cache=False, pull=False):
         for service in self.get_services(service_names):
             if service.can_be_built():
-                service.build(no_cache)
+                service.build(no_cache, pull)
             else:
                 log.info('%s uses an image, skipping' % service.name)
 

--- a/fig/service.py
+++ b/fig/service.py
@@ -419,7 +419,7 @@ class Service(object):
             tag = "latest"
         return '%s:%s' % (repo, tag)
 
-    def build(self, no_cache=False):
+    def build(self, no_cache=False, pull=False):
         log.info('Building %s...' % self.name)
 
         build_output = self.client.build(
@@ -428,6 +428,7 @@ class Service(object):
             stream=True,
             rm=True,
             nocache=no_cache,
+            pull=pull,
         )
 
         try:


### PR DESCRIPTION
Support for the --pull option in build images from Dockerfile

Issue: https://github.com/docker/fig/issues/726

Before merge we need "--pull" support in docker-py.

The test fails for the block. This feature is compatible with the next version of docker-py.

Block: https://github.com/docker/docker-py/pull/421