### PR TITLE
Extends file default behaviour and fixes circular reference bug

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -158,7 +158,7 @@ class ServiceLoader(object):
         if 'extends' not in service_dict:
             return service_dict
 
-        extends_options = process_extends_options(service_dict['name'], service_dict['extends'])
+        extends_options = validate_extends_options(service_dict['name'], service_dict['extends'])
 
         if self.working_dir is None:
             raise Exception("No working_dir passed to ServiceLoader()")
@@ -190,7 +190,7 @@ class ServiceLoader(object):
         return (self.filename, name)
 
 
-def process_extends_options(service_name, extends_options):
+def validate_extends_options(service_name, extends_options):
     error_prefix = "Invalid 'extends' configuration for %s:" % service_name
 
     if not isinstance(extends_options, dict):

--- a/compose/config.py
+++ b/compose/config.py
@@ -163,7 +163,12 @@ class ServiceLoader(object):
         if self.working_dir is None:
             raise Exception("No working_dir passed to ServiceLoader()")
 
-        other_config_path = expand_path(self.working_dir, extends_options['file'])
+        try:
+            extends_from_filename = extends_options['file']
+        except KeyError:
+            extends_from_filename = os.path.split(self.filename)[1]
+
+        other_config_path = expand_path(self.working_dir, extends_from_filename)
         other_working_dir = os.path.dirname(other_config_path)
         other_already_seen = self.already_seen + [self.signature(service_dict['name'])]
         other_loader = ServiceLoader(

--- a/compose/config.py
+++ b/compose/config.py
@@ -158,7 +158,7 @@ class ServiceLoader(object):
         if 'extends' not in service_dict:
             return service_dict
 
-        extends_options = validate_extends_options(service_dict['name'], service_dict['extends'])
+        extends_options = self.validate_extends_options(service_dict['name'], service_dict['extends'])
 
         if self.working_dir is None:
             raise Exception("No working_dir passed to ServiceLoader()")
@@ -194,25 +194,29 @@ class ServiceLoader(object):
     def signature(self, name):
         return (self.filename, name)
 
+    def validate_extends_options(self, service_name, extends_options):
+        error_prefix = "Invalid 'extends' configuration for %s:" % service_name
 
-def validate_extends_options(service_name, extends_options):
-    error_prefix = "Invalid 'extends' configuration for %s:" % service_name
+        if not isinstance(extends_options, dict):
+            raise ConfigurationError("%s must be a dictionary" % error_prefix)
 
-    if not isinstance(extends_options, dict):
-        raise ConfigurationError("%s must be a dictionary" % error_prefix)
-
-    if 'service' not in extends_options:
-        raise ConfigurationError(
-            "%s you need to specify a service, e.g. 'service: web'" % error_prefix
-        )
-
-    for k, _ in extends_options.items():
-        if k not in ['file', 'service']:
+        if 'service' not in extends_options:
             raise ConfigurationError(
-                "%s unsupported configuration option '%s'" % (error_prefix, k)
+                "%s you need to specify a service, e.g. 'service: web'" % error_prefix
             )
 
-    return extends_options
+        if 'file' not in extends_options and self.filename is None:
+            raise ConfigurationError(
+                "%s you need to specify a 'file', e.g. 'file: something.yml'" % error_prefix
+            )
+
+        for k, _ in extends_options.items():
+            if k not in ['file', 'service']:
+                raise ConfigurationError(
+                    "%s unsupported configuration option '%s'" % (error_prefix, k)
+                )
+
+        return extends_options
 
 
 def validate_extended_service_dict(service_dict, filename, service):

--- a/compose/config.py
+++ b/compose/config.py
@@ -149,7 +149,7 @@ class ServiceLoader(object):
 
     def make_service_dict(self, name, service_dict):
         if self.signature(name) in self.already_seen:
-            raise CircularReference(self.already_seen)
+            raise CircularReference(self.already_seen + [self.signature(name)])
 
         service_dict = service_dict.copy()
         service_dict['name'] = name

--- a/compose/config.py
+++ b/compose/config.py
@@ -147,10 +147,11 @@ class ServiceLoader(object):
             self.filename = filename
         self.already_seen = already_seen or []
 
-    def make_service_dict(self, name, service_dict):
+    def detect_cycle(self, name):
         if self.signature(name) in self.already_seen:
             raise CircularReference(self.already_seen + [self.signature(name)])
 
+    def make_service_dict(self, name, service_dict):
         service_dict = service_dict.copy()
         service_dict['name'] = name
         service_dict = resolve_environment(service_dict, working_dir=self.working_dir)
@@ -182,6 +183,7 @@ class ServiceLoader(object):
 
         other_config = load_yaml(other_config_path)
         other_service_dict = other_config[extends_options['service']]
+        other_loader.detect_cycle(extends_options['service'])
         other_service_dict = other_loader.make_service_dict(
             service_dict['name'],
             other_service_dict,

--- a/compose/config.py
+++ b/compose/config.py
@@ -140,8 +140,11 @@ def make_service_dict(name, service_dict, working_dir=None):
 
 class ServiceLoader(object):
     def __init__(self, working_dir, filename=None, already_seen=None):
-        self.working_dir = working_dir
-        self.filename = filename
+        self.working_dir = os.path.abspath(working_dir)
+        if filename:
+            self.filename = os.path.abspath(filename)
+        else:
+            self.filename = filename
         self.already_seen = already_seen or []
 
     def make_service_dict(self, name, service_dict):

--- a/compose/config.py
+++ b/compose/config.py
@@ -134,7 +134,7 @@ def load(config_details):
     return service_dicts
 
 
-def make_service_dict(name, service_dict, working_dir=None):
+def make_service_dict(name, service_dict, working_dir):
     return ServiceLoader(working_dir=working_dir).make_service_dict(name, service_dict)
 
 

--- a/compose/config.py
+++ b/compose/config.py
@@ -134,10 +134,6 @@ def load(config_details):
     return service_dicts
 
 
-def make_service_dict(name, service_dict, working_dir):
-    return ServiceLoader(working_dir=working_dir).make_service_dict(name, service_dict)
-
-
 class ServiceLoader(object):
     def __init__(self, working_dir, filename=None, already_seen=None):
         self.working_dir = os.path.abspath(working_dir)

--- a/compose/config.py
+++ b/compose/config.py
@@ -163,12 +163,12 @@ class ServiceLoader(object):
         if self.working_dir is None:
             raise Exception("No working_dir passed to ServiceLoader()")
 
-        try:
+        if 'file' in extends_options:
             extends_from_filename = extends_options['file']
-        except KeyError:
-            extends_from_filename = os.path.split(self.filename)[1]
+            other_config_path = expand_path(self.working_dir, extends_from_filename)
+        else:
+            other_config_path = self.filename
 
-        other_config_path = expand_path(self.working_dir, extends_from_filename)
         other_working_dir = os.path.dirname(other_config_path)
         other_already_seen = self.already_seen + [self.signature(service_dict['name'])]
         other_loader = ServiceLoader(

--- a/tests/fixtures/extends/no-file-specified.yml
+++ b/tests/fixtures/extends/no-file-specified.yml
@@ -1,0 +1,9 @@
+myweb:
+  extends:
+    service: web
+  environment:
+    - "BAR=1"
+web:
+  image: busybox
+  environment:
+    - "BAZ=3"

--- a/tests/fixtures/extends/specify-file-as-self.yml
+++ b/tests/fixtures/extends/specify-file-as-self.yml
@@ -1,0 +1,16 @@
+myweb:
+  extends:
+    file: specify-file-as-self.yml
+    service: web
+  environment:
+    - "BAR=1"
+web:
+  extends:
+    file: specify-file-as-self.yml
+    service: otherweb
+  image: busybox
+  environment:
+    - "BAZ=3"
+otherweb:
+  environment:
+    - "YEP=1"

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from compose.service import Service
-from compose.config import make_service_dict
+from compose.config import ServiceLoader
 from compose.const import LABEL_PROJECT
 from compose.cli.docker_client import docker_client
 from compose.progress_stream import stream_output
@@ -30,10 +30,12 @@ class DockerClientTestCase(unittest.TestCase):
         if 'command' not in kwargs:
             kwargs['command'] = ["top"]
 
+        options = ServiceLoader(working_dir='.').make_service_dict(name, kwargs)
+
         return Service(
             project='composetest',
             client=self.client,
-            **make_service_dict(name, kwargs, working_dir='.')
+            **options
         )
 
     def check_build(self, *args, **kwargs):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -459,6 +459,14 @@ class ExtendsTest(unittest.TestCase):
 
         self.assertRaisesRegexp(config.ConfigurationError, 'what', load_config)
 
+    def test_extends_validation_no_file_key_no_filename_set(self):
+        dictionary = {'extends': {'service': 'web'}}
+
+        def load_config():
+            return config.make_service_dict('myweb', dictionary, working_dir='tests/fixtures/extends')
+
+        self.assertRaisesRegexp(config.ConfigurationError, 'file', load_config)
+
     def test_extends_validation_valid_config(self):
         dictionary = {'extends': {'service': 'web', 'file': 'common.yml'}}
 

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -427,7 +427,7 @@ class ExtendsTest(unittest.TestCase):
                 ],
             )
 
-    def test_extends_validation(self):
+    def test_extends_validation_empty_dictionary(self):
         dictionary = {'extends': None}
 
         def load_config():
@@ -438,14 +438,34 @@ class ExtendsTest(unittest.TestCase):
         dictionary['extends'] = {}
         self.assertRaises(config.ConfigurationError, load_config)
 
-        dictionary['extends']['file'] = 'common.yml'
+    def test_extends_validation_missing_service_key(self):
+        dictionary = {'extends': {'file': 'common.yml'}}
+
+        def load_config():
+            return config.make_service_dict('myweb', dictionary, working_dir='tests/fixtures/extends')
+
         self.assertRaisesRegexp(config.ConfigurationError, 'service', load_config)
 
-        dictionary['extends']['service'] = 'web'
-        self.assertIsInstance(load_config(), dict)
+    def test_extends_validation_invalid_key(self):
+        dictionary = {
+            'extends':
+            {
+                'service': 'web', 'file': 'common.yml', 'what': 'is this'
+            }
+        }
 
-        dictionary['extends']['what'] = 'is this'
+        def load_config():
+            return config.make_service_dict('myweb', dictionary, working_dir='tests/fixtures/extends')
+
         self.assertRaisesRegexp(config.ConfigurationError, 'what', load_config)
+
+    def test_extends_validation_valid_config(self):
+        dictionary = {'extends': {'service': 'web', 'file': 'common.yml'}}
+
+        def load_config():
+            return config.make_service_dict('myweb', dictionary, working_dir='tests/fixtures/extends')
+
+        self.assertIsInstance(load_config(), dict)
 
     def test_extends_file_defaults_to_self(self):
         """

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -480,7 +480,7 @@ class ExtendsTest(unittest.TestCase):
         Test not specifying a file in our extends options that the
         config is valid and correctly extends from itself.
         """
-        service_dicts = config.load('tests/fixtures/extends/no-file-specified.yml')
+        service_dicts = load_from_filename('tests/fixtures/extends/no-file-specified.yml')
         self.assertEqual(service_dicts, [
             {
                 'name': 'myweb',

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -47,9 +47,9 @@ class ConfigTest(unittest.TestCase):
     def test_config_validation(self):
         self.assertRaises(
             config.ConfigurationError,
-            lambda: config.make_service_dict('foo', {'port': ['8000']})
+            lambda: config.make_service_dict('foo', {'port': ['8000']}, 'tests/')
         )
-        config.make_service_dict('foo', {'ports': ['8000']})
+        config.make_service_dict('foo', {'ports': ['8000']}, 'tests/')
 
 
 class VolumePathTest(unittest.TestCase):
@@ -219,36 +219,36 @@ class MergeLabelsTest(unittest.TestCase):
 
     def test_no_override(self):
         service_dict = config.merge_service_dicts(
-            config.make_service_dict('foo', {'labels': ['foo=1', 'bar']}),
-            config.make_service_dict('foo', {}),
+            config.make_service_dict('foo', {'labels': ['foo=1', 'bar']}, 'tests/'),
+            config.make_service_dict('foo', {}, 'tests/'),
         )
         self.assertEqual(service_dict['labels'], {'foo': '1', 'bar': ''})
 
     def test_no_base(self):
         service_dict = config.merge_service_dicts(
-            config.make_service_dict('foo', {}),
-            config.make_service_dict('foo', {'labels': ['foo=2']}),
+            config.make_service_dict('foo', {}, 'tests/'),
+            config.make_service_dict('foo', {'labels': ['foo=2']}, 'tests/'),
         )
         self.assertEqual(service_dict['labels'], {'foo': '2'})
 
     def test_override_explicit_value(self):
         service_dict = config.merge_service_dicts(
-            config.make_service_dict('foo', {'labels': ['foo=1', 'bar']}),
-            config.make_service_dict('foo', {'labels': ['foo=2']}),
+            config.make_service_dict('foo', {'labels': ['foo=1', 'bar']}, 'tests/'),
+            config.make_service_dict('foo', {'labels': ['foo=2']}, 'tests/'),
         )
         self.assertEqual(service_dict['labels'], {'foo': '2', 'bar': ''})
 
     def test_add_explicit_value(self):
         service_dict = config.merge_service_dicts(
-            config.make_service_dict('foo', {'labels': ['foo=1', 'bar']}),
-            config.make_service_dict('foo', {'labels': ['bar=2']}),
+            config.make_service_dict('foo', {'labels': ['foo=1', 'bar']}, 'tests/'),
+            config.make_service_dict('foo', {'labels': ['bar=2']}, 'tests/'),
         )
         self.assertEqual(service_dict['labels'], {'foo': '1', 'bar': '2'})
 
     def test_remove_explicit_value(self):
         service_dict = config.merge_service_dicts(
-            config.make_service_dict('foo', {'labels': ['foo=1', 'bar=2']}),
-            config.make_service_dict('foo', {'labels': ['bar']}),
+            config.make_service_dict('foo', {'labels': ['foo=1', 'bar=2']}, 'tests/'),
+            config.make_service_dict('foo', {'labels': ['bar']}, 'tests/'),
         )
         self.assertEqual(service_dict['labels'], {'foo': '1', 'bar': ''})
 
@@ -295,6 +295,7 @@ class EnvTest(unittest.TestCase):
                     'NO_DEF': None
                 },
             },
+            'tests/'
         )
 
         self.assertEqual(

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -413,6 +413,33 @@ class ExtendsTest(unittest.TestCase):
             },
         ])
 
