### PR TITLE
Fix regression in `docker-compose up`

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -248,10 +248,13 @@ class Project(object):
 
             if updated_dependencies:
                 log.debug(
-                    '%s has not changed but its dependencies (%s) have, so recreating',
+                    '%s has upstream changes (%s)',
                     service.name, ", ".join(updated_dependencies),
                 )
-                plan = service.recreate_plan()
+                plan = service.convergence_plan(
+                    allow_recreate=allow_recreate,
+                    smart_recreate=False,
+                )
             else:
                 plan = service.convergence_plan(
                     allow_recreate=allow_recreate,

--- a/compose/service.py
+++ b/compose/service.py
@@ -294,10 +294,6 @@ class Service(object):
 
         return ConvergencePlan('recreate', containers)
 
-    def recreate_plan(self):
-        containers = self.containers(stopped=True)
-        return ConvergencePlan('recreate', containers)
-
     def _containers_have_diverged(self, containers):
         config_hash = self.config_hash()
         has_diverged = False

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -174,6 +174,18 @@ class ProjectTest(DockerClientTestCase):
         project.kill()
         project.remove_stopped()
 
+    def test_project_up_starts_uncreated_services(self):
+        db = self.create_service('db')
+        web = self.create_service('web', links=[(db, 'db')])
+        project = Project('composetest', [db, web], self.client)
+        project.up(['db'])
+        self.assertEqual(len(project.containers()), 1)
+
+        project.up()
+        self.assertEqual(len(project.containers()), 2)
+        self.assertEqual(len(db.containers()), 1)
+        self.assertEqual(len(web.containers()), 1)
+
     def test_project_up_recreates_containers(self):
         web = self.create_service('web')
         db = self.create_service('db', volumes=['/etc'])


### PR DESCRIPTION
When an upstream dependency (e.g. a db) has a container but a downstream service (e.g. a web app) doesn't, a web container is not created on `docker-compose up`.
