### PR TITLE
Make test files and config files pep8 valid

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -39,14 +39,14 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
 ]
 
 DOCKER_CONFIG_HINTS = {
-    'cpu_share' : 'cpu_shares',
-    'link'      : 'links',
-    'port'      : 'ports',
-    'privilege' : 'privileged',
+    'cpu_share': 'cpu_shares',
+    'link': 'links',
+    'port': 'ports',
+    'privilege': 'privileged',
     'priviliged': 'privileged',
-    'privilige' : 'privileged',
-    'volume'    : 'volumes',
-    'workdir'   : 'working_dir',
+    'privilige': 'privileged',
+    'volume': 'volumes',
+    'workdir': 'working_dir',
 }
 
 

--- a/script/test-versions
+++ b/script/test-versions
@@ -8,7 +8,7 @@ set -e
 script/validate-dco
 
 >&2 echo "Running lint checks"
-flake8
+flake8 compose tests setup.py
 
 if [ "$DOCKER_VERSIONS" == "" ]; then
   DOCKER_VERSIONS="1.5.0"

--- a/script/test-versions
+++ b/script/test-versions
@@ -8,7 +8,7 @@ set -e
 script/validate-dco
 
 >&2 echo "Running lint checks"
-flake8 compose
+flake8
 
 if [ "$DOCKER_VERSIONS" == "" ]; then
   DOCKER_VERSIONS="1.5.0"

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ install_requires = [
     'six >= 1.3.0, < 2',
 ]
 
+
 tests_require = [
     'mock >= 1.0.1',
     'nose',
@@ -54,7 +55,7 @@ setup(
     url='https://www.docker.com/',
     author='Docker, Inc.',
     license='Apache License 2.0',
-    packages=find_packages(exclude=[ 'tests.*', 'tests' ]),
+    packages=find_packages(exclude=['tests.*', 'tests']),
     include_package_data=True,
     test_suite='nose.collector',
     install_requires=install_requires,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,6 @@
 import sys
 
-if sys.version_info >= (2,7):
+if sys.version_info >= (2, 7):
     import unittest
 else:
     import unittest2 as unittest
-

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
 if sys.version_info >= (2, 7):
-    import unittest
+    import unittest  # NOQA
 else:
-    import unittest2 as unittest
+    import unittest2 as unittest  # NOQA

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -70,7 +70,7 @@ class ProjectTest(DockerClientTestCase):
 
         web = project.get_service('web')
         net = project.get_service('net')
-        self.assertEqual(web._get_net(), 'container:'+net.containers()[0].id)
+        self.assertEqual(web._get_net(), 'container:' + net.containers()[0].id)
 
         project.kill()
         project.remove_stopped()
@@ -98,7 +98,7 @@ class ProjectTest(DockerClientTestCase):
         project.up()
 
         web = project.get_service('web')
-        self.assertEqual(web._get_net(), 'container:'+net_container.id)
+        self.assertEqual(web._get_net(), 'container:' + net_container.id)
 
         project.kill()
         project.remove_stopped()
@@ -266,7 +266,7 @@ class ProjectTest(DockerClientTestCase):
                     'image': 'busybox:latest',
                     'command': ["/bin/sleep", "300"],
                 },
-                'data' : {
+                'data': {
                     'image': 'busybox:latest',
                     'command': ["/bin/sleep", "300"]
                 },
@@ -304,7 +304,7 @@ class ProjectTest(DockerClientTestCase):
                     'image': 'busybox:latest',
                     'command': ["/bin/sleep", "300"],
                 },
-                'data' : {
+                'data': {
                     'image': 'busybox:latest',
                     'command': ["/bin/sleep", "300"]
                 },

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -182,7 +182,7 @@ class ServiceTest(DockerClientTestCase):
             entrypoint=['sleep'],
             command=['300']
         )
-        old_container = service.create_container()
+        service.create_container()
         self.assertEqual(len(service.containers(stopped=True)), 1)
         service.recreate_containers()
         self.assertEqual(len(service.containers(stopped=True)), 1)
@@ -262,8 +262,7 @@ class ServiceTest(DockerClientTestCase):
             set([
                 'composetest_db_1',
                 'composetest_db_2',
-                'db_3',
-                ]),
+                'db_3']),
         )
 
     def test_start_normal_container_does_not_create_links_to_its_own_service(self):

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -121,7 +121,7 @@ class ServiceTest(DockerClientTestCase):
         # Match the last component ("host-path"), because boot2docker symlinks /tmp
         actual_host_path = volumes[container_path]
         self.assertTrue(path.basename(actual_host_path) == path.basename(host_path),
-            msg=("Last component differs: %s, %s" % (actual_host_path, host_path)))
+                        msg=("Last component differs: %s, %s" % (actual_host_path, host_path)))
 
     def test_create_container_with_volumes_from(self):
         volume_service = self.create_service('data')
