### PR TITLE
Wait for all containers to exit

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -4,7 +4,7 @@ import sys
 
 from itertools import cycle
 
-from .multiplexer import Multiplexer, STOP
+from .multiplexer import Multiplexer
 from . import colors
 from .utils import split_buffer
 
@@ -61,7 +61,6 @@ class LogPrinter(object):
 
         exit_code = container.wait()
         yield color_fn("%s exited with code %s\n" % (container.name, exit_code))
-        yield STOP
 
     def _generate_prefix(self, container):
         """

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -13,8 +13,13 @@ STOP = object()
 
 
 class Multiplexer(object):
-    def __init__(self, generators):
-        self.generators = generators
+    """
+    Create a single iterator from several iterators by running all of them in
+    parallel and yielding results as they come in.
+    """
+
+    def __init__(self, iterators):
+        self.iterators = iterators
         self.queue = Queue()
 
     def loop(self):
@@ -31,12 +36,12 @@ class Multiplexer(object):
                 pass
 
     def _init_readers(self):
-        for generator in self.generators:
-            t = Thread(target=_enqueue_output, args=(generator, self.queue))
+        for iterator in self.iterators:
+            t = Thread(target=_enqueue_output, args=(iterator, self.queue))
             t.daemon = True
             t.start()
 
 
-def _enqueue_output(generator, queue):
-    for item in generator:
+def _enqueue_output(iterator, queue):
+    for item in iterator:
         queue.put(item)

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -45,3 +45,5 @@ class Multiplexer(object):
 def _enqueue_output(iterator, queue):
     for item in iterator:
         queue.put(item)
+
+    queue.put(STOP)

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -26,7 +26,11 @@ class Multiplexer(object):
 
         while self._num_running > 0:
             try:
-                item = self.queue.get(timeout=0.1)
+                item, exception = self.queue.get(timeout=0.1)
+
+                if exception:
+                    raise exception
+
                 if item is STOP:
                     self._num_running -= 1
                 else:
@@ -42,7 +46,9 @@ class Multiplexer(object):
 
 
 def _enqueue_output(iterator, queue):
-    for item in iterator:
-        queue.put(item)
-
-    queue.put(STOP)
+    try:
+        for item in iterator:
+            queue.put((item, None))
+        queue.put((STOP, None))
+    except Exception as e:
+        queue.put((None, e))

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -7,8 +7,6 @@ except ImportError:
     from queue import Queue, Empty  # Python 3.x
 
 
-# Yield STOP from an input generator to stop the
-# top-level loop without processing any more input.
 STOP = object()
 
 
@@ -20,16 +18,17 @@ class Multiplexer(object):
 
     def __init__(self, iterators):
         self.iterators = iterators
+        self._num_running = len(iterators)
         self.queue = Queue()
 
     def loop(self):
         self._init_readers()
 
-        while True:
+        while self._num_running > 0:
             try:
                 item = self.queue.get(timeout=0.1)
                 if item is STOP:
-                    break
+                    self._num_running -= 1
                 else:
                     yield item
             except Empty:

--- a/tests/unit/multiplexer_test.py
+++ b/tests/unit/multiplexer_test.py
@@ -26,3 +26,20 @@ class MultiplexerTest(unittest.TestCase):
             [0, 1, 2, 3, 4, 5],
             sorted(list(mux.loop())),
         )
+
+    def test_exception(self):
+        class Problem(Exception):
+            pass
+
+        def problematic_iterator():
+            yield 0
+            yield 2
+            raise Problem(":(")
+
+        mux = Multiplexer([
+            problematic_iterator(),
+            (x for x in [1, 3, 5]),
+        ])
+
+        with self.assertRaises(Problem):
+            list(mux.loop())

--- a/tests/unit/multiplexer_test.py
+++ b/tests/unit/multiplexer_test.py
@@ -1,0 +1,28 @@
+import unittest
+
+from compose.cli.multiplexer import Multiplexer
+
+
+class MultiplexerTest(unittest.TestCase):
+    def test_no_iterators(self):
+        mux = Multiplexer([])
+        self.assertEqual([], list(mux.loop()))
+
+    def test_empty_iterators(self):
+        mux = Multiplexer([
+            (x for x in []),
+            (x for x in []),
+        ])
+
+        self.assertEqual([], list(mux.loop()))
+
+    def test_aggregates_output(self):
+        mux = Multiplexer([
+            (x for x in [0, 2, 4]),
+            (x for x in [1, 3, 5]),
+        ])
+
+        self.assertEqual(
+            [0, 1, 2, 3, 4, 5],
+            sorted(list(mux.loop())),
+        )


### PR DESCRIPTION
Behold: the rainbow.

![stop](https://cloud.githubusercontent.com/assets/1062/8827530/2d86da84-3085-11e5-83b3-7c5cc7e1f838.gif)

I've also made it so that if an exception gets raised when attaching to a container, it gets raised in the main thread and `docker-compose up` exits immediately. This should fix the problem @icy was trying to solve in #1723.

This is a hard one to integration test without resorting to threads or multiprocessing, but I've written some unit tests for Multiplexer that assert the basic logic.

Would like to get some feedback on the approach and the change in functionality (which may surprise some users and qualify as breaking backwards-compatibility) before this is merged.