### PR TITLE
Docs: fix env_file example

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -172,8 +172,12 @@ env_file:
   - /opt/secrets.env
 ```
 
+Compose expects each line in an env file to be in `VAR=VAL` format. Lines
+beginning with `#` (i.e. comments) are ignored, as are blank lines.
+
 ```
-RACK_ENV: development
+# Set Rails/Rack environment
+RACK_ENV=development
 ```
 
 ### extends


### PR DESCRIPTION
I had some problems with that, thinking the `env` file is in YAML format.
Cheers