### PR TITLE
Use 'top' instead of 'sleep' as a dummy command

### DIFF
--- a/tests/fixtures/UpperCaseDir/docker-compose.yml
+++ b/tests/fixtures/UpperCaseDir/docker-compose.yml
@@ -1,6 +1,6 @@
 simple:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top
 another:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top

--- a/tests/fixtures/dockerfile-with-volume/Dockerfile
+++ b/tests/fixtures/dockerfile-with-volume/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox
 VOLUME /data
-CMD sleep 3000
+CMD top

--- a/tests/fixtures/environment-composefile/docker-compose.yml
+++ b/tests/fixtures/environment-composefile/docker-compose.yml
@@ -1,6 +1,6 @@
 service:
   image: busybox:latest
-  command: sleep 5
+  command: top
 
   environment:
     foo: bar

--- a/tests/fixtures/extends/docker-compose.yml
+++ b/tests/fixtures/extends/docker-compose.yml
@@ -2,7 +2,7 @@ myweb:
   extends:
     file: common.yml
     service: web
-  command: sleep 300
+  command: top
   links:
     - "mydb:db"
   environment:
@@ -13,4 +13,4 @@ myweb:
     BAZ: "2"
 mydb:
   image: busybox
-  command: sleep 300
+  command: top

--- a/tests/fixtures/links-composefile/docker-compose.yml
+++ b/tests/fixtures/links-composefile/docker-compose.yml
@@ -1,11 +1,11 @@
 db:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top
 web:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top
   links:
     - db:db
 console:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top

--- a/tests/fixtures/longer-filename-composefile/docker-compose.yaml
+++ b/tests/fixtures/longer-filename-composefile/docker-compose.yaml
@@ -1,3 +1,3 @@
 definedinyamlnotyml:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top

--- a/tests/fixtures/multiple-composefiles/compose2.yml
+++ b/tests/fixtures/multiple-composefiles/compose2.yml
@@ -1,3 +1,3 @@
 yetanother:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top

--- a/tests/fixtures/multiple-composefiles/docker-compose.yml
+++ b/tests/fixtures/multiple-composefiles/docker-compose.yml
@@ -1,6 +1,6 @@
 simple:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top
 another:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top

--- a/tests/fixtures/ports-composefile/docker-compose.yml
+++ b/tests/fixtures/ports-composefile/docker-compose.yml
@@ -1,7 +1,7 @@
 
 simple:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top
   ports:
     - '3000'
     - '49152:3001'

--- a/tests/fixtures/simple-composefile/docker-compose.yml
+++ b/tests/fixtures/simple-composefile/docker-compose.yml
@@ -1,6 +1,6 @@
 simple:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top
 another:
   image: busybox:latest
-  command: /bin/sleep 300
+  command: top

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -78,12 +78,12 @@ class ProjectTest(DockerClientTestCase):
             service_dicts=config.from_dictionary({
                 'net': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"]
+                    'command': ["top"]
                 },
                 'web': {
                     'image': 'busybox:latest',
                     'net': 'container:net',
-                    'command': ["/bin/sleep", "300"]
+                    'command': ["top"]
                 },
             }),
             client=self.client,
@@ -103,7 +103,7 @@ class ProjectTest(DockerClientTestCase):
             self.client,
             image='busybox:latest',
             name='composetest_net_container',
-            command='/bin/sleep 300'
+            command='top'
         )
         net_container.start()
 
@@ -288,20 +288,20 @@ class ProjectTest(DockerClientTestCase):
             service_dicts=config.from_dictionary({
                 'console': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"],
+                    'command': ["top"],
                 },
                 'data': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"]
+                    'command': ["top"]
                 },
                 'db': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"],
+                    'command': ["top"],
                     'volumes_from': ['data'],
                 },
                 'web': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"],
+                    'command': ["top"],
                     'links': ['db'],
                 },
             }),
@@ -326,20 +326,20 @@ class ProjectTest(DockerClientTestCase):
             service_dicts=config.from_dictionary({
                 'console': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"],
+                    'command': ["top"],
                 },
                 'data': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"]
+                    'command': ["top"]
                 },
                 'db': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"],
+                    'command': ["top"],
                     'volumes_from': ['data'],
                 },
                 'web': {
                     'image': 'busybox:latest',
-                    'command': ["/bin/sleep", "300"],
+                    'command': ["top"],
                     'links': ['db'],
                 },
             }),

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -236,7 +236,7 @@ class ServiceTest(DockerClientTestCase):
     def test_create_container_with_volumes_from(self):
         volume_service = self.create_service('data')
         volume_container_1 = volume_service.create_container()
-        volume_container_2 = Container.create(self.client, image='busybox:latest', command=["/bin/sleep", "300"])
+        volume_container_2 = Container.create(self.client, image='busybox:latest', command=["top"])
         host_service = self.create_service('host', volumes_from=[volume_service, volume_container_2])
         host_container = host_service.create_container()
         host_service.start_container(host_container)