@@ -187,7 +187,6 @@ class ServiceTest(DockerClientTestCase):
         service.recreate_containers()
         self.assertEqual(len(service.containers(stopped=True)), 1)
 
-
     def test_recreate_containers_with_image_declared_volume(self):
         service = Service(
             project='composetest',
@@ -229,8 +228,7 @@ class ServiceTest(DockerClientTestCase):
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',
-                'db',
-            ]),
+                'db'])
         )
 
     def test_start_container_creates_links_with_names(self):
@@ -246,8 +244,7 @@ class ServiceTest(DockerClientTestCase):
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',
-                'custom_link_name',
-            ]),
+                'custom_link_name'])
         )
 
     def test_start_container_with_external_links(self):
@@ -291,8 +288,7 @@ class ServiceTest(DockerClientTestCase):
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',
-                'db',
-            ]),
+                'db'])
         )
 
     def test_start_container_builds_images(self):
@@ -331,7 +327,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(container['HostConfig']['Privileged'], False)
 
     def test_start_container_becomes_priviliged(self):
-        service = self.create_service('web', privileged = True)
+        service = self.create_service('web', privileged=True)
         container = create_and_start_container(service).inspect()
         self.assertEqual(container['HostConfig']['Privileged'], True)
 
@@ -483,13 +479,13 @@ class ServiceTest(DockerClientTestCase):
     def test_split_env(self):
         service = self.create_service('web', environment=['NORMAL=F1', 'CONTAINS_EQUALS=F=2', 'TRAILING_EQUALS='])
         env = create_and_start_container(service).environment
-        for k,v in {'NORMAL': 'F1', 'CONTAINS_EQUALS': 'F=2', 'TRAILING_EQUALS': ''}.items():
+        for k, v in {'NORMAL': 'F1', 'CONTAINS_EQUALS': 'F=2', 'TRAILING_EQUALS': ''}.items():
             self.assertEqual(env[k], v)
 
     def test_env_from_file_combined_with_env(self):
         service = self.create_service('web', environment=['ONE=1', 'TWO=2', 'THREE=3'], env_file=['tests/fixtures/env/one.env', 'tests/fixtures/env/two.env'])
         env = create_and_start_container(service).environment
