### PR TITLE
Remove custom docker client initialization logic

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -1,8 +1,7 @@
 import os
-import ssl
 
 from docker import Client
-from docker import tls
+from docker.utils import kwargs_from_env
 
 
 def docker_client():
@@ -10,29 +9,7 @@ def docker_client():
     Returns a docker-py client configured using environment variables
     according to the same logic as the official Docker client.
     """
-    cert_path = os.environ.get('DOCKER_CERT_PATH', '')
-    if cert_path == '':
-        cert_path = os.path.join(os.environ.get('HOME', ''), '.docker')
-
-    base_url = os.environ.get('DOCKER_HOST')
-    api_version = os.environ.get('COMPOSE_API_VERSION', '1.19')
-
-    tls_config = None
-
-    if os.environ.get('DOCKER_TLS_VERIFY', '') != '':
-        parts = base_url.split('://', 1)
-        base_url = '%s://%s' % ('https', parts[1])
-
-        client_cert = (os.path.join(cert_path, 'cert.pem'), os.path.join(cert_path, 'key.pem'))
-        ca_cert = os.path.join(cert_path, 'ca.pem')
-
-        tls_config = tls.TLSConfig(
-            ssl_version=ssl.PROTOCOL_TLSv1,
-            verify=True,
-            assert_hostname=False,
-            client_cert=client_cert,
-            ca_cert=ca_cert,
-        )
-
-    timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
-    return Client(base_url=base_url, tls=tls_config, version=api_version, timeout=timeout)
+    kwargs = kwargs_from_env(assert_hostname=False)
+    kwargs['version'] = os.environ.get('COMPOSE_API_VERSION', '1.19')
+    kwargs['timeout'] = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
+    return Client(**kwargs)


### PR DESCRIPTION
Use `docker.utils.kwargs_from_env` instead.