### PR TITLE
feature: variables for scale: id, hostname

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: docker-compose.yml reference variables
+page_title: docker-compose.yml reference variables
+page_description: docker-compose.yml reference variables
+page_keywords: fig, composition, compose, docker
+---
+
+# docker-compose.yml reference variables
+
+When you scale a service defined in  `docker-compose.yml`, container names
+are automatically generated with the pattern PROJECTNAME_SERVICE_NUM.
+
+To allow conflicting hostnames, you can use the %%id%% placeholder, that
+will be replaced with the container number.
+
+This approach avoids messing with environment and all its security issues
+and perks (eg. involving bash variable expansion)
+
+```
+test:
+  image: busybox:latest
+  hostname: box-%%id%%
+```
+
+The placeholders: %%id%% and %%hostname%% are available to the 'command' options.
+You can then:
+
+```
+mysql:
+  image: ioggstream/mysql
+  hostname: db-%%id%%
+  ...
+  command: mysqld --server-id=%%id%% --relay-log=%%hostname%%-relay-log
+
+```
+
+To avoid conflicts in numeric fields (eg: server-id) you can just prepend a
+large integer (eg. 100)
+
+```
+master:
+  image: ioggstream/mysql
+  hostname: master-%%id%%
+  ...
+  command: mysqld --server-id=100%%id%% --relay-log=%%hostname%%-relay-log
+
+slave:
+  image: ioggstream/mysql
+  hostname: slave-%%id%%
+  ...
+  command: mysqld --server-id=%%id%% --relay-log=%%hostname%%-relay-log
+
+
+```
+
+
+### Running
+
+When running with:
+
+```
+#docker-compose scale master=1 slave=3
+```
+
+You get
+
+```
+#docker inspect -f '{{.Name}} {{.Config.Hostname}}' $(docker ps -q) | column -t
+/db_slave_3               slave-3
+/db_slave_2               slave-2
+/db_slave_1               slave-1
+/db_master_1              master-1
+```
+

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -161,6 +161,42 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(port_bindings["1000"],[("127.0.0.1","1000")])
         self.assertEqual(port_bindings["2000"],[("127.0.0.1","2000")])
 
+    def test_replace_container_num_hostname(self):
+        service = Service('foo', hostname='name-%%id%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['hostname'], 'name-1', 'hostname')
+
+    def test_replace_container_num_command(self):
+        service = Service('foo', hostname='name-%%id%%', command='echo %%id%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], 'echo 1', 'command')
+
+    def test_replace_container_num_command_list(self):
+        service = Service('foo', hostname='name-%%id%%', command=['echo', '%%id%%'], client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], ['echo', '1'], 'command')
+
+    def test_replace_hostname_command(self):
+        service = Service('foo', hostname='name', command='echo %%hostname%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], 'echo name', 'command')
+
+    def test_replace_hostname_command_list(self):
+        service = Service('foo', hostname='name', command=['echo', '%%hostname%%'], client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], ['echo', 'name'], 'command')
+
+    def test_replace_hostname_hostname(self):
+        service = Service('foo', hostname='name-%%hostname%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['hostname'], 'name-%%hostname%%', 'hostname')
+
     def test_split_domainname_none(self):
         service = Service('foo', hostname='name', client=self.mock_client)
         self.mock_client.containers.return_value = []


### PR DESCRIPTION
This patch enables parametric hostnames and commands when using `scale`
avoiding all bash variables expansion issues.

```
# docker-compose scale test=4
test:
  image: busybox:latest
  hostname: test-%%id%%
  command: runme.sh %%hostname%%
```

Signed-off-by: Roberto Polli <robipolli@gmail.com>