### PR TITLE
Bail out immediately if there are legacy containers

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -33,7 +33,7 @@ def main():
     except KeyboardInterrupt:
         log.error("\nAborting.")
         sys.exit(1)
-    except (UserError, NoSuchService, ConfigurationError) as e:
+    except (UserError, NoSuchService, ConfigurationError, legacy.LegacyContainersError) as e:
         log.error(e.msg)
         sys.exit(1)
     except NoSuchCommand as e:

--- a/tests/integration/legacy_test.py
+++ b/tests/integration/legacy_test.py
@@ -1,5 +1,3 @@
-import mock
-
 from compose import legacy
 from compose.project import Project
 from .testcases import DockerClientTestCase
@@ -49,9 +47,13 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(self.get_names(one_off=True)), 1)
 
     def test_migration_to_labels(self):
-        with mock.patch.object(legacy, 'log', autospec=True) as mock_log:
+        with self.assertRaises(legacy.LegacyContainersError) as cm:
             self.assertEqual(self.project.containers(stopped=True), [])
-            self.assertEqual(mock_log.warn.call_count, len(self.services))
+
+        self.assertEqual(
+            set(cm.exception.names),
+            set(['composetest_web_1', 'composetest_db_1']),
+        )
 
         legacy.migrate_project_to_labels(self.project)
         self.assertEqual(len(self.project.containers(stopped=True)), len(self.services))


### PR DESCRIPTION
Sits on top of #1440.

If there are legacy containers, then in almost all cases it's not safe to keep doing whatever we were about to do. Additionally, the error output was pretty difficult to read.

I've changed it so we display a single message with all the names, plus directions for removing the containers if the user doesn't want to migrate, and then exit.