### PR TITLE
Fixing docker-compose port with scale (#667)

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -170,13 +170,14 @@ class TopLevelCommand(Command):
         Usage: port [options] SERVICE PRIVATE_PORT
 
         Options:
-            --protocol=proto  tcp or udp (defaults to tcp)
+            --protocol=proto  tcp or udp [default: tcp]
             --index=index     index of the container if there are multiple
-                              instances of a service (defaults to 1)
+                              instances of a service [default: 1]
         """
+        index = int(options.get('--index'))
         service = project.get_service(options['SERVICE'])
         try:
-            container = service.get_container(number=options.get('--index') or 1)
+            container = service.get_container(number=index)
         except ValueError as e:
             raise UserError(str(e))
         print(container.get_local_port(

--- a/tests/fixtures/ports-composefile-scale/docker-compose.yml
+++ b/tests/fixtures/ports-composefile-scale/docker-compose.yml
@@ -1,0 +1,6 @@
+
+simple:
+  image: busybox:latest
+  command: /bin/sleep 300
+  ports:
+    - '3000'


### PR DESCRIPTION
Fixes #667 and Closes #735 (taking over it). The PR #735 is old and no integration tests provided so I'm submitting a new one.

Another thing, not related. The current behavior is to show the first port by default if no ``--index`` provided. What if we change this to display all port (prefixed with the name/id/number), kinda like ``docker port`` ? I guess it would be better to discuss this in another issue/PR (but https://github.com/docker/compose/issues/964 is a little about that already). 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>