### PR TITLE
Fix SSL "CERTIFICATE_VERIFY_FAILED" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM debian:wheezy
 RUN set -ex; \
     apt-get update -qq; \
     apt-get install -y \
-        python \
-        python-pip \
-        python-dev \
+        gcc \
+        make \
+        zlib1g \
+        zlib1g-dev \
+        libssl-dev \
         git \
         apt-transport-https \
         ca-certificates \
@@ -14,6 +16,37 @@ RUN set -ex; \
         iptables \
     ; \
     rm -rf /var/lib/apt/lists/*
+
+# Build Python 2.7.9 from source
+RUN set -ex; \
+    curl -LO https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz; \
+    tar -xzf Python-2.7.9.tgz; \
+    cd Python-2.7.9; \
+    ./configure --enable-shared; \
+    make; \
+    make install; \
+    cd ..; \
+    rm -rf /Python-2.7.9; \
+    rm Python-2.7.9.tgz
+
+# Make libpython findable
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+# Install setuptools
+RUN set -ex; \
+    curl -LO https://bootstrap.pypa.io/ez_setup.py; \
+    python ez_setup.py; \
+    rm ez_setup.py
+
+# Install pip
+RUN set -ex; \
+    curl -LO https://pypi.python.org/packages/source/p/pip/pip-7.0.1.tar.gz; \
+    tar -xzf pip-7.0.1.tar.gz; \
+    cd pip-7.0.1; \
+    python setup.py install; \
+    cd ..; \
+    rm -rf pip-7.0.1; \
+    rm pip-7.0.1.tar.gz
 
 ENV ALL_DOCKER_VERSIONS 1.6.0
 

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -8,6 +8,7 @@ from docker import version as docker_py_version
 import os
 import platform
 import subprocess
+import ssl
 
 
 def yesno(prompt, default=None):
@@ -132,6 +133,7 @@ def get_version_info(scope):
     elif scope == 'full':
         return versioninfo + '\n' \
             + "docker-py version: %s\n" % docker_py_version \
-            + "%s version: %s" % (platform.python_implementation(), platform.python_version())
+            + "%s version: %s\n" % (platform.python_implementation(), platform.python_version()) \
+            + "OpenSSL version: %s" % ssl.OPENSSL_VERSION
     else:
         raise RuntimeError('passed unallowed value to `cli.utils.get_version_info`')

--- a/script/build-linux-inner
+++ b/script/build-linux-inner
@@ -7,4 +7,4 @@ chmod 777 `pwd`/dist
 
 pyinstaller -F bin/docker-compose
 mv dist/docker-compose dist/docker-compose-Linux-x86_64
-dist/docker-compose-Linux-x86_64 --version
+dist/docker-compose-Linux-x86_64 version

--- a/script/build-osx
+++ b/script/build-osx
@@ -7,4 +7,4 @@ venv/bin/pip install -r requirements-dev.txt
 venv/bin/pip install .
 venv/bin/pyinstaller -F bin/docker-compose
 mv dist/docker-compose dist/docker-compose-Darwin-x86_64
-dist/docker-compose-Darwin-x86_64 --version
+dist/docker-compose-Darwin-x86_64 version

--- a/script/build-osx
+++ b/script/build-osx
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -ex
+
+PATH="/usr/local/bin:$PATH"
+
 rm -rf venv
 virtualenv -p /usr/local/bin/python venv
 venv/bin/pip install -r requirements.txt

--- a/script/prepare-osx
+++ b/script/prepare-osx
@@ -2,19 +2,50 @@
 
 set -ex
 
+python_version() {
+  python -V 2>&1
+}
+
+openssl_version() {
+  python -c "import ssl; print ssl.OPENSSL_VERSION"
+}
+
+desired_python_version="2.7.9"
+desired_python_brew_version="2.7.9"
+python_formula="https://raw.githubusercontent.com/Homebrew/homebrew/1681e193e4d91c9620c4901efd4458d9b6fcda8e/Library/Formula/python.rb"
+
+desired_openssl_version="1.0.1j"
+desired_openssl_brew_version="1.0.1j_1"
+openssl_formula="https://raw.githubusercontent.com/Homebrew/homebrew/62fc2a1a65e83ba9dbb30b2e0a2b7355831c714b/Library/Formula/openssl.rb"
+
+PATH="/usr/local/bin:$PATH"
+
 if !(which brew); then
   ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
 brew update
 
-if [ ! -f /usr/local/bin/python ]; then
-  brew install python
+if !(python_version | grep "$desired_python_version"); then
+  if brew list | grep python; then
+    brew unlink python
+  fi
+
+  brew install "$python_formula"
+  brew switch python "$desired_python_brew_version"
 fi
 
-if [ -n "$(brew outdated | grep python)" ]; then
-  brew upgrade python
+if !(openssl_version | grep "$desired_openssl_version"); then
+  if brew list | grep openssl; then
+    brew unlink openssl
+  fi
+
+  brew install "$openssl_formula"
+  brew switch openssl "$desired_openssl_brew_version"
 fi
+
+echo "*** Using $(python_version)"
+echo "*** Using $(openssl_version)"
 
 if !(which virtualenv); then
   pip install virtualenv


### PR DESCRIPTION
Python 2.7.9+ is very sensitive about the OpenSSL version used - this is the root cause of #890, which used to only come up for people who'd installed with Pip but is now happening in the Compose OSX binary, because we're now building it with Python 2.7.9 (which is necessary because otherwise `requests` will complain - rightly - that we're not making verified HTTPS connections).

In summary, the magic combination is **Python 2.7.9** and **OpenSSL 1.0.1**.

This PR changes two things:

1. `docker-compose --version` outputs Python and OpenSSL version information, as well as Compose's version.
2. `script/prepare-osx` makes sure that Python 2.7.9 and OpenSSL 1.0.1 are installed and activated in the Mac VM.