### PR TITLE
Added load_image yml option for optionally loading a tar image

### DIFF
--- a/compose/config.py
+++ b/compose/config.py
@@ -53,7 +53,8 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'dockerfile',
     'expose',
     'external_links',
-    'name',
+    'load_image',
+    'name'
 ]
 
 DOCKER_CONFIG_HINTS = {

--- a/compose/service.py
+++ b/compose/service.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from collections import namedtuple
 import logging
+import os
 import re
 import sys
 from operator import attrgetter
@@ -240,6 +241,10 @@ class Service(object):
                 self.build()
             else:
                 raise NeedsBuildError(self)
+
+        elif self.can_be_loaded():
+            with open(self.options['load_image'], 'r') as data:
+                self.client.load_image(data=data)
         else:
             self.pull(insecure_registry=insecure_registry)
 
@@ -682,6 +687,9 @@ class Service(object):
 
     def can_be_built(self):
         return 'build' in self.options
+
+    def can_be_loaded(self):
+        return 'load_image' in self.options and os.path.exists(self.options['load_image'])
 
     @property
     def full_name(self):

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -28,6 +28,14 @@ pull if it doesn't exist locally.
     image: orchardup/postgresql
     image: a4bc65fd
 
+### load_image
+
+Path to tar archive of an image to load. Use with `image` to load from a
+tar archive instead of pulling from a registry when the image doesn't
+exist locally.
+
+    load_image: /path/to/image/tar
+
 ### build
 
 Path to a directory containing a Dockerfile. When the value supplied is a


### PR DESCRIPTION
I am using a CI tool to build my dockers images. This addition allows me to bypass pulling from a registry if a tar image is available locally.