### PR TITLE
Allow overriding user on the command line

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -276,6 +276,7 @@ class TopLevelCommand(Command):
                                   new container name.
             --entrypoint CMD      Override the entrypoint of the image.
             -e KEY=VAL            Set an environment variable (can be used multiple times)
+            -u --user USER        Run as specified user.
             --no-deps             Don't start linked services.
             --rm                  Remove container after run. Ignored in detached mode.
             -T                    Disable pseudo-tty allocation. By default `fig run`
@@ -320,6 +321,10 @@ class TopLevelCommand(Command):
 
         if options['--entrypoint']:
             container_options['entrypoint'] = options.get('--entrypoint')
+
+        if options['--user']:
+            container_options['user'] = options.get('--user')
+
         container = service.create_container(
             one_off=True,
             insecure_registry=insecure_registry,

--- a/tests/fixtures/user-figfile/fig.yml
+++ b/tests/fixtures/user-figfile/fig.yml
@@ -1,0 +1,3 @@
+service:
+  image: busybox:latest
+  command: id


### PR DESCRIPTION
Allow overriding a user on the command line from the one specified in
the fig.yaml

Tests are a bit tricky since regenerating a docker image with multiple
users just for this is consuming so let's catch the error instead and
make sure it works.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>