### PR TITLE
Make Swarm schedule containers on the same node when they are linked together

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -32,4 +32,4 @@ def docker_client():
         )
 
     timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
-    return Client(base_url=base_url, tls=tls_config, version='1.14', timeout=timeout)
+    return Client(base_url=base_url, tls=tls_config, version='1.15', timeout=timeout)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -328,20 +328,20 @@ class TopLevelCommand(Command):
         if options['--user']:
             container_options['user'] = options.get('--user')
 
+        if not options['--service-ports']:
+            container_options['ports'] = []
+
         container = service.create_container(
             one_off=True,
             insecure_registry=insecure_registry,
             **container_options
         )
 
-        service_ports = None
-        if options['--service-ports']:
-            service_ports = service.options['ports']
         if options['-d']:
-            service.start_container(container, ports=service_ports, one_off=True)
+            service.start_container(container)
             print(container.name)
         else:
-            service.start_container(container, ports=service_ports, one_off=True)
+            service.start_container(container)
             dockerpty.start(project.client, container.id, interactive=not options['-T'])
             exit_code = container.wait()
             if options['--rm']:

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -13,7 +13,7 @@ from .testcases import DockerClientTestCase
 
 def create_and_start_container(service, **override_options):
     container = service.create_container(**override_options)
-    return service.start_container(container, **override_options)
+    return service.start_container(container)
 
 
 class ServiceTest(DockerClientTestCase):


### PR DESCRIPTION
... by specifying all HostConfig at create time. This is required for [Swarm integration](https://github.com/docker/fig/issues/814): the cluster needs to know about config like `links` and `volumes_from` at create time so that it can co-schedule containers. This is particularly important because we rely on `volumes_from` when recreating containers - if the old/intermediate/new containers aren't co-scheduled, they'll fail to start.

Because the ability to specify HostConfig at create time was introduced in Docker 1.4, that's our new minimum version requirement. The install docs have been updated accordingly.
