### PR TITLE
Use labels instead of names to identify containers

### DIFF
--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,3 @@
 from __future__ import unicode_literals
-from .service import Service  # noqa:flake8
 
 __version__ = '1.3.0dev'

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -11,6 +11,7 @@ from docker.errors import APIError
 import dockerpty
 
 from .. import __version__
+from .. import migration
 from ..project import NoSuchService, ConfigurationError
 from ..service import BuildError, CannotBeScaledError
 from ..config import parse_environment
@@ -81,20 +82,21 @@ class TopLevelCommand(Command):
       -v, --version             Print version and exit
 
     Commands:
-      build     Build or rebuild services
-      help      Get help on a command
-      kill      Kill containers
-      logs      View output from containers
-      port      Print the public port for a port binding
-      ps        List containers
-      pull      Pulls service images
-      restart   Restart services
-      rm        Remove stopped containers
-      run       Run a one-off command
-      scale     Set number of containers for a service
-      start     Start services
-      stop      Stop services
-      up        Create and start containers
+      build              Build or rebuild services
+      help               Get help on a command
+      kill               Kill containers
+      logs               View output from containers
+      port               Print the public port for a port binding
+      ps                 List containers
+      pull               Pulls service images
+      restart            Restart services
+      rm                 Remove stopped containers
+      run                Run a one-off command
+      scale              Set number of containers for a service
+      start              Start services
+      stop               Stop services
+      up                 Create and start containers
+      migrate_to_labels  Recreate containers to add labels
 
     """
     def docopt_options(self):
@@ -482,6 +484,9 @@ class TopLevelCommand(Command):
                 timeout = options.get('--timeout')
                 params = {} if timeout is None else {'timeout': int(timeout)}
                 project.stop(service_names=service_names, **params)
+
+    def migrate_to_labels(self, project, _options):
+        migration.migrate_project_to_labels(project)
 
 
 def list_containers(containers):

--- a/compose/const.py
+++ b/compose/const.py
@@ -1,0 +1,6 @@
+
+LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
+LABEL_ONE_OFF = 'com.docker.compose.oneoff'
+LABEL_PROJECT = 'com.docker.compose.project'
+LABEL_SERVICE = 'com.docker.compose.service'
+LABEL_VERSION = 'com.docker.compose.version'

--- a/compose/container.py
+++ b/compose/container.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 import six
 from functools import reduce
 
+from .const import LABEL_CONTAINER_NUMBER, LABEL_SERVICE
+
 
 class Container(object):
     """
@@ -58,14 +60,11 @@ class Container(object):
 
     @property
     def name_without_project(self):
-        return '_'.join(self.dictionary['Name'].split('_')[1:])
+        return '{0}_{1}'.format(self.labels.get(LABEL_SERVICE), self.number)
 
     @property
     def number(self):
-        try:
-            return int(self.name.split('_')[-1])
-        except ValueError:
-            return None
+        return int(self.labels.get(LABEL_CONTAINER_NUMBER) or 0)
 
     @property
     def ports(self):
@@ -159,6 +158,7 @@ class Container(object):
         self.has_been_inspected = True
         return self.dictionary
 
+    # TODO: only used by tests, move to test module
     def links(self):
         links = []
         for container in self.client.containers():

--- a/compose/container.py
+++ b/compose/container.py
@@ -64,7 +64,11 @@ class Container(object):
 
     @property
     def number(self):
-        return int(self.labels.get(LABEL_CONTAINER_NUMBER) or 0)
+        number = self.labels.get(LABEL_CONTAINER_NUMBER)
+        if not number:
+            raise ValueError("Container {0} does not have a {1} label".format(
+                self.short_id, LABEL_CONTAINER_NUMBER))
+        return int(number)
 
     @property
     def ports(self):

