### PR TITLE
Provide user override option on command line

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -275,6 +275,7 @@ class TopLevelCommand(Command):
                                   new container name.
             --entrypoint CMD      Override the entrypoint of the image.
             -e KEY=VAL            Set an environment variable (can be used multiple times)
+            -u, --user=""         Run as specified username or uid
             --no-deps             Don't start linked services.
             --rm                  Remove container after run. Ignored in detached mode.
             --service-ports       Run command with the service's ports enabled and mapped
@@ -322,6 +323,10 @@ class TopLevelCommand(Command):
 
         if options['--entrypoint']:
             container_options['entrypoint'] = options.get('--entrypoint')
+
+        if options['--user']:
+            container_options['user'] = options.get('--user')
+
         container = service.create_container(
             one_off=True,
             insecure_registry=insecure_registry,

--- a/tests/fixtures/user-composefile/docker-compose.yml
+++ b/tests/fixtures/user-composefile/docker-compose.yml
@@ -1,0 +1,4 @@
+service:
+  image: busybox:latest
+  user: notauser
+  command: id

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -232,6 +232,28 @@ class CLITestCase(DockerClientTestCase):
         )
 
     @patch('dockerpty.start')
+    def test_run_service_with_user_overridden(self, _):
+        self.command.base_dir = 'tests/fixtures/user-composefile'
+        name = 'service'
+        user = 'sshd'
+        args = ['run', '--user={}'.format(user), name]
+        self.command.dispatch(args, None)
+        service = self.project.get_service(name)
+        container = service.containers(stopped=True, one_off=True)[0]
+        self.assertEqual(user, container.get('Config.User'))
+
+    @patch('dockerpty.start')
+    def test_run_service_with_user_overridden_short_form(self, _):
+        self.command.base_dir = 'tests/fixtures/user-composefile'
+        name = 'service'
+        user = 'sshd'
+        args = ['run', '-u', user, name]
+        self.command.dispatch(args, None)
+        service = self.project.get_service(name)
+        container = service.containers(stopped=True, one_off=True)[0]
+        self.assertEqual(user, container.get('Config.User'))
+
+    @patch('dockerpty.start')
     def test_run_service_with_environement_overridden(self, _):
         name = 'service'
         self.command.base_dir = 'tests/fixtures/environment-composefile'

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -120,6 +120,7 @@ class CLITestCase(unittest.TestCase):
             'SERVICE': 'service',
             'COMMAND': None,
             '-e': ['BAR=NEW', 'OTHER=THREE'],
+            '--user': None,
             '--no-deps': None,
             '--allow-insecure-ssl': None,
             '-d': True,


### PR DESCRIPTION
Allow overriding a user on the command line from the one specified in
the docker-compose.yml

Based on commit f2f01e207b491866349db7168e3d48082d7abdda by @chmouel
See: https://github.com/docker/fig/pull/737

Signed-off-by: Ian VanSchooten <ian@badgelabsllc.com>