### PR TITLE
Allows empty `links` in YAML configuration file.

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -17,7 +17,7 @@ def sort_service_dicts(services):
     sorted_services = []
 
     def get_service_names(links):
-        return [link.split(':')[0] for link in links]
+        return [link.split(':')[0] for link in links or []]
 
     def visit(n):
         if n['name'] in temporary_marked:
@@ -118,7 +118,7 @@ class Project(object):
     def get_links(self, service_dict):
         links = []
         if 'links' in service_dict:
-            for link in service_dict.get('links', []):
+            for link in service_dict.get('links', []) or []:
                 if ':' in link:
                     service_name, link_name = link.split(':', 1)
                 else:

--- a/tests/fixtures/links-composefile/docker-compose.yml
+++ b/tests/fixtures/links-composefile/docker-compose.yml
@@ -9,3 +9,4 @@ web:
 console:
   image: busybox:latest
   command: /bin/sleep 300
+  links:


### PR DESCRIPTION
Fixed `TypeError: 'NoneType' object is not iterable` issue when service declares an empty list of `links`.
Fixes #1086 

Signed-off-by: Tristan Carel <tristan@cogniteev.com>