### PR TITLE
Test against Docker 1.6 RC2 only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,14 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
-ENV ALL_DOCKER_VERSIONS 1.3.3 1.4.1 1.5.0 1.6.0-rc2
+ENV ALL_DOCKER_VERSIONS 1.6.0-rc2
 
 RUN set -ex; \
-    for v in 1.3.3 1.4.1 1.5.0; do \
-        curl https://get.docker.com/builds/Linux/x86_64/docker-$v -o /usr/local/bin/docker-$v; \
-        chmod +x /usr/local/bin/docker-$v; \
-    done; \
     curl https://test.docker.com/builds/Linux/x86_64/docker-1.6.0-rc2 -o /usr/local/bin/docker-1.6.0-rc2; \
     chmod +x /usr/local/bin/docker-1.6.0-rc2
 
 # Set the default Docker to be run
-RUN ln -s /usr/local/bin/docker-1.3.3 /usr/local/bin/docker
+RUN ln -s /usr/local/bin/docker-1.6.0-rc2 /usr/local/bin/docker
 
 RUN useradd -d /home/user -m -s /bin/bash user
 WORKDIR /code/

--- a/script/test-versions
+++ b/script/test-versions
@@ -8,7 +8,7 @@ set -e
 flake8 compose tests setup.py
 
 if [ "$DOCKER_VERSIONS" == "" ]; then
-  DOCKER_VERSIONS="1.5.0"
+  DOCKER_VERSIONS="default"
 elif [ "$DOCKER_VERSIONS" == "all" ]; then
   DOCKER_VERSIONS="$ALL_DOCKER_VERSIONS"
 fi

--- a/script/wrapdocker
+++ b/script/wrapdocker
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-if [ "$DOCKER_VERSION" == "" ]; then
-    DOCKER_VERSION="1.5.0"
+if [ "$DOCKER_VERSION" != "" ] && [ "$DOCKER_VERSION" != "default" ]; then
+    ln -fs "/usr/local/bin/docker-$DOCKER_VERSION" "/usr/local/bin/docker"
 fi
-
-ln -fs "/usr/local/bin/docker-$DOCKER_VERSION" "/usr/local/bin/docker"
 
 # If a pidfile is still around (for example after a container restart),
 # delete it so that docker can start.


### PR DESCRIPTION
While Compose 1.2 will support Docker 1.3 and up, Compose 1.3 will introduce several features that rely on later versions - including labels, which were added in Docker 1.6.

We talked briefly about being able to specify an API version with an environment variable, but after some thought I don't think the combinatorial explosion of Docker versions and API versions is going to be worth the maintenance trouble.

Meanwhile, multiple PRs (#1011, #1075) can't be merged because they're waiting on us dropping support for older versions. Accordingly, I've updated the Dockerfile so that from now on we're only testing against Docker 1.6.