@@ -250,12 +250,12 @@ class ServiceTest(DockerClientTestCase):
             'db',
             environment={'FOO': '1'},
             volumes=['/etc'],
-            entrypoint=['sleep'],
-            command=['300']
+            entrypoint=['top'],
+            command=['-d', '1']
         )
         old_container = service.create_container()
-        self.assertEqual(old_container.get('Config.Entrypoint'), ['sleep'])
-        self.assertEqual(old_container.get('Config.Cmd'), ['300'])
+        self.assertEqual(old_container.get('Config.Entrypoint'), ['top'])
+        self.assertEqual(old_container.get('Config.Cmd'), ['-d', '1'])
         self.assertIn('FOO=1', old_container.get('Config.Env'))
         self.assertEqual(old_container.name, 'composetest_db_1')
         service.start_container(old_container)
@@ -267,8 +267,8 @@ class ServiceTest(DockerClientTestCase):
         service.options['environment']['FOO'] = '2'
         new_container = service.converge()[0]
 
-        self.assertEqual(new_container.get('Config.Entrypoint'), ['sleep'])
-        self.assertEqual(new_container.get('Config.Cmd'), ['300'])
+        self.assertEqual(new_container.get('Config.Entrypoint'), ['top'])
+        self.assertEqual(new_container.get('Config.Cmd'), ['-d', '1'])
         self.assertIn('FOO=2', new_container.get('Config.Env'))
         self.assertEqual(new_container.name, 'composetest_db_1')
         self.assertEqual(new_container.get('Volumes')['/etc'], volume_path)
@@ -287,8 +287,8 @@ class ServiceTest(DockerClientTestCase):
             'db',
             environment={'FOO': '1'},
             volumes=['/var/db'],
-            entrypoint=['sleep'],
-            command=['300']
+            entrypoint=['top'],
+            command=['-d', '1']
         )
         service.create_container()
         self.assertEqual(len(service.containers(stopped=True)), 1)

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -167,7 +167,7 @@ class ServiceStateTest(DockerClientTestCase):
         self.assertEqual(('noop', [container]), web.convergence_plan(smart_recreate=True))
 
     def test_trigger_start(self):
-        options = dict(command=["/bin/sleep", "300"])
+        options = dict(command=["top"])
 
         web = self.create_service('web', **options)
         web.scale(2)
@@ -185,10 +185,10 @@ class ServiceStateTest(DockerClientTestCase):
         )
 
     def test_trigger_recreate_with_config_change(self):
-        web = self.create_service('web', command=["/bin/sleep", "300"])
+        web = self.create_service('web', command=["top"])
         container = web.create_container()
 
-        web = self.create_service('web', command=["/bin/sleep", "400"])
+        web = self.create_service('web', command=["top", "-d", "1"])
         self.assertEqual(('recreate', [container]), web.convergence_plan(smart_recreate=True))
 
     def test_trigger_recreate_with_image_change(self):
@@ -254,10 +254,10 @@ class ConfigHashTest(DockerClientTestCase):
         self.assertIn('foo', container.labels)
 
     def test_config_hash_sticks_around(self):
-        web = self.create_service('web', command=["/bin/sleep", "300"])
+        web = self.create_service('web', command=["top"])
         container = web.converge()[0]
         self.assertIn(LABEL_CONFIG_HASH, container.labels)
 
-        web = self.create_service('web', command=["/bin/sleep", "400"])
+        web = self.create_service('web', command=["top", "-d", "1"])
         container = web.converge()[0]
         self.assertIn(LABEL_CONFIG_HASH, container.labels)

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -27,7 +27,7 @@ class DockerClientTestCase(unittest.TestCase):
             kwargs['image'] = 'busybox:latest'
 
         if 'command' not in kwargs:
-            kwargs['command'] = ["/bin/sleep", "300"]
+            kwargs['command'] = ["top"]
 
         return Service(
             project='composetest',

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -348,12 +348,12 @@ class ExtendsTest(unittest.TestCase):
             {
                 'name': 'mydb',
                 'image': 'busybox',
-                'command': 'sleep 300',
+                'command': 'top',
             },
             {
                 'name': 'myweb',
                 'image': 'busybox',
-                'command': 'sleep 300',
+                'command': 'top',
                 'links': ['mydb:db'],
                 'environment': {
                     "FOO": "1",

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -14,7 +14,7 @@ class ContainerTest(unittest.TestCase):
         self.container_dict = {
             "Id": "abc",
             "Image": "busybox:latest",
-            "Command": "sleep 300",
+            "Command": "top",
             "Created": 1387384730,
             "Status": "Up 8 seconds",
             "Ports": None,


### PR DESCRIPTION
When `sleep` is PID 1 it doesn't respond to SIGTERM, which means a call to `/containers/:id/stop` blocks for 10 seconds before SIGKILL is invoked. `top` responds properly and exits.

On my machine, this change cuts just over 2 minutes, or around 35%, off the total test suite running time. Not bad.