### PR TITLE
Support json serialization of env vars

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -1,6 +1,7 @@
 import os
 import yaml
 import six
+import json
 
 
 DOCKER_CONFIG_KEYS = [
@@ -322,7 +323,10 @@ def split_env(env):
 
 def resolve_env_var(key, val):
     if val is not None:
-        return key, val
+        if isinstance(val, dict) or isinstance(val, list):
+            return key, json.dumps(val)
+        else:
+            return key, val
     elif key in os.environ:
         return key, os.environ[key]
     else:


### PR DESCRIPTION
Env vars are great for injecting config into Docker containers, but when you begin to need nested config options, they become a bit cumbersome (imagine variables for each bit of info about a specific resource or service that your application needs to be able to connect to). This change enables docker-compose users to specify yaml dictionaries or lists under an environment variable option, which is then serialized to JSON for deserialization in the container.

Example:

```
environment:
   DATABASES:
      mysql_db:
         host: localhost
         username: root
         password: 
```
would result in

```
$ echo $DATABASES
$ {"mysql_db": {"host": "localhost", "username": "root", "password": ""}}
```

In theory you could store your entire app config under one env var if you really wanted to.