### PR TITLE
Update dockerproject.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Installation and documentation
 Contributing
 ------------
 
-[![Build Status](http://jenkins.dockerproject.com/buildStatus/icon?job=Compose Master)](http://jenkins.dockerproject.com/job/Compose%20Master/)
+[![Build Status](http://jenkins.dockerproject.org/buildStatus/icon?job=Compose%20Master)](http://jenkins.dockerproject.org/job/Compose%20Master/)
 
 Want to help build Compose? Check out our [contributing documentation](https://github.com/docker/compose/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
The dockerproject.com domain is moving to dockerproject.org this changes the buildstatus link to point to the new domain.

For reference, see https://github.com/docker/docker/pull/13709
