### PR TITLE
Advanced config file

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -71,14 +71,15 @@ class Command(DocoptCommand):
 
     def get_project(self, config_path, project_name=None, verbose=False):
         try:
+            config_dict = config.load(config_path)
             return Project.from_dicts(
-                self.get_project_name(config_path, project_name),
-                config.load(config_path),
+                self.get_project_name(config_dict, project_name),
+                config_dict,
                 self.get_client(verbose=verbose))
         except ConfigError as e:
             raise errors.UserError(six.text_type(e))
 
-    def get_project_name(self, config_path, project_name=None):
+    def get_project_name(self, config_dict, project_name=None):
         def normalize_name(name):
             return re.sub(r'[^a-z0-9]', '', name.lower())
 
@@ -90,9 +91,10 @@ class Command(DocoptCommand):
         if project_name is not None:
             return normalize_name(project_name)
 
-        project = os.path.basename(os.path.dirname(os.path.abspath(config_path)))
-        if project:
-            return normalize_name(project)
+        if config_dict:
+            project_name = config_dict['project']
+            if project_name:
+                return normalize_name(project_name)
 
         return 'default'
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -61,12 +61,12 @@ class Project(object):
         self.client = client
 
     @classmethod
-    def from_dicts(cls, name, service_dicts, client):
+    def from_dicts(cls, name, config_dict, client):
         """
         Construct a ServiceCollection from a list of dicts representing services.
         """
         project = cls(name, [], client)
-        for service_dict in sort_service_dicts(service_dicts):
+        for service_dict in sort_service_dicts(config_dict['services']):
             links = project.get_links(service_dict)
             volumes_from = project.get_volumes_from(service_dict)
             net = project.get_net(service_dict)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,7 +140,8 @@ By default, if there are existing containers for a service, `docker-compose up` 
 
 ### -p, --project-name NAME
 
- Specifies an alternate project name (default: current directory name)
+ Specifies an alternate project name (default: when defined, used the option
+ project in `docker-compose.yml` else use current directory name)
 
 
 ## Environment Variables

--- a/docs/django.md
+++ b/docs/django.md
@@ -43,17 +43,19 @@ describes the services that comprise your app (here, a web server and database),
 which Docker images they use, how they link together, what volumes will be
 mounted inside the containers, and what ports they expose.
 
-    db:
-      image: postgres
-    web:
-      build: .
-      command: python manage.py runserver 0.0.0.0:8000
-      volumes:
-        - .:/code
-      ports:
-        - "8000:8000"
-      links:
-        - db
+    version: 1.0
+    services:
+      db:
+        image: postgres
+      web:
+        build: .
+        command: python manage.py runserver 0.0.0.0:8000
+        volumes:
+          - .:/code
+        ports:
+          - "8000:8000"
+        links:
+          - db
 
 See the [`docker-compose.yml` reference](yml.html) for more information on how
 this file works.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,14 +31,16 @@ Next, you define the services that make up your app in `docker-compose.yml` so
 they can be run together in an isolated environment:
 
 ```yaml
-web:
-  build: .
-  links:
-   - db
-  ports:
-   - "8000:8000"
-db:
-  image: postgres
+version: 1.0
+services:
+  web:
+    build: .
+    links:
+     - db
+    ports:
+     - "8000:8000"
+  db:
+    image: postgres
 ```
 
 Lastly, run `docker-compose up` and Compose will start and run your entire app.
@@ -120,17 +122,19 @@ and the
 
 Next, define a set of services using `docker-compose.yml`:
 
-    web:
-      build: .
-      command: python app.py
-      ports:
-       - "5000:5000"
-      volumes:
-       - .:/code
-      links:
-       - redis
-    redis:
-      image: redis
+    version: 1.0
+    services:
+      web:
+        build: .
+        command: python app.py
+        ports:
+         - "5000:5000"
+        volumes:
+         - .:/code
+        links:
+         - redis
+      redis:
+        image: redis
 
 This defines two services:
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -33,19 +33,21 @@ Next, create a bootstrap `Gemfile` which just loads Rails. It'll be overwritten 
 
 Finally, `docker-compose.yml` is where the magic happens. This file describes the services that comprise your app (a database and a web app), how to get each one's Docker image (the database just runs on a pre-made PostgreSQL image, and the web app is built from the current directory), and the configuration needed to link them together and expose the web app's port.
 
