### PR TITLE
1651 parallelise stopping containers

### DIFF
--- a/compose/const.py
+++ b/compose/const.py
@@ -1,4 +1,5 @@
 
+DEFAULT_MAX_WORKERS = 5
 DEFAULT_TIMEOUT = 10
 LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
 LABEL_ONE_OFF = 'com.docker.compose.oneoff'

--- a/compose/service.py
+++ b/compose/service.py
@@ -129,6 +129,7 @@ class Service(object):
         for c in self.containers(stopped=True):
             self.start_container_if_stopped(c, **options)
 
+    # TODO: remove these functions, project takes care of starting/stopping,
     def stop(self, **options):
         for c in self.containers():
             log.info("Stopping %s..." % c.name)
@@ -143,6 +144,8 @@ class Service(object):
         for c in self.containers():
             log.info("Restarting %s..." % c.name)
             c.restart(**options)
+
+    # end TODO
 
     def scale(self, desired_num):
         """

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -1,5 +1,39 @@
-import json
 import hashlib
+import json
+import logging
+import os
+
+import concurrent.futures
+
+from .const import DEFAULT_MAX_WORKERS
+
+
+log = logging.getLogger(__name__)
+
+
+def parallel_execute(command, containers, doing_msg, done_msg, **options):
+    """
+    Execute a given command upon a list of containers in parallel.
+    """
+    max_workers = os.environ.get('MAX_WORKERS', DEFAULT_MAX_WORKERS)
+
+    def container_command_execute(container, command, **options):
+        log.info("{} {}...".format(doing_msg, container.name))
+        return getattr(container, command)(**options)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_container = {
+            executor.submit(
+                container_command_execute,
+                container,
+                command,
+                **options
+            ): container for container in containers
+        }
+
+        for future in concurrent.futures.as_completed(future_container):
+            container = future_container[future]
+            log.info("{} {}".format(done_msg, container.name))
 
 
 def json_hash(obj):

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,6 +193,12 @@ the daemon.
 
 Configures the path to the `ca.pem`, `cert.pem`, and `key.pem` files used for TLS verification. Defaults to `~/.docker`.
 
+### DEFAULT\_MAX\_WORKERS
+
+Configures the maximum number of worker threads to be used when executing
+commands in parallel. Only a subset of commands execute in parallel, `stop`,
+`kill` and `rm`.
+
 ## Compose documentation
 
 - [User guide](/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ PyYAML==3.10
 docker-py==1.2.3
 dockerpty==0.3.4
 docopt==0.6.1
+futures==3.0.3
 requests==2.6.1
 six==1.7.3
 texttable==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     'docker-py >= 1.2.3, < 1.3',
     'dockerpty >= 0.3.4, < 0.4',
     'six >= 1.3.0, < 2',
+    'futures >= 3.0.3',
 ]
 
 


### PR DESCRIPTION
As per issue: https://github.com/docker/compose/issues/1651 Stopping/killing/removing containers can be very slow, by doing it in parallel we gain significant speed improvements. Rough benchmarking was 60% faster with this approach.