### PR TITLE
Expand Expose statement to include IPAddr access

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -134,8 +134,8 @@ ports:
 
 ### expose
 
-Expose ports without publishing them to the host machine - they'll only be
-accessible to linked services. Only the internal port can be specified.
+Expose ports without publishing them to the host machine - this will make the ports 
+accessible to linked services as directly on the container when accessing it by its IP address assigned from the Docker Host. Only the internal port can be specified.
 
 ```
 expose:

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -135,7 +135,7 @@ ports:
 ### expose
 
 Expose ports without publishing them to the host machine - this will make the ports 
-accessible to linked services as directly on the container when accessing it by its IP address assigned from the Docker Host. Only the internal port can be specified.
+accessible to linked services as well as directly on the container when accessing it by its IP address assigned from the Docker Host. Only the internal port can be specified.
 
 ```
 expose:


### PR DESCRIPTION
Since I only use Docker Containers directly via their IP address I don't bind any ports of my containers directly to my Host Machine. If the expose for Docker Compose works just like that of the Dockerfile then this definition should be updated to reflect that a port can be exposed on the container and then accessible by using the IP address of the container along with the port specified in the "EXPOSE' statement.

Edit: I forgot to add two words on line 138 before submitting the pull request. It should read "accessible to linked services as well as directly..." I forgot to add the words "as well" to transition the statement properly.

If you accept this PR I'll add those words or I can submit another one with the corrected wording.