### PR TITLE
Formatter makes sure it's writing to a TTY before wrapping lines

### DIFF
--- a/compose/cli/formatter.py
+++ b/compose/cli/formatter.py
@@ -5,6 +5,8 @@ import texttable
 
 
 def get_tty_width():
+    if os.isatty(1) == False:
+        return 0
     tty_size = os.popen('stty size', 'r').read().split()
     if len(tty_size) != 2:
         return 0


### PR DESCRIPTION
I'm using the output of `docker-compose ps` in a script (admittedly overkill), and the output changing based on the size of my terminal makes my script do funny things.

Python isn't what I'm best at, so if it'd be better check for a TTY another way I'm open.

I also read over the contributing guidelines, it says I need tests but I didn't immediately see a place to put tests for this, if there's a spot to put them please let me know and I will add them.

Thanks!