### PR TITLE
Use overlay driver in tests

### DIFF
--- a/script/wrapdocker
+++ b/script/wrapdocker
@@ -7,7 +7,7 @@ fi
 # If a pidfile is still around (for example after a container restart),
 # delete it so that docker can start.
 rm -rf /var/run/docker.pid
-docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+docker -d --storage-driver="overlay" &>/var/log/docker.log &
 docker_pid=$!
 
 >&2 echo "Waiting for Docker to start..."


### PR DESCRIPTION
Using the overlay driver for the Docker daemon we start in our test script will hopefully make CI more stable.