### PR TITLE
Add security_opt as a docker-compose.yml option

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -30,6 +30,7 @@ DOCKER_CONFIG_KEYS = [
     'ports',
     'privileged',
     'restart',
+    'security_opt',
     'stdin_open',
     'tty',
     'user',

--- a/compose/service.py
+++ b/compose/service.py
@@ -42,6 +42,7 @@ DOCKER_START_KEYS = [
     'privileged',
     'restart',
     'volumes_from',
+    'security_opt',
 ]
 
 VALID_NAME_CHARS = '[a-zA-Z0-9]'
@@ -595,6 +596,7 @@ class Service(object):
         cap_drop = options.get('cap_drop', None)
         log_config = LogConfig(type=options.get('log_driver', 'json-file'))
         pid = options.get('pid', None)
+        security_opt = options.get('security_opt', None)
 
         dns = options.get('dns', None)
         if isinstance(dns, six.string_types):
@@ -627,7 +629,8 @@ class Service(object):
             log_config=log_config,
             extra_hosts=extra_hosts,
             read_only=read_only,
-            pid_mode=pid
+            pid_mode=pid,
+            security_opt=security_opt
         )
 
     def build(self, no_cache=False):

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -352,6 +352,16 @@ devices:
   - "/dev/ttyUSB0:/dev/ttyUSB0"
 ```
 
+### security_opt
+
+Override the default labeling scheme for each container.
+
+```
+security_opt:
+  - label:user:USER
+  - label:role:ROLE
+```
+
 ### working\_dir, entrypoint, user, hostname, domainname, mem\_limit, privileged, restart, stdin\_open, tty, cpu\_shares, cpuset, read\_only
 
 Each of these is a single value, analogous to its

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -192,6 +192,13 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(container.get('HostConfig.ReadonlyRootfs'), read_only, container.get('HostConfig'))
 
+    def test_create_container_with_security_opt(self):
+        security_opt = ['label:disable']
+        service = self.create_service('db', security_opt=security_opt)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(set(container.get('HostConfig.SecurityOpt')), set(security_opt))
+
     def test_create_container_with_specified_volume(self):
         host_path = '/tmp/host-path'
         container_path = '/container-path'


### PR DESCRIPTION
Addresses #842 by exposes the security_opt support recently implemented by docker-py in version 1.2.1.