+    def test_self_referencing_file(self):
+        """
+        We specify a 'file' key that is the filename we're already in.
+        """
+        service_dicts = load_from_filename('tests/fixtures/extends/specify-file-as-self.yml')
+        self.assertEqual(service_dicts, [
+            {
+                'environment':
+                {
+                    'YEP': '1', 'BAR': '1', 'BAZ': '3'
+                },
+                'image': 'busybox',
+                'name': 'myweb'
+            },
+            {
+                'environment':
+                {'YEP': '1'},
+                'name': 'otherweb'
+            },
+            {
+                'environment':
+                {'YEP': '1', 'BAZ': '3'},
+                'image': 'busybox',
+                'name': 'web'
+            }
+        ])
+
     def test_circular(self):
         try:
             load_from_filename('tests/fixtures/extends/circle-1.yml')

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -447,6 +447,30 @@ class ExtendsTest(unittest.TestCase):
         dictionary['extends']['what'] = 'is this'
         self.assertRaisesRegexp(config.ConfigurationError, 'what', load_config)
 
+    def test_extends_file_defaults_to_self(self):
+        """
+        Test not specifying a file in our extends options that the
+        config is valid and correctly extends from itself.
+        """
+        service_dicts = config.load('tests/fixtures/extends/no-file-specified.yml')
+        self.assertEqual(service_dicts, [
+            {
+                'name': 'myweb',
+                'image': 'busybox',
+                'environment': {
+                    "BAR": "1",
+                    "BAZ": "3",
+                }
+            },
+            {
+                'name': 'web',
+                'image': 'busybox',
+                'environment': {
+                    "BAZ": "3",
+                }
+            }
+        ])
+
     def test_blacklisted_options(self):
         def load_config():
             return config.make_service_dict('myweb', {


### PR DESCRIPTION
If no 'file' key is specified in the extends_options then by default we will look for the service within the same file.

This also includes a fix for circular reference checking which wasn't working entirely as desired.