### PR TITLE
Add a --no-tail option to fig logs

### DIFF
--- a/fig/cli/log_printer.py
+++ b/fig/cli/log_printer.py
@@ -10,16 +10,17 @@ from .utils import split_buffer
 
 
 class LogPrinter(object):
-    def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False):
+    def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False, tail=True):
         self.containers = containers
         self.attach_params = attach_params or {}
         self.prefix_width = self._calculate_prefix_width(containers)
         self.generators = self._make_log_generators(monochrome)
+        self.tail = tail
         self.output = output
 
     def run(self):
         mux = Multiplexer(self.generators)
-        for line in mux.loop():
+        for line in mux.loop(self.tail):
             self.output.write(line)
 
     def _calculate_prefix_width(self, containers):

--- a/fig/cli/main.py
+++ b/fig/cli/main.py
@@ -151,12 +151,14 @@ class TopLevelCommand(Command):
 
         Options:
             --no-color  Produce monochrome output.
+            --no-tail   Prints logs to stdout and returns.
         """
         containers = project.containers(service_names=options['SERVICE'], stopped=True)
 
         monochrome = options['--no-color']
+        tail = not options['--no-tail']
         print("Attaching to", list_containers(containers))
-        LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome).run()
+        LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome, tail=tail).run()
 
     def port(self, project, options):
         """

--- a/fig/cli/multiplexer.py
+++ b/fig/cli/multiplexer.py
@@ -17,7 +17,7 @@ class Multiplexer(object):
         self.generators = generators
         self.queue = Queue()
 
-    def loop(self):
+    def loop(self, tail=True):
         self._init_readers()
 
         while True:
@@ -28,7 +28,10 @@ class Multiplexer(object):
                 else:
                     yield item
             except Empty:
-                pass
+                if tail:
+                    pass
+                else:
+                    break
 
     def _init_readers(self):
         for generator in self.generators:

--- a/tests/unit/log_printer_test.py
+++ b/tests/unit/log_printer_test.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 import os
+import time
 
 from fig.cli.log_printer import LogPrinter
 from .. import unittest
@@ -40,11 +41,20 @@ class LogPrinterTest(unittest.TestCase):
 
         self.assertIn(glyph, output)
 
+    def test_notail(self):
+        def reader(*args, **kwargs):
+            for count in xrange(3):
+                yield "keep going\n"
+                time.sleep(1)
 
-def run_log_printer(containers, monochrome=False):
+        container = MockContainer(reader)
+        output = run_log_printer([container], monochrome=False, tail=False)
+        self.assertEqual(output.count('\n'), 1)
+        
+def run_log_printer(containers, monochrome=False, tail=True):
     r, w = os.pipe()
     reader, writer = os.fdopen(r, 'r'), os.fdopen(w, 'w')
-    printer = LogPrinter(containers, output=writer, monochrome=monochrome)
+    printer = LogPrinter(containers, output=writer, monochrome=monochrome, tail=tail)
     printer.run()
     writer.close()
     return reader.read()


### PR DESCRIPTION
I'd prefer to have --tail be explicit for `fig logs`, but this would break backwards compatibility. The motivation behind wanting this is so I can redirect the output of `fig logs` into a file (e.g. on a CI server where I want the logs as an artifact).

Signed-off-by: Ben Taitelbaum <ben@coshx.com>