-    db:
-      image: postgres
-      ports:
-        - "5432"
-    web:
-      build: .
-      command: bundle exec rails s -p 3000 -b '0.0.0.0'
-      volumes:
-        - .:/myapp
-      ports:
-        - "3000:3000"
-      links:
-        - db
+    version: 1.0
+    services:
+      db:
+        image: postgres
+        ports:
+          - "5432"
+      web:
+        build: .
+        command: bundle exec rails s -p 3000 -b '0.0.0.0'
+        volumes:
+          - .:/myapp
+        ports:
+          - "3000:3000"
+        links:
+          - db
 
 ### Build the project
 

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -37,19 +37,21 @@ Next you'll create a `docker-compose.yml` file that will start your web service
 and a separate MySQL instance:
 
 ```
-web:
-  build: .
-  command: php -S 0.0.0.0:8000 -t /code
-  ports:
-    - "8000:8000"
-  links:
-    - db
-  volumes:
-    - .:/code
-db:
-  image: orchardup/mysql
-  environment:
-    MYSQL_DATABASE: wordpress
+version: 1.0
+services:
+  web:
+    build: .
+    command: php -S 0.0.0.0:8000 -t /code
+    ports:
+      - "8000:8000"
+    links:
+      - db
+    volumes:
+      - .:/code
+  db:
+    image: orchardup/mysql
+    environment:
+      MYSQL_DATABASE: wordpress
 ```
 
 Two supporting files are needed to get this working - first, `wp-config.php` is

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -188,28 +188,32 @@ Here's a simple example. Suppose we have 2 files - **common.yml** and
 **common.yml**
 
 ```
-webapp:
-  build: ./webapp
-  environment:
-    - DEBUG=false
-    - SEND_EMAILS=false
+version: 1.0
+services:
+  webapp:
+    build: ./webapp
+    environment:
+      - DEBUG=false
+      - SEND_EMAILS=false
 ```
 
 **development.yml**
 
 ```
-web:
-  extends:
-    file: common.yml
-    service: webapp
-  ports:
-    - "8000:8000"
-  links:
-    - db
-  environment:
-    - DEBUG=true
-db:
-  image: postgres
+version: 1.0
+services:
+  web:
+    extends:
+      file: common.yml
+      service: webapp
+    ports:
+      - "8000:8000"
+    links:
+      - db
+    environment:
+      - DEBUG=true
+  db:
+    image: postgres
 ```
 
 Here, the `web` service in **development.yml** inherits the configuration of
@@ -220,15 +224,17 @@ environment variables (DEBUG) with a new value, and the other one
 this:
 
 ```yaml
-web:
-  build: ./webapp
-  ports:
-    - "8000:8000"
-  links:
-    - db
-  environment:
-    - DEBUG=true
-    - SEND_EMAILS=false
+version: 1.0
+services:
+  web:
+    build: ./webapp
+    ports:
+      - "8000:8000"
+    links:
+      - db
+    environment:
+      - DEBUG=true
+      - SEND_EMAILS=false
 ```
 
 The `extends` option is great for sharing configuration between different
@@ -237,21 +243,34 @@ You could write a new file for a staging environment, **staging.yml**, which
 binds to a different port and doesn't turn on debugging:
 
 ```
-web:
-  extends:
-    file: common.yml
-    service: webapp
-  ports:
-    - "80:8000"
-  links:
-    - db
-db:
-  image: postgres
+version: 1.0
+services:
+  web:
+    extends:
+      file: common.yml
+      service: webapp
+    ports:
+      - "80:8000"
+    links:
+      - db
+  db:
+    image: postgres
 ```
 
 > **Note:** When you extend a service, `links` and `volumes_from`
 > configuration options are **not** inherited - you will have to define
 > those manually each time you extend it.
+
+### project
+
+> **Note:** Since version 1.2
+
+The `project` option lets you defined an project name for your services.
+
+```
+version: 1.1
+project: secretproject
+```
 
 ### net
 

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -7,19 +7,18 @@ from .testcases import DockerClientTestCase
 
 class ProjectTest(DockerClientTestCase):
     def test_volumes_from_service(self):
-        service_dicts = config.from_dictionary({
-            'data': {
-                'image': 'busybox:latest',
-                'volumes': ['/var/data'],
-            },
-            'db': {
-                'image': 'busybox:latest',
-                'volumes_from': ['data'],
-            },
-        }, working_dir='.')
         project = Project.from_dicts(
             name='composetest',
-            service_dicts=service_dicts,
+            config_dict=config.from_dictionary({
+                'data': {
+                    'image': 'busybox:latest',
+                    'volumes': ['/var/data'],
+                },
+                'db': {
+                    'image': 'busybox:latest',
+                    'volumes_from': ['data'],
+                },
+            }, working_dir='.'),
             client=self.client,
         )
         db = project.get_service('db')
