### PR TITLE
Fix #1610: #run command exits if there is any DockerApi connective issue

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -66,7 +66,6 @@ class LogPrinter(object):
         except ConnectionError as e:
             yield color_fn("%s: Unable to connect to Docker Api. Aborting.\n" % (container.name))
             yield STOP
-            sys.exit(1)
 
     def _generate_prefix(self, container):
         """


### PR DESCRIPTION
When #docker-compose #up command is used, it may attach to user #tty to print logs.
During an #up session, if #docker daemon is restarted (any reason), #docker-compose
is unable to reconnect to #docker Api (#docker-compose should has a #reconnect feature).
it will print ConnectionError exception to #stdout, and keeps running without any
useful information, while all project containers actually exit.

This fix is useful when you use #supervisor to launch "#docker-compose up".