### PR TITLE
Remove logging on run --rm

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -348,7 +348,6 @@ class TopLevelCommand(Command):
             dockerpty.start(project.client, container.id, interactive=not options['-T'])
             exit_code = container.wait()
             if options['--rm']:
-                log.info("Removing %s..." % container.name)
                 project.client.remove_container(container.id)
             sys.exit(exit_code)
 


### PR DESCRIPTION
`docker run --rm` doesn't log that it's removing the container, and neither should we.