### PR TITLE
Validate DCO in script/test-versions

### DIFF
--- a/script/test
+++ b/script/test
@@ -9,6 +9,7 @@ docker build -t "$TAG" .
 docker run \
   --rm \
   --volume="/var/run/docker.sock:/var/run/docker.sock" \
+  --volume="$(pwd):/code" \
   -e DOCKER_VERSIONS \
   -e "TAG=$TAG" \
   --entrypoint="script/test-versions" \

--- a/script/test-versions
+++ b/script/test-versions
@@ -4,6 +4,9 @@
 
 set -e
 
+>&2 echo "Validating DCO"
+script/validate-dco
+
 >&2 echo "Running lint checks"
 flake8 compose
 

--- a/script/validate-dco
+++ b/script/validate-dco
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 source "$(dirname "$BASH_SOURCE")/.validate"
 
 adds=$(validate_diff --numstat | awk '{ s += $1 } END { print s }')


### PR DESCRIPTION
For this to pass, the line I've added to `script/test` (`--volume="$(pwd):/code"`) needs to be added to the `docker run` command in Jenkins.