### PR TITLE
Fix race condition in `docker-compose run`

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -341,7 +341,6 @@ class TopLevelCommand(Command):
             service.start_container(container)
             print(container.name)
         else:
-            service.start_container(container)
             dockerpty.start(project.client, container.id, interactive=not options['-T'])
             exit_code = container.wait()
             if options['--rm']:


### PR DESCRIPTION
We shouldn't start the container before handing it off to dockerpty - dockerpty will start it after attaching, which is the correct order. Otherwise the container might exit before we attach to it, which can lead to weird bugs.

For example, it looks as though the data streamed from an `/attach` call is different if the container has exited. Try running `docker-compose run SERVICE seq 10` - I frequently get marching output like this:

```
$ docker-compose run web seq 10
1
 2
  3
   4
    5
     6
      7
       8
        9
         10
```