### PR TITLE
Support an api version from the environment

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -32,4 +32,9 @@ def docker_client():
         )
 
     timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
-    return Client(base_url=base_url, tls=tls_config, version='1.18', timeout=timeout)
+    version = os.environ.get('COMPOSE_API_VERSION', '1.18')
+    return Client(
+        base_url=base_url,
+        tls=tls_config,
+        version=version,
+        timeout=timeout)


### PR DESCRIPTION
Right now I can't even run the test suite because it expects a version of the API that hasn't been officially released. 

By allowing the version to be specified from the environment developers can at least the older features in compose without upgrading the dockerd.