### PR TITLE
bash completion for migrate_to_labels

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -311,6 +311,7 @@ _docker-compose() {
 		help
 		kill
 		logs
+		migrate-to-labels
 		port
 		ps
 		pull


### PR DESCRIPTION
Adds `migrate_to_labels` to the list of available commands.