@@ -35,7 +34,7 @@ class ProjectTest(DockerClientTestCase):
         )
         project = Project.from_dicts(
             name='composetest',
-            service_dicts=config.from_dictionary({
+            config_dict=config.from_dictionary({
                 'db': {
                     'image': 'busybox:latest',
                     'volumes_from': ['composetest_data_container'],
@@ -52,7 +51,7 @@ class ProjectTest(DockerClientTestCase):
     def test_net_from_service(self):
         project = Project.from_dicts(
             name='composetest',
-            service_dicts=config.from_dictionary({
+            config_dict=config.from_dictionary({
                 'net': {
                     'image': 'busybox:latest',
                     'command': ["/bin/sleep", "300"]
@@ -86,7 +85,7 @@ class ProjectTest(DockerClientTestCase):
 
         project = Project.from_dicts(
             name='composetest',
-            service_dicts=config.from_dictionary({
+            config_dict=config.from_dictionary({
                 'web': {
                     'image': 'busybox:latest',
                     'net': 'container:composetest_net_container'
@@ -261,7 +260,7 @@ class ProjectTest(DockerClientTestCase):
     def test_project_up_starts_depends(self):
         project = Project.from_dicts(
             name='composetest',
-            service_dicts=config.from_dictionary({
+            config_dict=config.from_dictionary({
                 'console': {
                     'image': 'busybox:latest',
                     'command': ["/bin/sleep", "300"],
@@ -299,7 +298,7 @@ class ProjectTest(DockerClientTestCase):
     def test_project_up_with_no_deps(self):
         project = Project.from_dicts(
             name='composetest',
-            service_dicts=config.from_dictionary({
+            config_dict=config.from_dictionary({
                 'console': {
                     'image': 'busybox:latest',
                     'command': ["/bin/sleep", "300"],

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -13,6 +13,7 @@ from compose.cli import main
 from compose.cli.main import TopLevelCommand
 from compose.cli.errors import ComposeFileNotFound
 from compose.service import Service
+from compose import config
 
 
 class CLITestCase(unittest.TestCase):
@@ -22,7 +23,7 @@ class CLITestCase(unittest.TestCase):
         try:
             os.chdir('tests/fixtures/simple-composefile')
             command = TopLevelCommand()
-            project_name = command.get_project_name(command.get_config_path())
+            project_name = command.get_project_name(config.load(command.get_config_path()))
             self.assertEquals('simplecomposefile', project_name)
         finally:
             os.chdir(cwd)
@@ -30,13 +31,13 @@ class CLITestCase(unittest.TestCase):
     def test_project_name_with_explicit_base_dir(self):
         command = TopLevelCommand()
         command.base_dir = 'tests/fixtures/simple-composefile'
-        project_name = command.get_project_name(command.get_config_path())
+        project_name = command.get_project_name(config.load(command.get_config_path()))
         self.assertEquals('simplecomposefile', project_name)
 
     def test_project_name_with_explicit_uppercase_base_dir(self):
         command = TopLevelCommand()
         command.base_dir = 'tests/fixtures/UpperCaseDir'
-        project_name = command.get_project_name(command.get_config_path())
+        project_name = command.get_project_name(config.load(command.get_config_path()))
         self.assertEquals('uppercasedir', project_name)
 
     def test_project_name_with_explicit_project_name(self):

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -11,7 +11,7 @@ import docker
 
 class ProjectTest(unittest.TestCase):
     def test_from_dict(self):
-        project = Project.from_dicts('composetest', [
+        project = Project.from_dicts('composetest', {'services': [
             {
                 'name': 'web',
                 'image': 'busybox:latest'
@@ -20,7 +20,7 @@ class ProjectTest(unittest.TestCase):
                 'name': 'db',
                 'image': 'busybox:latest'
             },
-        ], None)
+        ]}, None)
         self.assertEqual(len(project.services), 2)
         self.assertEqual(project.get_service('web').name, 'web')
         self.assertEqual(project.get_service('web').options['image'], 'busybox:latest')
@@ -28,7 +28,7 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual(project.get_service('db').options['image'], 'busybox:latest')
 
     def test_from_dict_sorts_in_dependency_order(self):
-        project = Project.from_dicts('composetest', [
+        project = Project.from_dicts('composetest', {'services': [
             {
                 'name': 'web',
                 'image': 'busybox:latest',
@@ -44,7 +44,7 @@ class ProjectTest(unittest.TestCase):
                 'image': 'busybox:latest',
                 'volumes': ['/tmp'],
             }
-        ], None)
+        ]}, None)
 
         self.assertEqual(project.services[0].name, 'volume')
         self.assertEqual(project.services[1].name, 'db')
@@ -146,13 +146,13 @@ class ProjectTest(unittest.TestCase):
         container_dict = dict(Name='aaa', Id=container_id)
         mock_client = mock.create_autospec(docker.Client)
         mock_client.inspect_container.return_value = container_dict
-        project = Project.from_dicts('test', [
+        project = Project.from_dicts('test', {'services': [
             {
                 'name': 'test',
                 'image': 'busybox:latest',
                 'volumes_from': ['aaa']
             }
-        ], mock_client)
+        ]}, mock_client)
         self.assertEqual(project.get_service('test')._get_volumes_from(), [container_id])
 
     def test_use_volumes_from_service_no_container(self):
@@ -166,7 +166,7 @@ class ProjectTest(unittest.TestCase):
                 "Image": 'busybox:latest'
             }
         ]
-        project = Project.from_dicts('test', [
+        project = Project.from_dicts('test', {'services': [
             {
                 'name': 'vol',
                 'image': 'busybox:latest'
@@ -176,7 +176,7 @@ class ProjectTest(unittest.TestCase):
                 'image': 'busybox:latest',
                 'volumes_from': ['vol']
             }
-        ], mock_client)
+        ]}, mock_client)
         self.assertEqual(project.get_service('test')._get_volumes_from(), [container_name])
 
     @mock.patch.object(Service, 'containers')
@@ -186,7 +186,7 @@ class ProjectTest(unittest.TestCase):
             mock.Mock(id=container_id, spec=Container)
             for container_id in container_ids]
 
-        project = Project.from_dicts('test', [
+        project = Project.from_dicts('test', {'services': [
             {
                 'name': 'vol',
                 'image': 'busybox:latest'
@@ -196,7 +196,7 @@ class ProjectTest(unittest.TestCase):
                 'image': 'busybox:latest',
                 'volumes_from': ['vol']
             }
-        ], None)
+        ]}, None)
         self.assertEqual(project.get_service('test')._get_volumes_from(), container_ids)
 
     def test_use_net_from_container(self):
@@ -204,13 +204,13 @@ class ProjectTest(unittest.TestCase):
         container_dict = dict(Name='aaa', Id=container_id)
         mock_client = mock.create_autospec(docker.Client)
         mock_client.inspect_container.return_value = container_dict
-        project = Project.from_dicts('test', [
+        project = Project.from_dicts('test', {'services': [
             {
                 'name': 'test',
                 'image': 'busybox:latest',
                 'net': 'container:aaa'
             }
-        ], mock_client)
+        ]}, mock_client)
         service = project.get_service('test')
         self.assertEqual(service._get_net(), 'container:' + container_id)
 
@@ -225,7 +225,7 @@ class ProjectTest(unittest.TestCase):
                 "Image": 'busybox:latest'
             }
         ]
-        project = Project.from_dicts('test', [
+        project = Project.from_dicts('test', {'services': [
             {
                 'name': 'aaa',
                 'image': 'busybox:latest'
@@ -235,7 +235,7 @@ class ProjectTest(unittest.TestCase):
                 'image': 'busybox:latest',
                 'net': 'container:aaa'
             }
-        ], mock_client)
+        ]}, mock_client)
 
         service = project.get_service('test')
         self.assertEqual(service._get_net(), 'container:' + container_name)


### PR DESCRIPTION
This PR improve the config schema by moving the services under a new top level node `services`. 
```yaml
version: 1.0
services:
  db:
    image: postgres
  web:
    build: .
    command: python manage.py runserver 0.0.0.0:8000
    volumes:
      - .:/code
    ports:
      - "8000:8000"
    links:
      - db
```

Why ?

* Thank to the version property, the schema is extendable and we can keep Backward Compatibility
* We can add global parameters (like name, gobal env, global extends, ...)
* We can manage several versions of the schema (ie if a parameter is renamed in a future version).

What the difference with #463 ?

This PR does not mix service declaration and project configuration:

* More readable
* No collision between service's name and project key

I implement an usage of this new schema with an optional property `project` which replace the directory_name

```yaml
version: 1.1
project: foo
services:
  db:
    image: postgres
  web:
    build: .
```

This should fix tickets #45, #745
Then we could extends this schema to fix #210, #318

note: The script **does not** break backward compatibility :smiley: even if someone already use a service named `project` or `.project` or `version` or wathever