### PR TITLE
add all completions to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include requirements.txt
 include requirements-dev.txt
 include tox.ini
 include *.md
-include contrib/completion/bash/docker-compose
+recursive-include contrib/completion *
 recursive-include tests *
 global-exclude *.pyc
 global-exclude *.pyo


### PR DESCRIPTION
The zsh completion was recently added but missed from the sdist.  This
includes all completions that might be added at any point.