--- a/compose/migration.py
+++ b/compose/migration.py
@@ -1,0 +1,35 @@
+import logging
+import re
+
+from .container import get_container_name, Container
+
+
+log = logging.getLogger(__name__)
+
+
+# TODO: remove this section when migrate_project_to_labels is removed
+NAME_RE = re.compile(r'^([^_]+)_([^_]+)_(run_)?(\d+)$')
+
+
+def is_valid_name(name):
+    match = NAME_RE.match(name)
+    return match is not None
+
+
+def add_labels(project, container, name):
+    project_name, service_name, one_off, number = NAME_RE.match(name).groups()
+    if project_name != project.name or service_name not in project.service_names:
+        return
+    service = project.get_service(service_name)
+    service.recreate_container(container)
+
+
+def migrate_project_to_labels(project):
+    log.info("Running migration to labels for project %s", project.name)
+
+    client = project.client
+    for container in client.containers(all=True):
+        name = get_container_name(container)
+        if not is_valid_name(name):
+            continue
+        add_labels(project, Container.from_ps(client, container), name)

--- a/compose/service.py
+++ b/compose/service.py
@@ -10,8 +10,16 @@ import six
 from docker.errors import APIError
 from docker.utils import create_host_config, LogConfig
 
+from . import __version__
 from .config import DOCKER_CONFIG_KEYS, merge_environment
-from .container import Container, get_container_name
+from .const import (
+    LABEL_CONTAINER_NUMBER,
+    LABEL_ONE_OFF,
+    LABEL_PROJECT,
+    LABEL_SERVICE,
+    LABEL_VERSION,
+)
+from .container import Container
 from .progress_stream import stream_output, StreamOutputError
 
 log = logging.getLogger(__name__)
@@ -79,27 +87,17 @@ class Service(object):
 
     def containers(self, stopped=False, one_off=False):
         return [Container.from_ps(self.client, container)
-                for container in self.client.containers(all=stopped)
-                if self.has_container(container, one_off=one_off)]
-
-    def has_container(self, container, one_off=False):
-        """Return True if `container` was created to fulfill this service."""
-        name = get_container_name(container)
-        if not name or not is_valid_name(name, one_off):
-            return False
-        project, name, _number = parse_name(name)
-        return project == self.project and name == self.name
+                for container in self.client.containers(
+                    all=stopped,
+                    filters={'label': self.labels(one_off=one_off)})]
 
     def get_container(self, number=1):
         """Return a :class:`compose.container.Container` for this service. The
         container must be active, and match `number`.
         """
-        for container in self.client.containers():
-            if not self.has_container(container):
-                continue
-            _, _, container_number = parse_name(get_container_name(container))
-            if container_number == number:
-                return Container.from_ps(self.client, container)
+        labels = self.labels() + ['{0}={1}'.format(LABEL_CONTAINER_NUMBER, number)]
+        for container in self.client.containers(filters={'label': labels}):
+            return Container.from_ps(self.client, container)
 
         raise ValueError("No container found for %s_%s" % (self.name, number))
 
@@ -138,7 +136,6 @@ class Service(object):
         # Create enough containers
         containers = self.containers(stopped=True)
         while len(containers) < desired_num:
-            log.info("Creating %s..." % self._next_container_name(containers))
             containers.append(self.create_container(detach=True))
 
         running_containers = []
@@ -178,6 +175,7 @@ class Service(object):
                          insecure_registry=False,
                          do_build=True,
                          previous_container=None,
+                         number=None,
                          **override_options):
         """
         Create a container for this service. If the image doesn't exist, attempt to pull
@@ -185,6 +183,7 @@ class Service(object):
         """
         container_options = self._get_container_create_options(
             override_options,
+            number or self._next_container_number(one_off=one_off),
             one_off=one_off,
             previous_container=previous_container,
         )
