### PR TITLE
Resolve links set as DNS to their ip address.

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -189,7 +189,7 @@ net: "host"
 
 ### dns
 
-Custom DNS servers. Can be a single value or a list.
+Custom DNS servers. Can be a single value or a list. Names of linked containers are resolved.
 
 ```
 dns: 8.8.8.8


### PR DESCRIPTION
When a dns section contains names of linked services,
the names are replaced with the container addresses.

Example:

```yaml
mydns:
    image: ubuntu:14.04
    command: sleep 300 
web:
    image: ubuntu:14.04
    command: cat /etc/resolv.conf
    links:
      - mydns:dns
    dns:
       - dns
       - 8.8.8.8
```

This will configure the following resolv.conf in the "web" container:

```
nameserver 172.17.10.113
nameserver 8.8.8.8
```
