### PR TITLE
Add support for docker's client's --add-host command

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -70,6 +70,23 @@ external_links:
  - project_db_1:postgresql
 ```
 
+### extra_hosts
+
+Add hostname mappings. Use the same values as the docker client `--add-hosts` parameter.
+
+```
+extra_hosts:
+ - docker: 162.242.195.82
+ - fig: 50.31.209.229
+```
+
+An entry with the ip address and hostname will be created in `/etc/hosts` inside containers for this service, e.g:
+
+```
+162.242.195.82  docker
+50.31.209.229   fig
+```
+
 ### ports
 
 Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container port (a random host port will be chosen).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==0.6.0
+docker-py==0.7.1
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 0.12',
-    'docker-py >= 0.6.0, < 0.7',
+    'docker-py >= 0.7.1, < 0.8',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -106,6 +106,20 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(container.inspect()['Config']['CpuShares'], 73)
 
+    def test_create_container_with_extra_hosts_list(self):
+        extra_hosts = ['docker:162.242.195.82', 'fig:50.31.209.229']
+        service = self.create_service('db', extra_hosts=extra_hosts)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.ExtraHosts'), extra_hosts)
+
+    def test_create_container_with_extra_hosts_string(self):
+        extra_hosts = 'docker:162.242.195.82'
+        service = self.create_service('db', extra_hosts=extra_hosts)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.ExtraHosts'), [extra_hosts])
+
     def test_create_container_with_specified_volume(self):
         host_path = '/tmp/host-path'
         container_path = '/container-path'


### PR DESCRIPTION
Updated docker-py to the most recent version ( 0.7.1), which allows assigning values to extra_hosts (similar to ---add-host.)  Updated fig to allow passing in these parameters and added tests.

Implementation requested in the following issues:
#597 
#754 