### PR TITLE
When extending, `build` replaces `image` and vice versa

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -189,6 +189,12 @@ def merge_service_dicts(base, override):
             override.get('volumes'),
         )
 
+    if 'image' in override and 'build' in d:
+        del d['build']
+
+    if 'build' in override and 'image' in d:
+        del d['image']
+
     for k in ALLOWED_KEYS:
         if k not in ['environment', 'volumes']:
             if k in override:

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -80,6 +80,39 @@ class MergeTest(unittest.TestCase):
         )
         self.assertEqual(set(service_dict['volumes']), set(['/bar:/code', '/data']))
 
+    def test_merge_build_or_image_no_override(self):
+        self.assertEqual(
+            config.merge_service_dicts({'build': '.'}, {}),
+            {'build': '.'},
+        )
+
+        self.assertEqual(
+            config.merge_service_dicts({'image': 'redis'}, {}),
+            {'image': 'redis'},
+        )
+
+    def test_merge_build_or_image_override_with_same(self):
+        self.assertEqual(
+            config.merge_service_dicts({'build': '.'}, {'build': './web'}),
+            {'build': './web'},
+        )
+
+        self.assertEqual(
+            config.merge_service_dicts({'image': 'redis'}, {'image': 'postgres'}),
+            {'image': 'postgres'},
+        )
+
+    def test_merge_build_or_image_override_with_other(self):
+        self.assertEqual(
+            config.merge_service_dicts({'build': '.'}, {'image': 'redis'}),
+            {'image': 'redis'}
+        )
+
+        self.assertEqual(
+            config.merge_service_dicts({'image': 'redis'}, {'build': '.'}),
+            {'build': '.'}
+        )
+
 
 class EnvTest(unittest.TestCase):
     def test_parse_environment_as_list(self):


### PR DESCRIPTION
Closes #1222.