### PR TITLE
docker-compose create --readonly

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -17,6 +17,7 @@ DOCKER_CONFIG_KEYS = [
     'env_file',
     'environment',
     'extra_hosts',
+    'read_only',
     'hostname',
     'image',
     'labels',

--- a/compose/service.py
+++ b/compose/service.py
@@ -24,6 +24,7 @@ DOCKER_START_KEYS = [
     'dns_search',
     'env_file',
     'extra_hosts',
+    'read_only',
     'net',
     'pid',
     'privileged',
@@ -442,6 +443,7 @@ class Service(object):
         restart = parse_restart_spec(options.get('restart', None))
 
         extra_hosts = build_extra_hosts(options.get('extra_hosts', None))
+        read_only = options.get('read_only', None)
 
         return create_host_config(
             links=self._get_links(link_to_self=one_off),
@@ -456,6 +458,7 @@ class Service(object):
             cap_add=cap_add,
             cap_drop=cap_drop,
             extra_hosts=extra_hosts,
+            read_only=read_only,
             pid_mode=pid
         )
 

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -328,7 +328,7 @@ dns_search:
   - dc2.example.com
 ```
 
-### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged, restart, stdin\_open, tty, cpu\_shares, cpuset
+### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged, restart, stdin\_open, tty, cpu\_shares, cpuset, read\_only
 
 Each of these is a single value, analogous to its
 [docker run](https://docs.docker.com/reference/run/) counterpart.
@@ -351,6 +351,7 @@ restart: always
 
 stdin_open: true
 tty: true
+read_only: true
 ```
 
 ## Compose documentation

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -177,6 +177,13 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(container.inspect()['Config']['Cpuset'], '0')
 
+    def test_create_container_with_read_only_root_fs(self):
+        read_only = True
+        service = self.create_service('db', read_only=read_only)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.ReadonlyRootfs'), read_only, container.get('HostConfig'))
+
     def test_create_container_with_specified_volume(self):
         host_path = '/tmp/host-path'
         container_path = '/container-path'


### PR DESCRIPTION
mount the container's root filesystem as read only. Same as `--read-only`

```yaml
read_only: true
```

Signed-off: CJ <lim@chernjie.com>