### PR TITLE
Bugfix 1167

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -299,15 +299,22 @@ def env_vars_from_file(filename):
 def resolve_host_paths(volumes, working_dir=None):
     if working_dir is None:
         raise Exception("No working_dir passed to resolve_host_paths()")
-
+    
     return [resolve_host_path(v, working_dir) for v in volumes]
 
 
 def resolve_host_path(volume, working_dir):
     container_path, host_path = split_volume(volume)
-    if host_path is not None:
+    if "${" in container_path and "${" in host_path:
+        return "%s:%s" % (os.path.expandvars(host_path),
+            os.path.expandvars(container_path))
+    elif "${" in container_path and not "${" in host_path:
+        return os.path.expandvars(container_path)
+    elif host_path is not None:
+        print  "%s:%s" % (expand_path(working_dir, host_path), container_path)
         return "%s:%s" % (expand_path(working_dir, host_path), container_path)
     else:
+        print container_path
         return container_path
 
 

--- a/compose/config.py
+++ b/compose/config.py
@@ -299,23 +299,24 @@ def env_vars_from_file(filename):
 def resolve_host_paths(volumes, working_dir=None):
     if working_dir is None:
         raise Exception("No working_dir passed to resolve_host_paths()")
-    
+
     return [resolve_host_path(v, working_dir) for v in volumes]
 
 
 def resolve_host_path(volume, working_dir):
     container_path, host_path = split_volume(volume)
-    if "${" in container_path and "${" in host_path:
-        return "%s:%s" % (os.path.expandvars(host_path),
-            os.path.expandvars(container_path))
-    elif "${" in container_path and not "${" in host_path:
-        return os.path.expandvars(container_path)
-    elif host_path is not None:
-        print  "%s:%s" % (expand_path(working_dir, host_path), container_path)
-        return "%s:%s" % (expand_path(working_dir, host_path), container_path)
+
+    if host_path is not None:
+        if container_path.startswith('$') and host_path.startswith('$'):
+            return "%s:%s" % (os.path.expandvars(host_path),
+                              os.path.expandvars(container_path))
+        else:
+            return "%s:%s" % (expand_path(working_dir, host_path), container_path)
     else:
-        print container_path
-        return container_path
+        if container_path.startswith('$'):
+            return os.path.expandvars(container_path)
+        else:
+            return container_path
 
 
 def merge_volumes(base, override):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -186,6 +186,7 @@ class EnvTest(unittest.TestCase):
         )
         self.assertEqual(set(service_dict['volumes']), set(['/tmp/:/host/tmp/']))
 
+
 class ExtendsTest(unittest.TestCase):
     def test_extends(self):
         service_dicts = config.load('tests/fixtures/extends/docker-compose.yml')

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -174,6 +174,17 @@ class EnvTest(unittest.TestCase):
             {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
         )
 
+    @mock.patch.dict(os.environ)
+    def test_resolve_host_path(self):
+        os.environ['HOSTENV'] = '/tmp/'
+        os.environ['CONTAINERENV'] = '/host/tmp/'
+
+        service_dict = config.make_service_dict(
+            'foo',
+            {'volumes': ['$HOSTENV:$CONTAINERENV']},
+            working_dir="tests/fixtures/env"
+        )
+        self.assertEqual(set(service_dict['volumes']), set(['/tmp/:/host/tmp/']))
 
 class ExtendsTest(unittest.TestCase):
     def test_extends(self):


### PR DESCRIPTION
Aims to fix https://github.com/docker/compose/issues/1167

With this fix you can use

```
volumes:
  - ${APP_DIR_ON_HOST}:${APP_DIR_ON_CONTAINER}
```
Or
```
volumes:
  - $APP_DIR_ON_HOST:$APP_DIR_ON_CONTAINER

```

Or regular path names, only checks happen when using local env vars for volume identification