### PR TITLE
Modern exception syntax support, otherwise fails on python 3.4

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -25,7 +25,7 @@ class Command(DocoptCommand):
     def dispatch(self, *args, **kwargs):
         try:
             super(Command, self).dispatch(*args, **kwargs)
-        except SSLError, e:
+        except SSLError as e:
             raise errors.UserError('SSL error: %s' % e)
         except ConnectionError:
             if call_silently(['which', 'docker']) != 0:

--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -46,7 +46,7 @@ class LogPrinter(object):
             if monochrome:
                 color_fn = no_color
             else:
-                color_fn = color_fns.next()
+                color_fn = next(color_fns)
             generators.append(self._make_log_generator(container, color_fn))
 
         return generators
@@ -57,7 +57,7 @@ class LogPrinter(object):
         line_generator = split_buffer(self._attach(container), '\n')
 
         for line in line_generator:
-            yield prefix + line
+            yield prefix + line.encode('utf-8')
 
         exit_code = container.wait()
         yield color_fn("%s exited with code %s\n" % (container.name, exit_code))

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -75,7 +75,7 @@ def split_buffer(reader, separator):
     separator = str(separator)
 
     for data in reader:
-        buffered += data
+        buffered += str(data)
         while True:
             index = buffered.find(separator)
             if index == -1:

--- a/compose/cli/verbose_proxy.py
+++ b/compose/cli/verbose_proxy.py
@@ -9,7 +9,7 @@ import six
 
 def format_call(args, kwargs):
     args = (repr(a) for a in args)
-    kwargs = ("{0!s}={1!r}".format(*item) for item in six.iteritems(kwargs))
+    kwargs = ("{0!s}={1!r}".format(*item) for item in six.items(kwargs))
     return "({0})".format(", ".join(chain(args, kwargs)))
 
 

--- a/compose/container.py
+++ b/compose/container.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import six
-
+from functools import reduce
 
 class Container(object):
     """

--- a/compose/project.py
+++ b/compose/project.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 import logging
 
+from functools import reduce
 from .service import Service
 from .container import Container
 from docker.errors import APIError

--- a/compose/service.py
+++ b/compose/service.py
@@ -482,7 +482,7 @@ class Service(object):
 
         try:
             all_events = stream_output(build_output, sys.stdout)
-        except StreamOutputError, e:
+        except StreamOutputError as e:
             raise BuildError(self, unicode(e))
 
         image_id = None

--- a/compose/service.py
+++ b/compose/service.py
@@ -641,7 +641,7 @@ def merge_environment(options):
         else:
             env.update(options['environment'])
 
-    return dict(resolve_env(k, v) for k, v in env.iteritems())
+    return dict(resolve_env(k, v) for k, v in env.items())
 
 
 def split_env(env):

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -472,13 +472,13 @@ class ServiceTest(DockerClientTestCase):
     def test_split_env(self):
         service = self.create_service('web', environment=['NORMAL=F1', 'CONTAINS_EQUALS=F=2', 'TRAILING_EQUALS='])
         env = create_and_start_container(service).environment
-        for k,v in {'NORMAL': 'F1', 'CONTAINS_EQUALS': 'F=2', 'TRAILING_EQUALS': ''}.iteritems():
+        for k,v in {'NORMAL': 'F1', 'CONTAINS_EQUALS': 'F=2', 'TRAILING_EQUALS': ''}.items():
             self.assertEqual(env[k], v)
 
     def test_env_from_file_combined_with_env(self):
         service = self.create_service('web', environment=['ONE=1', 'TWO=2', 'THREE=3'], env_file=['tests/fixtures/env/one.env', 'tests/fixtures/env/two.env'])
         env = create_and_start_container(service).environment
-        for k,v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.iteritems():
+        for k,v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.items():
             self.assertEqual(env[k], v)
 
     def test_resolve_env(self):
@@ -488,7 +488,7 @@ class ServiceTest(DockerClientTestCase):
         os.environ['ENV_DEF'] = 'E3'
         try:
             env = create_and_start_container(service).environment
-            for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.iteritems():
+            for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
                 self.assertEqual(env[k], v)
         finally:
             del os.environ['FILE_DEF']


### PR DESCRIPTION
```
$ docker-compose 
Traceback (most recent call last):
  File "/usr/local/bin/docker-compose", line 9, in <module>
    load_entry_point('docker-compose==1.1.0', 'console_scripts', 'docker-compose')()
  File "/usr/local/lib/python3.4/dist-packages/setuptools-5.7-py3.4.egg/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.4/dist-packages/setuptools-5.7-py3.4.egg/pkg_resources.py", line 2472, in load_entry_point
    """Return the `name` entry point of `group` or raise ImportError"""
  File "/usr/local/lib/python3.4/dist-packages/setuptools-5.7-py3.4.egg/pkg_resources.py", line 2186, in load
    def load(self, require=True, env=None, installer=None):
  File "/usr/local/lib/python3.4/dist-packages/compose/__init__.py", line 2, in <module>
    from .service import Service  # noqa:flake8
  File "/usr/local/lib/python3.4/dist-packages/compose/service.py", line 485
    except StreamOutputError, e:
                            ^
SyntaxError: invalid syntax
```