### PR TITLE
docker-compose down

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+1.3.0 (2015-04-16)
+------------------
+
+- `docker-compose` now supports `down` option, which behaves exactly the same as the `stop` option.
+
 1.2.0 (2015-04-16)
 ------------------
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -94,6 +94,7 @@ class TopLevelCommand(Command):
       scale     Set number of containers for a service
       start     Start services
       stop      Stop services
+      down      Down services (same as stop but symmetrical to up)
       up        Create and start containers
 
     """
@@ -389,6 +390,22 @@ class TopLevelCommand(Command):
         Usage: start [SERVICE...]
         """
         project.start(service_names=options['SERVICE'])
+
+    def down(self, project, options):
+        """
+        Stop running containers without removing them.
+
+        They can be started again with `docker-compose start`.
+
+        Usage: down [options] [SERVICE...]
+
+        Options:
+          -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
+                                     (default: 10)
+        """
+        timeout = options.get('--timeout')
+        params = {} if timeout is None else {'timeout': int(timeout)}
+        project.stop(service_names=options['SERVICE'], **params)
 
     def stop(self, project, options):
         """

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -94,7 +94,7 @@ class TopLevelCommand(Command):
       scale     Set number of containers for a service
       start     Start services
       stop      Stop services
-      down      Down services (same as stop but symmetrical to up)
+      down      Same as stop (exactly the same)
       up        Create and start containers
 
     """


### PR DESCRIPTION
This PR adds docker-compose down as a simple alias for docker-compose stop.     docker-compose down seems a bit more intuitive for many than docker-compose stop.   