### PR TITLE
WIP: Service types

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -4,9 +4,9 @@ from requests.exceptions import ConnectionError, SSLError
 import logging
 import os
 import re
-import yaml
 import six
 
+from .. import config
 from ..project import Project
 from ..service import ConfigError
 from .docopt_command import DocoptCommand
@@ -69,18 +69,11 @@ class Command(DocoptCommand):
             return verbose_proxy.VerboseProxy('docker', client)
         return client
 
-    def get_config(self, config_path):
-        try:
-            with open(config_path, 'r') as fh:
-                return yaml.safe_load(fh)
-        except IOError as e:
-            raise errors.UserError(six.text_type(e))
-
     def get_project(self, config_path, project_name=None, verbose=False):
         try:
-            return Project.from_config(
+            return Project.from_dicts(
                 self.get_project_name(config_path, project_name),
-                self.get_config(config_path),
+                config.load(config_path),
                 self.get_client(verbose=verbose))
         except ConfigError as e:
             raise errors.UserError(six.text_type(e))

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -12,7 +12,8 @@ import dockerpty
 
 from .. import __version__
 from ..project import NoSuchService, ConfigurationError
-from ..service import BuildError, CannotBeScaledError, parse_environment
+from ..service import BuildError, CannotBeScaledError
+from ..config import parse_environment
 from .command import Command
 from .docopt_command import NoSuchCommand
 from .errors import UserError

--- a/compose/config.py
+++ b/compose/config.py
@@ -1,0 +1,209 @@
+import os
+import yaml
+import six
+
+
+DOCKER_CONFIG_KEYS = [
+    'cap_add',
+    'cap_drop',
+    'cpu_shares',
+    'command',
+    'detach',
+    'dns',
+    'dns_search',
+    'domainname',
+    'entrypoint',
+    'env_file',
+    'environment',
+    'hostname',
+    'image',
+    'links',
+    'mem_limit',
+    'net',
+    'ports',
+    'privileged',
+    'restart',
+    'stdin_open',
+    'tty',
+    'user',
+    'volumes',
+    'volumes_from',
+    'working_dir',
+]
+
+ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
+    'build',
+    'expose',
+    'external_links',
+    'name',
+]
+
+DOCKER_CONFIG_HINTS = {
+    'cpu_share' : 'cpu_shares',
+    'link'      : 'links',
+    'port'      : 'ports',
+    'privilege' : 'privileged',
+    'priviliged': 'privileged',
+    'privilige' : 'privileged',
+    'volume'    : 'volumes',
+    'workdir'   : 'working_dir',
+}
+
+
+def load(filename):
+    return from_dictionary(load_yaml(filename))
+
+
+def load_yaml(filename):
+    try:
+        with open(filename, 'r') as fh:
+            return yaml.safe_load(fh)
+    except IOError as e:
+        raise ConfigurationError(six.text_type(e))
+
+
+def from_dictionary(dictionary):
+    service_dicts = []
+
+    for service_name, service_dict in list(dictionary.items()):
+        if not isinstance(service_dict, dict):
+            raise ConfigurationError('Service "%s" doesn\'t have any configuration options. All top level keys in your docker-compose.yml must map to a dictionary of configuration options.' % service_name)
+        service_dict = make_service_dict(service_name, service_dict)
+        service_dicts.append(service_dict)
+
+    return service_dicts
+
+
+def make_service_dict(name, options):
+    service_dict = options.copy()
+    service_dict['name'] = name
+    return process_container_options(service_dict)
+
+
+def process_container_options(service_dict):
+    for k in service_dict:
+        if k not in ALLOWED_KEYS:
+            msg = "Unsupported config option for %s service: '%s'" % (service_dict['name'], k)
+            if k in DOCKER_CONFIG_HINTS:
+                msg += " (did you mean '%s'?)" % DOCKER_CONFIG_HINTS[k]
+            raise ConfigurationError(msg)
+
+    for filename in get_env_files(service_dict):
+        if not os.path.exists(filename):
+            raise ConfigurationError("Couldn't find env file for service %s: %s" % (service_dict['name'], filename))
+
+    if 'environment' in service_dict or 'env_file' in service_dict:
+        service_dict['environment'] = build_environment(service_dict)
+
+    return service_dict
+
+
+def merge_service_dicts(base, override):
+    d = base.copy()
+
+    if 'environment' in base or 'environment' in override:
+        d['environment'] = merge_environment(base, override)
+
+    if 'links' in base or 'links' in override:
+        d['links'] = merge_links(base, override)
+
+    for k in ALLOWED_KEYS:
+        if k not in ['links', 'environment']:
+            if k in override:
+                d[k] = override[k]
+
+    return d
+
+
+def merge_environment(base, override):
+    env = build_environment(base)
+    env.update(build_environment(override))
+    return env
+
+
+def merge_links(base, override):
+    d = parse_links(base.get('links', []))
+    d.update(parse_links(override.get('links', [])))
+    return ["%s:%s" % (source, alias) for (alias, source) in six.iteritems(d)]
+
+
+def parse_links(links):
+    return dict(parse_link(l) for l in links)
+
+
+def parse_link(link):
+    if ':' in link:
+        source, alias = link.split(':', 1)
+        return (alias, source)
+    else:
+        return (link, link)
+
+
+def get_env_files(options):
+    env_files = options.get('env_file', [])
+    if not isinstance(env_files, list):
+        env_files = [env_files]
+    return env_files
+
+
+def build_environment(options):
+    env = {}
+
+    for f in get_env_files(options):
+        env.update(env_vars_from_file(f))
+
+    env.update(parse_environment(options.get('environment')))
+    return dict(resolve_env(k, v) for k, v in six.iteritems(env))
+
+
+def parse_environment(environment):
+    if not environment:
+        return {}
+
+    if isinstance(environment, list):
+        return dict(split_env(e) for e in environment)
+
+    if isinstance(environment, dict):
+        return environment
+
+    raise ConfigurationError(
+        "environment \"%s\" must be a list or mapping," %
+        environment
+    )
+
+
+def split_env(env):
+    if '=' in env:
+        return env.split('=', 1)
+    else:
+        return env, None
+
+
+def resolve_env(key, val):
+    if val is not None:
+        return key, val
+    elif key in os.environ:
+        return key, os.environ[key]
+    else:
+        return key, ''
+
+
+def env_vars_from_file(filename):
+    """
+    Read in a line delimited file of environment variables.
+    """
+    env = {}
+    for line in open(filename, 'r'):
+        line = line.strip()
+        if line and not line.startswith('#'):
+            k, v = split_env(line)
+            env[k] = v
+    return env
+
+
+class ConfigurationError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg

