### PR TITLE
Added env var parsing to volume container paths

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -184,7 +184,7 @@ def process_container_options(service_dict, working_dir=None):
     service_dict = service_dict.copy()
 
     if 'volumes' in service_dict:
-        service_dict['volumes'] = resolve_host_paths(service_dict['volumes'], working_dir=working_dir)
+        service_dict['volumes'] = resolve_volume_paths(service_dict['volumes'], working_dir=working_dir)
 
     if 'build' in service_dict:
         service_dict['build'] = resolve_build_path(service_dict['build'], working_dir=working_dir)
@@ -345,18 +345,18 @@ def env_vars_from_file(filename):
     return env
 
 
-def resolve_host_paths(volumes, working_dir=None):
+def resolve_volume_paths(volumes, working_dir=None):
     if working_dir is None:
-        raise Exception("No working_dir passed to resolve_host_paths()")
+        raise Exception("No working_dir passed to resolve_volume_paths()")
 
-    return [resolve_host_path(v, working_dir) for v in volumes]
+    return [resolve_volume_path(v, working_dir) for v in volumes]
 
 
-def resolve_host_path(volume, working_dir):
+def resolve_volume_path(volume, working_dir):
     container_path, host_path = split_path_mapping(volume)
+    container_path = os.path.expanduser(os.path.expandvars(container_path))
     if host_path is not None:
-        host_path = os.path.expanduser(host_path)
-        host_path = os.path.expandvars(host_path)
+        host_path = os.path.expanduser(os.path.expandvars(host_path))
         return "%s:%s" % (expand_path(working_dir, host_path), container_path)
     else:
         return container_path

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -334,6 +334,25 @@ class EnvTest(unittest.TestCase):
             {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
         )
 
+    @mock.patch.dict(os.environ)
+    def test_resolve_path(self):
+        os.environ['HOSTENV'] = '/tmp'
+        os.environ['CONTAINERENV'] = '/host/tmp'
+
+        service_dict = config.make_service_dict(
+            'foo',
+            {'volumes': ['$HOSTENV:$CONTAINERENV']},
+            working_dir="tests/fixtures/env"
+        )
+        self.assertEqual(set(service_dict['volumes']), set(['/tmp:/host/tmp']))
+
+        service_dict = config.make_service_dict(
+            'foo',
+            {'volumes': ['/opt${HOSTENV}:/opt${CONTAINERENV}']},
+            working_dir="tests/fixtures/env"
+        )
+        self.assertEqual(set(service_dict['volumes']), set(['/opt/tmp:/opt/host/tmp']))
+
 
 class ExtendsTest(unittest.TestCase):
     def test_extends(self):


### PR DESCRIPTION
This commit adds environment variable parsing to the container side of the volume mapping in configs.  Currently only host side paths are evaluated for environment variable substitution. This commit fixes #1626.

The common use case for this is mounting SSH agent sockets in a container, but it's useful anywhere you may want to have external variables effect volume paths. An example of mounting an SSH agent socket, which currently fails, due to the host side not being evaluated: 

```
volumes:
    - $SSH_AUTH_SOCK:$SSH_AUTH_SOCK
environment:
    - SSH_AUTH_SOCK
```