### PR TITLE
Improve output for parallel command

### DIFF
--- a/compose/utils.py
+++ b/compose/utils.py
@@ -21,8 +21,10 @@ def parallel_execute(command, containers, doing_msg, done_msg, **options):
     stream = codecs.getwriter('utf-8')(sys.stdout)
     lines = []
 
-    def container_command_execute(container, command, **options):
+    for container in containers:
         write_out_msg(stream, lines, container.name, doing_msg)
+
+    def container_command_execute(container, command, **options):
         return getattr(container, command)(**options)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -41,6 +43,10 @@ def parallel_execute(command, containers, doing_msg, done_msg, **options):
 
 
 def write_out_msg(stream, lines, container_name, msg):
+    """
+    Using special ANSI code characters we can write out the msg over the top of
+    a previous status message, if it exists.
+    """
     if container_name in lines:
         position = lines.index(container_name)
         diff = len(lines) - position
@@ -55,6 +61,8 @@ def write_out_msg(stream, lines, container_name, msg):
         diff = 0
         lines.append(container_name)
         stream.write("{}: {}... \r\n".format(container_name, msg))
+
+    stream.flush()
 
 
 def json_hash(obj):

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -1,7 +1,9 @@
+import codecs
 import hashlib
 import json
 import logging
 import os
+import sys
 
 import concurrent.futures
 
@@ -16,9 +18,11 @@ def parallel_execute(command, containers, doing_msg, done_msg, **options):
     Execute a given command upon a list of containers in parallel.
     """
     max_workers = os.environ.get('COMPOSE_MAX_WORKERS', DEFAULT_MAX_WORKERS)
+    stream = codecs.getwriter('utf-8')(sys.stdout)
+    lines = []
 
     def container_command_execute(container, command, **options):
-        log.info("{} {}...".format(doing_msg, container.name))
+        write_out_msg(stream, lines, container.name, doing_msg)
         return getattr(container, command)(**options)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -33,7 +37,24 @@ def parallel_execute(command, containers, doing_msg, done_msg, **options):
 
         for future in concurrent.futures.as_completed(future_container):
             container = future_container[future]
-            log.info("{} {}".format(done_msg, container.name))
+            write_out_msg(stream, lines, container.name, done_msg)
+
+
+def write_out_msg(stream, lines, container_name, msg):
+    if container_name in lines:
+        position = lines.index(container_name)
+        diff = len(lines) - position
+        # move up
+        stream.write("%c[%dA" % (27, diff))
+        # erase
+        stream.write("%c[2K\r" % 27)
+        stream.write("{}: {} \n".format(container_name, msg))
+        # move back down
+        stream.write("%c[%dB" % (27, diff))
+    else:
+        diff = 0
+        lines.append(container_name)
+        stream.write("{}: {}... \r\n".format(container_name, msg))
 
 
 def json_hash(obj):


### PR DESCRIPTION
This approach takes the style of replacing the output message, in
place, when the command has finished executing. Bringing it a bit
more inline with what `docker pull` does and improves readability for
the user.

Signed-off-by: Mazz Mosley <mazz@houseofmnowster.com>