-        for k,v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.items():
+        for k, v in {'ONE': '1', 'TWO': '2', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'}.items():
             self.assertEqual(env[k], v)
 
     @mock.patch.dict(os.environ)
@@ -499,5 +495,5 @@ class ServiceTest(DockerClientTestCase):
         os.environ['ENV_DEF'] = 'E3'
         service = self.create_service('web', environment={'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': None, 'NO_DEF': None})
         env = create_and_start_container(service).environment
-        for k,v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
+        for k, v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
             self.assertEqual(env[k], v)

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -5,7 +5,7 @@ import os
 import mock
 from tests import unittest
 
-from compose.cli import docker_client 
+from compose.cli import docker_client
 
 
 class DockerClientTestCase(unittest.TestCase):

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -151,4 +151,3 @@ def make_files(dirname, filenames):
     for fname in filenames:
         with open(os.path.join(dirname, fname), 'w') as f:
             f.write('')
-

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -8,7 +8,6 @@ from .. import unittest
 
 import docker
 import mock
-from six import StringIO
 
 from compose.cli import main
 from compose.cli.main import TopLevelCommand

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -4,6 +4,7 @@ from .. import unittest
 
 from compose import config
 
+
 class ConfigTest(unittest.TestCase):
     def test_from_dictionary(self):
         service_dicts = config.from_dictionary({
@@ -82,7 +83,7 @@ class MergeTest(unittest.TestCase):
 
 class EnvTest(unittest.TestCase):
     def test_parse_environment_as_list(self):
-        environment =[
+        environment = [
             'NORMAL=F1',
             'CONTAINS_EQUALS=F=2',
             'TRAILING_EQUALS=',
@@ -114,9 +115,8 @@ class EnvTest(unittest.TestCase):
         os.environ['ENV_DEF'] = 'E3'
 
         service_dict = config.make_service_dict(
-            'foo',
-            {
-               'environment': {
+            'foo', {
+                'environment': {
                     'FILE_DEF': 'F1',
                     'FILE_DEF_EMPTY': '',
                     'ENV_DEF': None,
@@ -174,6 +174,7 @@ class EnvTest(unittest.TestCase):
             {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
         )
 
+
 class ExtendsTest(unittest.TestCase):
     def test_extends(self):
         service_dicts = config.load('tests/fixtures/extends/docker-compose.yml')
@@ -230,7 +231,6 @@ class ExtendsTest(unittest.TestCase):
                     ('circle-1.yml', 'web'),
                 ],
             )
-
 
     def test_extends_validation(self):
         dictionary = {'extends': None}

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -234,7 +234,9 @@ class ExtendsTest(unittest.TestCase):
 
     def test_extends_validation(self):
         dictionary = {'extends': None}
-        load_config = lambda: config.make_service_dict('myweb', dictionary, working_dir='tests/fixtures/extends')
+
+        def load_config():
+            return config.make_service_dict('myweb', dictionary, working_dir='tests/fixtures/extends')
 
         self.assertRaisesRegexp(config.ConfigurationError, 'dictionary', load_config)
 

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -9,7 +9,6 @@ from compose.container import Container
 
 class ContainerTest(unittest.TestCase):
 
-
     def setUp(self):
         self.container_dict = {
             "Id": "abc",
@@ -30,11 +29,13 @@ class ContainerTest(unittest.TestCase):
         container = Container.from_ps(None,
                                       self.container_dict,
                                       has_been_inspected=True)
-        self.assertEqual(container.dictionary, {
-            "Id": "abc",
-            "Image":"busybox:latest",
-            "Name": "/composetest_db_1",
-        })
+        self.assertEqual(
+            container.dictionary,
+            {
+                "Id": "abc",
+                "Image": "busybox:latest",
+                "Name": "/composetest_db_1",
+            })
 
     def test_from_ps_prefixed(self):
         self.container_dict['Names'] = ['/swarm-host-1' + n for n in self.container_dict['Names']]
@@ -44,7 +45,7 @@ class ContainerTest(unittest.TestCase):
                                       has_been_inspected=True)
         self.assertEqual(container.dictionary, {
             "Id": "abc",
-            "Image":"busybox:latest",
+            "Image": "busybox:latest",
             "Name": "/composetest_db_1",
         })
 
@@ -100,7 +101,7 @@ class ContainerTest(unittest.TestCase):
 
     def test_human_readable_ports_public_and_private(self):
         self.container_dict['NetworkSettings']['Ports'].update({
-            "45454/tcp": [ { "HostIp": "0.0.0.0", "HostPort": "49197" } ],
+            "45454/tcp": [{"HostIp": "0.0.0.0", "HostPort": "49197"}],
             "45453/tcp": [],
         })
         container = Container(None, self.container_dict, has_been_inspected=True)
@@ -110,7 +111,7 @@ class ContainerTest(unittest.TestCase):
 
     def test_get_local_port(self):
         self.container_dict['NetworkSettings']['Ports'].update({
-            "45454/tcp": [ { "HostIp": "0.0.0.0", "HostPort": "49197" } ],
+            "45454/tcp": [{"HostIp": "0.0.0.0", "HostPort": "49197"}],
         })
         container = Container(None, self.container_dict, has_been_inspected=True)
 
@@ -120,12 +121,12 @@ class ContainerTest(unittest.TestCase):
 
     def test_get(self):
         container = Container(None, {
-            "Status":"Up 8 seconds",
+            "Status": "Up 8 seconds",
             "HostConfig": {
-                "VolumesFrom": ["volume_id",]
+                "VolumesFrom": ["volume_id"]
             },
         }, has_been_inspected=True)
 
         self.assertEqual(container.get('Status'), "Up 8 seconds")
-        self.assertEqual(container.get('HostConfig.VolumesFrom'), ["volume_id",])
+        self.assertEqual(container.get('HostConfig.VolumesFrom'), ["volume_id"])
         self.assertEqual(container.get('Foo.Bar.DoesNotExist'), None)

--- a/tests/unit/progress_stream_test.py
+++ b/tests/unit/progress_stream_test.py
@@ -5,7 +5,7 @@ from tests import unittest
 import mock
 from six import StringIO
 
-from compose import progress_stream 
+from compose import progress_stream
 
 
 class ProgressStreamTestCase(unittest.TestCase):

--- a/tests/unit/progress_stream_test.py
+++ b/tests/unit/progress_stream_test.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from tests import unittest
 
-import mock
 from six import StringIO
 
 from compose import progress_stream

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -8,6 +8,7 @@ from compose import config
 import mock
 import docker
 
+
 class ProjectTest(unittest.TestCase):
     def test_from_dict(self):
         project = Project.from_dicts('composetest', [
@@ -211,7 +212,7 @@ class ProjectTest(unittest.TestCase):
             }
         ], mock_client)
         service = project.get_service('test')
-        self.assertEqual(service._get_net(), 'container:'+container_id)
+        self.assertEqual(service._get_net(), 'container:' + container_id)
 
     def test_use_net_from_service(self):
         container_name = 'test_aaa_1'
@@ -237,4 +238,4 @@ class ProjectTest(unittest.TestCase):
         ], mock_client)
 
         service = project.get_service('test')
-        self.assertEqual(service._get_net(), 'container:'+container_name)
+        self.assertEqual(service._get_net(), 'container:' + container_name)

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -146,16 +146,16 @@ class ServiceTest(unittest.TestCase):
 
     def test_build_port_bindings_with_one_port(self):
         port_bindings = build_port_bindings(["127.0.0.1:1000:1000"])
-        self.assertEqual(port_bindings["1000"],[("127.0.0.1","1000")])
+        self.assertEqual(port_bindings["1000"], [("127.0.0.1", "1000")])
 
     def test_build_port_bindings_with_matching_internal_ports(self):
-        port_bindings = build_port_bindings(["127.0.0.1:1000:1000","127.0.0.1:2000:1000"])
-        self.assertEqual(port_bindings["1000"],[("127.0.0.1","1000"),("127.0.0.1","2000")])
+        port_bindings = build_port_bindings(["127.0.0.1:1000:1000", "127.0.0.1:2000:1000"])
+        self.assertEqual(port_bindings["1000"], [("127.0.0.1", "1000"), ("127.0.0.1", "2000")])
 
     def test_build_port_bindings_with_nonmatching_internal_ports(self):
-        port_bindings = build_port_bindings(["127.0.0.1:1000:1000","127.0.0.1:2000:2000"])
-        self.assertEqual(port_bindings["1000"],[("127.0.0.1","1000")])
-        self.assertEqual(port_bindings["2000"],[("127.0.0.1","2000")])
+        port_bindings = build_port_bindings(["127.0.0.1:1000:1000", "127.0.0.1:2000:2000"])
+        self.assertEqual(port_bindings["1000"], [("127.0.0.1", "1000")])
+        self.assertEqual(port_bindings["2000"], [("127.0.0.1", "2000")])
 
     def test_split_domainname_none(self):
         service = Service('foo', hostname='name', client=self.mock_client)
@@ -165,29 +165,32 @@ class ServiceTest(unittest.TestCase):
         self.assertFalse('domainname' in opts, 'domainname')
 
     def test_split_domainname_fqdn(self):
-        service = Service('foo',
-                hostname='name.domain.tld',
-                client=self.mock_client)
+        service = Service(
+            'foo',
+            hostname='name.domain.tld',
+            client=self.mock_client)
         self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'image': 'foo'})
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
 
     def test_split_domainname_both(self):
-        service = Service('foo',
-                hostname='name',
-                domainname='domain.tld',
-                client=self.mock_client)
+        service = Service(
+            'foo',
+            hostname='name',
+            domainname='domain.tld',
+            client=self.mock_client)
         self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'image': 'foo'})
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
 
     def test_split_domainname_weird(self):
-        service = Service('foo',
-                hostname='name.sub',
-                domainname='domain.tld',
-                client=self.mock_client)
+        service = Service(
+            'foo',
+            hostname='name.sub',
+            domainname='domain.tld',
+            client=self.mock_client)
         self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'image': 'foo'})
         self.assertEqual(opts['hostname'], 'name.sub', 'hostname')
@@ -315,4 +318,3 @@ class ServiceVolumesTest(unittest.TestCase):
         self.assertEqual(
             binding,
             ('/home/user', dict(bind='/home/user', ro=False)))
-

--- a/tests/unit/split_buffer_test.py
+++ b/tests/unit/split_buffer_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from compose.cli.utils import split_buffer
 from .. import unittest
 
+
 class SplitBufferTest(unittest.TestCase):
     def test_single_line_chunks(self):
         def reader():

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     nosetests -v {posargs}
-    flake8
+    flake8 compose tests setup.py
 
 [flake8]
 # ignore line-length for now

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     nosetests -v {posargs}
-    flake8 compose
+    flake8
 
 [flake8]
 # ignore line-length for now


### PR DESCRIPTION
### What does it do?
Upon reading some config files I noticed they are not pep8 valid, so I ran the command on the root of compose. There were only issues in config files and tests. This pull request proposes a solution for this, in the name of clean code.
Resolves https://github.com/docker/compose/issues/1184
### Comments
![](http://media0.giphy.com/media/FaKV1cVKlVRxC/giphy.gif)
