### PR TITLE
Preserve individual volumes on recreate

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -317,10 +317,7 @@ class TopLevelCommand(Command):
         }
 
         if options['-e']:
-            # Merge environment from config with -e command line
-            container_options['environment'] = dict(
-                parse_environment(service.options.get('environment')),
-                **parse_environment(options['-e']))
+            container_options['environment'] = parse_environment(options['-e'])
 
         if options['--entrypoint']:
             container_options['entrypoint'] = options.get('--entrypoint')

--- a/compose/container.py
+++ b/compose/container.py
@@ -45,6 +45,10 @@ class Container(object):
         return self.dictionary['Image']
 
     @property
+    def image_config(self):
+        return self.client.inspect_image(self.image)
+
+    @property
     def short_id(self):
         return self.id[:10]
 


### PR DESCRIPTION
Resolves: #836

When a container is being recreated (during `docker-compose up`) we use `volumes-from` to copy every volume over to the new container. This has lead to a lot of confusion (there are numerous github issues, and stackoverflow questions about it).

Instead of blanket copying every volume with `volumes-from` this PR changes the behaviour to only copy over container data volumes that are still present in the configuration. Host volumes, and volumes that were removed from the configuration will no longer be copied over (although host volumes are still applied, they just aren't copied) .

#711 was the first attempt, but wasn't compatible with docker 1.4.1+
Related Issue #447
