### PR TITLE
Support image with ids instead of names

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -193,13 +193,7 @@ class Service(object):
             return Container.create(self.client, **container_options)
         except APIError as e:
             if e.response.status_code == 404 and e.explanation and 'No such image' in str(e.explanation):
-                log.info('Pulling image %s...' % container_options['image'])
-                output = self.client.pull(
-                    container_options['image'],
-                    stream=True,
-                    insecure_registry=insecure_registry
-                )
-                stream_output(output, sys.stdout)
+                self.pull(insecure_registry=insecure_registry)
                 return Container.create(self.client, **container_options)
             raise
 
@@ -413,8 +407,6 @@ class Service(object):
 
         if self.can_be_built():
             container_options['image'] = self.full_name
-        else:
-            container_options['image'] = self._get_image_name(container_options['image'])
 
         # Delete options which are only used when starting
         for key in DOCKER_START_KEYS:
@@ -463,12 +455,6 @@ class Service(object):
             pid_mode=pid
         )
 
-    def _get_image_name(self, image):
-        repo, tag = parse_repository_tag(image)
-        if tag == "":
-            tag = "latest"
-        return '%s:%s' % (repo, tag)
-
     def build(self, no_cache=False):
         log.info('Building %s...' % self.name)
 
@@ -515,13 +501,18 @@ class Service(object):
         return True
 
     def pull(self, insecure_registry=False):
-        if 'image' in self.options:
-            image_name = self._get_image_name(self.options['image'])
-            log.info('Pulling %s (%s)...' % (self.name, image_name))
-            self.client.pull(
-                image_name,
-                insecure_registry=insecure_registry
-            )
+        if 'image' not in self.options:
+            return
+
+        repo, tag = parse_repository_tag(self.options['image'])
+        tag = tag or 'latest'
+        log.info('Pulling %s (%s:%s)...' % (self.name, repo, tag))
+        output = self.client.pull(
+            repo,
+            tag=tag,
+            stream=True,
+            insecure_registry=insecure_registry)
+        stream_output(output, sys.stdout)
 
 
 NAME_RE = re.compile(r'^([^_]+)_([^_]+)_(run_)?(\d+)$')

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -391,6 +391,11 @@ class ServiceTest(DockerClientTestCase):
             ],
         })
 
+    def test_start_with_image_id(self):
+        # Image id for the current busybox:latest
+        service = self.create_service('foo', image='8c2e06607696')
+        self.assertTrue(service.start_or_create_containers())
+
     def test_scale(self):
         service = self.create_service('web')
         service.scale(1)

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -22,7 +22,7 @@ class DockerClientTestCase(unittest.TestCase):
                 self.client.remove_image(i)
 
     def create_service(self, name, **kwargs):
-        kwargs['image'] = "busybox:latest"
+        kwargs['image'] = kwargs.pop('image', 'busybox:latest')
 
         if 'command' not in kwargs:
             kwargs['command'] = ["/bin/sleep", "300"]


### PR DESCRIPTION
Fixes #923

Also consolidates the pulls to a single place.  Previously the pull triggered by `create` would stream output, but the direct pull would not. Now they will both stream output.

Integration test added to cover the failure case.