@@ -209,7 +208,6 @@ class Service(object):
         """
         containers = self.containers(stopped=True)
         if not containers:
-            log.info("Creating %s..." % self._next_container_name(containers))
             container = self.create_container(
                 insecure_registry=insecure_registry,
                 do_build=do_build,
@@ -256,6 +254,7 @@ class Service(object):
         new_container = self.create_container(
             do_build=False,
             previous_container=container,
+            number=container.labels.get(LABEL_CONTAINER_NUMBER),
             **override_options)
         self.start_container(new_container)
         container.remove()
@@ -280,7 +279,6 @@ class Service(object):
         containers = self.containers(stopped=True)
 
         if not containers:
-            log.info("Creating %s..." % self._next_container_name(containers))
             new_container = self.create_container(
                 insecure_registry=insecure_registry,
                 detach=detach,
@@ -302,14 +300,19 @@ class Service(object):
         else:
             return
 
-    def _next_container_name(self, all_containers, one_off=False):
-        bits = [self.project, self.name]
-        if one_off:
-            bits.append('run')
-        return '_'.join(bits + [str(self._next_container_number(all_containers))])
+    def get_container_name(self, number, one_off=False):
+        # TODO: Implement issue #652 here
+        return build_container_name(self.project, self.name, number, one_off)
 
-    def _next_container_number(self, all_containers):
-        numbers = [parse_name(c.name).number for c in all_containers]
+    # TODO: this would benefit from github.com/docker/docker/pull/11943
+    # to remove the need to inspect every container
+    def _next_container_number(self, one_off=False):
+        numbers = [
+            Container.from_ps(self.client, container).number
+            for container in self.client.containers(
+                all=True,
+                filters={'label': self.labels(one_off=one_off)})
+        ]
         return 1 if not numbers else max(numbers) + 1
 
     def _get_links(self, link_to_self):
@@ -369,6 +372,7 @@ class Service(object):
     def _get_container_create_options(
             self,
             override_options,
+            number,
             one_off=False,
             previous_container=None):
         container_options = dict(
@@ -376,9 +380,7 @@ class Service(object):
             for k in DOCKER_CONFIG_KEYS if k in self.options)
         container_options.update(override_options)
 
-        container_options['name'] = self._next_container_name(
-            self.containers(stopped=True, one_off=one_off),
-            one_off)
+        container_options['name'] = self.get_container_name(number, one_off)
 
         # If a qualified hostname was given, split it into an
         # unqualified hostname and a domainname unless domainname
@@ -418,6 +420,11 @@ class Service(object):
 
         if self.can_be_built():
             container_options['image'] = self.full_name
+
+        container_options['labels'] = build_container_labels(
+            container_options.get('labels', {}),
+            self.labels(one_off=one_off),
+            number)
 
         # Delete options which are only used when starting
         for key in DOCKER_START_KEYS:
@@ -520,6 +527,13 @@ class Service(object):
         """
         return '%s_%s' % (self.project, self.name)
 
+    def labels(self, one_off=False):
+        return [
+            '{0}={1}'.format(LABEL_PROJECT, self.project),
+            '{0}={1}'.format(LABEL_SERVICE, self.name),
+            '{0}={1}'.format(LABEL_ONE_OFF, "True" if one_off else "False")
+        ]
+
     def can_be_scaled(self):
         for port in self.options.get('ports', []):
             if ':' in str(port):
@@ -585,23 +599,19 @@ def merge_volume_bindings(volumes_option, previous_container):
     return volume_bindings
 
 
-NAME_RE = re.compile(r'^([^_]+)_([^_]+)_(run_)?(\d+)$')
-
-
-def is_valid_name(name, one_off=False):
-    match = NAME_RE.match(name)
-    if match is None:
-        return False
+def build_container_name(project, service, number, one_off=False):
+    bits = [project, service]
     if one_off:
-        return match.group(3) == 'run_'
-    else:
-        return match.group(3) is None
+        bits.append('run')
+    return '_'.join(bits + [str(number)])
 
 
-def parse_name(name):
-    match = NAME_RE.match(name)
-    (project, service_name, _, suffix) = match.groups()
-    return ServiceName(project, service_name, int(suffix))
+def build_container_labels(label_options, service_labels, number, one_off=False):
+    labels = label_options or {}
+    labels.update(label.split('=', 1) for label in service_labels)
+    labels[LABEL_CONTAINER_NUMBER] = str(number)
+    labels[LABEL_VERSION] = __version__
+    return labels
 
 
 def parse_restart_spec(restart_config):

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -21,6 +21,8 @@ class CLITestCase(DockerClientTestCase):
         sys.exit = self.old_sys_exit
         self.project.kill()
         self.project.remove_stopped()
+        for container in self.project.containers(stopped=True, one_off=True):
+            container.remove(force=True)
 
     @property
     def project(self):
