### PR TITLE
Fix NoneType on smart recreate

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -402,10 +402,14 @@ class Service(object):
         return json_hash(self.config_dict())
 
     def config_dict(self):
-        return {
+        dict = {
             'options': self.options,
-            'image_id': self.image()['Id'],
         }
+
+        if self.image() is not None:
+            dict['image_id'] = self.image()['Id']
+
+        return dict
 
     def get_dependency_names(self):
         net_name = self.get_net_name()


### PR DESCRIPTION
This fixes issue #1561 

smart-recreate hashes a dictionary of properties of the service, one of those is the image. The image can be null if it has not yet been fetched. By leaving it out of the hash in this case it will always mismatch causing the change to be recognised.

Alternatively the image existence could be checked for earlier.

Steps to reproduce bug from @josephpage:
```
$ mkdir demo
$ cd demo
$ cat <<EOF > docker-compose.yml
example:
  image: debian:latest
  command: echo "hello world"
EOF

$ docker-compose up -d --x-smart-recreate
Pulling example (debian:latest)...
latest: Pulling from debian
64e5325c0d9d: Pull complete
bf84c1d84a8f: Already exists
debian:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
Digest: sha256:2613dd69166e1bcc0a3e4b1f7cfe30d3dfde7762aea0e2f467632bda681d9765
Status: Downloaded newer image for debian:latest
Creating demo_example_1...
=> OK

$ cat <<EOF > docker-compose.yml
example:
  image: debian:8.1
  command: echo "hello world"
EOF

$ docker-compose up -d --x-smart-recreate
# BOOM
```