### PR TITLE
Implemented labels on docker compose

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -17,6 +17,7 @@ DOCKER_CONFIG_KEYS = [
     'environment',
     'hostname',
     'image',
+    'labels',
     'links',
     'mem_limit',
     'net',
@@ -138,7 +139,6 @@ def resolve_environment(service_dict, working_dir=None):
     service_dict['environment'] = env
     return service_dict
 
-
 def parse_environment(environment):
     if not environment:
         return {}
@@ -153,7 +153,6 @@ def parse_environment(environment):
         "environment \"%s\" must be a list or mapping," %
         environment
     )
-
 
 def split_env(env):
     if '=' in env:

--- a/compose/project.py
+++ b/compose/project.py
@@ -209,20 +209,30 @@ class Project(object):
            recreate=True,
            insecure_registry=False,
            detach=False,
-           do_build=True):
+           do_build=True,
+           prefix_labels=False,
+           remove_labels='',
+           labels_file=None
+           ):
         running_containers = []
         for service in self.get_services(service_names, include_deps=start_deps):
             if recreate:
                 for (_, container) in service.recreate_containers(
                         insecure_registry=insecure_registry,
                         detach=detach,
-                        do_build=do_build):
+                        do_build=do_build,
+                        prefix_labels=prefix_labels,
+                        remove_labels=remove_labels,
+                        labels_file=labels_file):
                     running_containers.append(container)
             else:
                 for container in service.start_or_create_containers(
                         insecure_registry=insecure_registry,
                         detach=detach,
-                        do_build=do_build):
+                        do_build=do_build,
+                        prefix_labels=prefix_labels,
+                        remove_labels=remove_labels,
+                        labels_file=labels_file):
                     running_containers.append(container)
 
         return running_containers


### PR DESCRIPTION
yml example file
```yml
web:
  labels:
   - ram=2g
  build: .
  command: python app.py
  ports:
   - "5000:5000"
  volumes:
   - .:/code
  links:
   - redis
redis:
  labels:
   - storage=ssd
   - ram=4g
   - production
  image: redis
```

Do not merge yet.
Depends on https://github.com/docker/docker-py/pull/529
Signed-off-by: André Martins <martins@noironetworks.com>