### PR TITLE
Change docker-compose kill integration tests

### DIFF
--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -352,36 +352,29 @@ class CLITestCase(DockerClientTestCase):
     def test_kill(self):
         self.command.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')
-        self.assertEqual(len(service.containers()), 1)
-        self.assertTrue(service.containers()[0].is_running)
+        containers = service.containers()
+        self.assertEqual(len(containers), 1)
+        self.assertTrue(containers[0].is_running)
 
         self.command.dispatch(['kill'], None)
-
-        self.assertEqual(len(service.containers(stopped=True)), 1)
-        self.assertFalse(service.containers(stopped=True)[0].is_running)
+        containers = service.containers(stopped=True)
+        container = containers[0]
+        self.assertFalse(container.is_running)
+        self.assertEqual(container.get('State.ExitCode'), 0)
 
     def test_kill_signal_sigint(self):
         self.command.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')
-        self.assertEqual(len(service.containers()), 1)
-        self.assertTrue(service.containers()[0].is_running)
+        containers = service.containers()
+        self.assertEqual(len(containers), 1)
+        self.assertTrue(containers[0].is_running)
 
         self.command.dispatch(['kill', '-s', 'SIGINT'], None)
 
-        self.assertEqual(len(service.containers()), 1)
-        # The container is still running. It has been only interrupted
-        self.assertTrue(service.containers()[0].is_running)
-
-    def test_kill_interrupted_service(self):
-        self.command.dispatch(['up', '-d'], None)
-        service = self.project.get_service('simple')
-        self.command.dispatch(['kill', '-s', 'SIGINT'], None)
-        self.assertTrue(service.containers()[0].is_running)
-
-        self.command.dispatch(['kill', '-s', 'SIGKILL'], None)
-
-        self.assertEqual(len(service.containers(stopped=True)), 1)
-        self.assertFalse(service.containers(stopped=True)[0].is_running)
+        containers = service.containers(stopped=True)
+        container = containers[0]
+        self.assertFalse(container.is_running)
+        self.assertEqual(container.get('State.ExitCode'), 0)
 
     def test_restart(self):
         service = self.project.get_service('simple')


### PR DESCRIPTION
Attempt to fix #759

Lets see what jenkins thinks about these changes. They pass locally, but they basically invert the previous logic.