### PR TITLE
Add test coverage support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 build
 dist
 venv
+coverage-html

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/_site
 /venv
 docker-compose.spec
+coverage-html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ git+https://github.com/pyinstaller/pyinstaller.git@12e40471c77f588ea5be352f7219c
 unittest2==0.8.0
 flake8==2.3.0
 pep8==1.6.1
+coverage==3.7.1

--- a/script/test
+++ b/script/test
@@ -5,6 +5,8 @@ set -ex
 
 TAG="docker-compose:$(git rev-parse --short HEAD)"
 
+rm -rf coverage-html
+
 docker build -t "$TAG" .
 docker run \
   --rm \
@@ -12,6 +14,7 @@ docker run \
   -e DOCKER_VERSIONS \
   -e "TAG=$TAG" \
   -e "affinity:image==$TAG" \
+  -e "COVERAGE_DIR=$(pwd)/coverage-html" \
   --entrypoint="script/test-versions" \
   "$TAG" \
   "$@"

--- a/script/test-versions
+++ b/script/test-versions
@@ -19,8 +19,9 @@ for version in $DOCKER_VERSIONS; do
     --rm \
     --privileged \
     --volume="/var/lib/docker" \
+    --volume="${COVERAGE_DIR:-$(pwd)/coverage-html}:/code/coverage-html" \
     -e "DOCKER_VERSION=$version" \
     --entrypoint="script/dind" \
     "$TAG" \
-    script/wrapdocker nosetests "$@"
+    script/wrapdocker nosetests --with-coverage --cover-branches --cover-package=compose --cover-erase --cover-html-dir=coverage-html --cover-html "$@"
 done


### PR DESCRIPTION
Prints out results on console and puts HTML report in `coverage-html`.

Could also be integrated with coveralls if we wanted: https://coveralls.io/