### PR TITLE
Added support for url build paths

### DIFF
--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -489,3 +489,19 @@ class BuildPathTest(unittest.TestCase):
     def test_from_file(self):
         service_dict = config.load('tests/fixtures/build-path/docker-compose.yml')
         self.assertEquals(service_dict, [{'name': 'foo', 'build': self.abs_context_path}])
+
+    def test_valid_url_path(self):
+        valid_urls = [
+            'git://github.com/docker/docker',
+            'git@github.com:docker/docker.git',
+            'git@bitbucket.org:atlassianlabs/atlassian-docker.git',
+            'https://github.com/docker/docker.git',
+            'http://github.com/docker/docker.git',
+        ]
+        for valid_url in valid_urls:
+            service_dict = config.make_service_dict(
+                'validurl',
+                {'build': valid_url},
+                working_dir='tests/fixtures/build-path'
+            )
+            self.assertEquals(service_dict['build'], valid_url)


### PR DESCRIPTION
Implements #1369 
Fixes #491

Shamelessly stole url validation logic from docker.

Manual testing works fine but I've been unable to run the unit tests due to a 404 error from docker when running script/test.