### PR TITLE
WIP: Jenkins script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN set -ex; \
     curl https://test.docker.com/builds/Linux/x86_64/docker-1.6.0-rc2 -o /usr/local/bin/docker-1.6.0-rc2; \
     chmod +x /usr/local/bin/docker-1.6.0-rc2
 
+# Set the default Docker to be run
+RUN ln -s /usr/local/bin/docker-1.3.3 /usr/local/bin/docker
+
 RUN useradd -d /home/user -m -s /bin/bash user
 WORKDIR /code/
 

--- a/script/build-linux
+++ b/script/build-linux
@@ -1,8 +1,12 @@
-#!/bin/sh
+#!/bin/bash
+
 set -ex
-mkdir -p `pwd`/dist
-chmod 777 `pwd`/dist
-docker build -t docker-compose .
-docker run -u user -v `pwd`/dist:/code/dist --rm --entrypoint pyinstaller docker-compose -F bin/docker-compose
-mv dist/docker-compose dist/docker-compose-Linux-x86_64
-docker run -u user -v `pwd`/dist:/code/dist --rm --entrypoint dist/docker-compose-Linux-x86_64 docker-compose --version
+
+TAG="docker-compose"
+docker build -t "$TAG" .
+docker run \
+  --rm \
+  --user=user \
+  --volume="$(pwd):/code" \
+  --entrypoint="script/build-linux-inner" \
+  "$TAG"

--- a/script/build-linux-inner
+++ b/script/build-linux-inner
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p `pwd`/dist
+chmod 777 `pwd`/dist
+
+pyinstaller -F bin/docker-compose
+mv dist/docker-compose dist/docker-compose-Linux-x86_64
+dist/docker-compose-Linux-x86_64 --version

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This should be run inside a container built from the Dockerfile
+# at the root of the repo:
+#
+# $ TAG="docker-compose:$(git rev-parse --short HEAD)"
+# $ docker build -t "$TAG" .
+# $ docker run --rm --volume="/var/run/docker.sock:/var/run/docker.sock" --volume="$(pwd)/.git:/code/.git" -e "TAG=$TAG" --entrypoint="script/ci" "$TAG"
+
+set -e
+
+>&2 echo "Validating DCO"
+script/validate-dco
+
+export DOCKER_VERSIONS=all
+. script/test-versions
+
+>&2 echo "Building Linux binary"
+su -c script/build-linux-inner user

--- a/script/test-versions
+++ b/script/test-versions
@@ -4,9 +4,6 @@
 
 set -e
 
->&2 echo "Validating DCO"
-script/validate-dco
-
 >&2 echo "Running lint checks"
 flake8 compose tests setup.py
 
@@ -18,7 +15,7 @@ fi
 
 for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"
-  docker-1.5.0 run \
+  docker run \
     --rm \
     --privileged \
     --volume="/var/lib/docker" \

--- a/script/wrapdocker
+++ b/script/wrapdocker
@@ -4,7 +4,7 @@ if [ "$DOCKER_VERSION" == "" ]; then
     DOCKER_VERSION="1.5.0"
 fi
 
-ln -s "/usr/local/bin/docker-$DOCKER_VERSION" "/usr/local/bin/docker"
+ln -fs "/usr/local/bin/docker-$DOCKER_VERSION" "/usr/local/bin/docker"
 
 # If a pidfile is still around (for example after a container restart),
 # delete it so that docker can start.


### PR DESCRIPTION
I've moved the DCO validation step out of `script/test-versions`, where it really doesn't belong, and added `script/ci`, which:

1. Performs DCO validation
2. Runs tests against all Docker versions
3. Builds the Linux binary

Currently the last step is failing with an odd `Permission denied` error, which I'm still investigating.