### PR TITLE
Fix requests version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def find_version(*file_paths):
 install_requires = [
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.2.1, < 3',
+    'requests >= 2.2.1, < 2.5.0',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 1.0',
     'docker-py >= 0.6.0, < 0.8',


### PR DESCRIPTION
It was more permissive than docker-py's, resulting in an incompatible version (2.5.x) being installed.

Long-term, docker-py should update its requirement (see https://github.com/docker/docker-py/pull/469) and we should update docker-py (see #997, for example) but this is critical as docker-compose 1.1.0-rc2 on PyPi is broken.

Closes #918.