### PR TITLE
Don't set network mode when none is specified

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -188,7 +188,7 @@ class Project(object):
             del service_dict['net']
 
         else:
-            net = 'bridge'
+            net = None
 
         return net
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -457,7 +457,7 @@ class Service(object):
 
     def _get_net(self):
         if not self.net:
-            return "bridge"
+            return None
 
         if isinstance(self.net, Service):
             containers = self.net.containers()


### PR DESCRIPTION
Setting a value overrides the new default network option.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>