--- a/compose/project.py
+++ b/compose/project.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 
 from functools import reduce
+from .config import ConfigurationError
 from .service import Service
 from .container import Container
 from docker.errors import APIError
@@ -63,16 +64,6 @@ class Project(object):
 
             project.services.append(Service(client=client, project=name, links=links, volumes_from=volumes_from, **service_dict))
         return project
-
-    @classmethod
-    def from_config(cls, name, config, client):
-        dicts = []
-        for service_name, service in list(config.items()):
-            if not isinstance(service, dict):
-                raise ConfigurationError('Service "%s" doesn\'t have any configuration options. All top level keys in your docker-compose.yml must map to a dictionary of configuration options.' % service_name)
-            service['name'] = service_name
-            dicts.append(service)
-        return cls.from_dicts(name, dicts, client)
 
     def get_service(self, name):
         """
@@ -226,14 +217,6 @@ class NoSuchService(Exception):
     def __init__(self, name):
         self.name = name
         self.msg = "No such service: %s" % self.name
-
-    def __str__(self):
-        return self.msg
-
-
-class ConfigurationError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
 
     def __str__(self):
         return self.msg

--- a/compose/project.py
+++ b/compose/project.py
@@ -5,6 +5,7 @@ import logging
 from functools import reduce
 from .config import ConfigurationError
 from .service import Service
+from .remote_service import RemoteService
 from .container import Container
 from docker.errors import APIError
 
@@ -49,7 +50,7 @@ class Project(object):
     """
     def __init__(self, name, services, client):
         self.name = name
