### PR TITLE
Support alternate Dockerfile name.

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -32,4 +32,4 @@ def docker_client():
         )
 
     timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
-    return Client(base_url=base_url, tls=tls_config, version='1.15', timeout=timeout)
+    return Client(base_url=base_url, tls=tls_config, version='1.17', timeout=timeout)

--- a/compose/config.py
+++ b/compose/config.py
@@ -33,6 +33,7 @@ DOCKER_CONFIG_KEYS = [
 
 ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'build',
+    'dockerfile',
     'expose',
     'external_links',
     'name',

--- a/compose/service.py
+++ b/compose/service.py
@@ -474,6 +474,7 @@ class Service(object):
             stream=True,
             rm=True,
             nocache=no_cache,
+            dockerfile=self.options.get('dockerfile', None),
         )
 
         try:

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -39,6 +39,16 @@ Compose will build and tag it with a generated name, and use that image thereaft
 build: /path/to/build/dir
 ```
 
+### dockerfile
+
+Alternate Dockerfile.
+
+Compose will use an alternate file to build with.
+
+```
+dockerfile: Dockerfile-alternate
+```
+
 ### command
 
 Override the default command.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 PyYAML==3.10
-docker-py==1.0.0
+docker-py==1.1.0
 dockerpty==0.3.2
 docopt==0.6.1
-requests==2.2.1
+requests==2.6.1
 six==1.7.3
 texttable==0.8.2
 websocket-client==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ def find_version(*file_paths):
 install_requires = [
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.2.1, < 2.6',
+    'requests >= 2.6.1, < 2.7',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 1.0',
-    'docker-py >= 1.0.0, < 1.2',
+    'docker-py >= 1.1.0, < 1.2',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]


### PR DESCRIPTION
Add support for compose support Docker's `-f`/`--file` option from within your docker-compose.yml file.

```yaml
app:
  build: .
  dockerfile: Dockerfile-alternate
```

I quickly threw this in, and it seems to work for me, please let me know if anything else is needed to get this into master.