### PR TITLE
Adds additional TLS configuration CLI arguments

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -61,12 +61,17 @@ class Command(DocoptCommand):
         project = self.get_project(
             self.get_config_path(explicit_config_path),
             project_name=options.get('--project-name'),
+            tls=options.get('--tls') in ("true", "t", "1"),
+            tls_ca_cert=options.get('--tlscacert'),
+            tls_cert=options.get('--tlscert'),
+            tls_key=options.get('--tlskey'),
+            tls_verify=options.get('--tlsverify') in ("true", "t", "1"),
             verbose=options.get('--verbose'))
 
         handler(project, command_options)
 
-    def get_client(self, verbose=False):
-        client = docker_client()
+    def get_client(self, tls=False, tls_ca_cert=None, tls_cert=None, tls_key=None, tls_verify=False, verbose=False):
+        client = docker_client(tls, tls_ca_cert, tls_cert, tls_key, tls_verify)
         if verbose:
             version_info = six.iteritems(client.version())
             log.info("Compose version %s", __version__)
@@ -76,12 +81,14 @@ class Command(DocoptCommand):
             return verbose_proxy.VerboseProxy('docker', client)
         return client
 
-    def get_project(self, config_path, project_name=None, verbose=False):
+    def get_project(self, config_path, project_name=None, tls=False, tls_ca_cert=None, tls_cert=None, tls_key=None,
+                    tls_verify=False, verbose=False):
         try:
             return Project.from_dicts(
                 self.get_project_name(config_path, project_name),
                 config.load(config_path),
-                self.get_client(verbose=verbose))
+                self.get_client(tls=tls, tls_ca_cert=tls_ca_cert, tls_cert=tls_cert, tls_key=tls_key,
+                                tls_verify=tls_verify, verbose=verbose))
         except ConfigError as e:
             raise errors.UserError(six.text_type(e))
 

--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -61,16 +61,16 @@ class Command(DocoptCommand):
         project = self.get_project(
             self.get_config_path(explicit_config_path),
             project_name=options.get('--project-name'),
-            tls=options.get('--tls') in ("true", "t", "1"),
+            tls=options.get('--tls'),
             tls_ca_cert=options.get('--tlscacert'),
             tls_cert=options.get('--tlscert'),
             tls_key=options.get('--tlskey'),
-            tls_verify=options.get('--tlsverify') in ("true", "t", "1"),
+            tls_verify=options.get('--tlsverify'),
             verbose=options.get('--verbose'))
 
         handler(project, command_options)
 
-    def get_client(self, tls=False, tls_ca_cert=None, tls_cert=None, tls_key=None, tls_verify=False, verbose=False):
+    def get_client(self, tls=None, tls_ca_cert=None, tls_cert=None, tls_key=None, tls_verify=None, verbose=False):
         client = docker_client(tls, tls_ca_cert, tls_cert, tls_key, tls_verify)
         if verbose:
             version_info = six.iteritems(client.version())
@@ -81,8 +81,8 @@ class Command(DocoptCommand):
             return verbose_proxy.VerboseProxy('docker', client)
         return client
 
