### PR TITLE
Use docker 1.7.0 and docker-py 1.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,13 +48,13 @@ RUN set -ex; \
     rm -rf pip-7.0.1; \
     rm pip-7.0.1.tar.gz
 
-ENV ALL_DOCKER_VERSIONS 1.6.0 1.7.0-rc5
+ENV ALL_DOCKER_VERSIONS 1.6.0 1.7.0
 
 RUN set -ex; \
     curl https://get.docker.com/builds/Linux/x86_64/docker-1.6.0 -o /usr/local/bin/docker-1.6.0; \
     chmod +x /usr/local/bin/docker-1.6.0; \
-    curl https://test.docker.com/builds/Linux/x86_64/docker-1.7.0-rc5 -o /usr/local/bin/docker-1.7.0-rc5; \
-    chmod +x /usr/local/bin/docker-1.7.0-rc5
+    curl https://test.docker.com/builds/Linux/x86_64/docker-1.7.0 -o /usr/local/bin/docker-1.7.0; \
+    chmod +x /usr/local/bin/docker-1.7.0
 
 # Set the default Docker to be run
 RUN ln -s /usr/local/bin/docker-1.6.0 /usr/local/bin/docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==1.2.3-rc1
+docker-py==1.2.3
 dockerpty==0.3.4
 docopt==0.6.1
 requests==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.6.1, < 2.7',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.11.0, < 1.0',
-    'docker-py >= 1.2.3-rc1, < 1.3',
+    'docker-py >= 1.2.3, < 1.3',
     'dockerpty >= 0.3.4, < 0.4',
     'six >= 1.3.0, < 2',
 ]


### PR DESCRIPTION
- Update test suite to use Docker 1.7.0
- Update `requirements.txt` and `setup.py` to use docker-py 1.2.3