### PR TITLE
Add script/shell

### DIFF
--- a/script/shell
+++ b/script/shell
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ex
+docker build -t docker-compose .
+exec docker run -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:/code -ti --rm --entrypoint bash docker-compose


### PR DESCRIPTION
Useful for running tests repeatedly without going through a `docker build` every time - even when cached, it's a pain for quickly iterating on unit tests.