### PR TITLE
fix version string - using pep0440

### DIFF
--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import unicode_literals
 from .service import Service  # noqa:flake8
 
-__version__ = '1.1.0-rc2'
+__version__ = '1.1.0rc2'


### PR DESCRIPTION
Using the PEP 0440 conversion to version name: https://www.python.org/dev/peps/pep-0440/#examples-of-compliant-version-schemes