### PR TITLE
Favour yml and yaml extensions in bash completion for -f

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -94,7 +94,7 @@ _docker-compose_build() {
 _docker-compose_docker-compose() {
 	case "$prev" in
 		--file|-f)
-			_filedir
+			_filedir y?(a)ml
 			return
 			;;
 		--project-name|-p)


### PR DESCRIPTION
When completing `docker-compose -f`, all non *.yml and *.yaml files now are ignored.