### PR TITLE
Abort tests if daemon fails to start

### DIFF
--- a/script/wrapdocker
+++ b/script/wrapdocker
@@ -8,9 +8,16 @@ fi
 # delete it so that docker can start.
 rm -rf /var/run/docker.pid
 docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+docker_pid=$!
 
 >&2 echo "Waiting for Docker to start..."
 while ! docker ps &>/dev/null; do
+    if ! kill -0 "$docker_pid" &>/dev/null; then
+        >&2 echo "Docker failed to start"
+        cat /var/log/docker.log
+        exit 1
+    fi
+
     sleep 1
 done
 


### PR DESCRIPTION
Currently the test suite hangs if our Docker-in-Docker daemon fails to start, which is pretty useless. This makes it abort if that happens and print the daemon logs so we can see what's gone wrong.

Longer term we should switch to using the dind image - see #1783 - but that's not quite working well enough yet.