### PR TITLE
Contributors can build public docs with compose docs in context

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -6,6 +6,14 @@ COPY . /src
 
 COPY . /docs/content/compose/
 
+RUN svn checkout https://github.com/docker/docker/trunk/docs /docs/content/docker
+RUN svn checkout https://github.com/docker/swarm/trunk/docs /docs/content/swarm
+RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/machine
+RUN svn checkout https://github.com/docker/distribution/trunk/docs /docs/content/registry
+RUN svn checkout https://github.com/docker/tutorials/trunk/docs /docs/content/tutorials
+RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content
+
+
 # Sed to process GitHub Markdown
 # 1-2 Remove comment code from metadata block
 # 3 Change ](/word to ](/project/ in links
@@ -15,10 +23,4 @@ COPY . /docs/content/compose/
 # 7 Change ](../../ to ](/project/ --> not implemented
 # 
 # 
-RUN find /docs/content/compose -type f -name "*.md" -exec sed -i.old \
-    -e '/^<!.*metadata]>/g' \
-    -e '/^<!.*end-metadata.*>/g' \
-    -e 's/\(\]\)\([(]\)\(\/\)/\1\2\/compose\//g' \
-    -e 's/\(\][(]\)\([A-z].*\)\(\.md\)/\1\/compose\/\2/g' \
-    -e 's/\([(]\)\(.*\)\(\.md\)/\1\2/g'  \
-    -e 's/\(\][(]\)\(\.\.\/\)/\1\/compose\//g' {} \;
+RUN /src/pre-process.sh /docs

--- a/docs/pre-process.sh
+++ b/docs/pre-process.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+
+# Populate an array with just docker dirs and one with content dirs
+docker_dir=(`ls -d /docs/content/docker/*`)
+content_dir=(`ls -d /docs/content/*`)
+
+# Loop content not of docker/
+#
+# Sed to process GitHub Markdown
+# 1-2 Remove comment code from metadata block
+# 3 Remove .md extension from link text
+# 4 Change ](/ to ](/project/ in links
+# 5 Change ](word) to ](/project/word)
+# 6 Change ](../../ to ](/project/
+# 7 Change ](../ to ](/project/word)
+# 
+for i in "${content_dir[@]}"
+do
+   :
+   case $i in
+      "/docs/content/windows")
+      ;;
+      "/docs/content/mac")
+      ;;
+      "/docs/content/linux")
+      ;;
+      "/docs/content/docker")
+         y=${i##*/}
+         find $i -type f -name "*.md" -exec sed -i.old \
+         -e '/^<!.*metadata]>/g' \
+         -e '/^<!.*end-metadata.*>/g' {} \;
+      ;;
+      *)
+        y=${i##*/}
+        find $i -type f -name "*.md" -exec sed -i.old \
+        -e '/^<!.*metadata]>/g' \
+        -e '/^<!.*end-metadata.*>/g' \
+        -e 's/\(\]\)\([(]\)\(\/\)/\1\2\/'$y'\//g' \
+        -e 's/\(\][(]\)\([A-z].*\)\(\.md\)/\1\/'$y'\/\2/g' \
+        -e 's/\([(]\)\(.*\)\(\.md\)/\1\2/g'  \
+        -e 's/\(\][(]\)\(\.\/\)/\1\/'$y'\//g' \
+        -e 's/\(\][(]\)\(\.\.\/\.\.\/\)/\1\/'$y'\//g' \
+        -e 's/\(\][(]\)\(\.\.\/\)/\1\/'$y'\//g' {} \;
+      ;;
+      esac
+done
+
+#
+#  Move docker directories to content
+#
+for i in "${docker_dir[@]}"
+do
+   :
+    if [ -d $i ]    
+      then
+        mv $i /docs/content/ 
+      fi
+done
+
+rm -rf /docs/content/docker
+

--- a/docs/reference/build.md
+++ b/docs/reference/build.md
@@ -4,6 +4,7 @@ title = "build"
 description = "build"
 keywords = ["fig, composition, compose, docker, orchestration, cli,  build"]
 [menu.main]
+identifier="build.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/help.md
+++ b/docs/reference/help.md
@@ -4,6 +4,7 @@ title = "help"
 description = "help"
 keywords = ["fig, composition, compose, docker, orchestration, cli,  help"]
 [menu.main]
+identifier="help.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/kill.md
+++ b/docs/reference/kill.md
@@ -4,6 +4,7 @@ title = "kill"
 description = "Forces running containers to stop."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  kill"]
 [menu.main]
+identifier="kill.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/logs.md
+++ b/docs/reference/logs.md
@@ -4,6 +4,7 @@ title = "logs"
 description = "Displays log output from services."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  logs"]
 [menu.main]
+identifier="logs.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/port.md
+++ b/docs/reference/port.md
@@ -4,6 +4,7 @@ title = "port"
 description = "Prints the public port for a port binding.s"
 keywords = ["fig, composition, compose, docker, orchestration, cli,  port"]
 [menu.main]
+identifier="port.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/ps.md
+++ b/docs/reference/ps.md
@@ -4,6 +4,7 @@ title = "ps"
 description = "Lists containers."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  ps"]
 [menu.main]
+identifier="ps.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/pull.md
+++ b/docs/reference/pull.md
@@ -4,6 +4,7 @@ title = "pull"
 description = "Pulls service images."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  pull"]
 [menu.main]
+identifier="pull.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/restart.md
+++ b/docs/reference/restart.md
@@ -4,6 +4,7 @@ title = "restart"
 description = "Restarts Docker Compose services."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  restart"]
 [menu.main]
+identifier="restart.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/rm.md
+++ b/docs/reference/rm.md
@@ -4,6 +4,7 @@ title = "rm"
 description = "Removes stopped service containers."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  rm"]
 [menu.main]
+identifier="rm.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -4,6 +4,7 @@ title = "run"
 description = "Runs a one-off command on a service."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  run"]
 [menu.main]
+identifier="run.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/start.md
+++ b/docs/reference/start.md
@@ -4,6 +4,7 @@ title = "start"
 description = "Starts existing containers for a service."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  start"]
 [menu.main]
+identifier="start.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/stop.md
+++ b/docs/reference/stop.md
@@ -4,6 +4,7 @@ title = "stop"
 description = "Stops running containers without removing them. "
 keywords = ["fig, composition, compose, docker, orchestration, cli, stop"]
 [menu.main]
+identifier="stop.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->

--- a/docs/reference/up.md
+++ b/docs/reference/up.md
@@ -4,6 +4,7 @@ title = "up"
 description = "Builds, (re)creates, starts, and attaches to containers for a service."
 keywords = ["fig, composition, compose, docker, orchestration, cli,  up"]
 [menu.main]
+identifier="up.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->


### PR DESCRIPTION
- Copy down all the other public repo docs and build
- Changed base image
- Users building compose docs can see their changes in the context of the entire docs.docker.com

Signed-off-by: Mary Anthony <mary@docker.com>