### PR TITLE
Use docker-py 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==0.7.1
+docker-py==1.0.0
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.2.1, < 3',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 1.0',
-    'docker-py >= 0.6.0, < 0.8',
+    'docker-py >= 1.0.0, < 1.1.0',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -19,4 +19,4 @@ class DockerClientTestCase(unittest.TestCase):
         with mock.patch.dict(os.environ):
             os.environ['DOCKER_CLIENT_TIMEOUT'] = timeout = "300"
             client = docker_client.docker_client()
-        self.assertEqual(client._timeout, int(timeout))
+        self.assertEqual(client.timeout, int(timeout))


### PR DESCRIPTION
This seems to fix an issue where `docker-compose` tries to connect to private docker registry via HTTP instead of HTTPS, so the auth data in `.dockercfg` doesn't match the URL, causing authentication to fail.

(Also, `1.0.0` is a Good Thing)

Let me know if `< 2.0.0` is too permissive. Minimum version is `1.0.0` because `Client.timeout` is a public attribute from `1.0.0`, breaking the (so far not public) api of `Client._timeout`.