### PR TITLE
Stop 'rm' and 'ps' listing services not defined in the current file

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -288,6 +288,9 @@ class Project(object):
     def containers(self, service_names=None, stopped=False, one_off=False):
         if service_names:
             self.validate_service_names(service_names)
+        else:
+            service_names = self.service_names
+
         containers = [
             Container.from_ps(self.client, container)
             for container in self.client.containers(
@@ -295,8 +298,6 @@ class Project(object):
                 filters={'label': self.labels(one_off=one_off)})]
 
         def matches_service_names(container):
-            if not service_names:
-                return True
             return container.labels.get(LABEL_SERVICE) in service_names
 
         if not containers:

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -35,6 +35,21 @@ class ProjectTest(DockerClientTestCase):
             [c.name for c in containers],
             ['composetest_web_1'])
 
+    def test_containers_with_extra_service(self):
+        web = self.create_service('web')
+        web_1 = web.create_container()
+
+        db = self.create_service('db')
+        db_1 = db.create_container()
+
+        self.create_service('extra').create_container()
+
+        project = Project('composetest', [web, db], self.client)
+        self.assertEqual(
+            set(project.containers(stopped=True)),
+            set([web_1, db_1]),
+        )
+
     def test_volumes_from_service(self):
         service_dicts = build_service_dicts({
             'data': {


### PR DESCRIPTION
If you have an alternate YAML file with different services defined, containers for those services will be shown in `docker-compose ps` even if you don't pass that file in.

Furthermore, `docker-compose rm` will claim that it's going to remove them, but actually won't.

Closes #1596.