### PR TITLE
Use the tty variable to specify whether to create an interactive dockerpty.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -341,7 +341,7 @@ class TopLevelCommand(Command):
             print(container.name)
         else:
             service.start_container(container, ports=service_ports, one_off=True)
-            dockerpty.start(project.client, container.id, interactive=not options['-T'])
+            dockerpty.start(project.client, container.id, interactive=tty)
             exit_code = container.wait()
             if options['--rm']:
                 log.info("Removing %s..." % container.name)


### PR DESCRIPTION
When run in an environment without a TTY, compose will launch docker containers without ttys, but will still create interactive dockerptys, unless the -T flag is given.  This PR ensures that whenever compose launches containers without ttys, the dockerptys are non-interactive.

I'm not sure how to write tests for this, but am happy to try if I can be pointed in the right direction.