### PR TITLE
Allow API version specification via env var

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -14,6 +14,8 @@ def docker_client():
         cert_path = os.path.join(os.environ.get('HOME', ''), '.docker')
 
     base_url = os.environ.get('DOCKER_HOST')
+    api_version = os.environ.get('COMPOSE_API_VERSION', '1.18')
+
     tls_config = None
 
     if os.environ.get('DOCKER_TLS_VERIFY', '') != '':
@@ -32,4 +34,4 @@ def docker_client():
         )
 
     timeout = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
-    return Client(base_url=base_url, tls=tls_config, version='1.18', timeout=timeout)
+    return Client(base_url=base_url, tls=tls_config, version=api_version, timeout=timeout)


### PR DESCRIPTION
Hard-coding the API version to '1.18' with the docker-py constructor will
cause the docker-py logic at https://github.com/docker/docker-py/blob/master/docker/client.py#L143-L146
to always fail, which will cause authentication issues if you're using a
remote daemon using API version 1.19 (boot2docker running docker 1.7.1) - regardless of the API version of the registry.

Allow the user to set the API version via an environment variable. If the variable is not present, it will still default to '1.18,' like it does today.