### PR TITLE
Update docker-py to 1.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==1.2.1
+docker-py==1.2.2
 dockerpty==0.3.2
 docopt==0.6.1
 requests==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.6.1, < 2.7',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 1.0',
-    'docker-py >= 1.2.0, < 1.3',
+    'docker-py >= 1.2.2, < 1.3',
     'dockerpty >= 0.3.2, < 0.4',
     'six >= 1.3.0, < 2',
 ]


### PR DESCRIPTION
Closes #75.

(It had theoretically been closed by #1075, but docker-py had a [regression](https://github.com/docker/docker-py/commit/a266448b0037fcb289e811a3022f052e62530edb).)