### PR TITLE
Remove Service.start_or_create_containers()

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -392,21 +392,6 @@ class Service(object):
         container.start()
         return container
 
-    def start_or_create_containers(
-            self,
-            insecure_registry=False,
-            do_build=True):
-        containers = self.containers(stopped=True)
-
-        if not containers:
-            new_container = self.create_container(
-                insecure_registry=insecure_registry,
-                do_build=do_build,
-            )
-            return [self.start_container(new_container)]
-        else:
-            return [self.start_container_if_stopped(c) for c in containers]
-
     def config_hash(self):
         return json_hash(self.config_dict())
 

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -501,10 +501,10 @@ class ServiceTest(DockerClientTestCase):
             ],
         })
 
-    def test_start_with_image_id(self):
+    def test_create_with_image_id(self):
         # Image id for the current busybox:latest
         service = self.create_service('foo', image='8c2e06607696')
-        self.assertTrue(service.start_or_create_containers())
+        service.create_container()
 
     def test_scale(self):
         service = self.create_service('web')


### PR DESCRIPTION
It's used in one place, which is a test, and that test doesn't even need to start the container.