### PR TITLE
Alphabetise reference list

### DIFF
--- a/docs/yml.md
+++ b/docs/yml.md
@@ -19,15 +19,6 @@ As with `docker run`, options specified in the Dockerfile (e.g., `CMD`,
 `EXPOSE`, `VOLUME`, `ENV`) are respected by default - you don't need to
 specify them again in `docker-compose.yml`.
 
-### image
-
-Tag or partial image ID. Can be local or remote - Compose will attempt to
-pull if it doesn't exist locally.
-
-    image: ubuntu
-    image: orchardup/postgresql
-    image: a4bc65fd
-
 ### build
 
 Path to a directory containing a Dockerfile. When the value supplied is a
@@ -38,13 +29,17 @@ Compose will build and tag it with a generated name, and use that image thereaft
 
     build: /path/to/build/dir
 
-### dockerfile
+### cap_add, cap_drop
 
-Alternate Dockerfile.
+Add or drop container capabilities.
+See `man 7 capabilities` for a full list.
 
-Compose will use an alternate file to build with.
+    cap_add:
+      - ALL
 
-    dockerfile: Dockerfile-alternate
+    cap_drop:
+      - NET_ADMIN
+      - SYS_ADMIN
 
 ### command
 
@@ -52,110 +47,49 @@ Override the default command.
 
     command: bundle exec thin -p 3000
 
-<a name="links"></a>
-### links
+### container_name
 
-Link to containers in another service. Either specify both the service name and
-the link alias (`SERVICE:ALIAS`), or just the service name (which will also be
-used for the alias).
+Specify a custom container name, rather than a generated default name.
 
-    links:
-     - db
-     - db:database
-     - redis
+    container_name: my-web-container
 
-An entry with the alias' name will be created in `/etc/hosts` inside containers
-for this service, e.g:
+Because Docker container names must be unique, you cannot scale a service
+beyond 1 container if you have specified a custom name. Attempting to do so
+results in an error.
 
-    172.17.2.186  db
-    172.17.2.186  database
-    172.17.2.187  redis
+### devices
 
-Environment variables will also be created - see the [environment variable
-reference](env.md) for details.
+List of device mappings.  Uses the same format as the `--device` docker 
+client create option.
 
-### external_links
+    devices:
+      - "/dev/ttyUSB0:/dev/ttyUSB0"
 
-Link to containers started outside this `docker-compose.yml` or even outside
-of Compose, especially for containers that provide shared or common services.
-`external_links` follow semantics similar to `links` when specifying both the
-container name and the link alias (`CONTAINER:ALIAS`).
+### dns
 
-    external_links:
-     - redis_1
-     - project_db_1:mysql
-     - project_db_1:postgresql
+Custom DNS servers. Can be a single value or a list.
 
-### extra_hosts
+    dns: 8.8.8.8
+    dns:
+      - 8.8.8.8
+      - 9.9.9.9
 
-Add hostname mappings. Use the same values as the docker client `--add-host` parameter.
+### dns_search
 
-    extra_hosts:
-     - "somehost:162.242.195.82"
-     - "otherhost:50.31.209.229"
+Custom DNS search domains. Can be a single value or a list.
 
-An entry with the ip address and hostname will be created in `/etc/hosts` inside containers for this service, e.g:
+    dns_search: example.com
+    dns_search:
+      - dc1.example.com
+      - dc2.example.com
 
-    162.242.195.82  somehost
-    50.31.209.229   otherhost
+### dockerfile
 
-### ports
+Alternate Dockerfile.
 
-Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container
-port (a random host port will be chosen).
+Compose will use an alternate file to build with.
 
-> **Note:** When mapping ports in the `HOST:CONTAINER` format, you may experience
-> erroneous results when using a container port lower than 60, because YAML will
-> parse numbers in the format `xx:yy` as sexagesimal (base 60). For this reason,
-> we recommend always explicitly specifying your port mappings as strings.
-
-    ports:
-     - "3000"
-     - "8000:8000"
-     - "49100:22"
-     - "127.0.0.1:8001:8001"
-
-### expose
-
-Expose ports without publishing them to the host machine - they'll only be
-accessible to linked services. Only the internal port can be specified.
-
-    expose:
-     - "3000"
-     - "8000"
-
-### volumes
-
-Mount paths as volumes, optionally specifying a path on the host machine
-(`HOST:CONTAINER`), or an access mode (`HOST:CONTAINER:ro`).
-
-    volumes:
-     - /var/lib/mysql
-     - cache/:/tmp/cache
-     - ~/configs:/etc/configs/:ro
-
-### volumes_from
-
-Mount all of the volumes from another service or container.
-
-    volumes_from:
-     - service_name
-     - container_name
-
-### environment
-
-Add environment variables. You can use either an array or a dictionary.
-
-Environment variables with only a key are resolved to their values on the
-machine Compose is running on, which can be helpful for secret or host-specific values.
-
-    environment:
-      RACK_ENV: development
-      SESSION_SECRET:
-
-    environment:
-      - RACK_ENV=development
-      - SESSION_SECRET
+    dockerfile: Dockerfile-alternate
 
 ### env_file
 
@@ -178,6 +112,30 @@ beginning with `#` (i.e. comments) are ignored, as are blank lines.
 
     # Set Rails/Rack environment
     RACK_ENV=development
