### PR TITLE
service.py: configurable entrypoint

### DIFF
--- a/fig/service.py
+++ b/fig/service.py
@@ -284,7 +284,7 @@ class Service(object):
         intermediate_container = Container.create(
             self.client,
             image=container.image,
-            entrypoint=['/bin/echo'],
+            entrypoint=intermediate_options.get('entrypoint', '/bin/echo'),
             command=[],
             detach=True,
         )


### PR DESCRIPTION
In case your image is small enough to not contain /bin/echo, fig will 
not work properly failing with "stat /bin/echo: no such file or directory".

Fixes #514, #613, #843