### PR TITLE
Deprecate --allow-insecure-ssl

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -26,6 +26,11 @@ from .utils import yesno, get_version_info
 
 log = logging.getLogger(__name__)
 
+INSECURE_SSL_WARNING = """
+Warning: --allow-insecure-ssl is deprecated and has no effect.
+It will be removed in a future version of Compose.
+"""
+
 
 def main():
     setup_logging()
@@ -232,13 +237,13 @@ class TopLevelCommand(Command):
         Usage: pull [options] [SERVICE...]
 
         Options:
-            --allow-insecure-ssl    Allow insecure connections to the docker
-                                    registry
+            --allow-insecure-ssl    Deprecated - no effect.
         """
-        insecure_registry = options['--allow-insecure-ssl']
+        if options['--allow-insecure-ssl']:
+            log.warn(INSECURE_SSL_WARNING)
+
         project.pull(
             service_names=options['SERVICE'],
-            insecure_registry=insecure_registry
         )
 
     def rm(self, project, options):
@@ -280,8 +285,7 @@ class TopLevelCommand(Command):
         Usage: run [options] [-e KEY=VAL...] SERVICE [COMMAND] [ARGS...]
 
         Options:
-            --allow-insecure-ssl  Allow insecure connections to the docker
-                                  registry
+            --allow-insecure-ssl  Deprecated - no effect.
             -d                    Detached mode: Run container in the background, print
                                   new container name.
             --entrypoint CMD      Override the entrypoint of the image.
@@ -296,7 +300,8 @@ class TopLevelCommand(Command):
         """
         service = project.get_service(options['SERVICE'])
 
-        insecure_registry = options['--allow-insecure-ssl']
+        if options['--allow-insecure-ssl']:
+            log.warn(INSECURE_SSL_WARNING)
 
         if not options['--no-deps']:
             deps = service.get_linked_names()
@@ -306,7 +311,6 @@ class TopLevelCommand(Command):
                     service_names=deps,
                     start_deps=True,
                     allow_recreate=False,
-                    insecure_registry=insecure_registry,
                 )
 
         tty = True
@@ -344,7 +348,6 @@ class TopLevelCommand(Command):
             container = service.create_container(
                 quiet=True,
                 one_off=True,
-                insecure_registry=insecure_registry,
                 **container_options
             )
         except APIError as e:
@@ -453,8 +456,7 @@ class TopLevelCommand(Command):
         Usage: up [options] [SERVICE...]
 
         Options:
-            --allow-insecure-ssl   Allow insecure connections to the docker
-                                   registry
+            --allow-insecure-ssl   Deprecated - no effect.
             -d                     Detached mode: Run containers in the background,
                                    print new container names.
             --no-color             Produce monochrome output.
@@ -468,7 +470,9 @@ class TopLevelCommand(Command):
                                    when attached or when containers are already
                                    running. (default: 10)
         """
-        insecure_registry = options['--allow-insecure-ssl']
+        if options['--allow-insecure-ssl']:
+            log.warn(INSECURE_SSL_WARNING)
+
         detached = options['-d']
 
         monochrome = options['--no-color']
@@ -487,7 +491,6 @@ class TopLevelCommand(Command):
             start_deps=start_deps,
             allow_recreate=allow_recreate,
             force_recreate=force_recreate,
-            insecure_registry=insecure_registry,
             do_build=not options['--no-build'],
             timeout=timeout
         )

--- a/compose/project.py
+++ b/compose/project.py
@@ -239,7 +239,6 @@ class Project(object):
            start_deps=True,
            allow_recreate=True,
            force_recreate=False,
-           insecure_registry=False,
            do_build=True,
            timeout=DEFAULT_TIMEOUT):
 
@@ -262,7 +261,6 @@ class Project(object):
             for service in services
             for container in service.execute_convergence_plan(
                 plans[service.name],
-                insecure_registry=insecure_registry,
                 do_build=do_build,
                 timeout=timeout
             )
@@ -302,9 +300,9 @@ class Project(object):
 
         return plans
 
-    def pull(self, service_names=None, insecure_registry=False):
+    def pull(self, service_names=None):
         for service in self.get_services(service_names, include_deps=True):
-            service.pull(insecure_registry=insecure_registry)
+            service.pull()
 
     def containers(self, service_names=None, stopped=False, one_off=False):
         if service_names:

--- a/compose/service.py
+++ b/compose/service.py
@@ -247,7 +247,6 @@ class Service(object):
 
     def create_container(self,
                          one_off=False,
-                         insecure_registry=False,
                          do_build=True,
                          previous_container=None,
                          number=None,
@@ -259,7 +258,6 @@ class Service(object):
         """
         self.ensure_image_exists(
             do_build=do_build,
-            insecure_registry=insecure_registry,
         )
 
         container_options = self._get_container_create_options(
@@ -275,8 +273,7 @@ class Service(object):
         return Container.create(self.client, **container_options)
 
     def ensure_image_exists(self,
-                            do_build=True,
-                            insecure_registry=False):
+                            do_build=True):
 
         try:
             self.image()
