### PR TITLE
Fix regression in Dns and DnsSearch settings

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -6,6 +6,7 @@ import re
 import os
 from operator import attrgetter
 import sys
+import six
 
 from docker.errors import APIError
 from docker.utils import create_host_config
@@ -435,11 +436,11 @@ class Service(object):
         cap_drop = options.get('cap_drop', None)
 
         dns = options.get('dns', None)
-        if not isinstance(dns, list):
+        if isinstance(dns, six.string_types):
             dns = [dns]
 
         dns_search = options.get('dns_search', None)
-        if not isinstance(dns_search, list):
+        if isinstance(dns_search, six.string_types):
             dns_search = [dns_search]
 
         restart = parse_restart_spec(options.get('restart', None))

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -424,6 +424,11 @@ class ServiceTest(DockerClientTestCase):
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.NetworkMode'), 'host')
 
+    def test_dns_no_value(self):
+        service = self.create_service('web')
+        container = create_and_start_container(service)
+        self.assertIsNone(container.get('HostConfig.Dns'))
+
     def test_dns_single_value(self):
         service = self.create_service('web', dns='8.8.8.8')
         container = create_and_start_container(service)
@@ -454,6 +459,11 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('web', cap_drop=['SYS_ADMIN', 'NET_ADMIN'])
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.CapDrop'), ['SYS_ADMIN', 'NET_ADMIN'])
+
+    def test_dns_search_no_value(self):
+        service = self.create_service('web')
+        container = create_and_start_container(service)
+        self.assertIsNone(container.get('HostConfig.DnsSearch'))
 
     def test_dns_search_single_value(self):
         service = self.create_service('web', dns_search='example.com')


### PR DESCRIPTION
Dns and DnsSearch are coming out as `[""]` instead of `None` when no value is provided.