### PR TITLE
Remove useless postgres 'port' configuration

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -40,8 +40,6 @@ Finally, `docker-compose.yml` is where the magic happens. This file describes th
 
     db:
       image: postgres
-      ports:
-        - "5432"
     web:
       build: .
       command: bundle exec rails s -p 3000 -b '0.0.0.0'


### PR DESCRIPTION
If I'm not wrong `ports` should be `expose`, but the image is already exposing that port, so it could be cleaned.
I've seen it's already done in [Djanjo version](https://github.com/docker/compose/blob/master/docs/django.md).

BTW, why could be the reason to use `ports` without setting the host port number up? I really don't get that option :confused: 

Really nice work in composer, I like it so much!! 