### PR TITLE
feature: variables for scale: id, hostname

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -371,11 +371,44 @@ class Service(object):
 
         return net
 
+    def _safe_replace(self, old, new, haystack):
+        '''
+        Replace old with new in haystack (or in its elements).
+        :param old: The string to search
+        :param new: The replacement
+        :param haystack: A list or a string
+        :return: a copy of haystack with all the occurrencies of old are replaced with new
+        '''
+        if isinstance(haystack, list):
+            return [x.replace(old, new) for x in haystack]
+        return haystack.replace(old, new)
+
     def _get_container_create_options(self, override_options, one_off=False, intermediate_container=None):
         container_options = dict(
             (k, self.options[k])
             for k in DOCKER_CONFIG_KEYS if k in self.options)
         container_options.update(override_options)
+
+        # Get the container_number and replace the
+        # placeholder %%id%% and %%hostname%% in
+        # the order-aware REPLACEABLE_OPTIONS.
+        # This approach is
+        #  - quite safe (avoids messing with env)
+        #  - allows scaling nodes to be identified by
+        #     some id in the command line
+        REPLACEABLE_OPTIONS = ['hostname', 'command']
+        container_number = self._next_container_number(
+            self.containers(stopped=True, one_off=one_off))
+        for k in REPLACEABLE_OPTIONS:
+            if not container_options.get(k):
+                continue
+
+            container_options[k] = self._safe_replace(r"%%id%%", str(container_number), container_options[k])
+            if 'hostname' in container_options and k is not 'hostname':
+                # Note that:
+                #  - 'hostname' have been already processed
+                #  - don't replace %%hostname%% in hostname
+                container_options[k] = self._safe_replace(r"%%hostname%%", container_options['hostname'], container_options[k])
 
         container_options['name'] = self._next_container_name(
             self.containers(stopped=True, one_off=one_off),

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: docker-compose.yml reference variables
+page_title: docker-compose.yml reference variables
+page_description: docker-compose.yml reference variables
+page_keywords: fig, composition, compose, docker
+---
+
+# docker-compose.yml reference variables
+
+When you scale a service defined in  `docker-compose.yml`, container names
+are automatically generated with the pattern PROJECTNAME_SERVICE_NUM.
+
+To allow conflicting hostnames, you can use the %%id%% placeholder, that
+will be replaced with the container number.
+
+This approach avoids messing with environment and all its security issues
+and perks (eg. involving bash variable expansion)
+
+```
+test:
+  image: busybox:latest
+  hostname: box-%%id%%
+```
+
+The placeholders: %%id%% and %%hostname%% are available to the 'command' options.
+You can then:
+
+```
+mysql:
+  image: ioggstream/mysql
+  hostname: db-%%id%%
+  ...
+  command: mysqld --server-id=%%id%% --relay-log=%%hostname%%-relay-log
+
+```
+
+To avoid conflicts in numeric fields (eg: server-id) you can just prepend a
+large integer (eg. 100)
+
+```
+master:
+  image: ioggstream/mysql
+  hostname: master-%%id%%
+  ...
+  command: mysqld --server-id=100%%id%% --relay-log=%%hostname%%-relay-log
+
+slave:
+  image: ioggstream/mysql
+  hostname: slave-%%id%%
+  ...
+  command: mysqld --server-id=%%id%% --relay-log=%%hostname%%-relay-log
+
+
+```
+
+
+### Running
+
+When running with:
+
+```
+#docker-compose scale master=1 slave=3
+```
+
+You get
+
+```
+#docker inspect -f '{{.Name}} {{.Config.Hostname}}' $(docker ps -q) | column -t
+/db_slave_3               slave-3
+/db_slave_2               slave-2
+/db_slave_1               slave-1
+/db_master_1              master-1
+```
+

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -156,6 +156,42 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(port_bindings["1000"], [("127.0.0.1", "1000")])
         self.assertEqual(port_bindings["2000"], [("127.0.0.1", "2000")])
 
+    def test_replace_container_num_hostname(self):
+        service = Service('foo', hostname='name-%%id%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['hostname'], 'name-1', 'hostname')
+
+    def test_replace_container_num_command(self):
+        service = Service('foo', hostname='name-%%id%%', command='echo %%id%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], 'echo 1', 'command')
+
+    def test_replace_container_num_command_list(self):
+        service = Service('foo', hostname='name-%%id%%', command=['echo', '%%id%%'], client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], ['echo', '1'], 'command')
+
+    def test_replace_hostname_command(self):
+        service = Service('foo', hostname='name', command='echo %%hostname%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], 'echo name', 'command')
+
+    def test_replace_hostname_command_list(self):
+        service = Service('foo', hostname='name', command=['echo', '%%hostname%%'], client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['command'], ['echo', 'name'], 'command')
+
+    def test_replace_hostname_hostname(self):
+        service = Service('foo', hostname='name-%%hostname%%', client=self.mock_client)
+        self.mock_client.containers.return_value = []
+        opts = service._get_container_create_options({'image': 'foo'})
+        self.assertEqual(opts['hostname'], 'name-%%hostname%%', 'hostname')
+
     def test_split_domainname_none(self):
         service = Service('foo', hostname='name', client=self.mock_client)
         self.mock_client.containers.return_value = []


### PR DESCRIPTION
This patch enables parametric hostnames and commands when using `scale`
avoiding all bash variables expansion issues.

```
# docker-compose scale test=4
test:
  image: busybox:latest
  hostname: test-%%id%%
  command: runme.sh %%hostname%%
```

From https://github.com/docker/compose/pull/1006

Signed-off-by: Roberto Polli <robipolli@gmail.com>