### PR TITLE
Missing router.php file in php command

### DIFF
--- a/wordpress.html
+++ b/wordpress.html
@@ -32,7 +32,7 @@ ADD . /code
 <p>Next up, <code>fig.yml</code> starts our web service and a separate MySQL instance:</p>
 <div class="highlight"><pre><code class="text language-text" data-lang="text">web:
   build: .
-  command: php -S 0.0.0.0:8000 -t /code
+  command: php -S 0.0.0.0:8000 -t /code router.php
   ports:
     - &quot;8000:8000&quot;
   links:

--- a/wordpress.html
+++ b/wordpress.html
@@ -32,7 +32,7 @@ ADD . /code
 <p>Next up, <code>fig.yml</code> starts our web service and a separate MySQL instance:</p>
 <div class="highlight"><pre><code class="text language-text" data-lang="text">web:
   build: .
-  command: php -S 0.0.0.0:8000 -t /code router.php
+  command: php -S 0.0.0.0:8000 -t /code /code/router.php
   ports:
     - &quot;8000:8000&quot;
   links:


### PR DESCRIPTION
The `router.php`was missing in the `php -S`command, and the router was therefore never called.