### PR TITLE
changes default logging behavior to not tail logs

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -10,16 +10,17 @@ from .utils import split_buffer
 
 
 class LogPrinter(object):
-    def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False):
+    def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False, tail=True):
         self.containers = containers
         self.attach_params = attach_params or {}
         self.prefix_width = self._calculate_prefix_width(containers)
         self.generators = self._make_log_generators(monochrome)
+        self.tail = tail
         self.output = output
 
     def run(self):
         mux = Multiplexer(self.generators)
-        for line in mux.loop():
+        for line in mux.loop(self.tail):
             self.output.write(line)
 
     def _calculate_prefix_width(self, containers):

--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -10,7 +10,7 @@ from .utils import split_buffer
 
 
 class LogPrinter(object):
-    def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False, tail=True):
+    def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False, tail=False):
         self.containers = containers
         self.attach_params = attach_params or {}
         self.prefix_width = self._calculate_prefix_width(containers)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -151,12 +151,14 @@ class TopLevelCommand(Command):
 
         Options:
             --no-color  Produce monochrome output.
+            --no-tail   Prints logs to stdout and returns.
         """
         containers = project.containers(service_names=options['SERVICE'], stopped=True)
 
         monochrome = options['--no-color']
+        tail = not options['--no-tail']
         print("Attaching to", list_containers(containers))
-        LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome).run()
+        LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome, tail=tail).run()
 
     def port(self, project, options):
         """

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -151,12 +151,12 @@ class TopLevelCommand(Command):
 
         Options:
             --no-color  Produce monochrome output.
-            --no-tail   Prints logs to stdout and returns.
+            --tail      Prints logs to stdout and returns.
         """
         containers = project.containers(service_names=options['SERVICE'], stopped=True)
 
         monochrome = options['--no-color']
-        tail = not options['--no-tail']
+        tail = options['--tail']
         print("Attaching to", list_containers(containers))
         LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome, tail=tail).run()
 

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -28,10 +28,8 @@ class Multiplexer(object):
                 else:
                     yield item
             except Empty:
-                if tail:
-                    pass
-                else:
-                    break
+                if not tail:
+                    return
 
     def _init_readers(self):
         for generator in self.generators:

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -17,7 +17,7 @@ class Multiplexer(object):
         self.generators = generators
         self.queue = Queue()
 
-    def loop(self):
+    def loop(self, tail=True):
         self._init_readers()
 
         while True:
@@ -28,7 +28,10 @@ class Multiplexer(object):
                 else:
                     yield item
             except Empty:
-                pass
+                if tail:
+                    pass
+                else:
+                    break
 
     def _init_readers(self):
         for generator in self.generators:

--- a/tests/unit/log_printer_test.py
+++ b/tests/unit/log_printer_test.py
@@ -49,7 +49,17 @@ class LogPrinterTest(unittest.TestCase):
 
         container = MockContainer(reader)
         output = run_log_printer([container], monochrome=False, tail=False)
-        self.assertEqual(output.count('\n'), 1)
+        self.assertEqual(output.count('keep going'), 1)
+
+    def test_tail(self):
+        def reader(*args, **kwargs):
+            for count in xrange(3):
+                yield "keep going\n"
+                time.sleep(1)
+
+        container = MockContainer(reader)
+        output = run_log_printer([container], monochrome=False, tail=True)
+        self.assertEqual(output.count('keep going'), 3)
         
 def run_log_printer(containers, monochrome=False, tail=True):
     r, w = os.pipe()

--- a/tests/unit/log_printer_test.py
+++ b/tests/unit/log_printer_test.py
@@ -45,7 +45,7 @@ class LogPrinterTest(unittest.TestCase):
         def reader(*args, **kwargs):
             for count in xrange(3):
                 yield "keep going\n"
-                time.sleep(1)
+                time.sleep(0.2)
 
         container = MockContainer(reader)
         output = run_log_printer([container], monochrome=False, tail=False)
@@ -55,7 +55,7 @@ class LogPrinterTest(unittest.TestCase):
         def reader(*args, **kwargs):
             for count in xrange(3):
                 yield "keep going\n"
-                time.sleep(1)
+                time.sleep(0.2)
 
         container = MockContainer(reader)
         output = run_log_printer([container], monochrome=False, tail=True)


### PR DESCRIPTION
  - adds a `--tail` option to `fig logs`
  - see docker/fig#802 for discussion of `--tail` vs `--no-tail`

Signed-off-by: Ben Taitelbaum <ben@coshx.com>