### PR TITLE
Support version command in Bash completion

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -302,6 +302,15 @@ _docker-compose_up() {
 }
 
 
+_docker-compose_version() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--short" -- "$cur" ) )
+			;;
+	esac
+}
+
+
 _docker-compose() {
 	local previous_extglob_setting=$(shopt -p extglob)
 	shopt -s extglob
@@ -322,6 +331,7 @@ _docker-compose() {
 		start
 		stop
 		up
+		version
 	)
 
 	COMPREPLY=()


### PR DESCRIPTION
See #878 and #1499 for corresponding zsh completion
Thanks @sdurrheimer for pointing me to this addition.