### PR TITLE
Fix for #1350, nonexisting build path in parent section causes extending section to fail

### DIFF
--- a/tests/fixtures/extends/nonexistent-path-base.yml
+++ b/tests/fixtures/extends/nonexistent-path-base.yml
@@ -1,0 +1,6 @@
+dnebase:
+  build: nonexistent.path
+  command: /bin/true
+  environment:
+    - FOO=1
+    - BAR=1

--- a/tests/fixtures/extends/nonexistent-path-child.yml
+++ b/tests/fixtures/extends/nonexistent-path-child.yml
@@ -1,0 +1,8 @@
+dnechild:
+  extends:
+    file: nonexistent-path-base.yml
+    service: dnebase
+  image: busybox
+  command: /bin/true
+  environment:
+    - BAR=2

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -398,6 +398,21 @@ class ExtendsTest(unittest.TestCase):
 
         self.assertEqual(set(dicts[0]['volumes']), set(paths))
 
+    def test_parent_build_path_dne(self):
+        child = config.load('tests/fixtures/extends/nonexistent-path-child.yml')
+
+        self.assertEqual(child, [
+            {
+                'name': 'dnechild',
+                'image': 'busybox',
+                'command': '/bin/true',
+                'environment': {
+                    "FOO": "1",
+                    "BAR": "2",
+                },
+            },
+        ])
+
 
 class BuildPathTest(unittest.TestCase):
     def setUp(self):
@@ -407,7 +422,10 @@ class BuildPathTest(unittest.TestCase):
         options = {'build': 'nonexistent.path'}
         self.assertRaises(
             config.ConfigurationError,
-            lambda: config.make_service_dict('foo', options, 'tests/fixtures/build-path'),
+            lambda: config.from_dictionary({
+                'foo': options,
+                'working_dir': 'tests/fixtures/build-path'
+            })
         )
 
     def test_relative_path(self):


### PR DESCRIPTION
Now we can have `build` sections in a base yml file that don't exist if those sections are overridden with `image` or `build` sections in a child.