### PR TITLE
Option to remove containers as part of kill sub-command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -152,10 +152,21 @@ class TopLevelCommand(Command):
         Options:
             -s SIGNAL         SIGNAL to send to the container.
                               Default signal is SIGKILL.
+            --rm              Remove containers nd associated volumes forcefully
+                              after stopping them
         """
         signal = options.get('-s', 'SIGKILL')
 
         project.kill(service_names=options['SERVICE'], signal=signal)
+        if options['--rm']:
+            all_containers = project.containers(service_names=options['SERVICE'], stopped=True)
+            stopped_containers = [c for c in all_containers if not c.is_running]
+
+            if len(stopped_containers) > 0:
+                print("Going to remove", list_containers(stopped_containers))
+                project.remove_stopped(service_names=options['SERVICE'],v=True)
+            else:
+                print("No stopped containers")
 
     def logs(self, project, options):
         """


### PR DESCRIPTION
Most of the times, during development of a docker-compose.yml file, I found myself killing services and then removing them. It would be very convinient if one command did the complete clean-up , viz., killing AND removing the stopped containers.
Accordingly, added option to remove all containers and associated volumes, forcefully, after killing the respective services.
