### PR TITLE
Improve missing DOCKER_HOST stack traces

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -1,5 +1,6 @@
 from docker import Client
 from docker import tls
+from ..service import ConfigError
 import ssl
 import os
 
@@ -15,6 +16,9 @@ def docker_client():
 
     base_url = os.environ.get('DOCKER_HOST')
     tls_config = None
+
+    if not base_url:
+        raise ConfigError('Required environment variable DOCKER_HOST is not set.')
 
     if os.environ.get('DOCKER_TLS_VERIFY', '') != '':
         parts = base_url.split('://', 1)

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -6,6 +6,7 @@ import mock
 from tests import unittest
 
 from compose.cli import docker_client
+from compose.service import ConfigError
 
 
 class DockerClientTestCase(unittest.TestCase):
@@ -14,6 +15,16 @@ class DockerClientTestCase(unittest.TestCase):
         with mock.patch.dict(os.environ):
             del os.environ['HOME']
             docker_client.docker_client()
+
+    def test_docker_client_no_docker_host(self):
+        with mock.patch.dict(os.environ):
+            del os.environ['DOCKER_HOST']
+            try:
+                docker_client.docker_client()
+            except ConfigError as e:
+                self.assertIn('DOCKER_HOST is not set', e.msg)
+            else:
+                self.fail('Should have thrown an ConfigError')
 
     def test_docker_client_with_custom_timeout(self):
         with mock.patch.dict(os.environ):


### PR DESCRIPTION
Adds a more user-friendly message when DOCKER_HOST is not set.

One possible addition would be suggest fixes — perhaps `eval` the docker-machine env output — but that might be making too much of an assumption about the user's setup.