### PR TITLE
Add image affinity to test script

### DIFF
--- a/script/test
+++ b/script/test
@@ -11,6 +11,7 @@ docker run \
   --volume="/var/run/docker.sock:/var/run/docker.sock" \
   -e DOCKER_VERSIONS \
   -e "TAG=$TAG" \
+  -e "affinity:image==$TAG" \
   --entrypoint="script/test-versions" \
   "$TAG" \
   "$@"


### PR DESCRIPTION
This will allow tests to be run on a Swarm. This is being fixed in
Swarm 0.4: https://github.com/docker/swarm/issues/743

Signed-off-by: Ben Firshman <ben@firshman.co.uk>