### PR TITLE
Add a --pid=host feature to expose the host PID space to the container

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -20,6 +20,7 @@ DOCKER_CONFIG_KEYS = [
     'links',
     'mem_limit',
     'net',
+    'pid',
     'ports',
     'privileged',
     'restart',

--- a/compose/service.py
+++ b/compose/service.py
@@ -25,6 +25,7 @@ DOCKER_START_KEYS = [
     'dns_search',
     'env_file',
     'net',
+    'pid',
     'privileged',
     'restart',
 ]
@@ -434,6 +435,7 @@ class Service(object):
         privileged = options.get('privileged', False)
         cap_add = options.get('cap_add', None)
         cap_drop = options.get('cap_drop', None)
+        pid = options.get('pid', None)
 
         dns = options.get('dns', None)
         if isinstance(dns, six.string_types):
@@ -457,6 +459,7 @@ class Service(object):
             restart_policy=restart,
             cap_add=cap_add,
             cap_drop=cap_drop,
+            pid_mode=pid
         )
 
     def _get_image_name(self, image):

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -264,6 +264,16 @@ net: "none"
 net: "container:[name or id]"
 net: "host"
 ```
+### pid
+
+```
+pid: "host"
+```
+
+Sets the PID mode to the host PID mode.  This turns on sharing between
+container and the host operating system the PID address space.  Containers
+launched with this flag will be able to access and manipulate other
+containers in the bare-metal machine's namespace and vise-versa.
 
 ### dns
 

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -419,6 +419,17 @@ class ServiceTest(DockerClientTestCase):
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.NetworkMode'), 'host')
 
+    def test_pid_mode_none_defined(self):
+        service = self.create_service('web', pid=None)
+        container = create_and_start_container(service)
+        print 'STEAK %s' % (container.get('HostConfig.PidMode'))
+        self.assertEqual(container.get('HostConfig.PidMode'), '')
+
+    def test_pid_mode_host(self):
+        service = self.create_service('web', pid='host')
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.PidMode'), 'host')
+
     def test_dns_no_value(self):
         service = self.create_service('web')
         container = create_and_start_container(service)


### PR DESCRIPTION
Docker 1.5.0 introduces a --pid=host feature which is fantastic for monitoring
containers from the baremetal system or atomically upgrading or rolling back
a deployed application.

For more details of a real-life use case, check out:
http://sdake.io/2015/01/28/an-atomic-upgrade-process-for-openstack-compute-nodes/

Docker-DCO-1.1-Signed-off-by: Steven Dake <stdake@cisco.com> sdake@github