### PR TITLE
Close connection after building or pulling

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -476,6 +476,11 @@ class Service(object):
         except StreamOutputError as e:
             raise BuildError(self, unicode(e))
 
+        # Ensure the HTTP connection is not reused for another
+        # streaming command, as the Docker daemon can sometimes
+        # complain about it
+        self.client.close()
+
         image_id = None
 
         for event in all_events:


### PR DESCRIPTION
This ensures that the connection is not recycled, which can cause the Docker daemon to complain if we perform two streaming actions in a row.

Closes #1275.