### PR TITLE
Fix volume path warning

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -399,12 +399,12 @@ def resolve_volume_path(volume, working_dir, service_name):
     if host_path is not None:
         if not any(host_path.startswith(c) for c in PATH_START_CHARS):
             log.warn(
-                'Warning: the mapping "{0}" in the volumes config for '
-                'service "{1}" is ambiguous. In a future version of Docker, '
+                'Warning: the mapping "{0}:{1}" in the volumes config for '
+                'service "{2}" is ambiguous. In a future version of Docker, '
                 'it will designate a "named" volume '
                 '(see https://github.com/docker/docker/pull/14242). '
-                'To prevent unexpected behaviour, change it to "./{0}"'
-                .format(volume, service_name)
+                'To prevent unexpected behaviour, change it to "./{0}:{1}"'
+                .format(host_path, container_path, service_name)
             )
 
         host_path = os.path.expanduser(host_path)


### PR DESCRIPTION
Though this change has no effect on master, it will fix the problem described in #1867 when cherry-picked on top of `1.4.0`, because variable interpolation for volume paths is done differently there.

Closes #1867.