### PR TITLE
Add bash completion for docker-compose run --user

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -232,14 +232,14 @@ _docker-compose_run() {
 			compopt -o nospace
 			return
 			;;
-		--entrypoint)
+		--entrypoint|--user|-u)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --entrypoint -e --no-deps --rm --service-ports -T" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --entrypoint -e --no-deps --rm --service-ports -T --user -u" -- "$cur" ) )
 			;;
 		*)
 			__docker-compose_services_all


### PR DESCRIPTION
Sorry, couldn't make it earlier. Can this still find its way into 1.2.0?