### PR TITLE
Stop printing a stack trace when there's an error when pulling

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -16,6 +16,7 @@ from ..const import DEFAULT_TIMEOUT
 from ..project import NoSuchService, ConfigurationError
 from ..service import BuildError, NeedsBuildError
 from ..config import parse_environment
+from ..progress_stream import StreamOutputError
 from .command import Command
 from .docopt_command import NoSuchCommand
 from .errors import UserError
@@ -47,6 +48,9 @@ def main():
         sys.exit(1)
     except BuildError as e:
         log.error("Service '%s' failed to build: %s" % (e.service.name, e.reason))
+        sys.exit(1)
+    except StreamOutputError as e:
+        log.error(e)
         sys.exit(1)
     except NeedsBuildError as e:
         log.error("Service '%s' needs to be built, but --no-build was passed." % e.service.name)


### PR DESCRIPTION
No more of this:

```
Pulling redis (redisasldjkfawef:latest)...
Pulling repository redisasldjkfawef
Traceback (most recent call last):
  File "/Users/aanand/.virtualenvs/docker-compose/bin/docker-compose", line 9, in <module>
    load_entry_point('docker-compose==1.4.0.dev0', 'console_scripts', 'docker-compose')()
  File "/Users/aanand/work/docker/compose/compose/cli/main.py", line 33, in main
    command.sys_dispatch()
  File "/Users/aanand/work/docker/compose/compose/cli/docopt_command.py", line 21, in sys_dispatch
    self.dispatch(sys.argv[1:], None)
  File "/Users/aanand/work/docker/compose/compose/cli/command.py", line 27, in dispatch
    super(Command, self).dispatch(*args, **kwargs)
  File "/Users/aanand/work/docker/compose/compose/cli/docopt_command.py", line 24, in dispatch
    self.perform_command(*self.parse(argv, global_options))
  File "/Users/aanand/work/docker/compose/compose/cli/command.py", line 59, in perform_command
    handler(project, command_options)
  File "/Users/aanand/work/docker/compose/compose/cli/main.py", line 237, in pull
    insecure_registry=insecure_registry
  File "/Users/aanand/work/docker/compose/compose/project.py", line 292, in pull
    service.pull(insecure_registry=insecure_registry)
  File "/Users/aanand/work/docker/compose/compose/service.py", line 724, in pull
    stream_output(output, sys.stdout)
  File "/Users/aanand/work/docker/compose/compose/progress_stream.py", line 37, in stream_output
    print_output_event(event, stream, is_terminal)
  File "/Users/aanand/work/docker/compose/compose/progress_stream.py", line 50, in print_output_event
    raise StreamOutputError(event['errorDetail']['message'])
compose.progress_stream.StreamOutputError: Error: image library/redisasldjkfawef:latest not found
```

Instead:

```
Pulling redis (redisasldjkfawef:latest)...
Pulling repository redisasldjkfawef
Error: image library/redisasldjkfawef:latest not found
```