### PR TITLE
Rename max workers environment variable

### DIFF
--- a/compose/utils.py
+++ b/compose/utils.py
@@ -15,7 +15,7 @@ def parallel_execute(command, containers, doing_msg, done_msg, **options):
     """
     Execute a given command upon a list of containers in parallel.
     """
-    max_workers = os.environ.get('MAX_WORKERS', DEFAULT_MAX_WORKERS)
+    max_workers = os.environ.get('COMPOSE_MAX_WORKERS', DEFAULT_MAX_WORKERS)
 
     def container_command_execute(container, command, **options):
         log.info("{} {}...".format(doing_msg, container.name))

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,7 +193,7 @@ the daemon.
 
 Configures the path to the `ca.pem`, `cert.pem`, and `key.pem` files used for TLS verification. Defaults to `~/.docker`.
 
-### DEFAULT\_MAX\_WORKERS
+### COMPOSE\_MAX\_WORKERS
 
 Configures the maximum number of worker threads to be used when executing
 commands in parallel. Only a subset of commands execute in parallel, `stop`,


### PR DESCRIPTION
We should prefix our variables with `COMPOSE_`. Also, the name in the docs was wrong (`DEFAULT_MAX_WORKERS` instead of `MAX_WORKERS`), but that needs to change anyhow.