### PR TITLE
Fix #1386 by ensuring that exglob is set in bash completion

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -94,7 +94,7 @@ _docker-compose_build() {
 _docker-compose_docker-compose() {
 	case "$prev" in
 		--file|-f)
-			_filedir y?(a)ml
+			_filedir "y?(a)ml"
 			return
 			;;
 		--project-name|-p)
@@ -303,6 +303,9 @@ _docker-compose_up() {
 
 
 _docker-compose() {
+	local previous_extglob_setting=$(shopt -p extglob)
+	shopt -s extglob
+
 	local commands=(
 		build
 		help
@@ -352,6 +355,7 @@ _docker-compose() {
 	local completions_func=_docker-compose_${command}
 	declare -F $completions_func >/dev/null && $completions_func
 
+	eval "$previous_extglob_setting"
 	return 0
 }
 


### PR DESCRIPTION
On systems where the `extglob` shell option is not set by default, sourcing the completion produces an error (as reported in #1386):

    -bash: /etc/bash_completion.d/docker-compose: line 97: syntax error near unexpected token `('
    -bash: /etc/bash_completion.d/docker-compose: line 97: `                        _filedir y?(a)ml'

The `extglob` feature is required for the extended file glob `*.y?(a)ml`.

This PR temporarily sets `extglob` during completion and restores its old value afterwards in the same way as Docker's completion does, [see](https://github.com/docker/docker/blob/master/contrib/completion/bash/docker#L1109).