### PR TITLE
Make scale timeout configurable, default to 10

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -372,8 +372,14 @@ class TopLevelCommand(Command):
 
             $ docker-compose scale web=2 worker=3
 
-        Usage: scale [SERVICE=NUM...]
+        Usage: scale [options] [SERVICE=NUM...]
+
+        Options:
+          -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
+                                     (default: 10)
         """
+        timeout = int(options.get('--timeout') or DEFAULT_TIMEOUT)
+
         for s in options['SERVICE=NUM']:
             if '=' not in s:
                 raise UserError('Arguments to scale should be in the form service=num')
@@ -383,7 +389,7 @@ class TopLevelCommand(Command):
             except ValueError:
                 raise UserError('Number of containers for service "%s" is not a '
                                 'number' % service_name)
-            project.get_service(service_name).scale(num)
+            project.get_service(service_name).scale(num, timeout=timeout)
 
     def start(self, project, options):
         """

--- a/compose/service.py
+++ b/compose/service.py
@@ -147,7 +147,7 @@ class Service(object):
 
     # end TODO
 
-    def scale(self, desired_num):
+    def scale(self, desired_num, timeout=DEFAULT_TIMEOUT):
         """
         Adjusts the number of containers to the specified number and ensures
         they are running.
@@ -181,7 +181,7 @@ class Service(object):
         while len(running_containers) > desired_num:
             c = running_containers.pop()
             log.info("Stopping %s..." % c.name)
-            c.stop(timeout=1)
+            c.stop(timeout=timeout)
             stopped_containers.append(c)
 
         # Start containers


### PR DESCRIPTION
Rather than forcing a timeout of 1 second when scaling a service down, use the default timeout of 10 seconds and make it configurable via the `--timeout` flag, as with `stop`, `restart` and `up`.

This makes scaling down slow when containers don't handle SIGINT properly, but that will be less of an issue when we're stopping them in parallel, which will be implemented soon.

Closes #1707.