### PR TITLE
Include external config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Pull requests will need:
 
 ## Development environment
 
-If you're looking contribute to [Fig](http://www.fig.sh/)
+If you're looking to contribute to [Fig](http://www.fig.sh/)
 but you're new to the project or maybe even to Python, here are the steps
 that should get you started.
 

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -199,3 +199,42 @@ privileged: true
 
 restart: always
 ```
+
+## Project Includes
+
+External projects can be included by specifying a url to the projects `fig.yml`
+file. Only services with `image` may be included (because there would be no way
+to build the service without the full project).
+
+Urls may be filepaths, http/https or s3.  Remote files will be cached locally
+using the specified cache settings (defaults to a path of ~/.fig-cache/ with
+a ttl of 5 minutes).
+
+Example:
+
+```yaml
+
+project-config:
+
+    include:
+        projecta:
+            url: 's3://bucket/path/to/key/projecta.yml'
+        projectb:
+            url: 'http://example.com/projectb/fig.yml'
+        projectc:
+            url: './path/to/projectc/fig.yml'
+
+    # This section is optional, below are the default values
+    cache:
+        enable: True
+        path: ~/.fig-cache/
+        ttl: 5min
+
+webapp:
+    build: .
+    links:
+        - projecta_webapp
+        - pojrectb_webapp
+    volumes_from:
+        - projectc_data
+```

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -56,8 +56,8 @@ def setup_logging():
     root_logger.addHandler(console_handler)
     root_logger.setLevel(logging.DEBUG)
 
-    # Disable requests logging
-    logging.getLogger("requests").propagate = False
+    logging.getLogger("requests").setLevel(logging.WARN)
+    logging.getLogger("boto").setLevel(logging.WARN)
 
 
 # stolen from docopt master

--- a/fig/container.py
+++ b/fig/container.py
@@ -148,6 +148,7 @@ class Container(object):
         self.has_been_inspected = True
         return self.dictionary
 
+    # TODO: this is only used by tests, should move to a module under tests/
     def links(self):
         links = []
         for container in self.client.containers():

--- a/fig/includes.py
+++ b/fig/includes.py
@@ -109,7 +109,13 @@ class LocalConfigCache(object):
         ttl = timeparse.timeparse(cache_config.get('ttl', '5 min'))
 
         if not os.path.isdir(path):
-            os.makedirs(path)
+            try:
+                os.makedirs(path)
+            except OSError:
+                # Handle the race condition where some other process creates
+                # this directory after the isdir check
+                if not os.path.isdir(path):
+                    raise
 
         if ttl is None:
             raise ConfigError("Cache ttl \'%s\' could not be parsed" %

--- a/fig/includes.py
+++ b/fig/includes.py
@@ -1,0 +1,157 @@
+"""Include external projects, allowing services to link to a service
+defined in an external project.
+"""
+import logging
+import os
+import time
+
+from pytimeparse import timeparse
+import requests
+import requests.exceptions
+import six
+from six.moves.urllib.parse import urlparse, quote
+import yaml
+
+from fig.service import ConfigError
+
+
+log = logging.getLogger(__name__)
+
+
+class FetchExternalConfigError(Exception):
+    pass
+
+
+def normalize_url(url):
+    url = urlparse(url)
+    return url if url.scheme else url._replace(scheme='file')
+
+
+def read_config(content):
+    return yaml.safe_load(content)
+
+
+def get_project_from_file(url):
+    # Handle urls in the form file://./some/relative/path
+    path = url.netloc + url.path if url.netloc.startswith('.') else url.path
+    with open(path, 'r') as fh:
+        return read_config(fh.read())
+
+
+def get_project_from_http(url, config):
+    try:
+        response = requests.get(
+            url.geturl(),
+            timeout=config.get('timeout', 20),
+            verify=config.get('verify_ssl_cert', True),
+            cert=config.get('ssl_cert', None),
+            proxies=config.get('proxies', None))
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise FetchExternalConfigError("Failed to include %s: %s" % (
+            url.geturl(), e))
+    return read_config(response.text)
+
+
+def fetch_external_config(url, include_config):
+    log.info("Fetching config from %s" % url.geturl())
+
+    if url.scheme in ('http', 'https'):
+        return get_project_from_http(url, include_config)
+
+    if url.scheme == 'file':
+        return get_project_from_file(url)
+
+    raise ConfigError("Unsupported url scheme \"%s\" for %s." % (
+        url.scheme,
+        url))
+
+
+class LocalConfigCache(object):
+
+    def __init__(self, path, ttl):
+        self.path = path
+        self.ttl = ttl
+
+    @classmethod
+    def from_config(cls, cache_config):
+        if not cache_config.get('enable', True):
+            return {}
+
+        path = os.path.expanduser(cache_config.get('path', '~/.fig-cache'))
+        ttl = timeparse.timeparse(cache_config.get('ttl', '5 min'))
+
+        if not os.path.isdir(path):
+            os.makedirs(path)
+
+        if ttl is None:
+            raise ConfigError("Cache ttl \'%s\' could not be parsed" %
+                              cache_config.get('ttl'))
+
+        return cls(path, ttl)
+
+    def is_fresh(self, mtime):
+        return mtime + self.ttl > time.time()
+
+    def __contains__(self, url):
+        path = url_to_filename(self.path, url)
+        return os.path.exists(path) and self.is_fresh(os.path.getmtime(path))
+
+    def __getitem__(self, url):
+        if url not in self:
+            raise KeyError(url)
+        with open(url_to_filename(self.path, url), 'r') as fh:
+            return read_config(fh.read())
+
+    def __setitem__(self, url, contents):
+        with open(url_to_filename(self.path, url), 'w') as fh:
+            return fh.write(yaml.dump(contents))
+
+
+def url_to_filename(path, url):
+    return os.path.join(path, quote(url.geturl(), safe=''))
+
+
+class ExternalProjectCache(object):
+    """Cache each Project by the url used to retreive the projects fig.yml.
+    If multiple projects include the same url, re-use the same instance of the
+    project.
+    """
+
+    def __init__(self, cache, client, factory):
+        self.config_cache = cache
+        self.project_cache = {}
+        self.client = client
+        self.factory = factory
+
+    def get_project_from_include(self, name, include):
+        if 'url' not in include:
+            raise ConfigError("Project include '%s' requires a url" % name)
+        url = normalize_url(include['url'])
+
+        if url not in self.project_cache:
+            config = self.get_config(url, include)
+            self.project_cache[url] = self.build_project(name, config)
+
+        return self.project_cache[url]
+
+    def get_config(self, url, include):
+        if url in self.config_cache:
+            return self.config_cache[url]
+
+        self.config_cache[url] = config = fetch_external_config(url, include)
+        return config
+
+    def build_project(self, name, config):
+        def is_build_service(service_name, service):
+            if 'build' not in service:
+                return False
+            log.info("Service %s_%s is external and uses build, skipping" % (
+                name,
+                service_name))
+            return True
+
+        config = dict(
+            (name, service) for name, service in six.iteritems(config)
+            if not is_build_service(name, service))
+        return self.factory(name, config, self.client, project_cache=self)

--- a/fig/service.py
+++ b/fig/service.py
@@ -1,16 +1,18 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
+
 from collections import namedtuple
 import logging
-import re
-import os
 from operator import attrgetter
+import os
+import re
 import sys
 
 from docker.errors import APIError
 
-from .container import Container
-from .progress_stream import stream_output, StreamOutputError
+from fig.container import Container
+from fig.progress_stream import stream_output, StreamOutputError
+
 
 log = logging.getLogger(__name__)
 
@@ -82,6 +84,9 @@ VolumeSpec = namedtuple('VolumeSpec', 'external internal mode')
 
 
 ServiceName = namedtuple('ServiceName', 'project service number')
+
+
+ServiceLink = namedtuple('ServiceLink', 'service alias')
 
 
 class Service(object):
@@ -352,7 +357,10 @@ class Service(object):
             return [self.start_container_if_stopped(c) for c in containers]
 
     def get_linked_names(self):
-        return [s.name for (s, _) in self.links]
+        return [link.service.full_name for link in self.links]
+
+    def get_linked_services(self):
+        return [link.service for link in self.links]
 
     def _next_container_name(self, all_containers, one_off=False):
         bits = [self.project, self.name]
@@ -507,6 +515,12 @@ class Service(object):
                 image_name,
                 insecure_registry=insecure_registry
             )
+
+    def __repr__(self):
+        return "Service(%s, project='%s', links=%r)" % (
+            self.name,
+            self.project,
+            self.get_linked_names())
 
 
 NAME_RE = re.compile(r'^([^_]+)_([^_]+)_(run_)?(\d+)$')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ nose
 git+https://github.com/pyinstaller/pyinstaller.git@12e40471c77f588ea5be352f7219c873ddaae056#egg=pyinstaller
 unittest2
 flake8
+boto

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ PyYAML==3.10
 docker-py==0.6.0
 dockerpty==0.3.2
 docopt==0.6.1
+pytimeparse==1.1.2
 requests==2.2.1
 six==1.7.3
 texttable==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'docker-py >= 0.6.0, < 0.7',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
+    'pytimeparse >= 1.1.2',
 ]
 
 tests_require = [

--- a/tests/fixtures/external-includes-figfile/fig.yml
+++ b/tests/fixtures/external-includes-figfile/fig.yml
@@ -1,0 +1,20 @@
+
+project-config:
+  include:
+    projectb:
+      url: ./tests/fixtures/external-includes-figfile/project_b/fig.yml
+
+    projectc:
+      url: ./tests/fixtures/external-includes-figfile/project_c/fig.yml
+
+db:
+  image: busybox:latest
+  command: /bin/sleep 300
+
+webapp:
+  image: busybox:latest
+  command: /bin/sleep 300
+  links:
+    - db
+    - projectb_webapp
+    - projectc_webapp

--- a/tests/fixtures/external-includes-figfile/project_b/fig.yml
+++ b/tests/fixtures/external-includes-figfile/project_b/fig.yml
@@ -1,0 +1,23 @@
+
+project-config:
+  include:
+    proejctc:
+      url: ./tests/fixtures/external-includes-figfile/project_c/fig.yml
+
+db:
+  image: busybox:latest
+  command: /bin/sleep 300
+
+configs:
+  image: busybox:latest
+  volumes:
+    - /home
+
+webapp:
+  image: busybox:latest
+  command: /bin/sleep 300
+  links:
+    - db
+    - projectc_webapp
+  volumes_from:
+    - configs

--- a/tests/fixtures/external-includes-figfile/project_c/fig.yml
+++ b/tests/fixtures/external-includes-figfile/project_c/fig.yml
@@ -1,0 +1,14 @@
+
+configs:
+  image: busybox:latest
+  volumes:
+    - /home
+
+webapp:
+  image: busybox:latest
+  command: /bin/sleep 300
+  volumes_from:
+    - configs
+
+unrelated:
+  image: busybox:latest

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
+import contextlib
+import os
 import sys
 
-from six import StringIO
 from mock import patch
+from six import StringIO
 
 from .testcases import DockerClientTestCase
 from fig.cli.main import TopLevelCommand

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -449,6 +449,5 @@ def assert_has_links_and_volumes(
     if expected_links is not None:
         assert expected_links.issubset(set(container.links()))
 
-    # TODO: use container.get()
     if expected_volumes is not None:
-        assert expected_volumes == container.inspect()['VolumesRW'].keys()
+        assert expected_volumes == container.get('Volumes').keys()

--- a/tests/integration/includes_test.py
+++ b/tests/integration/includes_test.py
@@ -1,0 +1,33 @@
+
+from .. import unittest
+
+from fig.includes import (
+    FetchExternalConfigError,
+    get_project_from_http,
+    get_project_from_s3,
+    normalize_url,
+)
+
+
+class IncludeHttpTest(unittest.TestCase):
+
+    def test_get_project_from_http(self):
+        # returns JSON, but yaml can parse that just fine
+        url = normalize_url('http://httpbin.org/get')
+        project = get_project_from_http(url, {})
+        self.assertIn('url', project)
+
+    def test_get_project_from_http_with_http_error(self):
+        url = normalize_url('http://httpbin.org/status/404')
+        with self.assertRaises(FetchExternalConfigError) as exc_context:
+            get_project_from_http(url, {})
+        self.assertEqual(
+            'Failed to include http://httpbin.org/status/404: '
+            '404 Client Error: NOT FOUND',
+            str(exc_context.exception))
+
+    def test_get_project_from_http_with_connection_error(self):
+        url = normalize_url('http://hostdoesnotexist.bogus/')
+        with self.assertRaises(FetchExternalConfigError) as exc_context:
+            get_project_from_http(url, {'timeout': 2})
+        self.assertIn('Name or service not known', str(exc_context.exception))

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
-from fig.project import Project, ConfigurationError
+
 from fig.container import Container
+from fig.project import Project, ConfigurationError
+from fig.service import ServiceLink
 from .testcases import DockerClientTestCase
 
 
@@ -184,7 +186,7 @@ class ProjectTest(DockerClientTestCase):
     def test_project_up_starts_links(self):
         console = self.create_service('console')
         db = self.create_service('db', volumes=['/var/db'])
-        web = self.create_service('web', links=[(db, 'db')])
+        web = self.create_service('web', links=[ServiceLink(db, 'db')])
 
         project = Project('figtest', [web, db, console], self.client)
         project.start()

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -66,4 +66,5 @@ class CLITestCase(unittest.TestCase):
     def test_setup_logging(self):
         main.setup_logging()
         self.assertEqual(logging.getLogger().level, logging.DEBUG)
-        self.assertEqual(logging.getLogger('requests').propagate, False)
+        self.assertEqual(logging.getLogger('requests').level, logging.WARN)
+        self.assertEqual(logging.getLogger('boto').level, logging.WARN)

--- a/tests/unit/includes_test.py
+++ b/tests/unit/includes_test.py
@@ -1,0 +1,252 @@
+import contextlib
+import os.path
+import shutil
+import tempfile
+
+import boto.exception
+import boto.s3.connection
+import mock
+from .. import unittest
+
+from fig.includes import (
+    ExternalProjectCache,
+    FetchExternalConfigError,
+    LocalConfigCache,
+    fetch_external_config,
+    get_project_from_file,
+    get_project_from_s3,
+    normalize_url,
+    url_to_filename,
+)
+from fig.project import Project
+from fig.service import ConfigError
+
+
+class NormalizeUrlTest(unittest.TestCase):
+
+    def test_normalize_url_with_scheme(self):
+        url = normalize_url('HTTPS://example.com')
+        self.assertEqual(url.scheme, 'https')
+
+    def test_normalize_url_without_scheme(self):
+        url = normalize_url('./path/to/somewhere')
+        self.assertEqual(url.scheme, 'file')
+
+
+class GetProjectFromS3Test(unittest.TestCase):
+
+    @mock.patch('fig.includes.get_boto_conn', autospec=True)
+    def test_get_project_from_s3(self, mock_get_conn):
+        mock_bucket = mock_get_conn.return_value.get_bucket.return_value
+        mock_key = mock_bucket.get_key.return_value
+        mock_key.get_contents_as_string.return_value = 'foo:\n  build: .'
+        url = normalize_url('s3://bucket/path/to/key/fig.yml')
+
+        project = get_project_from_s3(url)
+        self.assertEqual(project, {'foo': {'build': '.'}})
+
+        mock_get_conn.assert_called_once_with()
+        mock_get_conn.return_value.get_bucket.assert_called_once_with('bucket')
+        mock_bucket.get_key.assert_called_once_with('/path/to/key/fig.yml')
+
+
+    @mock.patch('fig.includes.get_boto_conn', autospec=True)
+    def test_get_project_from_s3_not_found(self, mock_get_conn):
+        mock_bucket = mock_get_conn.return_value.get_bucket.return_value
+        mock_bucket.get_key.return_value = None
+        url = normalize_url('s3://bucket/path/to/key/fig.yml')
+
+        with self.assertRaises(FetchExternalConfigError) as exc_context:
+            get_project_from_s3(url)
+        self.assertEqual(
+            "Failed to include %s: Not Found" % url.geturl(),
+            str(exc_context.exception))
+
+    @mock.patch('fig.includes.get_boto_conn', autospec=True)
+    def test_get_project_from_s3_bucket_error(self, mock_get_conn):
+        mock_get_bucket = mock_get_conn.return_value.get_bucket
+        mock_get_bucket.side_effect = boto.exception.S3ResponseError(
+            404, "Bucket Not Found")
+
+        url = normalize_url('s3://bucket/path/to/key/fig.yml')
+        with self.assertRaises(FetchExternalConfigError) as exc_context:
+            get_project_from_s3(url)
+        self.assertEqual(
+            "Failed to include %s: S3ResponseError: 404 Bucket Not Found\n" %
+                url.geturl(), str(exc_context.exception))
+
+
+class FetchExternalConfigTest(unittest.TestCase):
+
+    def test_unsupported_scheme(self):
+        with self.assertRaises(ConfigError) as exc:
+            fetch_external_config(normalize_url("bogus://something"), None)
+        self.assertIn("bogus", str(exc.exception))
+
+    def test_fetch_from_file(self):
+        url = "./tests/fixtures/external-includes-figfile/fig.yml"
+        config = fetch_external_config(normalize_url(url), None)
+        self.assertEqual(
+            set(config.keys()),
+            set(['db', 'webapp', 'project-config']))
+
+
+class GetProjectFromFileWithNormalizeUrlTest(unittest.TestCase):
+
+    def setUp(self):
+        self.expected = set(['db', 'webapp', 'project-config'])
+        self.path = "tests/fixtures/external-includes-figfile/fig.yml"
+
+    def test_fetch_from_file_relative_no_context(self):
+        config = get_project_from_file(normalize_url(self.path))
+        self.assertEqual(set(config.keys()), self.expected)
+
+    def test_fetch_from_file_relative_with_context(self):
+        url = './' + self.path
+        config = get_project_from_file(normalize_url(url))
+        self.assertEqual(set(config.keys()), self.expected)
+
+    def test_fetch_from_file_absolute_path(self):
+        url = os.path.abspath(self.path)
+        config = get_project_from_file(normalize_url(url))
+        self.assertEqual(set(config.keys()), self.expected)
+
+    def test_fetch_from_file_relative_with_scheme(self):
+        url = 'file://./' + self.path
+        config = get_project_from_file(normalize_url(url))
+        self.assertEqual(set(config.keys()), self.expected)
+
+    def test_fetch_from_file_absolute_with_scheme(self):
+        url = 'file://' + os.path.abspath(self.path)
+        config = get_project_from_file(normalize_url(url))
+        self.assertEqual(set(config.keys()), self.expected)
+
+
+class LocalConfigCacheTest(unittest.TestCase):
+
+    url = "http://example.com/path/to/file.yml"
+
+    def setUp(self):
+        self.path = '/base/path'
+        self.ttl = 20
+
+    def test_url_to_filename(self):
+        path = '/base'
+        filename = url_to_filename(path, normalize_url(self.url))
+        expected = '/base/http%3A%2F%2Fexample.com%2Fpath%2Fto%2Ffile.yml'
+        self.assertEqual(filename, expected)
+
+    @mock.patch('fig.includes.time.time', autospec=True)
+    def test_is_fresh_false(self, mock_time):
+        cache = LocalConfigCache(self.path, self.ttl)
+        mock_time.return_value = 1000
+        self.assertFalse(cache.is_fresh(900))
+
+    @mock.patch('fig.includes.time.time', autospec=True)
+    def test_is_fresh_true(self, mock_time):
+        cache = LocalConfigCache(self.path, self.ttl)
+        mock_time.return_value = 1000
+        self.assertTrue(cache.is_fresh(990))
+
+    @mock.patch('fig.includes.os.path.isdir', autospec=True)
+    def test_from_config(self, mock_isdir):
+        mock_isdir.return_value = True
+        cache = LocalConfigCache.from_config({
+            'ttl': '6 min',
+            'path': '~/.cache-path'
+        })
+        self.assertEqual(cache.ttl, 360)
+        self.assertEqual(cache.path, os.path.expandvars('$HOME/.cache-path'))
+
+    def test_get_and_set(self):
+        url = normalize_url(self.url)
+        config = {'foo': {'image': 'busybox'}}
+
+        with temp_dir() as path:
+            cache = LocalConfigCache(path, self.ttl)
+
+            self.assertNotIn(url, cache)
+            cache[url] = config
+            self.assertIn(url, cache)
+            self.assertEqual(config, cache[url])
+
+
+@contextlib.contextmanager
+def temp_dir():
+    path = tempfile.mkdtemp()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)
+
+
+class ExternalProjectCacheTest(unittest.TestCase):
+
+    project_b = {
+        'url': 'http://example.com/project_b/fig.yml'
+    }
+
+    def setUp(self):
+        self.client = mock.Mock()
+        self.mock_factory = mock.create_autospec(Project.from_config)
+        self.externals = ExternalProjectCache({}, self.client, self.mock_factory)
+
+    def test_get_project_from_include_invalid_config(self):
+        with self.assertRaises(ConfigError) as exc:
+            self.externals.get_project_from_include('something', {})
+        self.assertIn(
+            "Project include 'something' requires a url",
+            str(exc.exception))
+
+    @mock.patch('fig.includes.fetch_external_config', autospec=True)
+    def test_get_external_projects_no_cache(self, mock_fetch):
+        name = 'project_b'
+        project = self.externals.get_project_from_include(name, self.project_b)
+
+        url = normalize_url(self.project_b['url'])
+        mock_fetch.assert_called_once_with(url, self.project_b)
+
+        self.mock_factory.assert_called_once_with(
+            name,
+            {},
+            self.client,
+            project_cache=self.externals)
+
+        self.assertEqual(project, self.mock_factory.return_value)
+        self.assertIn(url, self.externals.config_cache)
+        self.assertIn(url, self.externals.project_cache)
+
+    @mock.patch('fig.includes.fetch_external_config', autospec=True)
+    def test_get_external_projects_from_cache(self, mock_fetch):
+        mock_project = mock.create_autospec(Project)
+        url = normalize_url(self.project_b['url'])
+        self.externals.project_cache[url] = mock_project
+
+        name = 'project_b'
+        project = self.externals.get_project_from_include(name, self.project_b)
+
+        self.assertEqual(mock_fetch.called, False)
+        self.assertEqual(self.mock_factory.called, False)
+        self.assertEqual(project, mock_project)
+
+    def test_build_project_with_build_directive(self):
+        config = {
+            'foo': {'build': '.'},
+            'other': {'image': 'busybox'},
+        }
+        self.externals.factory = Project.from_config
+        with mock.patch('fig.includes.log', autospec=True) as mock_log:
+            project = self.externals.build_project('project', config)
+            self.assertEqual(len(project.services), 1)
+            self.assertEqual(project.services[0].full_name, 'project_other')
+
+            mock_log.info.assert_called_once_with(
+                "Service project_foo is external and uses build, skipping")
+
+    def test_get_config_from_config_cache(self):
+        url = normalize_url(self.project_b['url'])
+        mock_config = mock.Mock()
+        self.externals.config_cache = {url: mock_config}
+
+        config = self.externals.get_config(url, self.project_b)
+        self.assertEqual(mock_config, config)

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -1,7 +1,21 @@
 from __future__ import unicode_literals
+
+import docker
+import mock
 from .. import unittest
-from fig.service import Service
-from fig.project import Project, ConfigurationError
+
+from fig import includes
+from fig.service import (
+    Service,
+    ServiceLink,
+)
+from fig.project import (
+    ConfigurationError,
+    NoSuchService,
+    Project,
+    get_external_projects,
+)
+
 
 class ProjectTest(unittest.TestCase):
     def test_from_dict(self):
@@ -14,7 +28,7 @@ class ProjectTest(unittest.TestCase):
                 'name': 'db',
                 'image': 'busybox:latest'
             },
-        ], None)
+        ], None, None, None)
         self.assertEqual(len(project.services), 2)
         self.assertEqual(project.get_service('web').name, 'web')
         self.assertEqual(project.get_service('web').options['image'], 'busybox:latest')
@@ -38,7 +52,7 @@ class ProjectTest(unittest.TestCase):
                 'image': 'busybox:latest',
                 'volumes': ['/tmp'],
             }
-        ], None)
+        ], None, None, None)
 
         self.assertEqual(project.services[0].name, 'volume')
         self.assertEqual(project.services[1].name, 'db')
@@ -72,11 +86,11 @@ class ProjectTest(unittest.TestCase):
             client=None,
             image="busybox:latest",
         )
-        project = Project('test', [web], None)
+        project = Project('test', [web], None, None)
         self.assertEqual(project.get_service('web'), web)
 
     def test_get_service_with_project_name(self):
-        web = Service( project='figtest', name='web')
+        web = Service(project='figtest', name='web')
         project = Project('test', [web], None, None)
         self.assertEqual(project.get_service('test_web'), web)
 
@@ -86,24 +100,26 @@ class ProjectTest(unittest.TestCase):
             project.get_service('not_found')
 
     def test_get_service_from_external(self):
+        project_name = 'theproject'
         web = Service(project='test', name='web')
         external_web = Service(project='other', name='web')
-        external_project = Project('other', [external_web], None, None)
-        project = Project('test', [web], None, [external_project])
+        external_project = Project(
+            project_name + 'other',
+            [external_web],
+            None,
+            project_name)
+        project = Project(project_name, [web], None, None, [external_project])
 
         self.assertEqual(project.get_service('other_web'), external_web)
 
     def test_get_services_returns_all_services_without_args(self):
-        web = Service(
-            project='figtest',
-            name='web',
-        )
-        console = Service(
-            project='figtest',
-            name='console',
-        )
-        project = Project('test', [web, console], None)
-        self.assertEqual(project.get_services(), [web, console])
+        web = Service(project='figtest', name='web')
+        console = Service(project='figtest', name='console')
+        external_web = Service(project='servicea', name='web')
+
+        external_projects = [Project('servicea',[external_web], None, None)]
+        project = Project('test', [web, console], None, None, external_projects)
+        self.assertEqual(project.get_services(), [external_web, web, console])
 
     def test_get_services_returns_listed_services_with_args(self):
         web = Service(project='figtest', name='web')
@@ -161,3 +177,62 @@ class ProjectTest(unittest.TestCase):
     def test_get_links_no_links(self):
         project = Project('test', [], None)
         self.assertEqual(project.get_links(None, None), [])
+
+
+class GetExternalProjectsTest(unittest.TestCase):
+
+    project_includes = {
+        'project_b': {
+            'url': 'http://example.com/project_b/fig.yml'
+        },
+        'project_c': {
+            'url': 'http://example.com/project_c/fig.yml'
+        },
+    }
+
+    def setUp(self):
+        self.mock_client = mock.create_autospec(docker.Client)
+        self.mock_externals_cache = mock.create_autospec(
+            includes.ExternalProjectCache)
+        self.project_name = 'rootproject'
+
+    def test_get_external_projects_none(self):
+        self.assertEqual(get_external_projects({}, {}, None, None, None), [])
+
+    @mock.patch('fig.project.includes.LocalConfigCache', autospec=True)
+    @mock.patch('fig.project.includes.ExternalProjectCache', autospec=True)
+    def test_get_external_projects_empty_cache(
+            self,
+            mock_externals_cache,
+            mock_config_cache):
+        projects = get_external_projects(
+            self.project_includes,
+            {'ttl': 30},
+            self.mock_client,
+            self.project_name,
+            None)
+
+        self.assertEqual(len(projects), 2)
+        mock_externals_cache.assert_called_once_with(
+            mock_config_cache.from_config.return_value,
+            self.mock_client,
+            mock.ANY)
+
+        mock_config_cache.from_config.assert_called_once_with({'ttl': 30})
+
+        _, _, build_project = mock_externals_cache.mock_calls[0][1]
+        project = build_project('included', {}, self.mock_client)
+        self.assertEqual(project.name, 'rootprojectincluded')
+
+    def test_get_external_projects_with_cache(self):
+        projects = get_external_projects(
+            self.project_includes,
+            {},
+            self.mock_client,
+            self.project_name,
+            self.mock_externals_cache)
+
+        self.assertEqual(
+            [self.mock_externals_cache.get_project_from_include.return_value
+             for _ in range(2)],
+            projects)


### PR DESCRIPTION
Resolves #318

Adds support for including other `fig.yml` files by url (or relative path).  

Requires an additional `fig.yml` key of `project-config` to support additional configuration.  I would see this being used for things like project name as well.

Feedback welcome