### PR TITLE
Removing references to boot2docker

### DIFF
--- a/docs/django.md
+++ b/docs/django.md
@@ -115,8 +115,7 @@ Then, run `docker-compose up`:
     myapp_web_1 | Starting development server at http://0.0.0.0:8000/
     myapp_web_1 | Quit the server with CONTROL-C.
 
-Your Django app should nw be running at port 8000 on your Docker daemon (if
-you're using Boot2docker, `boot2docker ip` will tell you its address).
+Your Django app should nw be running at port 8000 on your Docker daemon. If you are using a Docker Machine VM, you can use the `docker-machine ip MACHINE_NAME` to get the IP address.
 
 You can also run management commands with Docker. To set up your database, for
 example, run `docker-compose up` and in another terminal run:

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,7 +161,7 @@ Now, when you run `docker-compose up`, Compose will pull a Redis image, build an
     web_1   |  * Running on http://0.0.0.0:5000/
     web_1   |  * Restarting with stat
 
-If you're using [Boot2docker](https://github.com/boot2docker/boot2docker), then `boot2docker ip` will tell you its address and you can open `http://ip-from-boot2docker:5000` in a browser. 
+If you're using [Docker Machine](https://docs.docker.com/machine), then `docker-machine ip MACHINE_VM` will tell you its address and you can open `http://MACHINE_VM_IP:5000` in a browser. 
 
 If you're not using Boot2docker and are on linux, then the web app should now be listening on port 5000 on your Docker daemon host. If http://0.0.0.0:5000 doesn't resolve, you can also try localhost:5000.
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -119,8 +119,8 @@ Finally, you need to create the database. In another terminal, run:
 
     $ docker-compose run web rake db:create
 
-That's it. Your app should now be running on port 3000 on your Docker daemon (if
-you're using Boot2docker, `boot2docker ip` will tell you its address).
+That's it. Your app should now be running on port 3000 on your Docker daemon. If you're using [Docker Machine](https://docs.docker.com/machine), then `docker-machine ip MACHINE_VM` returns the Docker host IP address. 
+
 
 ## More Compose documentation
 

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -108,9 +108,7 @@ Second, `router.php` tells PHP's built-in web server how to run Wordpress:
 
 With those four files in place, run `docker-compose up` inside your Wordpress
 directory and it'll pull and build the needed images, and then start the web and
-database containers. You'll then be able to visit Wordpress at port 8000 on your
-Docker daemon (if you're using Boot2docker, `boot2docker ip` will tell you its
-address).
+database containers. If you're using [Docker Machine](https://docs.docker.com/machine), then `docker-machine ip MACHINE_VM` gives you the machine address and you can open `http://MACHINE_VM_IP:8000` in a browser. 
 
 ## More Compose documentation
 


### PR DESCRIPTION
- Replace with machine references
- 1.8 boot2docker is deprecated
- Fixes #1720 

Signed-off-by: Mary Anthony <mary@docker.com>