+
+### environment
+
+Add environment variables. You can use either an array or a dictionary.
+
+Environment variables with only a key are resolved to their values on the
+machine Compose is running on, which can be helpful for secret or host-specific values.
+
+    environment:
+      RACK_ENV: development
+      SESSION_SECRET:
+
+    environment:
+      - RACK_ENV=development
+      - SESSION_SECRET
+
+### expose
+
+Expose ports without publishing them to the host machine - they'll only be
+accessible to linked services. Only the internal port can be specified.
+
+    expose:
+     - "3000"
+     - "8000"
 
 ### extends
 
@@ -223,6 +181,40 @@ service within the current file.
 For more on `extends`, see the [tutorial](extends.md#example) and
 [reference](extends.md#reference).
 
+### external_links
+
+Link to containers started outside this `docker-compose.yml` or even outside
+of Compose, especially for containers that provide shared or common services.
+`external_links` follow semantics similar to `links` when specifying both the
+container name and the link alias (`CONTAINER:ALIAS`).
+
+    external_links:
+     - redis_1
+     - project_db_1:mysql
+     - project_db_1:postgresql
+
+### extra_hosts
+
+Add hostname mappings. Use the same values as the docker client `--add-host` parameter.
+
+    extra_hosts:
+     - "somehost:162.242.195.82"
+     - "otherhost:50.31.209.229"
+
+An entry with the ip address and hostname will be created in `/etc/hosts` inside containers for this service, e.g:
+
+    162.242.195.82  somehost
+    50.31.209.229   otherhost
+
+### image
+
+Tag or partial image ID. Can be local or remote - Compose will attempt to
+pull if it doesn't exist locally.
+
+    image: ubuntu
+    image: orchardup/postgresql
+    image: a4bc65fd
+
 ### labels
 
 Add metadata to containers using [Docker labels](http://docs.docker.com/userguide/labels-custom-metadata/). You can use either an array or a dictionary.
@@ -239,15 +231,26 @@ It's recommended that you use reverse-DNS notation to prevent your labels from c
       - "com.example.department=Finance"
       - "com.example.label-with-empty-value"
 
-### container_name
+### links
 
-Specify a custom container name, rather than a generated default name.
+Link to containers in another service. Either specify both the service name and
+the link alias (`SERVICE:ALIAS`), or just the service name (which will also be
+used for the alias).
 
-    container_name: my-web-container
+    links:
+     - db
+     - db:database
+     - redis
 
-Because Docker container names must be unique, you cannot scale a service
-beyond 1 container if you have specified a custom name. Attempting to do so
-results in an error.
+An entry with the alias' name will be created in `/etc/hosts` inside containers
+for this service, e.g:
+
+    172.17.2.186  db
+    172.17.2.186  database
+    172.17.2.187  redis
+
+Environment variables will also be created - see the [environment variable
+reference](env.md) for details.
 
 ### log driver
 
@@ -287,43 +290,21 @@ container and the host operating system the PID address space.  Containers
 launched with this flag will be able to access and manipulate other
 containers in the bare-metal machine's namespace and vise-versa.
 
-### dns
+### ports
 
-Custom DNS servers. Can be a single value or a list.
+Expose ports. Either specify both ports (`HOST:CONTAINER`), or just the container
+port (a random host port will be chosen).
 
-    dns: 8.8.8.8
-    dns:
-      - 8.8.8.8
-      - 9.9.9.9
+> **Note:** When mapping ports in the `HOST:CONTAINER` format, you may experience
+> erroneous results when using a container port lower than 60, because YAML will
+> parse numbers in the format `xx:yy` as sexagesimal (base 60). For this reason,
+> we recommend always explicitly specifying your port mappings as strings.
 
-### cap_add, cap_drop
-
-Add or drop container capabilities.
-See `man 7 capabilities` for a full list.
-
-    cap_add:
-      - ALL
-
-    cap_drop:
-      - NET_ADMIN
-      - SYS_ADMIN
-
-### dns_search
-
-Custom DNS search domains. Can be a single value or a list.
-
-    dns_search: example.com
-    dns_search:
-      - dc1.example.com
-      - dc2.example.com
-
-### devices
-
-List of device mappings.  Uses the same format as the `--device` docker 
-client create option.
-
-    devices:
-      - "/dev/ttyUSB0:/dev/ttyUSB0"
+    ports:
+     - "3000"
+     - "8000:8000"
+     - "49100:22"
+     - "127.0.0.1:8001:8001"
 
 ### security_opt
 
@@ -332,6 +313,24 @@ Override the default labeling scheme for each container.
       security_opt:
         - label:user:USER
         - label:role:ROLE
+
+### volumes
+
+Mount paths as volumes, optionally specifying a path on the host machine
+(`HOST:CONTAINER`), or an access mode (`HOST:CONTAINER:ro`).
+
+    volumes:
+     - /var/lib/mysql
+     - cache/:/tmp/cache
+     - ~/configs:/etc/configs/:ro
+
+### volumes_from
+
+Mount all of the volumes from another service or container.
+
+    volumes_from:
+     - service_name
+     - container_name
 
 ### working\_dir, entrypoint, user, hostname, domainname, mac\_address, mem\_limit, memswap\_limit, privileged, restart, stdin\_open, tty, cpu\_shares, cpuset, read\_only 
 
@@ -371,3 +370,4 @@ Each of these is a single value, analogous to its
 - [Command line reference](cli.md)
 - [Compose environment variables](env.md)
 - [Compose command line completion](completion.md)
+


### PR DESCRIPTION
Bring in line with Glossary. https://docs.docker.com/reference/glossary/

Alphabetising list makes makes parsing by humans easier.