### PR TITLE
Enhanced version information and Docker-like version command

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -48,7 +48,7 @@ class Command(DocoptCommand):
                 raise errors.ConnectionErrorGeneric(self.get_client().base_url)
 
     def perform_command(self, options, handler, command_options):
-        if options['COMMAND'] == 'help':
+        if options['COMMAND'] in ('help', 'version'):
             # Skip looking up the compose file.
             handler(None, command_options)
             return

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -10,8 +10,7 @@ import sys
 from docker.errors import APIError
 import dockerpty
 
-from .. import __version__
-from .. import legacy
+from .. import __version__, legacy
 from ..project import NoSuchService, ConfigurationError
 from ..service import BuildError, CannotBeScaledError, NeedsBuildError
 from ..config import parse_environment
@@ -20,7 +19,7 @@ from .docopt_command import NoSuchCommand
 from .errors import UserError
 from .formatter import Formatter
 from .log_printer import LogPrinter
-from .utils import yesno
+from .utils import yesno, get_version_info
 
 log = logging.getLogger(__name__)
 
@@ -100,11 +99,12 @@ class TopLevelCommand(Command):
       stop               Stop services
       up                 Create and start containers
       migrate-to-labels  Recreate containers to add labels
+      version            Show the Docker-Compose version information
 
     """
     def docopt_options(self):
         options = super(TopLevelCommand, self).docopt_options()
-        options['version'] = "docker-compose %s" % __version__
+        options['version'] = get_version_info('compose')
         return options
 
     def build(self, project, options):
@@ -496,6 +496,20 @@ class TopLevelCommand(Command):
         Usage: migrate-to-labels
         """
         legacy.migrate_project_to_labels(project)
+
+    def version(self, project, options):
+        """
+        Show version informations
+
+        Usage: version [--short]
+
+        Options:
+            --short     Shows only Compose's version number.
+        """
+        if options['--short']:
+            print(__version__)
+        else:
+            print(get_version_info('full'))
 
 
 def list_containers(containers):

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -1,10 +1,13 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from __future__ import division
+
+from .. import __version__
 import datetime
+from docker import version as docker_py_version
 import os
-import subprocess
 import platform
+import subprocess
 
 
 def yesno(prompt, default=None):
@@ -120,3 +123,15 @@ def is_mac():
 
 def is_ubuntu():
     return platform.system() == 'Linux' and platform.linux_distribution()[0] == 'Ubuntu'
+
+
+def get_version_info(scope):
+    versioninfo = 'docker-compose version: %s' % __version__
+    if scope == 'compose':
+        return versioninfo
+    elif scope == 'full':
+        return versioninfo + '\n' \
+            + "docker-py version: %s\n" % docker_py_version \
+            + "%s version: %s" % (platform.python_implementation(), platform.python_version())
+    else:
+        raise RuntimeError('passed unallowed value to `cli.utils.get_version_info`')


### PR DESCRIPTION
I changed the version output, so also information about Python and docker-py are shown. Also implemented a command version to mimic Docker.

This is intended for trouble-shooting situations and to match Docker's behaviour.