### PR TITLE
Fix for #1503

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -217,6 +217,7 @@ class Service(object):
         )
 
         if 'name' in container_options:
+            container_options['environment'].setdefault('COMPOSE_CONTAINER_NAME', container_options['name'])
             log.info("Creating %s..." % container_options['name'])
 
         return Container.create(self.client, **container_options)

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -134,7 +134,7 @@ class CLITestCase(unittest.TestCase):
         _, _, call_kwargs = mock_client.create_container.mock_calls[0]
         self.assertEqual(
             call_kwargs['environment'],
-            {'FOO': 'ONE', 'BAR': 'NEW', 'OTHER': 'THREE'})
+            {'FOO': 'ONE', 'BAR': 'NEW', 'OTHER': 'THREE', 'COMPOSE_CONTAINER_NAME': 'default_service_run_1'})
 
     def test_run_service_with_restart_always(self):
         command = TopLevelCommand()


### PR DESCRIPTION
(too naive ?) Fix for #1503 
- inject container name at creation in environment variables when
  available. The variable is name COMPOSE_CONTAINER_NAME