### PR TITLE
1519 relax service name restrictions

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -47,7 +47,7 @@ DOCKER_START_KEYS = [
     'security_opt',
 ]
 
-VALID_NAME_CHARS = '[a-zA-Z0-9]'
+VALID_NAME_CHARS = '[a-zA-Z0-9\._\-]'
 
 
 class BuildError(Exception):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -34,18 +34,23 @@ class ServiceTest(unittest.TestCase):
         self.assertRaises(ConfigError, lambda: Service(name='/', image='foo'))
         self.assertRaises(ConfigError, lambda: Service(name='!', image='foo'))
         self.assertRaises(ConfigError, lambda: Service(name='\xe2', image='foo'))
-        self.assertRaises(ConfigError, lambda: Service(name='_', image='foo'))
-        self.assertRaises(ConfigError, lambda: Service(name='____', image='foo'))
-        self.assertRaises(ConfigError, lambda: Service(name='foo_bar', image='foo'))
-        self.assertRaises(ConfigError, lambda: Service(name='__foo_bar__', image='foo'))
 
         Service('a', image='foo')
         Service('foo', image='foo')
+        Service('foo-bar', image='foo')
+        Service('foo.bar', image='foo')
+        Service('foo_bar', image='foo')
+        Service('_', image='foo')
+        Service('___', image='foo')
+        Service('-', image='foo')
+        Service('--', image='foo')
+        Service('.__.', image='foo')
 
     def test_project_validation(self):
         self.assertRaises(ConfigError, lambda: Service('bar'))
-        self.assertRaises(ConfigError, lambda: Service(name='foo', project='_', image='foo'))
-        Service(name='foo', project='bar', image='foo')
+        self.assertRaises(ConfigError, lambda: Service(name='foo', project='>', image='foo'))
+
+        Service(name='foo', project='bar.bar__', image='foo')
 
     def test_containers(self):
         service = Service('db', self.mock_client, 'myproject', image='foo')

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -28,16 +28,16 @@ class ServiceTest(unittest.TestCase):
         self.mock_client = mock.create_autospec(docker.Client)
 
     def test_name_validations(self):
-        self.assertRaises(ConfigError, lambda: Service(name=''))
+        self.assertRaises(ConfigError, lambda: Service(name='', image='foo'))
 
-        self.assertRaises(ConfigError, lambda: Service(name=' '))
-        self.assertRaises(ConfigError, lambda: Service(name='/'))
-        self.assertRaises(ConfigError, lambda: Service(name='!'))
-        self.assertRaises(ConfigError, lambda: Service(name='\xe2'))
-        self.assertRaises(ConfigError, lambda: Service(name='_'))
-        self.assertRaises(ConfigError, lambda: Service(name='____'))
-        self.assertRaises(ConfigError, lambda: Service(name='foo_bar'))
-        self.assertRaises(ConfigError, lambda: Service(name='__foo_bar__'))
+        self.assertRaises(ConfigError, lambda: Service(name=' ', image='foo'))
+        self.assertRaises(ConfigError, lambda: Service(name='/', image='foo'))
+        self.assertRaises(ConfigError, lambda: Service(name='!', image='foo'))
+        self.assertRaises(ConfigError, lambda: Service(name='\xe2', image='foo'))
+        self.assertRaises(ConfigError, lambda: Service(name='_', image='foo'))
+        self.assertRaises(ConfigError, lambda: Service(name='____', image='foo'))
+        self.assertRaises(ConfigError, lambda: Service(name='foo_bar', image='foo'))
+        self.assertRaises(ConfigError, lambda: Service(name='__foo_bar__', image='foo'))
 
         Service('a', image='foo')
         Service('foo', image='foo')


### PR DESCRIPTION
Allow _.- characters to be used in Service and Project names, as requested per this issue: https://github.com/docker/compose/issues/1519