### PR TITLE
Add support for options (ro/rw) in volumes_from (#1188)

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -136,11 +136,15 @@ Mount paths as volumes, optionally specifying a path on the host machine
 
 ### volumes_from
 
-Mount all of the volumes from another service or container.
+Mount all of the volumes from another service or container, with the
+supported flags by docker : ``ro``, ``rw``.
 
-    volumes_from:
-     - service_name
-     - container_name
+```
+volumes_from:
+ - service_name
+ - container_name:ro
+ - service_name:rw
+```
 
 ### environment
 

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from compose import config
 from compose.const import LABEL_PROJECT
 from compose.project import Project
+from compose.service import VolumeFromSpec
 from compose.container import Container
 from .testcases import DockerClientTestCase
 
@@ -68,7 +69,7 @@ class ProjectTest(DockerClientTestCase):
         )
         db = project.get_service('db')
         data = project.get_service('data')
-        self.assertEqual(db.volumes_from, [data])
+        self.assertEqual(db.volumes_from, [VolumeFromSpec(data, 'rw')])
 
     def test_volumes_from_container(self):
         data_container = Container.create(
@@ -89,7 +90,7 @@ class ProjectTest(DockerClientTestCase):
             client=self.client,
         )
         db = project.get_service('db')
-        self.assertEqual(db.volumes_from, [data_container])
+        self.assertEqual(db._get_volumes_from(), [data_container.id + ':rw'])
 
     def test_net_from_service(self):
         project = Project.from_dicts(

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -22,6 +22,7 @@ from compose.service import (
     ConvergencePlan,
     Service,
     build_extra_hosts,
+    VolumeFromSpec,
 )
 from compose.container import Container
 from .testcases import DockerClientTestCase
@@ -248,12 +249,12 @@ class ServiceTest(DockerClientTestCase):
             command=["top"],
             labels={LABEL_PROJECT: 'composetest'},
         )
-        host_service = self.create_service('host', volumes_from=[volume_service, volume_container_2])
+        host_service = self.create_service('host', volumes_from=[VolumeFromSpec(volume_service, 'rw'), VolumeFromSpec(volume_container_2, 'rw')])
         host_container = host_service.create_container()
         host_service.start_container(host_container)
-        self.assertIn(volume_container_1.id,
+        self.assertIn(volume_container_1.id + ':rw',
                       host_container.get('HostConfig.VolumesFrom'))
-        self.assertIn(volume_container_2.id,
+        self.assertIn(volume_container_2.id + ':rw',
                       host_container.get('HostConfig.VolumesFrom'))
 
     def test_execute_convergence_plan_recreate(self):

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -166,7 +166,7 @@ class ProjectTest(unittest.TestCase):
                 'volumes_from': ['aaa']
             }
         ], self.mock_client)
-        self.assertEqual(project.get_service('test')._get_volumes_from(), [container_id])
+        self.assertEqual(project.get_service('test')._get_volumes_from(), [container_id + ":rw"])
 
     def test_use_volumes_from_service_no_container(self):
         container_name = 'test_vol_1'
@@ -189,7 +189,7 @@ class ProjectTest(unittest.TestCase):
                 'volumes_from': ['vol']
             }
         ], self.mock_client)
-        self.assertEqual(project.get_service('test')._get_volumes_from(), [container_name])
+        self.assertEqual(project.get_service('test')._get_volumes_from(), [container_name + ":rw"])
 
     @mock.patch.object(Service, 'containers')
     def test_use_volumes_from_service_container(self, mock_return):
@@ -209,7 +209,7 @@ class ProjectTest(unittest.TestCase):
                 'volumes_from': ['vol']
             }
         ], None)
-        self.assertEqual(project.get_service('test')._get_volumes_from(), container_ids)
+        self.assertEqual(project.get_service('test')._get_volumes_from(), [cid + ':rw' for cid in container_ids])
 
     def test_net_unset(self):
         project = Project.from_dicts('test', [

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -21,6 +21,7 @@ from compose.service import (
     parse_repository_tag,
     parse_volume_spec,
     split_port,
+    VolumeFromSpec,
 )
 
 
@@ -81,9 +82,18 @@ class ServiceTest(unittest.TestCase):
         service = Service(
             'test',
             image='foo',
-            volumes_from=[mock.Mock(id=container_id, spec=Container)])
+            volumes_from=[VolumeFromSpec(mock.Mock(id=container_id, spec=Container), 'rw')])
 
-        self.assertEqual(service._get_volumes_from(), [container_id])
+        self.assertEqual(service._get_volumes_from(), [container_id + ':rw'])
+
+    def test_get_volumes_from_container_read_only(self):
+        container_id = 'aabbccddee'
+        service = Service(
+            'test',
+            image='foo',
+            volumes_from=[VolumeFromSpec(mock.Mock(id=container_id, spec=Container), 'ro')])
+
+        self.assertEqual(service._get_volumes_from(), [container_id + ':ro'])
 
     def test_get_volumes_from_service_container_exists(self):
         container_ids = ['aabbccddee', '12345']
@@ -92,9 +102,21 @@ class ServiceTest(unittest.TestCase):
             mock.Mock(id=container_id, spec=Container)
             for container_id in container_ids
         ]
-        service = Service('test', volumes_from=[from_service], image='foo')
+        service = Service('test', volumes_from=[VolumeFromSpec(from_service, 'rw')], image='foo')
 
-        self.assertEqual(service._get_volumes_from(), container_ids)
+        self.assertEqual(service._get_volumes_from(), [cid + ":rw" for cid in container_ids])
+
+    def test_get_volumes_from_service_container_exists_with_flags(self):
+        for mode in ['ro', 'rw', 'z', 'rw,z', 'z,rw']:
+            container_ids = ['aabbccddee:' + mode, '12345:' + mode]
+            from_service = mock.create_autospec(Service)
+            from_service.containers.return_value = [
+                mock.Mock(id=container_id.split(':')[0], spec=Container)
+                for container_id in container_ids
+            ]
+            service = Service('test', volumes_from=[VolumeFromSpec(from_service, mode)], image='foo')
+
+            self.assertEqual(service._get_volumes_from(), container_ids)
 
     def test_get_volumes_from_service_no_container(self):
         container_id = 'abababab'
@@ -103,9 +125,9 @@ class ServiceTest(unittest.TestCase):
         from_service.create_container.return_value = mock.Mock(
             id=container_id,
             spec=Container)
-        service = Service('test', image='foo', volumes_from=[from_service])
+        service = Service('test', image='foo', volumes_from=[VolumeFromSpec(from_service, 'rw')])
 
-        self.assertEqual(service._get_volumes_from(), [container_id])
+        self.assertEqual(service._get_volumes_from(), [container_id + ':rw'])
         from_service.create_container.assert_called_once_with()
 
     def test_split_port_with_host_ip(self):


### PR DESCRIPTION
Add support for ``volumes_from`` with read-only, with integration and unit tests, related to #1188.

```yaml
container:
  build: .
  ports:
    - '19198:22'
  volumes_from:
    - 'nginx_logs_1:ro'
```

This changes a bit how ``Service`` treats its ``volumes_from`` attribute, as it now asks for a ``tuple`` of ``(object, string)`` where the object can be a ``Service`` or ``Container`` and the string could be ``None`` or a option like ``'ro'``, ``'rw'``.

I think there is rooms of improvement in the implementation, so reviews are more than welcome :wink:.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>