### PR TITLE
Avoid duplicate warnings if an unset env variable is used multiple times

### DIFF
--- a/tests/unit/interpolation_test.py
+++ b/tests/unit/interpolation_test.py
@@ -1,31 +1,32 @@
 import unittest
 
 from compose.config.interpolation import interpolate, InvalidInterpolation
+from compose.config.interpolation import BlankDefaultDict as bddict
 
 
 class InterpolationTest(unittest.TestCase):
     def test_valid_interpolations(self):
-        self.assertEqual(interpolate('$foo', dict(foo='hi')), 'hi')
-        self.assertEqual(interpolate('${foo}', dict(foo='hi')), 'hi')
+        self.assertEqual(interpolate('$foo', bddict(foo='hi')), 'hi')
+        self.assertEqual(interpolate('${foo}', bddict(foo='hi')), 'hi')
 
-        self.assertEqual(interpolate('${subject} love you', dict(subject='i')), 'i love you')
-        self.assertEqual(interpolate('i ${verb} you', dict(verb='love')), 'i love you')
-        self.assertEqual(interpolate('i love ${object}', dict(object='you')), 'i love you')
+        self.assertEqual(interpolate('${subject} love you', bddict(subject='i')), 'i love you')
+        self.assertEqual(interpolate('i ${verb} you', bddict(verb='love')), 'i love you')
+        self.assertEqual(interpolate('i love ${object}', bddict(object='you')), 'i love you')
 
     def test_empty_value(self):
-        self.assertEqual(interpolate('${foo}', dict(foo='')), '')
+        self.assertEqual(interpolate('${foo}', bddict(foo='')), '')
 
     def test_unset_value(self):
-        self.assertEqual(interpolate('${foo}', dict()), '')
+        self.assertEqual(interpolate('${foo}', bddict()), '')
 
     def test_escaped_interpolation(self):
-        self.assertEqual(interpolate('$${foo}', dict(foo='hi')), '${foo}')
+        self.assertEqual(interpolate('$${foo}', bddict(foo='hi')), '${foo}')
 
     def test_invalid_strings(self):
-        self.assertRaises(InvalidInterpolation, lambda: interpolate('${', dict()))
-        self.assertRaises(InvalidInterpolation, lambda: interpolate('$}', dict()))
-        self.assertRaises(InvalidInterpolation, lambda: interpolate('${}', dict()))
-        self.assertRaises(InvalidInterpolation, lambda: interpolate('${ }', dict()))
-        self.assertRaises(InvalidInterpolation, lambda: interpolate('${ foo}', dict()))
-        self.assertRaises(InvalidInterpolation, lambda: interpolate('${foo }', dict()))
-        self.assertRaises(InvalidInterpolation, lambda: interpolate('${foo!}', dict()))
+        self.assertRaises(InvalidInterpolation, lambda: interpolate('${', bddict()))
+        self.assertRaises(InvalidInterpolation, lambda: interpolate('$}', bddict()))
+        self.assertRaises(InvalidInterpolation, lambda: interpolate('${}', bddict()))
+        self.assertRaises(InvalidInterpolation, lambda: interpolate('${ }', bddict()))
+        self.assertRaises(InvalidInterpolation, lambda: interpolate('${ foo}', bddict()))
+        self.assertRaises(InvalidInterpolation, lambda: interpolate('${foo }', bddict()))
+        self.assertRaises(InvalidInterpolation, lambda: interpolate('${foo!}', bddict()))


### PR DESCRIPTION
Suppose a `docker-compose.yml` has a section like this:

```yaml
labels:
  - "foo=${FOO}"
  - "bar=${BAR}"
  - "foobar=${FOO}${BAR}"
```

Currently, Compose will print 4 warnings when any `docker-compose` command is run:

```
$ docker-compose up
The FOO variable is not set. Substituting a blank string.
The BAR variable is not set. Substituting a blank string.
The FOO variable is not set. Substituting a blank string.
The BAR variable is not set. Substituting a blank string.
...
```

This changes it so we only print one warning per variable:

```
$ docker-compose up
The FOO variable is not set. Substituting a blank string.
The BAR variable is not set. Substituting a blank string.
...
```