### PR TITLE
Fix volume binds de-duplication

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -731,7 +731,7 @@ def merge_volume_bindings(volumes_option, previous_container):
         volume_bindings.update(
             get_container_data_volumes(previous_container, volumes_option))
 
-    return volume_bindings
+    return volume_bindings.values()
 
 
 def get_container_data_volumes(container, volumes_option):
@@ -763,8 +763,7 @@ def get_container_data_volumes(container, volumes_option):
 
 
 def build_volume_binding(volume_spec):
-    internal = {'bind': volume_spec.internal, 'ro': volume_spec.mode == 'ro'}
-    return volume_spec.external, internal
+    return volume_spec.internal, "{}:{}:{}".format(*volume_spec)
 
 
 def parse_volume_spec(volume_config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==1.2.2
+docker-py==1.2.3-rc1
 dockerpty==0.3.4
 docopt==0.6.1
 requests==2.6.1


### PR DESCRIPTION
Volume binds are currently deduped based on the host path. They should be deduped based on the container path.

Closes #983 and also fixes a regression introduced by #858 where, if an existing container for a service reports a different host path for a volume than was supplied (e.g. by prepending `/mnt/sda1`, as sometimes happens), a binding for each host path is passed to the new container's config, which is an error.

Waiting on https://github.com/docker/docker-py/pull/635.
