### PR TITLE
Make parallel tasks interruptible with Ctrl-C

### DIFF
--- a/compose/const.py
+++ b/compose/const.py
@@ -1,5 +1,4 @@
 
-DEFAULT_MAX_WORKERS = 20
 DEFAULT_TIMEOUT = 10
 LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
 LABEL_ONE_OFF = 'com.docker.compose.oneoff'

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -44,12 +44,6 @@ the `docker` daemon.
 
 Configures the path to the `ca.pem`, `cert.pem`, and `key.pem` files used for TLS verification. Defaults to `~/.docker`.
 
-### COMPOSE\_MAX\_WORKERS
-
-Configures the maximum number of worker threads to be used when executing
-commands in parallel. Only a subset of commands execute in parallel, `stop`,
-`kill` and `rm`.
-
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ PyYAML==3.10
 docker-py==1.3.0
 dockerpty==0.3.4
 docopt==0.6.1
-futures==3.0.3
 requests==2.6.1
 six==1.7.3
 texttable==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ install_requires = [
     'docker-py >= 1.3.0, < 1.4',
     'dockerpty >= 0.3.4, < 0.4',
     'six >= 1.3.0, < 2',
-    'futures >= 3.0.3',
 ]
 
 


### PR DESCRIPTION
The `concurrent.futures` backport doesn't play well with KeyboardInterrupt, so I'm using Thread and Queue instead.

Since thread pooling would likely be a pain to implement, I've just removed `COMPOSE_MAX_WORKERS` for now. We'll implement it later if we decide we need it.

Closes #1729.