-    def get_project(self, config_path, project_name=None, tls=False, tls_ca_cert=None, tls_cert=None, tls_key=None,
-                    tls_verify=False, verbose=False):
+    def get_project(self, config_path, project_name=None, tls=None, tls_ca_cert=None, tls_cert=None, tls_key=None,
+                    tls_verify=None, verbose=False):
         try:
             return Project.from_dicts(
                 self.get_project_name(config_path, project_name),

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -6,7 +6,7 @@ import warnings
 from . import errors
 
 
-def docker_client(tls=False, tls_ca_cert=None, tls_cert=None, tls_key=None, tls_verify=False):
+def docker_client(tls=None, tls_ca_cert=None, tls_cert=None, tls_key=None, tls_verify=None):
     """
     Returns a docker-py client configured using environment variables
     according to the same logic as the official Docker client.
@@ -18,33 +18,23 @@ def docker_client(tls=False, tls_ca_cert=None, tls_cert=None, tls_key=None, tls_
     base_url = os.environ.get('DOCKER_HOST')
     tls_config = None
 
-    tls_verify = tls_verify or os.environ.get('DOCKER_TLS_VERIFY', '') != ''
+    tls = tls in ("true", "t", "1")
+    tls_verify = os.environ.get('DOCKER_TLS_VERIFY', '') != '' if tls_verify is None else tls_verify in ("true", "t", "1")
     if tls or tls_verify:
+        parts = base_url.split('://', 1)
+        base_url = '%s://%s' % ('https', parts[1])
+
+        # Prefer cli argument over environment variable
+        tls_ca_cert = os.path.expanduser(os.path.join(cert_path, 'ca.pem') if tls_ca_cert is None else tls_ca_cert)
+        tls_cert = os.path.expanduser(os.path.join(cert_path, 'cert.pem') if tls_cert is None else tls_cert)
+        tls_key = os.path.expanduser(os.path.join(cert_path, 'key.pem') if tls_key is None else tls_key)
+
         if not tls_verify:
             warnings.warn((
                 'Unverified HTTPS request is being made. '
                 'Adding certificate verification is strongly advised. See: '
                 'https://urllib3.readthedocs.org/en/latest/security.html'),
                 errors.InsecureRequestWarning)
-
-        parts = base_url.split('://', 1)
-        base_url = '%s://%s' % ('https', parts[1])
-
-        # Prefer cli argument over environment variable
-        if tls_ca_cert is None:
-            tls_ca_cert = os.path.join(cert_path, 'ca.pem')
-
-        if tls_key is None:
-            tls_key = os.path.join(cert_path, 'key.pem')
-
-        if tls_cert is None:
-            tls_cert = os.path.join(cert_path, 'cert.pem')
-
-        tls_ca_cert = os.path.expanduser(tls_ca_cert)
-        tls_cert = os.path.expanduser(tls_cert)
-        tls_key = os.path.expanduser(tls_key)
-
-        if not tls_verify:
             tls_ca_cert = None
 
         tls_config = docker_tls.TLSConfig(

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -1,10 +1,12 @@
 from docker import Client
-from docker import tls
+from docker import tls as docker_tls
 import ssl
 import os
+import warnings
+from . import errors
 
 
-def docker_client():
+def docker_client(tls=False, tls_ca_cert=None, tls_cert=None, tls_key=None, tls_verify=False):
     """
     Returns a docker-py client configured using environment variables
     according to the same logic as the official Docker client.
@@ -16,19 +18,41 @@ def docker_client():
     base_url = os.environ.get('DOCKER_HOST')
     tls_config = None
 
-    if os.environ.get('DOCKER_TLS_VERIFY', '') != '':
+    tls_verify = tls_verify or os.environ.get('DOCKER_TLS_VERIFY', '') != ''
+    if tls or tls_verify:
+        if not tls_verify:
+            warnings.warn((
+                'Unverified HTTPS request is being made. '
+                'Adding certificate verification is strongly advised. See: '
+                'https://urllib3.readthedocs.org/en/latest/security.html'),
+                errors.InsecureRequestWarning)
+
         parts = base_url.split('://', 1)
         base_url = '%s://%s' % ('https', parts[1])
 
-        client_cert = (os.path.join(cert_path, 'cert.pem'), os.path.join(cert_path, 'key.pem'))
-        ca_cert = os.path.join(cert_path, 'ca.pem')
+        # Prefer cli argument over environment variable
+        if tls_ca_cert is None:
+            tls_ca_cert = os.path.join(cert_path, 'ca.pem')
 
-        tls_config = tls.TLSConfig(
+        if tls_key is None:
+            tls_key = os.path.join(cert_path, 'key.pem')
+
+        if tls_cert is None:
+            tls_cert = os.path.join(cert_path, 'cert.pem')
+
+        tls_ca_cert = os.path.expanduser(tls_ca_cert)
+        tls_cert = os.path.expanduser(tls_cert)
+        tls_key = os.path.expanduser(tls_key)
+
+        if not tls_verify:
+            tls_ca_cert = None
+
+        tls_config = docker_tls.TLSConfig(
             ssl_version=ssl.PROTOCOL_TLSv1,
-            verify=True,
+            verify=tls_verify,
             assert_hostname=False,
-            client_cert=client_cert,
-            ca_cert=ca_cert,
+            client_cert=(tls_cert, tls_key),
+            ca_cert=tls_ca_cert,
         )
 
     timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))

