### PR TITLE
Modified scale awareness from exception to warning

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -13,7 +13,7 @@ import dockerpty
 from .. import __version__
 from .. import legacy
 from ..project import NoSuchService, ConfigurationError
-from ..service import BuildError, CannotBeScaledError, NeedsBuildError
+from ..service import BuildError, NeedsBuildError
 from ..config import parse_environment
 from .command import Command
 from .docopt_command import NoSuchCommand
@@ -372,15 +372,7 @@ class TopLevelCommand(Command):
             except ValueError:
                 raise UserError('Number of containers for service "%s" is not a '
                                 'number' % service_name)
-            try:
-                project.get_service(service_name).scale(num)
-            except CannotBeScaledError:
-                raise UserError(
-                    'Service "%s" cannot be scaled because it specifies a port '
-                    'on the host. If multiple containers for this service were '
-                    'created, the port would clash.\n\nRemove the ":" from the '
-                    'port definition in docker-compose.yml so Docker can choose a random '
-                    'port for each container.' % service_name)
+            project.get_service(service_name).scale(num)
 
     def start(self, project, options):
         """

--- a/compose/service.py
+++ b/compose/service.py
@@ -55,10 +55,6 @@ class BuildError(Exception):
         self.reason = reason
 
 
-class CannotBeScaledError(Exception):
-    pass
-
-
 class ConfigError(ValueError):
     pass
 
@@ -154,7 +150,9 @@ class Service(object):
         - removes all stopped containers
         """
         if not self.can_be_scaled():
-            raise CannotBeScaledError()
+            log.warn('Service %s specifies a port on the host. If multiple containers '
+                     'for this service are created on a single host, the port will clash.'
+                     % self.name)
 
         # Create enough containers
         containers = self.containers(stopped=True)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -17,7 +17,6 @@ from compose.const import (
     LABEL_VERSION,
 )
 from compose.service import (
-    CannotBeScaledError,
     ConfigError,
     Service,
     build_extra_hosts,
@@ -525,10 +524,6 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(len(service.containers()), 1)
         service.scale(0)
         self.assertEqual(len(service.containers()), 0)
-
-    def test_scale_on_service_that_cannot_be_scaled(self):
-        service = self.create_service('web', ports=['8000:8000'])
-        self.assertRaises(CannotBeScaledError, lambda: service.scale(1))
 
     def test_scale_sets_ports(self):
         service = self.create_service('web', ports=['8000'])


### PR DESCRIPTION
It starts not making sense only use docker-compose on a single host environment. I'm proposing removing the scale awareness of port collision from exception to a warning.
Fixes: #1378
Signed-off-by: André Martins <martins@noironetworks.com>