### PR TITLE
Make sure up/restart/stop timeout is an int

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -405,7 +405,7 @@ class TopLevelCommand(Command):
           -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
                                      (default: 10)
         """
-        timeout = float(options.get('--timeout') or DEFAULT_TIMEOUT)
+        timeout = int(options.get('--timeout') or DEFAULT_TIMEOUT)
         project.stop(service_names=options['SERVICE'], timeout=timeout)
 
     def restart(self, project, options):
@@ -418,7 +418,7 @@ class TopLevelCommand(Command):
           -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
                                      (default: 10)
         """
-        timeout = float(options.get('--timeout') or DEFAULT_TIMEOUT)
+        timeout = int(options.get('--timeout') or DEFAULT_TIMEOUT)
         project.restart(service_names=options['SERVICE'], timeout=timeout)
 
     def up(self, project, options):
@@ -461,7 +461,7 @@ class TopLevelCommand(Command):
         allow_recreate = not options['--no-recreate']
         smart_recreate = options['--x-smart-recreate']
         service_names = options['SERVICE']
-        timeout = float(options.get('--timeout') or DEFAULT_TIMEOUT)
+        timeout = int(options.get('--timeout') or DEFAULT_TIMEOUT)
 
         to_attach = project.up(
             service_names=service_names,

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -13,7 +13,7 @@ from .testcases import DockerClientTestCase
 class ProjectTestCase(DockerClientTestCase):
     def run_up(self, cfg, **kwargs):
         kwargs.setdefault('smart_recreate', True)
-        kwargs.setdefault('timeout', 0.1)
+        kwargs.setdefault('timeout', 1)
 
         project = self.make_project(cfg)
         project.up(**kwargs)
@@ -171,7 +171,7 @@ def converge(service,
         plan,
         insecure_registry=insecure_registry,
         do_build=do_build,
-        timeout=0.1,
+        timeout=1,
     )
 
 


### PR DESCRIPTION
Sadly, it appears the Docker Engine doesn't support non-integer timeouts - if it can't parse the value as an int, it sets it to 0.

Excerpt from logs - `t=10.0` is sent but the daemon reports `failed to exit within 0 seconds`.

```
time="2015-07-15T15:57:51.944158277Z" level=info msg="POST /v1.18/containers/027ae89192e2dc1a286dd4d2611272a8183dc55ae5df97d0476c002c663fc6a6/stop?t=10.0"
time="2015-07-15T15:57:51.944186916Z" level=debug msg="Sending 15 to 027ae89192e2dc1a286dd4d2611272a8183dc55ae5df97d0476c002c663fc6a6"
time="2015-07-15T15:57:51.944304964Z" level=info msg="Container 027ae89192e2dc1a286dd4d2611272a8183dc55ae5df97d0476c002c663fc6a6 failed to exit within 0 seconds of SIGTERM - using the force"
time="2015-07-15T15:57:51.944324001Z" level=debug msg="Sending 9 to 027ae89192e2dc1a286dd4d2611272a8183dc55ae5df97d0476c002c663fc6a6"
```

I've set the timeout in tests to 1 second, instead of 0.1.