### PR TITLE
Fix regression in `up`

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -245,26 +245,30 @@ class Project(object):
         if force_recreate and not allow_recreate:
             raise ValueError("force_recreate and allow_recreate are in conflict")
 
-        services = self.get_services(service_names, include_deps=start_deps)
+        services = self.get_services(service_names, include_deps=False)
+        all_services = self.get_services(service_names, include_deps=start_deps)
 
-        for service in services:
+        for service in all_services:
             service.remove_duplicate_containers()
 
         plans = self._get_convergence_plans(
-            services,
+            all_services,
             allow_recreate=allow_recreate,
             force_recreate=force_recreate,
         )
 
-        return [
-            container
-            for service in services
-            for container in service.execute_convergence_plan(
+        containers_to_return = []
+
+        for service in all_services:
+            containers = service.execute_convergence_plan(
                 plans[service.name],
                 do_build=do_build,
                 timeout=timeout
             )
-        ]
+            if service in services:
+                containers_to_return += containers
+
+        return containers_to_return
 
     def _get_convergence_plans(self,
                                services,

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -174,16 +174,29 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(project.containers(stopped=True)), 0)
 
     def test_project_up(self):
-        web = self.create_service('web')
         db = self.create_service('db', volumes=['/var/db'])
-        project = Project('composetest', [web, db], self.client)
+        web = self.create_service('web', links=[(db, 'db')])
+        project = Project('composetest', [db, web], self.client)
         project.start()
         self.assertEqual(len(project.containers()), 0)
 
-        project.up(['db'])
+        containers = project.up(['db'])
         self.assertEqual(len(project.containers()), 1)
         self.assertEqual(len(db.containers()), 1)
         self.assertEqual(len(web.containers()), 0)
+        self.assertEqual(set(containers), set(db.containers()))
+
+        containers = project.up(['web'])
+        self.assertEqual(len(project.containers()), 2)
+        self.assertEqual(len(db.containers()), 1)
+        self.assertEqual(len(web.containers()), 1)
+        self.assertEqual(set(containers), set(web.containers()))
+
+        containers = project.up([])
+        self.assertEqual(len(project.containers()), 2)
+        self.assertEqual(len(db.containers()), 1)
+        self.assertEqual(len(web.containers()), 1)
+        self.assertEqual(set(containers), set(project.containers()))
 
     def test_project_up_starts_uncreated_services(self):
         db = self.create_service('db')


### PR DESCRIPTION
When running `docker-compose up A B`, logs are shown for those services *and all their dependencies*, which is not what the user expects. This regressed in #1645.

Not wild about the variable names here - would appreciate a second pair of eyes.

Closes #1856.