@@ -290,7 +287,7 @@ class Service(object):
             else:
                 raise NeedsBuildError(self)
         else:
-            self.pull(insecure_registry=insecure_registry)
+            self.pull()
 
     def image(self):
         try:
@@ -360,14 +357,12 @@ class Service(object):
 
     def execute_convergence_plan(self,
                                  plan,
-                                 insecure_registry=False,
                                  do_build=True,
                                  timeout=DEFAULT_TIMEOUT):
         (action, containers) = plan
 
         if action == 'create':
             container = self.create_container(
-                insecure_registry=insecure_registry,
                 do_build=do_build,
             )
             self.start_container(container)
@@ -378,7 +373,6 @@ class Service(object):
             return [
                 self.recreate_container(
                     c,
-                    insecure_registry=insecure_registry,
                     timeout=timeout
                 )
                 for c in containers
@@ -401,7 +395,6 @@ class Service(object):
 
     def recreate_container(self,
                            container,
-                           insecure_registry=False,
                            timeout=DEFAULT_TIMEOUT):
         """Recreate a container.
 
@@ -426,7 +419,6 @@ class Service(object):
             '%s_%s' % (container.short_id, container.name))
 
         new_container = self.create_container(
-            insecure_registry=insecure_registry,
             do_build=False,
             previous_container=container,
             number=container.labels.get(LABEL_CONTAINER_NUMBER),
@@ -761,7 +753,7 @@ class Service(object):
                 return True
         return False
 
-    def pull(self, insecure_registry=False):
+    def pull(self):
         if 'image' not in self.options:
             return
 
@@ -772,7 +764,7 @@ class Service(object):
             repo,
             tag=tag,
             stream=True,
-            insecure_registry=insecure_registry)
+        )
         stream_output(output, sys.stdout)
 
 

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -195,7 +195,7 @@ _docker-compose_ps() {
 _docker-compose_pull() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--allow-insecure-ssl --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
 			__docker-compose_services_from_image
@@ -248,7 +248,7 @@ _docker-compose_run() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --entrypoint -e --help --no-deps --rm --service-ports -T --user -u" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-d --entrypoint -e --help --no-deps --rm --service-ports -T --user -u" -- "$cur" ) )
 			;;
 		*)
 			__docker-compose_services_all
@@ -315,7 +315,7 @@ _docker-compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--allow-insecure-ssl -d --help --no-build --no-color --no-deps --no-recreate --force-recreate --timeout -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-d --help --no-build --no-color --no-deps --no-recreate --force-recreate --timeout -t" -- "$cur" ) )
 			;;
 		*)
 			__docker-compose_services_all

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -202,7 +202,6 @@ __docker-compose_subcommand () {
             ;;
         (pull)
             _arguments \
-                '--allow-insecure-ssl[Allow insecure connections to the docker registry]' \
                 '--help[Print usage]' \
                 '*:services:__docker-compose_services_from_image' && ret=0
             ;;
@@ -215,7 +214,6 @@ __docker-compose_subcommand () {
             ;;
         (run)
             _arguments \
-                '--allow-insecure-ssl[Allow insecure connections to the docker registry]' \
                 '-d[Detached mode: Run container in the background, print new container name.]' \
                 '--entrypoint[Overwrite the entrypoint of the image.]:entry point: ' \
                 '*-e[KEY=VAL Set an environment variable (can be used multiple times)]:environment variable KEY=VAL: ' \
@@ -247,7 +245,6 @@ __docker-compose_subcommand () {
             ;;
         (up)
             _arguments \
-                '--allow-insecure-ssl[Allow insecure connections to the docker registry]' \
                 '-d[Detached mode: Run containers in the background, print new container names.]' \
                 '--help[Print usage]' \
                 '--no-color[Produce monochrome output.]' \

--- a/docs/reference/pull.md
+++ b/docs/reference/pull.md
@@ -12,9 +12,6 @@ parent = "smn_compose_cli"
 
 ```
 Usage: pull [options] [SERVICE...]
-
-Options:
---allow-insecure-ssl    Allow insecure connections to the docker registry
 ```
 
 Pulls service images.

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -14,8 +14,6 @@ parent = "smn_compose_cli"
 Usage: run [options] [-e KEY=VAL...] SERVICE [COMMAND] [ARGS...]
 
 Options:
---allow-insecure-ssl  Allow insecure connections to the docker
-                          registry
 -d                    Detached mode: Run container in the background, print
                           new container name.
 --entrypoint CMD      Override the entrypoint of the image.

--- a/docs/reference/up.md
+++ b/docs/reference/up.md
@@ -14,8 +14,6 @@ parent = "smn_compose_cli"
 Usage: up [options] [SERVICE...]
 
 Options:
---allow-insecure-ssl   Allow insecure connections to the docker
-                       registry
 -d                     Detached mode: Run containers in the background,
                        print new container names.
 --no-color             Produce monochrome output.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML==3.10
-docker-py==1.3.0
+docker-py==1.3.1
 dockerpty==0.3.4
 docopt==0.6.1
 requests==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'requests >= 2.6.1, < 2.7',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker-py >= 1.3.0, < 1.4',
+    'docker-py >= 1.3.1, < 1.4',
     'dockerpty >= 0.3.4, < 0.4',
     'six >= 1.3.0, < 2',
 ]

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -155,7 +155,6 @@ class ProjectWithDependenciesTest(ProjectTestCase):
 def converge(service,
              allow_recreate=True,
              force_recreate=False,
-             insecure_registry=False,
              do_build=True):
     """
     If a container for this service doesn't exist, create and start one. If there are
@@ -168,7 +167,6 @@ def converge(service,
 
     return service.execute_convergence_plan(
         plan,
-        insecure_registry=insecure_registry,
         do_build=do_build,
         timeout=1,
     )

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -229,11 +229,10 @@ class ServiceTest(unittest.TestCase):
     @mock.patch('compose.service.log', autospec=True)
     def test_pull_image(self, mock_log):
         service = Service('foo', client=self.mock_client, image='someimage:sometag')
-        service.pull(insecure_registry=True)
+        service.pull()
         self.mock_client.pull.assert_called_once_with(
             'someimage',
             tag='sometag',
-            insecure_registry=True,
             stream=True)
         mock_log.info.assert_called_once_with('Pulling foo (someimage:sometag)...')
 
@@ -243,25 +242,7 @@ class ServiceTest(unittest.TestCase):
         self.mock_client.pull.assert_called_once_with(
             'ababab',
             tag='latest',
-            insecure_registry=False,
             stream=True)
-
-    def test_create_container_from_insecure_registry(self):
-        service = Service('foo', client=self.mock_client, image='someimage:sometag')
-        images = []
-
-        def pull(repo, tag=None, insecure_registry=False, **kwargs):
-            self.assertEqual('someimage', repo)
-            self.assertEqual('sometag', tag)
-            self.assertTrue(insecure_registry)
-            images.append({'Id': 'abc123'})
-            return []
-
-        service.image = lambda *args, **kwargs: mock_get_image(images)
-        self.mock_client.pull = pull
-
-        service.create_container(insecure_registry=True)
-        self.assertEqual(1, len(images))
 
     @mock.patch('compose.service.Container', autospec=True)
     def test_recreate_container(self, _):


### PR DESCRIPTION
Waiting on https://github.com/docker/docker-py/pull/681 to be merged and released. We'll be rid of "HTTPS endpoint unresponsive and insecure mode isn't enabled" once and for all.