### PR TITLE
Fix #1610: #run command exits if there is any DockerApi connective issue

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -7,7 +7,7 @@ from itertools import cycle
 from .multiplexer import Multiplexer, STOP
 from . import colors
 from .utils import split_buffer
-
+from requests.exceptions import ConnectionError
 
 class LogPrinter(object):
     def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False):
@@ -52,16 +52,20 @@ class LogPrinter(object):
         return generators
 
     def _make_log_generator(self, container, color_fn):
-        prefix = color_fn(self._generate_prefix(container)).encode('utf-8')
-        # Attach to container before log printer starts running
-        line_generator = split_buffer(self._attach(container), '\n')
+        try:
+            prefix = color_fn(self._generate_prefix(container)).encode('utf-8')
+            # Attach to container before log printer starts running
+            line_generator = split_buffer(self._attach(container), '\n')
 
-        for line in line_generator:
-            yield prefix + line
+            for line in line_generator:
+                yield prefix + line
 
-        exit_code = container.wait()
-        yield color_fn("%s exited with code %s\n" % (container.name, exit_code))
-        yield STOP
+            exit_code = container.wait()
+            yield color_fn("%s exited with code %s\n" % (container.name, exit_code))
+            yield STOP
+        except ConnectionError as e:
+            yield color_fn("%s: Unable to connect to Docker Api. Aborting.\n" % (container.name))
+            yield STOP
 
     def _generate_prefix(self, container):
         """

--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -9,6 +9,7 @@ from . import colors
 from .utils import split_buffer
 from requests.exceptions import ConnectionError
 
+
 class LogPrinter(object):
     def __init__(self, containers, attach_params=None, output=sys.stdout, monochrome=False):
         self.containers = containers
@@ -63,7 +64,7 @@ class LogPrinter(object):
             exit_code = container.wait()
             yield color_fn("%s exited with code %s\n" % (container.name, exit_code))
             yield STOP
-        except ConnectionError as e:
+        except ConnectionError:
             yield color_fn("%s: Unable to connect to Docker Api. Aborting.\n" % (container.name))
             yield STOP
 


### PR DESCRIPTION
When #docker-compose #up command is used, it may attach to user #tty to print logs.
During an #up session, if #docker daemon is restarted (any reason), #docker-compose
is unable to reconnect to #docker Api (#docker-compose should has a #reconnect feature).
it will print ConnectionError exception to #stdout, and keeps running without any
useful information, while all project containers actually exit.

This fix is useful when you use #supervisor to launch "#docker-compose up".