### PR TITLE
Stack traces when DOCKER_HOST is invalid Issue:945

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -1,5 +1,6 @@
 from docker import Client
 from docker import tls
+from . import errors
 import ssl
 import os
 
@@ -17,6 +18,8 @@ def docker_client():
     tls_config = None
 
     if os.environ.get('DOCKER_TLS_VERIFY', '') != '':
+        if not base_url and not base_url.strip():
+            raise errors.TLSParameterError()
         parts = base_url.split('://', 1)
         base_url = '%s://%s' % ('https', parts[1])
 

--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -62,3 +62,12 @@ class ComposeFileNotFound(UserError):
 
         Supported filenames: %s
         """ % ", ".join(supported_filenames))
+
+
+class TLSParameterError(UserError):
+    def __init__(self):
+        super(TLSParameterError, self).__init__("""
+        TLS configured but no DOCKER_HOST is set.
+
+        See http://docs.docker.com/examples/https/ for client configurations.
+        """)

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -5,7 +5,9 @@ import os
 import mock
 from tests import unittest
 
+from compose.cli import errors
 from compose.cli import docker_client 
+
 
 
 class DockerClientTestCase(unittest.TestCase):
@@ -20,3 +22,12 @@ class DockerClientTestCase(unittest.TestCase):
             os.environ['DOCKER_CLIENT_TIMEOUT'] = timeout = "300"
             client = docker_client.docker_client()
         self.assertEqual(client._timeout, int(timeout))
+
+    def test_docker_client_tls_no_docker_host(self):
+        with mock.patch.dict(os.environ):
+            os.environ['DOCKER_HOST'] = ''
+            os.environ['DOCKER_TLS_VERIFY'] = '1'
+            try:
+                docker_client.docker_client()
+            except errors.TLSParameterError:
+                pass


### PR DESCRIPTION
Throws an error if the docker client is attempting to use TLS via a unix socket through not setting a Docker Home env variable. Includes test, and new TLSParameterError class.

The Docker Client model throws this error but behaves differently in Compose as TLS is configured prior to creating the Client object in docker_client.py. Suppresses the stack traces through the error class.

This is my first pull request against Compose so let me know if I've made some incorrect assumptions or my style is poor.