### PR TITLE
Docs: Update boot2docker shellinit example to use 'eval'

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,7 +157,7 @@ By default, if there are existing containers for a service, `docker-compose up` 
 Several environment variables are available for you to configure Compose's behaviour.
 
 Variables starting with `DOCKER_` are the same as those used to configure the
-Docker command-line client. If you're using boot2docker, `$(boot2docker shellinit)`
+Docker command-line client. If you're using boot2docker, `eval "$(boot2docker shellinit)"`
 will set them to their correct values.
 
 ### COMPOSE\_PROJECT\_NAME


### PR DESCRIPTION
The boot2docker documentation has since changed the recommended way to use shellinit - see boot2docker/boot2docker#786.