### PR TITLE
Revert labels and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,13 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
-# ENV ALL_DOCKER_VERSIONS 1.6.0
+ENV ALL_DOCKER_VERSIONS 1.3.3 1.4.1 1.5.0
 
-# RUN set -ex; \
-#     for v in ${ALL_DOCKER_VERSIONS}; do \
-#         curl https://get.docker.com/builds/Linux/x86_64/docker-$v -o /usr/local/bin/docker-$v; \
-#         chmod +x /usr/local/bin/docker-$v; \
-#     done
-
-# Temporarily use dev version of Docker
-ENV ALL_DOCKER_VERSIONS dev
-RUN curl https://master.dockerproject.com/linux/amd64/docker-1.5.0-dev > /usr/local/bin/docker-dev
-RUN chmod +x /usr/local/bin/docker-dev
+RUN set -ex; \
+    for v in ${ALL_DOCKER_VERSIONS}; do \
+        curl https://get.docker.com/builds/Linux/x86_64/docker-$v -o /usr/local/bin/docker-$v; \
+        chmod +x /usr/local/bin/docker-$v; \
+    done
 
 RUN useradd -d /home/user -m -s /bin/bash user
 WORKDIR /code/

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -32,4 +32,4 @@ def docker_client():
         )
 
     timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
-    return Client(base_url=base_url, tls=tls_config, version='1.18', timeout=timeout)
+    return Client(base_url=base_url, tls=tls_config, version='1.15', timeout=timeout)

--- a/compose/config.py
+++ b/compose/config.py
@@ -17,7 +17,6 @@ DOCKER_CONFIG_KEYS = [
     'environment',
     'hostname',
     'image',
-    'labels',
     'links',
     'mem_limit',
     'net',
@@ -171,9 +170,6 @@ def process_container_options(service_dict, working_dir=None):
 
     if 'volumes' in service_dict:
         service_dict['volumes'] = resolve_host_paths(service_dict['volumes'], working_dir=working_dir)
-
-    if 'labels' in service_dict:
-        service_dict['labels'] = parse_labels(service_dict['labels'])
 
     return service_dict
 
@@ -334,29 +330,6 @@ def split_volume(volume):
 
 def volumes_from_dict(d):
     return ["%s:%s" % (host_path, container_path) for (container_path, host_path) in d.items()]
-
-
-def parse_labels(labels):
-    if not labels:
-        return {}
-
-    if isinstance(labels, list):
-        return dict(split_label(e) for e in labels)
-
-    if isinstance(labels, dict):
-        return labels
-
-    raise ConfigurationError(
-        "labels \"%s\" must be a list or mapping" %
-        labels
-    )
-
-
-def split_label(label):
-    if '=' in label:
-        return label.split('=', 1)
-    else:
-        return label, ''
 
 
 def expand_path(working_dir, path):

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ Compose with a `curl` command.
 
 ### Install Docker
 
-First, install Docker version 1.6 or greater:
+First, install Docker version 1.3 or greater:
 
 - [Instructions for Mac OS X](http://docs.docker.com/installation/mac/)
 - [Instructions for Ubuntu](http://docs.docker.com/installation/ubuntulinux/)

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -253,24 +253,6 @@ db:
 > configuration options are **not** inherited - you will have to define
 > those manually each time you extend it.
 
-### labels
-
-Add metadata to containers using [Docker labels](http://docs.docker.com/userguide/labels-custom-metadata/). You can use either an array or a dictionary.
-
-It's recommended that you use reverse-DNS notation to prevent your labels from conflicting with those used by other software.
-
-```
-labels:
-  com.example.description: "Accounting webapp"
-  com.example.department: "Finance"
-  com.example.label-with-empty-value: ""
-
-labels:
-  - "com.example.description=Accounting webapp"
-  - "com.example.department=Finance"
-  - "com.example.label-with-empty-value"
-```
-
 ### net
 
 Networking mode. Use the same values as the docker client `--net` parameter.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 PyYAML==3.10
-docker-py==1.1.0
+docker-py==1.0.0
 dockerpty==0.3.2
 docopt==0.6.1
-requests==2.5.3
+requests==2.2.1
 six==1.7.3
 texttable==0.8.2
 websocket-client==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
--e git+https://github.com/docker/docker-py.git@70ce156e26d283d181e6ec10bd1309ddc1da1bbd#egg=docker-py
+docker-py==1.1.0
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.5.3

--- a/script/test-versions
+++ b/script/test-versions
@@ -11,14 +11,14 @@ script/validate-dco
 flake8 compose
 
 if [ "$DOCKER_VERSIONS" == "" ]; then
-  DOCKER_VERSIONS="dev"
+  DOCKER_VERSIONS="1.5.0"
 elif [ "$DOCKER_VERSIONS" == "all" ]; then
   DOCKER_VERSIONS="$ALL_DOCKER_VERSIONS"
 fi
 
 for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"
-  docker-$version run \
+  docker-1.5.0 run \
     --rm \
     --privileged \
     --volume="/var/lib/docker" \

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ def find_version(*file_paths):
 install_requires = [
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.2.1, < 2.5.0',
+    'requests >= 2.2.1, < 2.6',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 1.0',
-    'docker-py >= 1.0.0, < 1.1.0',
+    'docker-py >= 1.0.0, < 1.2',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ def find_version(*file_paths):
 install_requires = [
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.5.0, < 2.6',
+    'requests >= 2.2.1, < 2.5.0',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 1.0',
-    'docker-py >= 1.1.0, < 1.2',
+    'docker-py >= 1.0.0, < 1.1.0',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -491,30 +491,3 @@ class ServiceTest(DockerClientTestCase):
         env = create_and_start_container(service).environment
         for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
             self.assertEqual(env[k], v)
-
-    def test_labels(self):
-        labels_dict = {
-            'com.example.description': "Accounting webapp",
-            'com.example.department': "Finance",
-            'com.example.label-with-empty-value': "",
-        }
-
-        service = self.create_service('web', labels=labels_dict)
-        labels = create_and_start_container(service).get('Config.Labels').items()
-        for pair in labels_dict.items():
-            self.assertIn(pair, labels)
-
-        labels_list = ["%s=%s" % pair for pair in labels_dict.items()]
-
-        service = self.create_service('web', labels=labels_list)
-        labels = create_and_start_container(service).get('Config.Labels').items()
-        for pair in labels_dict.items():
-            self.assertIn(pair, labels)
-
-    def test_empty_labels(self):
-        labels_list = ['foo', 'bar']
-
-        service = self.create_service('web', labels=labels_list)
-        labels = create_and_start_container(service).get('Config.Labels').items()
-        for name in labels_list:
-            self.assertIn((name, ''), labels)


### PR DESCRIPTION
When we updated our docker-py and requests versions in #1100, we inadvertently introduced a dependency on a version of requests that [doesn't play nicely with PyInstaller](http://stackoverflow.com/questions/28775276/pyinstaller-error-importerror-no-module-named-requests-packages-chardet-sys).

Since this hasn't been fixed yet, and the only feature we have that depends on an up-to-date docker-py is [labels](https://github.com/docker/compose/pull/1145), I'm backing it out and resetting our pinned versions.

We can still specify a wider version range in `setup.py` for people who install with pip and want to use newer versions of docker-py or requests, but for the purposes of building the binary, we're sticking with docker-py 1.0.0 and requests 2.2.1 for now.