### PR TITLE
Move several steps closer to python3 compatibility

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -25,7 +25,7 @@ class Command(DocoptCommand):
     def dispatch(self, *args, **kwargs):
         try:
             super(Command, self).dispatch(*args, **kwargs)
-        except SSLError, e:
+        except SSLError as e:
             raise errors.UserError('SSL error: %s' % e)
         except ConnectionError:
             if call_silently(['which', 'docker']) != 0:

--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -46,7 +46,7 @@ class LogPrinter(object):
             if monochrome:
                 color_fn = no_color
             else:
-                color_fn = color_fns.next()
+                color_fn = next(color_fns)
             generators.append(self._make_log_generator(container, color_fn))
 
         return generators

--- a/compose/container.py
+++ b/compose/container.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import six
+from functools import reduce
 
 
 class Container(object):

--- a/compose/project.py
+++ b/compose/project.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 import logging
 
+from functools import reduce
 from .service import Service
 from .container import Container
 from docker.errors import APIError

--- a/compose/service.py
+++ b/compose/service.py
@@ -482,7 +482,7 @@ class Service(object):
 
         try:
             all_events = stream_output(build_output, sys.stdout)
-        except StreamOutputError, e:
+        except StreamOutputError as e:
             raise BuildError(self, unicode(e))
 
         image_id = None
@@ -641,7 +641,7 @@ def merge_environment(options):
         else:
             env.update(options['environment'])
 
-    return dict(resolve_env(k, v) for k, v in env.iteritems())
+    return dict(resolve_env(k, v) for k, v in env.items())
 
 
 def split_env(env):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ dockerpty==0.3.2
 docopt==0.6.1
 requests==2.2.1
 six==1.7.3
-texttable==0.8.1
+texttable==0.8.2
 websocket-client==0.11.0

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -472,13 +472,13 @@ class ServiceTest(DockerClientTestCase):
     def test_split_env(self):
         service = self.create_service('web', environment=['NORMAL=F1', 'CONTAINS_EQUALS=F=2', 'TRAILING_EQUALS='])
         env = create_and_start_container(service).environment
-        for k,v in {'NORMAL': 'F1', 'CONTAINS_EQUALS': 'F=2', 'TRAILING_EQUALS': ''}.iteritems():
+        for k,v in {'NORMAL': 'F1', 'CONTAINS_EQUALS': 'F=2', 'TRAILING_EQUALS': ''}.items():
             self.assertEqual(env[k], v)
 
     def test_env_from_file_combined_with_env(self):
         service = self.create_service('web', environment=['ONE=1', 'TWO=2', 'THREE=3'], env_file=['tests/fixtures/env/one.env', 'tests/fixtures/env/two.env'])
         env = create_and_start_container(service).environment
-        for k,v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.iteritems():
+        for k,v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.items():
             self.assertEqual(env[k], v)
 
     def test_resolve_env(self):
@@ -488,7 +488,7 @@ class ServiceTest(DockerClientTestCase):
         os.environ['ENV_DEF'] = 'E3'
         try:
             env = create_and_start_container(service).environment
-            for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.iteritems():
+            for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
                 self.assertEqual(env[k], v)
         finally:
             del os.environ['FILE_DEF']


### PR DESCRIPTION
- Exception syntax from `except Exception, e:` to `except Exception as e:`
- `iteritems()` to `items()`
- `xxx.next()` to `next(xxx)`
- `reduce()` to `functools.reduce()`

TODO: byte vs str collision within split
 
Signed-off-by: Igor Ch <usrenmae@gmail.com>