### PR TITLE
Validate that service names passed to Project.containers aren't bogus.

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -274,6 +274,9 @@ class Project(object):
             service.remove_stopped(**options)
 
     def containers(self, service_names=None, stopped=False, one_off=False):
+        if service_names:
+            # Will raise NoSuchService if one of the names is invalid
+            self.get_services(service_names)
         containers = [
             Container.from_ps(self.client, container)
             for container in self.client.containers(

--- a/compose/project.py
+++ b/compose/project.py
@@ -99,6 +99,16 @@ class Project(object):
 
         raise NoSuchService(name)
 
+    def validate_service_names(self, service_names):
+        """
+        Validate that the given list of service names only contains valid
+        services. Raises NoSuchService if one of the names is invalid.
+        """
+        valid_names = self.service_names
+        for name in service_names:
+            if name not in valid_names:
+                raise NoSuchService(name)
+
     def get_services(self, service_names=None, include_deps=False):
         """
         Returns a list of this project's services filtered
@@ -275,8 +285,7 @@ class Project(object):
 
     def containers(self, service_names=None, stopped=False, one_off=False):
         if service_names:
-            # Will raise NoSuchService if one of the names is invalid
-            self.get_services(service_names)
+            self.validate_service_names(service_names)
         containers = [
             Container.from_ps(self.client, container)
             for container in self.client.containers(

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -7,6 +7,7 @@ from mock import patch
 
 from .testcases import DockerClientTestCase
 from compose.cli.main import TopLevelCommand
+from compose.project import NoSuchService
 
 
 class CLITestCase(DockerClientTestCase):
@@ -348,6 +349,10 @@ class CLITestCase(DockerClientTestCase):
 
         self.assertEqual(len(service.containers(stopped=True)), 1)
         self.assertFalse(service.containers(stopped=True)[0].is_running)
+
+    def test_logs_invalid_service_name(self):
+        with self.assertRaises(NoSuchService):
+            self.command.dispatch(['logs', 'madeupname'], None)
 
     def test_kill(self):
         self.command.dispatch(['up', '-d'], None)


### PR DESCRIPTION
The `Project.containers` method doesn't validate the list of service names passed to it, which leads to behavior like this:

```
dan@dandesk:~/test$ sudo docker-compose logs madeupnamesdfg
Attaching to 
```
The invalid service name just gets ignored. This behavior is seen with `ps` and `rm`, in addition to `logs`. However, to be consistent with all the other docker-compose commands, a `NoSuchService` exception should be raised instead.

With this patch, the previous example does just that:
```
dan@dandesk:~/test$ sudo docker-compose logs madeupnamesdfg
No such service: madeupnamesdfg
```
Let me know if this needs a unit test, or if you'd prefer something other than using `get_services` (like a dedicated `validate_service_names` method) to do the validation.
