### PR TITLE
Add extra_hosts to yml configuration --add-hosts

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -43,6 +43,8 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
 DOCKER_CONFIG_HINTS = {
     'cpu_share': 'cpu_shares',
     'add_host': 'extra_hosts',
+    'hosts': 'extra_hosts',
+    'extra_host': 'extra_hosts',
     'link': 'links',
     'port': 'ports',
     'privilege': 'privileged',

--- a/compose/config.py
+++ b/compose/config.py
@@ -15,6 +15,7 @@ DOCKER_CONFIG_KEYS = [
     'entrypoint',
     'env_file',
     'environment',
+    'extra_hosts',
     'hostname',
     'image',
     'links',
@@ -41,6 +42,7 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
 
 DOCKER_CONFIG_HINTS = {
     'cpu_share': 'cpu_shares',
+    'add_host': 'extra_hosts',
     'link': 'links',
     'port': 'ports',
     'privilege': 'privileged',

--- a/compose/service.py
+++ b/compose/service.py
@@ -629,7 +629,17 @@ def build_extra_hosts(extra_hosts_config):
     if extra_hosts_config is None:
         return None
 
-    if isinstance(extra_hosts_config, list):
-        return dict(r.split(':') for r in extra_hosts_config)
-    else:
-        return dict([extra_hosts_config.split(':')])
+    if isinstance(extra_hosts_config, basestring):
+        extra_hosts_config = [extra_hosts_config]
+
+    extra_hosts_dict = {}
+    for extra_hosts_line in extra_hosts_config:
+        if isinstance(extra_hosts_line, dict):
+            # already interpreted as a dict (depends on pyyaml version)
+            extra_hosts_dict.update(extra_hosts_line)
+        else:
+            # not already interpreted as a dict
+            host, ip = extra_hosts_line.split(':')
+            extra_hosts_dict.update({host.strip(): ip.strip()})
+
+    return extra_hosts_dict

--- a/compose/service.py
+++ b/compose/service.py
@@ -23,6 +23,7 @@ DOCKER_START_KEYS = [
     'dns',
     'dns_search',
     'env_file',
+    'extra_hosts',
     'net',
     'pid',
     'privileged',
@@ -448,6 +449,8 @@ class Service(object):
 
         restart = parse_restart_spec(options.get('restart', None))
 
+        extra_hosts = build_extra_hosts(options.get('extra_hosts', None))
+
         return create_host_config(
             links=self._get_links(link_to_self=one_off),
             port_bindings=port_bindings,
@@ -460,6 +463,7 @@ class Service(object):
             restart_policy=restart,
             cap_add=cap_add,
             cap_drop=cap_drop,
+            extra_hosts=extra_hosts,
             pid_mode=pid
         )
 
@@ -619,3 +623,13 @@ def split_port(port):
 
     external_ip, external_port, internal_port = parts
     return internal_port, (external_ip, external_port or None)
+
+
+def build_extra_hosts(extra_hosts_config):
+    if extra_hosts_config is None:
+        return None
+
+    if isinstance(extra_hosts_config, list):
+        return dict(r.split(':') for r in extra_hosts_config)
+    else:
+        return dict([extra_hosts_config.split(':')])

--- a/compose/service.py
+++ b/compose/service.py
@@ -626,20 +626,25 @@ def split_port(port):
 
 
 def build_extra_hosts(extra_hosts_config):
-    if extra_hosts_config is None:
-        return None
+    if not extra_hosts_config:
+        return {}
 
-    if isinstance(extra_hosts_config, basestring):
-        extra_hosts_config = [extra_hosts_config]
-
-    extra_hosts_dict = {}
-    for extra_hosts_line in extra_hosts_config:
-        if isinstance(extra_hosts_line, dict):
-            # already interpreted as a dict (depends on pyyaml version)
-            extra_hosts_dict.update(extra_hosts_line)
-        else:
-            # not already interpreted as a dict
+    if isinstance(extra_hosts_config, list):
+        extra_hosts_dict = {}
+        for extra_hosts_line in extra_hosts_config:
+            if not isinstance(extra_hosts_line, six.string_types):
+                raise ConfigError(
+                    "extra_hosts_config \"%s\" must be either a list of strings or a string->string mapping," %
+                    extra_hosts_config
+                )
             host, ip = extra_hosts_line.split(':')
             extra_hosts_dict.update({host.strip(): ip.strip()})
+        extra_hosts_config = extra_hosts_dict
 
-    return extra_hosts_dict
+    if isinstance(extra_hosts_config, dict):
+        return extra_hosts_config
+
+    raise ConfigError(
+        "extra_hosts_config \"%s\" must be either a list of strings or a string->string mapping," %
+        extra_hosts_config
+    )

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -89,19 +89,19 @@ external_links:
 
 ### extra_hosts
 
-Add hostname mappings. Use the same values as the docker client `--add-hosts` parameter.
+Add hostname mappings. Use the same values as the docker client `--add-host` parameter.
 
 ```
 extra_hosts:
- - docker: 162.242.195.82
- - fig: 50.31.209.229
+ - "somehost:162.242.195.82"
+ - "otherhost:50.31.209.229"
 ```
 
 An entry with the ip address and hostname will be created in `/etc/hosts` inside containers for this service, e.g:
 
 ```
-162.242.195.82  docker
-50.31.209.229   fig
+162.242.195.82  somehost
+50.31.209.229   otherhost
 ```
 
 ### ports

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -87,6 +87,23 @@ external_links:
  - project_db_1:postgresql
 ```
 
+### extra_hosts
+
+Add hostname mappings. Use the same values as the docker client `--add-hosts` parameter.
+
+```
+extra_hosts:
+ - docker: 162.242.195.82
+ - fig: 50.31.209.229
+```
+
+An entry with the ip address and hostname will be created in `/etc/hosts` inside containers for this service, e.g:
+
+```
+162.242.195.82  docker
+50.31.209.229   fig
+```
+
 ### ports
 
 Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -6,6 +6,7 @@ import mock
 
 from compose import Service
 from compose.service import CannotBeScaledError
+from compose.service import build_extra_hosts
 from compose.container import Container
 from docker.errors import APIError
 from .testcases import DockerClientTestCase
@@ -106,6 +107,28 @@ class ServiceTest(DockerClientTestCase):
         container = service.create_container()
         service.start_container(container)
         self.assertEqual(container.inspect()['Config']['CpuShares'], 73)
+
+    def test_build_extra_hosts(self):
+        # string
+        self.assertEqual(build_extra_hosts("www.example.com: 192.168.0.17"),
+                         {'www.example.com': '192.168.0.17'})
+
+        # list of strings
+        self.assertEqual(build_extra_hosts(
+                          ["www.example.com: 192.168.0.17"]),
+                         {'www.example.com': '192.168.0.17'})
+        self.assertEqual(build_extra_hosts(
+                          ["www.example.com: 192.168.0.17",
+                           "api.example.com: 192.168.0.18"]),
+                         {'www.example.com': '192.168.0.17',
+                          'api.example.com': '192.168.0.18'})
+        # list of dictionaries
+        self.assertEqual(build_extra_hosts(
+                          [{'www.example.com': '192.168.0.17'},
+                           {'api.example.com': '192.168.0.18'}
+                          ]),
+                          {'www.example.com': '192.168.0.17',
+                           'api.example.com': '192.168.0.18'})
 
     def test_create_container_with_extra_hosts_list(self):
         extra_hosts = ['docker:162.242.195.82', 'fig:50.31.209.229']

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -107,6 +107,20 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(container.inspect()['Config']['CpuShares'], 73)
 
+    def test_create_container_with_extra_hosts_list(self):
+        extra_hosts = ['docker:162.242.195.82', 'fig:50.31.209.229']
+        service = self.create_service('db', extra_hosts=extra_hosts)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.ExtraHosts'), extra_hosts)
+
+    def test_create_container_with_extra_hosts_string(self):
+        extra_hosts = 'docker:162.242.195.82'
+        service = self.create_service('db', extra_hosts=extra_hosts)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.ExtraHosts'), [extra_hosts])
+
     def test_create_container_with_specified_volume(self):
         host_path = '/tmp/host-path'
         container_path = '/container-path'

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -5,8 +5,11 @@ from os import path
 import mock
 
 from compose import Service
-from compose.service import CannotBeScaledError
-from compose.service import build_extra_hosts
+from compose.service import (
+    CannotBeScaledError,
+    build_extra_hosts,
+    ConfigError,
+)
 from compose.container import Container
 from docker.errors import APIError
 from .testcases import DockerClientTestCase
@@ -110,39 +113,59 @@ class ServiceTest(DockerClientTestCase):
 
     def test_build_extra_hosts(self):
         # string
-        self.assertEqual(build_extra_hosts("www.example.com: 192.168.0.17"),
-                         {'www.example.com': '192.168.0.17'})
+        self.assertRaises(ConfigError, lambda: build_extra_hosts("www.example.com: 192.168.0.17"))
 
         # list of strings
         self.assertEqual(build_extra_hosts(
-                          ["www.example.com: 192.168.0.17"]),
-                         {'www.example.com': '192.168.0.17'})
+            ["www.example.com:192.168.0.17"]),
+            {'www.example.com': '192.168.0.17'})
         self.assertEqual(build_extra_hosts(
-                          ["www.example.com: 192.168.0.17",
-                           "api.example.com: 192.168.0.18"]),
-                         {'www.example.com': '192.168.0.17',
-                          'api.example.com': '192.168.0.18'})
+            ["www.example.com: 192.168.0.17"]),
+            {'www.example.com': '192.168.0.17'})
+        self.assertEqual(build_extra_hosts(
+            ["www.example.com: 192.168.0.17",
+             "static.example.com:192.168.0.19",
+             "api.example.com: 192.168.0.18"]),
+            {'www.example.com': '192.168.0.17',
+             'static.example.com': '192.168.0.19',
+             'api.example.com': '192.168.0.18'})
+
         # list of dictionaries
+        self.assertRaises(ConfigError, lambda: build_extra_hosts(
+            [{'www.example.com': '192.168.0.17'},
+             {'api.example.com': '192.168.0.18'}]))
+
+        # dictionaries
         self.assertEqual(build_extra_hosts(
-                          [{'www.example.com': '192.168.0.17'},
-                           {'api.example.com': '192.168.0.18'}
-                          ]),
-                          {'www.example.com': '192.168.0.17',
-                           'api.example.com': '192.168.0.18'})
+            {'www.example.com': '192.168.0.17',
+             'api.example.com': '192.168.0.18'}),
+            {'www.example.com': '192.168.0.17',
+             'api.example.com': '192.168.0.18'})
 
     def test_create_container_with_extra_hosts_list(self):
-        extra_hosts = ['docker:162.242.195.82', 'fig:50.31.209.229']
+        extra_hosts = ['somehost:162.242.195.82', 'otherhost:50.31.209.229']
         service = self.create_service('db', extra_hosts=extra_hosts)
         container = service.create_container()
         service.start_container(container)
-        self.assertEqual(container.get('HostConfig.ExtraHosts'), extra_hosts)
+        self.assertEqual(set(container.get('HostConfig.ExtraHosts')), set(extra_hosts))
 
     def test_create_container_with_extra_hosts_string(self):
-        extra_hosts = 'docker:162.242.195.82'
+        extra_hosts = 'somehost:162.242.195.82'
+        service = self.create_service('db', extra_hosts=extra_hosts)
+        self.assertRaises(ConfigError, lambda: service.create_container())
+
+    def test_create_container_with_extra_hosts_list_of_dicts(self):
+        extra_hosts = [{'somehost': '162.242.195.82'}, {'otherhost': '50.31.209.229'}]
+        service = self.create_service('db', extra_hosts=extra_hosts)
+        self.assertRaises(ConfigError, lambda: service.create_container())
+
+    def test_create_container_with_extra_hosts_dicts(self):
+        extra_hosts = {'somehost': '162.242.195.82', 'otherhost': '50.31.209.229'}
+        extra_hosts_list = ['somehost:162.242.195.82', 'otherhost:50.31.209.229']
         service = self.create_service('db', extra_hosts=extra_hosts)
         container = service.create_container()
         service.start_container(container)
-        self.assertEqual(container.get('HostConfig.ExtraHosts'), [extra_hosts])
+        self.assertEqual(set(container.get('HostConfig.ExtraHosts')), set(extra_hosts_list))
 
     def test_create_container_with_specified_volume(self):
         host_path = '/tmp/host-path'


### PR DESCRIPTION
Add extra_hosts to yml configuration

Followup from:
- #597
- #754 
- #848 
- #958 

### Example:
```yml
extra_hosts:
 - "docker:162.242.195.82"
 - "fig:50.31.209.229"
```

Signed-off-by: CJ <lim@chernjie.com>