### PR TITLE
Allow manual port mapping when using "run" command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -282,7 +282,7 @@ class TopLevelCommand(Command):
         running. If you do not want to start linked services, use
         `docker-compose run --no-deps SERVICE COMMAND [ARGS...]`.
 
-        Usage: run [options] [-e KEY=VAL...] SERVICE [COMMAND] [ARGS...]
+        Usage: run [options] [-p PORT...] [-e KEY=VAL...] SERVICE [COMMAND] [ARGS...]
 
         Options:
             --allow-insecure-ssl  Deprecated - no effect.
@@ -293,6 +293,7 @@ class TopLevelCommand(Command):
             -u, --user=""         Run as specified username or uid
             --no-deps             Don't start linked services.
             --rm                  Remove container after run. Ignored in detached mode.
+            -p, --publish=[]      Publish a container's port(s) to the host
             --service-ports       Run command with the service's ports enabled and mapped
                                   to the host.
             -T                    Disable pseudo-tty allocation. By default `docker-compose run`
@@ -343,6 +344,15 @@ class TopLevelCommand(Command):
 
         if not options['--service-ports']:
             container_options['ports'] = []
+
+        if options['--publish']:
+            container_options['ports'] = options.get('--publish')
+
+        if options['--publish'] and options['--service-ports']:
+            raise UserError(
+                'Service port mapping and manual port mapping '
+                'can not be used togather'
+            )
 
         try:
             container = service.create_container(

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -248,7 +248,7 @@ _docker-compose_run() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "-d --entrypoint -e --help --no-deps --rm --service-ports -T --user -u" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-d --entrypoint -e --help --no-deps --rm --service-ports --publish -p -T --user -u" -- "$cur" ) )
 			;;
 		*)
 			__docker-compose_services_all

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -221,6 +221,7 @@ __docker-compose_subcommand () {
                 '(-u --user)'{-u,--user=-}'[Run as specified username or uid]:username or uid:_users' \
                 "--no-deps[Don't start linked services.]" \
                 '--rm[Remove container after run. Ignored in detached mode.]' \
+                "--publish[Run command with manually mapped container's port(s) to the host.]" \
                 "--service-ports[Run command with the service's ports enabled and mapped to the host.]" \
                 '-T[Disable pseudo-tty allocation. By default `docker-compose run` allocates a TTY.]' \
                 '(-):services:__docker-compose_services' \

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -22,6 +22,7 @@ Options:
 -u, --user=""         Run as specified username or uid
 --no-deps             Don't start linked services.
 --rm                  Remove container after run. Ignored in detached mode.
+-p, --publish=[]      Publish a container's port(s) to the host
 --service-ports       Run command with the service's ports enabled and mapped to the host.
 -T                    Disable pseudo-tty allocation. By default `docker-compose run` allocates a TTY.
 ```
@@ -37,6 +38,10 @@ First, the command passed by `run` overrides the command defined in the service 
 The second difference is the `docker-compose run` command does not create any of the ports specified in the service configuration. This prevents the port collisions with already open ports. If you *do want* the service's ports created and mapped to the host, specify the `--service-ports` flag:
 
     $ docker-compose run --service-ports web python manage.py shell
+
+Alternatively manual port mapping can be specified. Same as when running Docker's `run` command - using `--publish` or `-p` options:
+
+    $ docker-compose run --publish 8080:80 -p 2022:22 -p 127.0.0.1:2021:21 web python manage.py shell
 
 If you start a service configured with links, the `run` command first checks to see if the linked service is running and starts the service if it is stopped.  Once all the linked services are running, the `run` executes the command you passed it.  So, for example, you could run:
 

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -343,6 +343,44 @@ class CLITestCase(DockerClientTestCase):
         self.assertIn("0.0.0.0", port_random)
         self.assertEqual(port_assigned, "0.0.0.0:49152")
 
+    @patch('dockerpty.start')
+    def test_run_service_with_explicitly_maped_ports(self, __):
+
+        # create one off container
+        self.command.base_dir = 'tests/fixtures/ports-composefile'
+        self.command.dispatch(['run', '-d', '-p', '30000:3000', '--publish', '30001:3001', 'simple'], None)
+        container = self.project.get_service('simple').containers(one_off=True)[0]
+
+        # get port information
+        port_short = container.get_local_port(3000)
+        port_full = container.get_local_port(3001)
+
+        # close all one off containers we just created
+        container.stop()
+
+        # check the ports
+        self.assertEqual(port_short, "0.0.0.0:30000")
+        self.assertEqual(port_full, "0.0.0.0:30001")
+
+    @patch('dockerpty.start')
+    def test_run_service_with_explicitly_maped_ip_ports(self, __):
+
+        # create one off container
+        self.command.base_dir = 'tests/fixtures/ports-composefile'
+        self.command.dispatch(['run', '-d', '-p', '127.0.0.1:30000:3000', '--publish', '127.0.0.1:30001:3001', 'simple'], None)
+        container = self.project.get_service('simple').containers(one_off=True)[0]
+
+        # get port information
+        port_short = container.get_local_port(3000)
+        port_full = container.get_local_port(3001)
+
+        # close all one off containers we just created
+        container.stop()
+
+        # check the ports
+        self.assertEqual(port_short, "127.0.0.1:30000")
+        self.assertEqual(port_full, "127.0.0.1:30001")
+
     def test_rm(self):
         service = self.project.get_service('simple')
         service.create_container()


### PR DESCRIPTION
Support mapping specific ports in "docker-compose run" #1709 

Signed-off-by: Karol Duleba <mr.fuxi@gmail.com>