### PR TITLE
Fix #1426 - migrate_to_labels not found

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -490,6 +490,11 @@ class TopLevelCommand(Command):
                 project.stop(service_names=service_names, **params)
 
     def migrate_to_labels(self, project, _options):
+        """
+        Recreate containers to add labels
+
+        Usage: migrate_to_labels
+        """
         migration.migrate_project_to_labels(project)
 
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -786,7 +786,7 @@ def check_for_legacy_containers(
                 "labels. As of compose 1.3.0 containers are identified with "
                 "labels instead of naming convention. If you'd like compose "
                 "to use this container, please run "
-                "`docker-compose --migrate-to-labels`" % (name,))
+                "`docker-compose migrate_to_labels`" % (name,))
 
 
 def parse_restart_spec(restart_config):


### PR DESCRIPTION
Fixes the two issues from #1426: 
* _No such command: migrate_to_labels_ when running `docker-compose migrate_to_labels` 
* wrong usage example `--migrate-to-labels` in help message

I added a minimalistic help message just to get the command working. It could benefit from some polishing, maybe @thaJeztah has ideas about that.