### PR TITLE
Fix a unit test that was failing occasionally

### DIFF
--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -478,10 +478,10 @@ class BuildPathTest(unittest.TestCase):
         options = {'build': 'nonexistent.path'}
         self.assertRaises(
             config.ConfigurationError,
-            lambda: config.from_dictionary({
-                'foo': options,
-                'working_dir': 'tests/fixtures/build-path'
-            })
+            lambda: config.from_dictionary(
+                {'foo': options},
+                working_dir='tests/fixtures/build-path'
+            )
         )
 
     def test_relative_path(self):


### PR DESCRIPTION
I'm not sure how this ever worked, but it was failing occasionally while I was running unit tests locally.  The `working_dir` is actually a kwarg to this function, not part of the dict.