-        self.services = services
+        self._services = services
         self.client = client
 
     @classmethod
@@ -58,12 +59,26 @@ class Project(object):
         Construct a ServiceCollection from a list of dicts representing services.
         """
         project = cls(name, [], client)
-        for service_dict in sort_service_dicts(service_dicts):
-            links = project.get_links(service_dict)
-            volumes_from = project.get_volumes_from(service_dict)
 
-            project.services.append(Service(client=client, project=name, links=links, volumes_from=volumes_from, **service_dict))
+        for service_dict in sort_service_dicts(service_dicts):
+            service_type = service_dict.pop('type')
+
+            if service_type == 'container':
+                links = project.get_links(service_dict)
+                volumes_from = project.get_volumes_from(service_dict)
+                service = Service(client=client, project=name, links=links, volumes_from=volumes_from, **service_dict)
+            elif service_type == 'remote':
+                service = RemoteService(client=client, project=name, **service_dict)
+            else:
+                raise Exception('Unexpected service type: %s' % service_dict['type'])
+
+            project._services.append(service)
+
         return project
+
+    @property
+    def services(self):
+        return [s for s in self._services if isinstance(s, Service)]
 
     def get_service(self, name):
         """
@@ -71,6 +86,17 @@ class Project(object):
         if the named service does not exist.
         """
         for service in self.services:
+            if service.name == name:
+                return service
+
+        raise NoSuchService(name)
+
+    def _get_service(self, name):
+        """
+        Retrieve a service by name, including remote "services".
+        Raises NoSuchService if the named service does not exist.
+        """
+        for service in self._services:
             if service.name == name:
                 return service
 
@@ -115,7 +141,7 @@ class Project(object):
                 else:
                     service_name, link_name = link, None
                 try:
-                    links.append((self.get_service(service_name), link_name))
+                    links.append((self._get_service(service_name), link_name))
                 except NoSuchService:
                     raise ConfigurationError('Service "%s" has a link to service "%s" which does not exist.' % (service_dict['name'], service_name))
             del service_dict['links']
@@ -200,6 +226,8 @@ class Project(object):
 
     def _inject_links(self, acc, service):
         linked_names = service.get_linked_names()
+        # Don't include links to remote services
+        linked_names = [n for n in linked_names if isinstance(self._get_service(n), Service)]
 
         if len(linked_names) > 0:
             linked_services = self.get_services(

--- a/compose/remote_service.py
+++ b/compose/remote_service.py
@@ -1,0 +1,38 @@
+class RemoteService(object):
+    def __init__(
+        self,
+        name,
+        host,
+        client=None,
+        project='default',
+        port=None,
+        environment=None
+    ):
+        self.name = name
+        self.client = client
+        self.project = project
+        self.host = host
+        self.port = port
+        self.environment = environment
+
+    def containers(self):
+        return []
+
+    def link_environment_variables(self):
+        env = {}
+
+        if self.environment is not None:
+            for (key, value) in self.environment.items():
+                env["ENV_%s" % key] = value
+
+        if self.port is not None:
+            env["PORT"] = "tcp://%s:%s" % (self.host, self.port)
+            env["PORT_%s_TCP" % self.port] = "tcp://%s:%s" % (self.host, self.port)
+            env["PORT_%s_TCP_ADDR" % self.port] = self.host
+            env["PORT_%s_TCP_PORT" % self.port] = self.port
+            env["PORT_%s_TCP_PROTO" % self.port] = "tcp"
+
+        return env
+
+    def link_hostnames(self):
+        return [self.host]

--- a/compose/service.py
+++ b/compose/service.py
@@ -8,50 +8,13 @@ from operator import attrgetter
 import sys
 
 from docker.errors import APIError
-import six
 
+from .config import DOCKER_CONFIG_KEYS
 from .container import Container, get_container_name
 from .progress_stream import stream_output, StreamOutputError
 
 log = logging.getLogger(__name__)
 
-
-DOCKER_CONFIG_KEYS = [
-    'cap_add',
-    'cap_drop',
-    'cpu_shares',
-    'command',
-    'detach',
-    'dns',
-    'dns_search',
-    'domainname',
-    'entrypoint',
-    'env_file',
-    'environment',
-    'hostname',
-    'image',
-    'mem_limit',
-    'net',
-    'ports',
-    'privileged',
-    'restart',
-    'stdin_open',
-    'tty',
-    'user',
-    'volumes',
-    'volumes_from',
-    'working_dir',
-]
-DOCKER_CONFIG_HINTS = {
-    'cpu_share' : 'cpu_shares',
-    'link'      : 'links',
-    'port'      : 'ports',
-    'privilege' : 'privileged',
-    'priviliged': 'privileged',
-    'privilige' : 'privileged',
-    'volume'    : 'volumes',
-    'workdir'   : 'working_dir',
-}
 
 DOCKER_START_KEYS = [
     'cap_add',
@@ -95,20 +58,6 @@ class Service(object):
             raise ConfigError('Invalid project name "%s" - only %s are allowed' % (project, VALID_NAME_CHARS))
         if 'image' in options and 'build' in options:
             raise ConfigError('Service %s has both an image and build path specified. A service can either be built to image or use an existing image, not both.' % name)
-
-        for filename in get_env_files(options):
-            if not os.path.exists(filename):
-                raise ConfigError("Couldn't find env file for service %s: %s" % (name, filename))
-
-        supported_options = DOCKER_CONFIG_KEYS + ['build', 'expose',
-                                                  'external_links']
-
-        for k in options:
-            if k not in supported_options:
-                msg = "Unsupported config option for %s service: '%s'" % (name, k)
-                if k in DOCKER_CONFIG_HINTS:
-                    msg += " (did you mean '%s'?)" % DOCKER_CONFIG_HINTS[k]
-                raise ConfigError(msg)
 
         self.name = name
         self.client = client
@@ -451,8 +400,6 @@ class Service(object):
                 (parse_volume_spec(v).internal, {})
                 for v in container_options['volumes'])
 
-        container_options['environment'] = build_environment(container_options)
-
         if self.can_be_built():
             container_options['image'] = self.full_name
         else:
@@ -621,63 +568,3 @@ def split_port(port):
 
     external_ip, external_port, internal_port = parts
     return internal_port, (external_ip, external_port or None)
-
-
-def get_env_files(options):
-    env_files = options.get('env_file', [])
-    if not isinstance(env_files, list):
-        env_files = [env_files]
-    return env_files
-
-
-def build_environment(options):
-    env = {}
-
-    for f in get_env_files(options):
-        env.update(env_vars_from_file(f))
-
-    env.update(parse_environment(options.get('environment')))
-    return dict(resolve_env(k, v) for k, v in six.iteritems(env))
-
-
-def parse_environment(environment):
-    if not environment:
-        return {}
-
-    if isinstance(environment, list):
-        return dict(split_env(e) for e in environment)
-
-    if isinstance(environment, dict):
-        return environment
-
-    raise ConfigError("environment \"%s\" must be a list or mapping," %
-                      environment)
-
-
-def split_env(env):
-    if '=' in env:
-        return env.split('=', 1)
-    else:
-        return env, None
-
-
-def resolve_env(key, val):
-    if val is not None:
-        return key, val
-    elif key in os.environ:
-        return key, os.environ[key]
-    else:
-        return key, ''
-
-
-def env_vars_from_file(filename):
-    """
-    Read in a line delimited file of environment variables.
-    """
-    env = {}
-    for line in open(filename, 'r'):
-        line = line.strip()
-        if line and not line.startswith('#'):
-            k, v = split_env(line)
-            env[k] = v
-    return env

--- a/tests/fixtures/copy/common.yml
+++ b/tests/fixtures/copy/common.yml
@@ -1,0 +1,8 @@
+web:
+  image: busybox
+  command: /bin/true
+  links:
+    - db
+  environment:
+    - FOO=1
+    - BAR=1

--- a/tests/fixtures/copy/docker-compose.yml
+++ b/tests/fixtures/copy/docker-compose.yml
@@ -1,0 +1,17 @@
+myweb:
+  type: copy
+  path: common.yml
+  service: web
+  command: sleep 300
+  links:
+    # override link
+    - "mydb:db"
+  environment:
+    # leave FOO alone
+    # override BAR
+    BAR: "2"
+    # add BAZ
+    BAZ: "2"
+mydb:
+  image: busybox
+  command: sleep 300

--- a/tests/fixtures/remote/docker-compose.yml
+++ b/tests/fixtures/remote/docker-compose.yml
@@ -1,0 +1,12 @@
+web:
+  image: busybox
+  command: sleep 300
+  links:
+    - db
+db:
+  type: remote
+  host: 1.2.3.4
+  port: 5678
+  environment:
+    - USERNAME=devuser
+    - PASSWORD=devpass

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -387,3 +387,30 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(get_port(3000), container.get_local_port(3000))
         self.assertEqual(get_port(3001), "0.0.0.0:9999")
         self.assertEqual(get_port(3002), "")
+
+    def test_up_with_copy(self):
+        self.command.base_dir = 'tests/fixtures/copy'
+        self.command.dispatch(['up', '-d'], None)
+
+        self.assertEqual(
+            set([s.name for s in self.project.services]),
+            set(['mydb', 'myweb']),
+        )
+
+        # Sort by name so we get [db, web]
+        containers = sorted(
+            self.project.containers(stopped=True),
+            key=lambda c: c.name,
+        )
+
+        self.assertEqual(len(containers), 2)
+        web = containers[1]
+
+        self.assertEqual(set(web.links()), set(['db', 'mydb_1', 'copy_mydb_1']))
+
+        expected_env = set([
+            "FOO=1",
+            "BAR=2",
+            "BAZ=2",
+        ])
+        self.assertTrue(expected_env <= set(web.get('Config.Env')))

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -414,3 +414,31 @@ class CLITestCase(DockerClientTestCase):
             "BAZ=2",
         ])
         self.assertTrue(expected_env <= set(web.get('Config.Env')))
+
+    def test_up_with_remote(self):
+        self.command.base_dir = 'tests/fixtures/remote'
+        self.command.dispatch(['up', '-d'], None)
+
+        self.assertEqual([s.name for s in self.project.services], ['web'])
+
+        containers = self.project.containers(stopped=True)
+        self.assertEqual(len(containers), 1)
+        web = containers[0]
+
+        self.assertEqual(web.get('HostConfig.ExtraHosts'), ['db:1.2.3.4'])
+
+        expected_env = [
+            "DB_PORT=tcp://1.2.3.4:5678",
+            "DB_PORT_5678_TCP=tcp://1.2.3.4:5678",
+            "DB_PORT_5678_TCP_ADDR=1.2.3.4",
+            "DB_PORT_5678_TCP_PORT=5678",
+            "DB_PORT_5678_TCP_PROTO=tcp",
+            "DB_ENV_USERNAME=devuser",
+            "DB_ENV_PASSWORD=devpass",
+        ]
+
+        env = web.get('Config.Env')
+
+        for e in expected_env:
+            self.assertIn(e, env)
+

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from compose import config
 from compose.project import Project, ConfigurationError
 from compose.container import Container
 from .testcases import DockerClientTestCase
@@ -6,9 +7,9 @@ from .testcases import DockerClientTestCase
 
 class ProjectTest(DockerClientTestCase):
     def test_volumes_from_service(self):
-        project = Project.from_config(
+        project = Project.from_dicts(
             name='composetest',
-            config={
+            service_dicts=config.from_dictionary({
                 'data': {
                     'image': 'busybox:latest',
                     'volumes': ['/var/data'],
@@ -17,7 +18,7 @@ class ProjectTest(DockerClientTestCase):
                     'image': 'busybox:latest',
                     'volumes_from': ['data'],
                 },
-            },
+            }),
             client=self.client,
         )
         db = project.get_service('db')
@@ -31,14 +32,14 @@ class ProjectTest(DockerClientTestCase):
             volumes=['/var/data'],
             name='composetest_data_container',
         )
-        project = Project.from_config(
+        project = Project.from_dicts(
             name='composetest',
-            config={
+            service_dicts=config.from_dictionary({
                 'db': {
                     'image': 'busybox:latest',
                     'volumes_from': ['composetest_data_container'],
                 },
-            },
+            }),
             client=self.client,
         )
         db = project.get_service('db')

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 import os
 from os import path
+import mock
 
 from compose import Service
 from compose.service import CannotBeScaledError
@@ -481,16 +482,12 @@ class ServiceTest(DockerClientTestCase):
         for k,v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.items():
             self.assertEqual(env[k], v)
 
+    @mock.patch.dict(os.environ)
     def test_resolve_env(self):
-        service = self.create_service('web', environment={'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': None, 'NO_DEF': None})
         os.environ['FILE_DEF'] = 'E1'
         os.environ['FILE_DEF_EMPTY'] = 'E2'
         os.environ['ENV_DEF'] = 'E3'
-        try:
-            env = create_and_start_container(service).environment
-            for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
-                self.assertEqual(env[k], v)
-        finally:
-            del os.environ['FILE_DEF']
-            del os.environ['FILE_DEF_EMPTY']
-            del os.environ['ENV_DEF']
+        service = self.create_service('web', environment={'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': None, 'NO_DEF': None})
+        env = create_and_start_container(service).environment
+        for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
+            self.assertEqual(env[k], v)

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from compose.service import Service
+from compose.config import make_service_dict
 from compose.cli.docker_client import docker_client
 from compose.progress_stream import stream_output
 from .. import unittest
@@ -21,14 +22,15 @@ class DockerClientTestCase(unittest.TestCase):
                 self.client.remove_image(i)
 
     def create_service(self, name, **kwargs):
+        kwargs['image'] = "busybox:latest"
+
         if 'command' not in kwargs:
             kwargs['command'] = ["/bin/sleep", "300"]
+
         return Service(
             project='composetest',
-            name=name,
             client=self.client,
-            image="busybox:latest",
-            **kwargs
+            **make_service_dict(name, kwargs)
         )
 
     def check_build(self, *args, **kwargs):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -161,3 +161,30 @@ class ConfigTest(unittest.TestCase):
             service_dict['environment'],
             {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
         )
+
+    def test_copy(self):
+        service_dicts = config.load('tests/fixtures/copy/docker-compose.yml')
+
+        service_dicts = sorted(
+            service_dicts,
+            key=lambda sd: sd['name'],
+        )
+
+        self.assertEqual(service_dicts, [
+            {
+                'name': 'mydb',
+                'image': 'busybox',
+                'command': 'sleep 300',
+            },
+            {
+                'name': 'myweb',
+                'image': 'busybox',
+                'command': 'sleep 300',
+                'links': ['mydb:db'],
+                'environment': {
+                    "FOO": "1",
+                    "BAR": "2",
+                    "BAZ": "2",
+                },
+            }
+        ])

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -15,10 +15,12 @@ class ConfigTest(unittest.TestCase):
             sorted(service_dicts, key=lambda d: d['name']),
             sorted([
                 {
+                    'type': 'container',
                     'name': 'bar',
                     'environment': {'FOO': '1'},
                 },
                 {
+                    'type': 'container',
                     'name': 'foo',
                     'image': 'busybox',
                 }
@@ -37,6 +39,17 @@ class ConfigTest(unittest.TestCase):
             lambda: config.make_service_dict('foo', {'port': ['8000']})
         )
         config.make_service_dict('foo', {'ports': ['8000']})
+
+    def test_remote_env(self):
+        service_dict = config.make_service_dict('db', {
+            'type': 'remote',
+            'host': '1.2.3.4',
+            'environment': [
+                'FOO=1',
+            ]
+        })
+
+        self.assertEqual(service_dict['environment'], {'FOO': '1'})
 
     def test_merge_links(self):
         base = {"links": [
@@ -172,11 +185,13 @@ class ConfigTest(unittest.TestCase):
 
         self.assertEqual(service_dicts, [
             {
+                'type': 'container',
                 'name': 'mydb',
                 'image': 'busybox',
                 'command': 'sleep 300',
             },
             {
+                'type': 'container',
                 'name': 'myweb',
                 'image': 'busybox',
                 'command': 'sleep 300',

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -1,0 +1,163 @@
+import os
+import mock
+from .. import unittest
+
+from compose import config
+
+class ConfigTest(unittest.TestCase):
+    def test_from_dictionary(self):
+        service_dicts = config.from_dictionary({
+            'foo': {'image': 'busybox'},
+            'bar': {'environment': ['FOO=1']},
+        })
+
+        self.assertEqual(
+            sorted(service_dicts, key=lambda d: d['name']),
+            sorted([
+                {
+                    'name': 'bar',
+                    'environment': {'FOO': '1'},
+                },
+                {
+                    'name': 'foo',
+                    'image': 'busybox',
+                }
+            ])
+        )
+
+    def test_from_dictionary_throws_error_when_not_dict(self):
+        with self.assertRaises(config.ConfigurationError):
+            config.from_dictionary({
+                'web': 'busybox:latest',
+            })
+
+    def test_config_validation(self):
+        self.assertRaises(
+            config.ConfigurationError,
+            lambda: config.make_service_dict('foo', {'port': ['8000']})
+        )
+        config.make_service_dict('foo', {'ports': ['8000']})
+
+    def test_merge_links(self):
+        base = {"links": [
+            "foo",
+            "other-bar:bar",
+            "baz",
+            "quux-source:quux",
+        ]}
+
+        override = {"links": [
+            "other-baz:baz",
+            "quux",
+            "one-more",
+        ]}
+
+        merged = config.merge_links(base, override)
+
+        self.assertEqual(sorted(merged), sorted([
+            # leave foo alone
+            "foo:foo",
+            # leave bar alone
+            "other-bar:bar",
+            # override baz with custom source
+            "other-baz:baz",
+            # remove custom quux source
+            "quux:quux",
+            # add a new link
+            "one-more:one-more",
+        ]))
+
+    def test_parse_environment_as_list(self):
+        environment =[
+            'NORMAL=F1',
+            'CONTAINS_EQUALS=F=2',
+            'TRAILING_EQUALS=',
+        ]
+        self.assertEqual(
+            config.parse_environment(environment),
+            {'NORMAL': 'F1', 'CONTAINS_EQUALS': 'F=2', 'TRAILING_EQUALS': ''},
+        )
+
+    def test_parse_environment_as_dict(self):
+        environment = {
+            'NORMAL': 'F1',
+            'CONTAINS_EQUALS': 'F=2',
+            'TRAILING_EQUALS': None,
+        }
+        self.assertEqual(config.parse_environment(environment), environment)
+
+    def test_parse_environment_invalid(self):
+        with self.assertRaises(config.ConfigurationError):
+            config.parse_environment('a=b')
+
+    def test_parse_environment_empty(self):
+        self.assertEqual(config.parse_environment(None), {})
+
+    @mock.patch.dict(os.environ)
+    def test_resolve_environment(self):
+        os.environ['FILE_DEF'] = 'E1'
+        os.environ['FILE_DEF_EMPTY'] = 'E2'
+        os.environ['ENV_DEF'] = 'E3'
+
+        service_dict = config.make_service_dict(
+            'foo',
+            {
+               'environment': {
+                    'FILE_DEF': 'F1',
+                    'FILE_DEF_EMPTY': '',
+                    'ENV_DEF': None,
+                    'NO_DEF': None
+                },
+            },
+        )
+
+        self.assertEqual(
+            service_dict['environment'],
+            {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
+        )
+
+    def test_env_from_file(self):
+        service_dict = config.make_service_dict(
+            'foo',
+            {'env_file': 'tests/fixtures/env/one.env'},
+        )
+        self.assertEqual(
+            service_dict['environment'],
+            {'ONE': '2', 'TWO': '1', 'THREE': '3', 'FOO': 'bar'},
+        )
+
+    def test_env_from_multiple_files(self):
+        service_dict = config.make_service_dict(
+            'foo',
+            {
+                'env_file': [
+                    'tests/fixtures/env/one.env',
+                    'tests/fixtures/env/two.env',
+                ],
+            },
+        )
+        self.assertEqual(
+            service_dict['environment'],
+            {'ONE': '2', 'TWO': '1', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'},
+        )
+
+    def test_env_nonexistent_file(self):
+        options = {'env_file': 'tests/fixtures/env/nonexistent.env'}
+        self.assertRaises(
+            config.ConfigurationError,
+            lambda: config.make_service_dict('foo', options),
+        )
+
+    @mock.patch.dict(os.environ)
+    def test_resolve_environment_from_file(self):
+        os.environ['FILE_DEF'] = 'E1'
+        os.environ['FILE_DEF_EMPTY'] = 'E2'
+        os.environ['ENV_DEF'] = 'E3'
+        service_dict = config.make_service_dict(
+            'foo',
+            {'env_file': 'tests/fixtures/env/resolve.env'},
+        )
+        self.assertEqual(
+            service_dict['environment'],
+            {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
+        )

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from .. import unittest
 from compose.service import Service
 from compose.project import Project, ConfigurationError
+from compose import config
 
 class ProjectTest(unittest.TestCase):
     def test_from_dict(self):
@@ -45,25 +46,20 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual(project.services[2].name, 'web')
 
     def test_from_config(self):
-        project = Project.from_config('composetest', {
+        dicts = config.from_dictionary({
             'web': {
                 'image': 'busybox:latest',
             },
             'db': {
                 'image': 'busybox:latest',
             },
-        }, None)
+        })
+        project = Project.from_dicts('composetest', dicts, None)
         self.assertEqual(len(project.services), 2)
         self.assertEqual(project.get_service('web').name, 'web')
         self.assertEqual(project.get_service('web').options['image'], 'busybox:latest')
         self.assertEqual(project.get_service('db').name, 'db')
         self.assertEqual(project.get_service('db').options['image'], 'busybox:latest')
-
-    def test_from_config_throws_error_when_not_dict(self):
-        with self.assertRaises(ConfigurationError):
-            project = Project.from_config('composetest', {
-                'web': 'busybox:latest',
-            }, None)
 
     def test_get_service(self):
         web = Service(

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -8,10 +8,12 @@ class ProjectTest(unittest.TestCase):
     def test_from_dict(self):
         project = Project.from_dicts('composetest', [
             {
+                'type': 'container',
                 'name': 'web',
                 'image': 'busybox:latest'
             },
             {
+                'type': 'container',
                 'name': 'db',
                 'image': 'busybox:latest'
             },
@@ -25,16 +27,19 @@ class ProjectTest(unittest.TestCase):
     def test_from_dict_sorts_in_dependency_order(self):
         project = Project.from_dicts('composetest', [
             {
+                'type': 'container',
                 'name': 'web',
                 'image': 'busybox:latest',
                 'links': ['db'],
             },
             {
+                'type': 'container',
                 'name': 'db',
                 'image': 'busybox:latest',
                 'volumes_from': ['volume']
             },
             {
+                'type': 'container',
                 'name': 'volume',
                 'image': 'busybox:latest',
                 'volumes': ['/tmp'],


### PR DESCRIPTION
This is an unfinished first attempt at implementing the "service types" proposed in #988, to feel out what it's like to implement. It differs from what's proposed there in a few ways:

1. Instead of specifying `type: path/to/file.yml#servicename`, you go:

    ```yaml
    type: copy
    path: path/to/file.yml
    service: servicename
    ```

   This is mostly to speed up implementation for now.

2. The `copy` type is equivalent to plucking a single service dictionary out of another file and merging the two (including the smart merging of links and environment variables). It doesn't pull in transitive dependencies or look at any other services in the other file.

   Service names in `links`/`volumes_from` therefore have "dynamic scope", not "lexical scope" - if I pull in something with `links: ["db"]`, it'll get linked to my locally-defined `db` service.

   This is much simpler than trying to implement a full-on import system, but doesn't cover as many use cases.

3. What #988 calls `external`, I here call `remote`. It feels like a better name to me, but I'm willing to be persuaded otherwise.