### PR TITLE
Don't attach stdin and stdout when in detach mode

### DIFF
--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -294,6 +294,7 @@ class TopLevelCommand(Command):
                     start_links=True,
                     recreate=False,
                     insecure_registry=insecure_registry,
+                    detach=options['-d']
                 )
 
         tty = True
@@ -309,6 +310,7 @@ class TopLevelCommand(Command):
             'command': command,
             'tty': tty,
             'stdin_open': not options['-d'],
+            'detach': options['-d'],
         }
 
         if options['-e']:
@@ -432,6 +434,7 @@ class TopLevelCommand(Command):
             start_links=start_links,
             recreate=recreate,
             insecure_registry=insecure_registry,
+            detach=options['-d']
         )
 
         to_attach = [c for s in project.get_services(service_names) for c in s.containers()]

--- a/fig/project.py
+++ b/fig/project.py
@@ -167,14 +167,14 @@ class Project(object):
             else:
                 log.info('%s uses an image, skipping' % service.name)
 
-    def up(self, service_names=None, start_links=True, recreate=True, insecure_registry=False):
+    def up(self, service_names=None, start_links=True, recreate=True, insecure_registry=False, detach=False):
         running_containers = []
         for service in self.get_services(service_names, include_links=start_links):
             if recreate:
-                for (_, container) in service.recreate_containers(insecure_registry=insecure_registry):
+                for (_, container) in service.recreate_containers(insecure_registry=insecure_registry, detach=detach):
                     running_containers.append(container)
             else:
-                for container in service.start_or_create_containers(insecure_registry=insecure_registry):
+                for container in service.start_or_create_containers(insecure_registry=insecure_registry, detach=detach):
                     running_containers.append(container)
 
         return running_containers

--- a/fig/service.py
+++ b/fig/service.py
@@ -157,7 +157,7 @@ class Service(object):
         # Create enough containers
         containers = self.containers(stopped=True)
         while len(containers) < desired_num:
-            containers.append(self.create_container())
+            containers.append(self.create_container(detach=True))
 
         running_containers = []
         stopped_containers = []
@@ -251,6 +251,7 @@ class Service(object):
             image=container.image,
             entrypoint=['/bin/echo'],
             command=[],
+            detach=True,
         )
         intermediate_container.start(volumes_from=container.id)
         intermediate_container.wait()
@@ -303,12 +304,15 @@ class Service(object):
         )
         return container
 
-    def start_or_create_containers(self, insecure_registry=False):
+    def start_or_create_containers(self, insecure_registry=False, detach=False):
         containers = self.containers(stopped=True)
 
         if not containers:
             log.info("Creating %s..." % self._next_container_name(containers))
-            new_container = self.create_container(insecure_registry=insecure_registry)
+            new_container = self.create_container(
+                insecure_registry=insecure_registry,
+                detach=detach
+            )
             return [self.start_container(new_container)]
         else:
             return [self.start_container_if_stopped(c) for c in containers]

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -332,6 +332,14 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('web')
         service.scale(1)
         self.assertEqual(len(service.containers()), 1)
+
+        # Ensure containers don't have stdout or stdin connected
+        container = service.containers()[0]
+        config = container.inspect()['Config']
+        self.assertFalse(config['AttachStderr'])
+        self.assertFalse(config['AttachStdout'])
+        self.assertFalse(config['AttachStdin'])
+
         service.scale(3)
         self.assertEqual(len(service.containers()), 3)
         service.scale(1)


### PR DESCRIPTION
This is primarily to make it work with Swarm, which checks that AttachStd{in,out,err} is false when creating containers.