@@ -62,6 +64,10 @@ class CLITestCase(DockerClientTestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ps_alternate_composefile(self, mock_stdout):
+        config_path = os.path.abspath(
+            'tests/fixtures/multiple-composefiles/compose2.yml')
+        self._project = self.command.get_project(config_path)
+
         self.command.base_dir = 'tests/fixtures/multiple-composefiles'
         self.command.dispatch(['-f', 'compose2.yml', 'up', '-d'], None)
         self.command.dispatch(['-f', 'compose2.yml', 'ps'], None)
@@ -416,7 +422,6 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(len(project.get_service('another').containers()), 0)
 
     def test_port(self):
-
         self.command.base_dir = 'tests/fixtures/ports-composefile'
         self.command.dispatch(['up', '-d'], None)
         container = self.project.get_service('simple').get_container()

--- a/tests/integration/migration_test.py
+++ b/tests/integration/migration_test.py
@@ -1,0 +1,23 @@
+import mock
+
+from compose import service, migration
+from compose.project import Project
+from .testcases import DockerClientTestCase
+
+
+class ProjectTest(DockerClientTestCase):
+
+    def test_migration_to_labels(self):
+        web = self.create_service('web')
+        db = self.create_service('db')
+        project = Project('composetest', [web, db], self.client)
+
+        self.client.create_container(name='composetest_web_1', **web.options)
+        self.client.create_container(name='composetest_db_1', **db.options)
+
+        with mock.patch.object(service, 'log', autospec=True) as mock_log:
+            self.assertEqual(project.containers(stopped=True), [])
+            self.assertEqual(mock_log.warn.call_count, 2)
+
+        migration.migrate_project_to_labels(project)
+        self.assertEqual(len(project.containers(stopped=True)), 2)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -8,11 +8,19 @@ import tempfile
 import shutil
 import six
 
-from compose import Service
+from compose import __version__
+from compose.const import (
+    LABEL_CONTAINER_NUMBER,
+    LABEL_ONE_OFF,
+    LABEL_PROJECT,
+    LABEL_SERVICE,
+    LABEL_VERSION,
+)
 from compose.service import (
     CannotBeScaledError,
-    build_extra_hosts,
     ConfigError,
+    Service,
+    build_extra_hosts,
 )
 from compose.container import Container
 from docker.errors import APIError
@@ -633,17 +641,18 @@ class ServiceTest(DockerClientTestCase):
             'com.example.label-with-empty-value': "",
         }
 
+        compose_labels = {
+            LABEL_CONTAINER_NUMBER: '1',
+            LABEL_ONE_OFF: 'False',
+            LABEL_PROJECT: 'composetest',
+            LABEL_SERVICE: 'web',
+            LABEL_VERSION: __version__,
+        }
+        expected = dict(labels_dict, **compose_labels)
+
         service = self.create_service('web', labels=labels_dict)
-        labels = create_and_start_container(service).labels.items()
-        for pair in labels_dict.items():
-            self.assertIn(pair, labels)
-
-        labels_list = ["%s=%s" % pair for pair in labels_dict.items()]
-
-        service = self.create_service('web', labels=labels_list)
-        labels = create_and_start_container(service).labels.items()
-        for pair in labels_dict.items():
-            self.assertIn(pair, labels)
+        labels = create_and_start_container(service).labels
+        self.assertEqual(labels, expected)
 
     def test_empty_labels(self):
         labels_list = ['foo', 'bar']

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -12,6 +12,7 @@ class DockerClientTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.client = docker_client()
 
+    # TODO: update to use labels in #652
     def setUp(self):
         for c in self.client.containers(all=True):
             if c['Names'] and 'composetest' in c['Names'][0]:

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -28,7 +28,7 @@ class ContainerTest(unittest.TestCase):
                 "Labels": {
                     "com.docker.compose.project": "composetest",
                     "com.docker.compose.service": "web",
-                    "com.docker.compose.container_number": 7,
+                    "com.docker.compose.container-number": 7,
                 },
             }
         }


### PR DESCRIPTION
Resolves #1066 

Should be compatible with #1269

Also includes:
* a fix for the integration test suite, it was leaving behind one_off containers (the first commit)
* a small refactor of `create_container` and `next_container_number()`. I moved the logging into `create_container()` instead of having it happen in all the callers, and changed it so that `find_next_number()` only happens once.