### PR TITLE
Add timeout flag to stop, restart, and up

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -387,17 +387,29 @@ class TopLevelCommand(Command):
 
         They can be started again with `docker-compose start`.
 
-        Usage: stop [SERVICE...]
+        Usage: stop [options] [SERVICE...]
+
+        Options:
+          -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
+                                     (default: 10)
         """
-        project.stop(service_names=options['SERVICE'])
+        timeout = options.get('--timeout')
+        params = {} if timeout is None else {'timeout': int(timeout)}
+        project.stop(service_names=options['SERVICE'], **params)
 
     def restart(self, project, options):
         """
         Restart running containers.
 
-        Usage: restart [SERVICE...]
+        Usage: restart [options] [SERVICE...]
+
+        Options:
+          -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
+                                     (default: 10)
         """
-        project.restart(service_names=options['SERVICE'])
+        timeout = options.get('--timeout')
+        params = {} if timeout is None else {'timeout': int(timeout)}
+        project.restart(service_names=options['SERVICE'], **params)
 
     def up(self, project, options):
         """
@@ -416,14 +428,17 @@ class TopLevelCommand(Command):
         Usage: up [options] [SERVICE...]
 
         Options:
-            --allow-insecure-ssl  Allow insecure connections to the docker
-                                  registry
-            -d                    Detached mode: Run containers in the background,
-                                  print new container names.
-            --no-color            Produce monochrome output.
-            --no-deps             Don't start linked services.
-            --no-recreate         If containers already exist, don't recreate them.
-            --no-build            Don't build an image, even if it's missing
+            --allow-insecure-ssl   Allow insecure connections to the docker
+                                   registry
+            -d                     Detached mode: Run containers in the background,
+                                   print new container names.
+            --no-color             Produce monochrome output.
+            --no-deps              Don't start linked services.
+            --no-recreate          If containers already exist, don't recreate them.
+            --no-build             Don't build an image, even if it's missing
+            -t, --timeout TIMEOUT  When attached, use this timeout in seconds
+                                   for the shutdown. (default: 10)
+
         """
         insecure_registry = options['--allow-insecure-ssl']
         detached = options['-d']
@@ -439,7 +454,7 @@ class TopLevelCommand(Command):
             start_links=start_links,
             recreate=recreate,
             insecure_registry=insecure_registry,
-            detach=options['-d'],
+            detach=detached,
             do_build=not options['--no-build'],
         )
 
@@ -458,7 +473,9 @@ class TopLevelCommand(Command):
                 signal.signal(signal.SIGINT, handler)
 
                 print("Gracefully stopping... (press Ctrl+C again to force)")
-                project.stop(service_names=service_names)
+                timeout = options.get('--timeout')
+                params = {} if timeout is None else {'timeout': int(timeout)}
+                project.stop(service_names=service_names, **params)
 
 
 def list_containers(containers):

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -1,7 +1,7 @@
 #!bash
 #
 # bash completion for docker-compose
-# 
+#
 # This work is based on the completion for the docker command.
 #
 # This script provides completion of:
@@ -196,7 +196,20 @@ _docker-compose_pull() {
 
 
 _docker-compose_restart() {
-	__docker-compose_services_running
+	case "$prev" in
+		-t | --timeout)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "-t --timeout" -- "$cur" ) )
+			;;
+		*)
+			__docker-compose_services_running
+			;;
+	esac
 }
 
 
@@ -221,7 +234,7 @@ _docker-compose_run() {
 			;;
 		--entrypoint)
 			return
-			;;	
+			;;
 	esac
 
 	case "$cur" in
@@ -254,14 +267,33 @@ _docker-compose_start() {
 
 
 _docker-compose_stop() {
-	__docker-compose_services_running
+	case "$prev" in
+		-t | --timeout)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "-t --timeout" -- "$cur" ) )
+			;;
+		*)
+			__docker-compose_services_running
+			;;
+	esac
 }
 
 
 _docker-compose_up() {
+	case "$prev" in
+		-t | --timeout)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --no-build --no-color --no-deps --no-recreate" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --no-build --no-color --no-deps --no-recreate -t --timeout" -- "$cur" ) )
 			;;
 		*)
 			__docker-compose_services_all


### PR DESCRIPTION
I am in the unfortunate situation, where one container takes a rather
long time to shut down. It's like a database, that flushes the whole
dataset to disk or rather to the mounted volume.
The default timeout of 10 seconds (by docker-py, actually) kills of the
shutdown process, leaving my container with corrupted state.

This PR adds the possiblity to increase the timeout for
`stop`, `restart`, and `up` (only relevant if not `-d`).