### PR TITLE
Add parent directories search for default compose-files

### DIFF
--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -58,7 +58,7 @@ class ConnectionErrorGeneric(UserError):
 class ComposeFileNotFound(UserError):
     def __init__(self, supported_filenames):
         super(ComposeFileNotFound, self).__init__("""
-        Can't find a suitable configuration file. Are you in the right directory?
+        Can't find a suitable configuration file in this directory or any parent. Are you in the right directory?
 
         Supported filenames: %s
         """ % ", ".join(supported_filenames))

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -62,6 +62,25 @@ def mkdir(path, permissions=0o700):
     return path
 
 
+def find_candidates_in_parent_dirs(filenames, path):
+    """
+    Given a directory path to start, looks for filenames in the
+    directory, and then each parent directory successively,
+    until found.
+
+    Returns tuple (candidates, path).
+    """
+    candidates = [filename for filename in filenames
+                  if os.path.exists(os.path.join(path, filename))]
+
+    if len(candidates) == 0:
+        parent_dir = os.path.join(path, '..')
+        if os.path.abspath(parent_dir) != os.path.abspath(path):
+            return find_candidates_in_parent_dirs(filenames, parent_dir)
+
+    return (candidates, path)
+
+
 def split_buffer(reader, separator):
     """
     Given a generator which yields strings and a separator string,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,7 +136,10 @@ By default, if there are existing containers for a service, `docker-compose up` 
 
 ### -f, --file FILE
 
- Specifies an alternate Compose yaml file (default: `docker-compose.yml`)
+ Specify what file to read configuration from. If not provided, Compose will look
+ for `docker-compose.yml` in the current working directory, and then each parent
+ directory successively, until found.
+
 
 ### -p, --project-name NAME
 
@@ -157,7 +160,9 @@ Sets the project name, which is prepended to the name of every container started
 
 ### COMPOSE\_FILE
 
-Sets the path to the `docker-compose.yml` to use. Defaults to `docker-compose.yml` in the current working directory.
+Specify what file to read configuration from. If not provided, Compose will look
+for `docker-compose.yml` in the current working directory, and then each parent
+directory successively, until found.
 
 ### DOCKER\_HOST
 


### PR DESCRIPTION
Does not change directory to the parent with the compose-file found.
Works like passing '--file' or setting 'COMPOSE_FILE' with absolute path.
Resolves issue #946.

Signed-off-by: Aleksandr Vinokurov <aleksandr.vin@gmail.com>