### PR TITLE
Use cool new IRCCloud links for IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Installation and documentation
 ------------------------------
 
 - Full documentation is available on [Docker's website](http://docs.docker.com/compose/).
-- Hop into #docker-compose on Freenode if you have any questions.
+- If you have any questions, you can talk in real-time with other developers in the #docker-compose IRC channel on Freenode. [Click here to join using IRCCloud.](https://www.irccloud.com/invite?hostname=irc.freenode.net&channel=%23docker-compose)
 
 Contributing
 ------------


### PR DESCRIPTION
IRCCloud have a slick new experience for joining specific channels. This will ask you to sign up for IRCCloud, then put you straight into the channel.

@jonty <3

@fredlf Do you think we should add this to the docs page? Happy to go through other projects and add it too.