### PR TITLE
Increase max-workers

### DIFF
--- a/compose/const.py
+++ b/compose/const.py
@@ -1,5 +1,5 @@
 
-DEFAULT_MAX_WORKERS = 5
+DEFAULT_MAX_WORKERS = 20
 DEFAULT_TIMEOUT = 10
 LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
 LABEL_ONE_OFF = 'com.docker.compose.oneoff'


### PR DESCRIPTION
There's significant speed improvement by having more workers. This
value still shouldn't cause anyone's machines to melt/explode.

Signed-off-by: Mazz Mosley <mazz@houseofmnowster.com>