### PR TITLE
A number is a valid service name

### DIFF
--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import os
 
 from docker.utils.ports import split_port
@@ -34,6 +35,29 @@ def format_ports(instance):
     except ValueError:
         return False
     return True
+
+
+def validate_service_names(func):
+    @wraps(func)
+    def func_wrapper(config):
+        for service_name in config.keys():
+            if type(service_name) is int:
+                raise ConfigurationError(
+                    "Service name: {} needs to be a string, eg '{}'".format(service_name, service_name)
+                )
+        return func(config)
+    return func_wrapper
+
+
+def validate_top_level_object(func):
+    @wraps(func)
+    def func_wrapper(config):
+        if not isinstance(config, dict):
+            raise ConfigurationError(
+                "Top level object needs to be a dictionary. Check your .yml file that you have defined a service at the top level."
+            )
+        return func(config)
+    return func_wrapper
 
 
 def get_unsupported_config_msg(service_name, error_key):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -64,6 +64,17 @@ class ConfigTest(unittest.TestCase):
                     )
                 )
 
+    def test_config_integer_service_name_raise_validation_error(self):
+        expected_error_msg = "Service name: 1 needs to be a string, eg '1'"
+        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
+            config.load(
+                config.ConfigDetails(
+                    {1: {'image': 'busybox'}},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+
     def test_config_valid_service_names(self):
         for valid_name in ['_', '-', '.__.', '_what-up.', 'what_.up----', 'whatup']:
             config.load(


### PR DESCRIPTION
While we technically allow a service name to be a number, it was causing the code
to blow up with a TypeError, as reported https://github.com/docker/compose/issues/1845. 

This is due to it expecting a string or a buffer. So I took the approach to ensure all
service names get converted to strings.

Signed-off-by: Mazz Mosley <mazz@houseofmnowster.com>