### PR TITLE
add bash completion to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include requirements.txt
 include requirements-dev.txt
 include tox.ini
 include *.md
+include contrib/completion/bash/docker-compose
 recursive-include tests *
 global-exclude *.pyc
 global-exclude *.pyo


### PR DESCRIPTION
When installing from the source distribution (for packaging or other
purposes), it's convenient to be able to install the bash completion
file as part of that process.