### PR TITLE
Fix 'docker-compose help migrate-to-labels'

### DIFF
--- a/compose/cli/docopt_command.py
+++ b/compose/cli/docopt_command.py
@@ -33,12 +33,7 @@ class DocoptCommand(object):
         if command is None:
             raise SystemExit(getdoc(self))
 
-        command = command.replace('-', '_')
-
-        if not hasattr(self, command):
-            raise NoSuchCommand(command, self)
-
-        handler = getattr(self, command)
+        handler = self.get_handler(command)
         docstring = getdoc(handler)
 
         if docstring is None:
@@ -46,6 +41,14 @@ class DocoptCommand(object):
 
         command_options = docopt_full_help(docstring, options['ARGS'], options_first=True)
         return options, handler, command_options
+
+    def get_handler(self, command):
+        command = command.replace('-', '_')
+
+        if not hasattr(self, command):
+            raise NoSuchCommand(command, self)
+
+        return getattr(self, command)
 
 
 class NoSuchCommand(Exception):

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -131,10 +131,8 @@ class TopLevelCommand(Command):
 
         Usage: help COMMAND
         """
-        command = options['COMMAND']
-        if not hasattr(self, command):
-            raise NoSuchCommand(command, self)
-        raise SystemExit(getdoc(getattr(self, command)))
+        handler = self.get_handler(options['COMMAND'])
+        raise SystemExit(getdoc(handler))
 
     def kill(self, project, options):
         """
@@ -485,6 +483,24 @@ class TopLevelCommand(Command):
     def migrate_to_labels(self, project, _options):
         """
         Recreate containers to add labels
+
+        If you're coming from Compose 1.2 or earlier, you'll need to remove or
+        migrate your existing containers after upgrading Compose. This is
+        because, as of version 1.3, Compose uses Docker labels to keep track
+        of containers, and so they need to be recreated with labels added.
+
+        If Compose detects containers that were created without labels, it
+        will refuse to run so that you don't end up with two sets of them. If
+        you want to keep using your existing containers (for example, because
+        they have data volumes you want to preserve) you can migrate them with
+        the following command:
+
+            docker-compose migrate-to-labels
+
+        Alternatively, if you're not worried about keeping them, you can
+        remove them - Compose will just create new ones.
+
+            docker rm -f myapp_web_1 myapp_db_1 ...
 
         Usage: migrate-to-labels
         """

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -11,6 +11,7 @@ import mock
 
 from compose.cli import main
 from compose.cli.main import TopLevelCommand
+from compose.cli.docopt_command import NoSuchCommand
 from compose.cli.errors import ComposeFileNotFound
 from compose.service import Service
 
@@ -100,6 +101,22 @@ class CLITestCase(unittest.TestCase):
         command = TopLevelCommand()
         with self.assertRaises(SystemExit):
             command.dispatch(['-h'], None)
+
+    def test_command_help(self):
+        with self.assertRaises(SystemExit) as ctx:
+            TopLevelCommand().dispatch(['help', 'up'], None)
+
+        self.assertIn('Usage: up', str(ctx.exception))
+
+    def test_command_help_dashes(self):
+        with self.assertRaises(SystemExit) as ctx:
+            TopLevelCommand().dispatch(['help', 'migrate-to-labels'], None)
+
+        self.assertIn('Usage: migrate-to-labels', str(ctx.exception))
+
+    def test_command_help_nonexistent(self):
+        with self.assertRaises(NoSuchCommand):
+            TopLevelCommand().dispatch(['help', 'nonexistent'], None)
 
     def test_setup_logging(self):
         main.setup_logging()


### PR DESCRIPTION
- Fix "No such command" error

- Add text from migration section of install docs

Closes #1571