### PR TITLE
Add support for log-driver as a docker-compose.yml option

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -23,6 +23,7 @@ DOCKER_CONFIG_KEYS = [
     'links',
     'mem_limit',
     'net',
+    'log_driver',
     'pid',
     'ports',
     'privileged',

--- a/compose/container.py
+++ b/compose/container.py
@@ -84,6 +84,10 @@ class Container(object):
         return self.get('Config.Labels') or {}
 
     @property
+    def log_config(self):
+        return self.get('HostConfig.LogConfig') or None
+
+    @property
     def human_readable_state(self):
         if self.is_running:
             return 'Ghost' if self.get('State.Ghost') else 'Up'

--- a/compose/service.py
+++ b/compose/service.py
@@ -8,7 +8,7 @@ import sys
 import six
 
 from docker.errors import APIError
-from docker.utils import create_host_config
+from docker.utils import create_host_config, LogConfig
 
 from .config import DOCKER_CONFIG_KEYS
 from .container import Container, get_container_name
@@ -25,6 +25,7 @@ DOCKER_START_KEYS = [
     'env_file',
     'extra_hosts',
     'net',
+    'log_driver',
     'pid',
     'privileged',
     'restart',
@@ -429,6 +430,7 @@ class Service(object):
         privileged = options.get('privileged', False)
         cap_add = options.get('cap_add', None)
         cap_drop = options.get('cap_drop', None)
+        log_config = LogConfig(type=options.get('log_driver', 'json-file'))
         pid = options.get('pid', None)
 
         dns = options.get('dns', None)
@@ -455,6 +457,7 @@ class Service(object):
             restart_policy=restart,
             cap_add=cap_add,
             cap_drop=cap_drop,
+            log_config=log_config,
             extra_hosts=extra_hosts,
             pid_mode=pid
         )

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -271,6 +271,20 @@ labels:
   - "com.example.label-with-empty-value"
 ```
 
+### log driver
+
+Specify a logging driver for the service's containers, as with the ``--log-driver`` option for docker run ([documented here](http://docs.docker.com/reference/run/#logging-drivers-log-driver)).
+
+Allowed values are currently ``json-file``, ``syslog`` and ``none``. The list will change over time as more drivers are added to the Docker engine.
+
+The default value is json-file.
+
+```
+log_driver: "json-file"
+log_driver: "syslog"
+log_driver: "none"
+```
+
 ### net
 
 Networking mode. Use the same values as the docker client `--net` parameter.

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -649,3 +649,21 @@ class ServiceTest(DockerClientTestCase):
         labels = create_and_start_container(service).labels.items()
         for name in labels_list:
             self.assertIn((name, ''), labels)
+
+    def test_log_drive_invalid(self):
+        service = self.create_service('web', log_driver='xxx')
+        self.assertRaises(ValueError, lambda: create_and_start_container(service))
+
+    def test_log_drive_empty_default_jsonfile(self):
+        service = self.create_service('web')
+        log_config = create_and_start_container(service).log_config
+
+        self.assertEqual('json-file', log_config['Type'])
+        self.assertFalse(log_config['Config'])
+
+    def test_log_drive_none(self):
+        service = self.create_service('web', log_driver='none')
+        log_config = create_and_start_container(service).log_config
+
+        self.assertEqual('none', log_config['Type'])
+        self.assertFalse(log_config['Config'])


### PR DESCRIPTION
Discussed in #1303, as ``docker-py`` version 1.2.1 support this, we can add it as an option for ``docker-compose.yml`` files.

It's kept simple for now, the config files would look like :

```yaml
web1:
    image: busybox
    log_driver: syslog
web2:
    image: busybox
    log_driver: json-file
web3:
    image: busybox
    log_driver: none
```

The choice of ``log_driver`` is to keep it coherent with the ``--log-driver`` option of ``docker run`` (even though it's ``LogConfig`` in the API).

Signed-off-by: Vincent Demeester <vincent@sbr.pm>