--- a/compose/cli/docopt_command.py
+++ b/compose/cli/docopt_command.py
@@ -5,6 +5,9 @@ import sys
 from inspect import getdoc
 from docopt import docopt, DocoptExit
 
+import warnings
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
 
 def docopt_full_help(docstring, *args, **kwargs):
     try:
@@ -21,7 +24,9 @@ class DocoptCommand(object):
         self.dispatch(sys.argv[1:], None)
 
     def dispatch(self, argv, global_options):
-        self.perform_command(*self.parse(argv, global_options))
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action='ignore', category=InsecureRequestWarning)
+            self.perform_command(*self.parse(argv, global_options))
 
     def perform_command(self, options, handler, command_options):
         handler(command_options)

--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -62,3 +62,8 @@ class ComposeFileNotFound(UserError):
 
         Supported filenames: %s
         """ % ", ".join(supported_filenames))
+
+
+class InsecureRequestWarning(Warning):
+    """Unverified HTTPS request is being made. Adding certificate verification is strongly advised."""
+    pass

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -82,11 +82,11 @@ class TopLevelCommand(Command):
     Options:
       -f, --file FILE           Specify an alternate compose file (default: docker-compose.yml)
       -p, --project-name NAME   Specify an alternate project name (default: directory name)
-      --tls=false               Use TLS; implied by --tlsverify
+      --tls=BOOL                Use TLS; implied by --tlsverify
       --tlscacert=FILE          Trust certs signed only by this ca (default: ~/.docker/ca.pem)
       --tlscert=FILE            Path to tls certificate file (default: ~/.docker/cert.pem)
       --tlskey=FILE             Path to tls key file (default: ~/.docker/key.pem)
-      --tlsverify=false         Use TLS and verify the remote
+      --tlsverify=BOOL          Use TLS and verify the remote
       --verbose                 Show more output
       -v, --version             Print version and exit
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -82,6 +82,11 @@ class TopLevelCommand(Command):
     Options:
       -f, --file FILE           Specify an alternate compose file (default: docker-compose.yml)
       -p, --project-name NAME   Specify an alternate project name (default: directory name)
+      --tls=false               Use TLS; implied by --tlsverify
+      --tlscacert=FILE          Trust certs signed only by this ca (default: ~/.docker/ca.pem)
+      --tlscert=FILE            Path to tls certificate file (default: ~/.docker/cert.pem)
+      --tlskey=FILE             Path to tls key file (default: ~/.docker/key.pem)
+      --tlsverify=false         Use TLS and verify the remote
       --verbose                 Show more output
       -v, --version             Print version and exit
 


### PR DESCRIPTION
A few notes: :notes: 

- I am ignoring urllib3 InsecureRequestWarning as it gets displayed for every request and is rather spammy. I think it makes sense to show a custom error once instead since the user has to explicitly set verification off. I am using the same text from urllib3's InsecureRequestWarning, but it might make sense to modify it for compose.

- --tls and --tlsverify arguments can bet set equal to a few values that docker seems to support: true, t, 1. 

- --tls argument without any assignment does not work the way it does with docker. I could not figure out how to achieve that behavior with docopt.

See #1317 #977 