### PR TITLE
Add support for dockerfile when building

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -11,6 +11,7 @@ DOCKER_CONFIG_KEYS = [
     'detach',
     'dns',
     'dns_search',
+    'dockerfile',
     'domainname',
     'entrypoint',
     'env_file',

--- a/compose/service.py
+++ b/compose/service.py
@@ -60,6 +60,8 @@ class Service(object):
             raise ConfigError('Invalid project name "%s" - only %s are allowed' % (project, VALID_NAME_CHARS))
         if 'image' in options and 'build' in options:
             raise ConfigError('Service %s has both an image and build path specified. A service can either be built to image or use an existing image, not both.' % name)
+        if 'dockerfile' in options and 'build' not in options:
+            raise ConfigError('Service %s has a dockerfile specified but no build path. A service with a dockerfile must also have a build path.' % name)
 
         self.name = name
         self.client = client
@@ -68,6 +70,7 @@ class Service(object):
         self.external_links = external_links or []
         self.volumes_from = volumes_from or []
         self.net = net or None
+        self.dockerfile = options.pop('dockerfile', None)
         self.options = options
 
     def containers(self, stopped=False, one_off=False):
@@ -474,6 +477,7 @@ class Service(object):
             stream=True,
             rm=True,
             nocache=no_cache,
+            dockerfile=self.dockerfile,
         )
 
         try:


### PR DESCRIPTION
This is my feeble attempt at fixing this.  The builds currently fail; I think because of an old version of docker-py.  The required docker-py support was added by this: https://github.com/docker/docker-py/commit/0713488faca9a473135021ad5425bf216ab54ba4 but I can't tell what version that is included in.

This is to fix issue #1228 