### PR TITLE
Recognise container id's in instance name

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -517,7 +517,7 @@ class Service(object):
             )
 
 
-NAME_RE = re.compile(r'^([^_]+)_([^_]+)_(run_)?(\d+)$')
+NAME_RE = re.compile(r'^([^_]+)_([^_]+)_(run_)?([\da-f]+]+)$')
 
 
 def is_valid_name(name, one_off=False):


### PR DESCRIPTION
This change is to allow fig to stop spawned containers that match a container id.

For example if the container is named `project_service_1`. And that container spawns a child container that is named `project_service_1adbf8551905`. Then this change will recognise the hexadecimal characters in the last part (taken from the container id).

We want this since we cannot name spawned containers as _2, _3 as that may interfere with the regular multi-instance mechanism. Yet we want `fig stop` to be able to stop any running spawned container(s) that are a part of the same running service.

This change is specifically requested for Sven's popular samba image to work better in fig. (but also for any other plugins using the same general pattern / mechanism).