### PR TITLE
Script to prepare OSX build environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,16 +53,20 @@ you can specify a test directory, file, module, class or method:
 
 ## Building binaries
 
-Linux:
+`script/build-linux` will build the Linux binary inside a Docker container:
 
     $ script/build-linux
 
-OS X:
+`script/build-osx` will build the Mac OS X binary inside a virtualenv:
 
     $ script/build-osx
 
-Note that this only works on Mountain Lion, not Mavericks, due to a
-[bug in PyInstaller](http://www.pyinstaller.org/ticket/807).
+For official releases, you should build inside a Mountain Lion VM for proper
+compatibility. Run the this script first to prepare the environment before
+building - it will use Homebrew to make sure Python is installed and
+up-to-date.
+
+    $ script/prepare-osx
 
 ## Release process
 

--- a/script/build-osx
+++ b/script/build-osx
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 rm -rf venv
-virtualenv venv
+virtualenv -p /usr/local/bin/python venv
 venv/bin/pip install -r requirements.txt
 venv/bin/pip install -r requirements-dev.txt
 venv/bin/pip install .

--- a/script/prepare-osx
+++ b/script/prepare-osx
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+if !(which brew); then
+  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+fi
+
+brew update
+
+if [ ! -f /usr/local/bin/python ]; then
+  brew install python
+fi
+
+if [ -n "$(brew outdated | grep python)" ]; then
+  brew upgrade python
+fi
+
+if !(which virtualenv); then
+  pip install virtualenv
+fi
+


### PR DESCRIPTION
This will make sure we build on an up-to-date Python. This is relevant right now because `requests` logs `InsecurePlatformWarning` messages on Python <2.7.9.