### PR TITLE
Add rm --kill option to kill containers before removing them

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -152,21 +152,10 @@ class TopLevelCommand(Command):
         Options:
             -s SIGNAL         SIGNAL to send to the container.
                               Default signal is SIGKILL.
-            --rm              Remove containers nd associated volumes forcefully
-                              after stopping them
         """
         signal = options.get('-s', 'SIGKILL')
 
         project.kill(service_names=options['SERVICE'], signal=signal)
-        if options['--rm']:
-            all_containers = project.containers(service_names=options['SERVICE'], stopped=True)
-            stopped_containers = [c for c in all_containers if not c.is_running]
-
-            if len(stopped_containers) > 0:
-                print("Going to remove", list_containers(stopped_containers))
-                project.remove_stopped(service_names=options['SERVICE'], v=True)
-            else:
-                print("No stopped containers")
 
     def logs(self, project, options):
         """
@@ -264,9 +253,14 @@ class TopLevelCommand(Command):
         Usage: rm [options] [SERVICE...]
 
         Options:
+            --kill        Kill all the running Services
             -f, --force   Don't ask to confirm removal
             -v            Remove volumes associated with containers
         """
+        if options['--kill']:
+            print("Going to kill all the Services")
+            project.kill(service_names=options['SERVICE'], signal='SIGKILL')
+
         all_containers = project.containers(service_names=options['SERVICE'], stopped=True)
         stopped_containers = [c for c in all_containers if not c.is_running]
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -257,16 +257,22 @@ class TopLevelCommand(Command):
             -f, --force   Don't ask to confirm removal
             -v            Remove volumes associated with containers
         """
+        killed=False
         if options['--kill']:
-            print("Going to kill all the Services")
-            project.kill(service_names=options['SERVICE'], signal='SIGKILL')
+            print("Going to kill all containers")
+            if options.get('--force') \
+                    or yesno("Are you sure? [yN] ", default=False):
+                        project.kill(service_names=options['SERVICE'], signal='SIGKILL')
+                        killed=True
+            else:
+                print("No containers killed")
 
         all_containers = project.containers(service_names=options['SERVICE'], stopped=True)
         stopped_containers = [c for c in all_containers if not c.is_running]
 
         if len(stopped_containers) > 0:
             print("Going to remove", list_containers(stopped_containers))
-            if options.get('--force') \
+            if killed or options.get('--force') \
                     or yesno("Are you sure? [yN] ", default=False):
                 project.remove_stopped(
                     service_names=options['SERVICE'],

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -259,7 +259,7 @@ class TopLevelCommand(Command):
         """
         killed = False
         if options['--kill']:
-            print("Going to kill all containers")
+            print("Going to kill and remove all containers")
             if options.get('--force') \
                     or yesno("Are you sure? [yN] ", default=False):
                         project.kill(service_names=options['SERVICE'], signal='SIGKILL')

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -164,7 +164,7 @@ class TopLevelCommand(Command):
 
             if len(stopped_containers) > 0:
                 print("Going to remove", list_containers(stopped_containers))
-                project.remove_stopped(service_names=options['SERVICE'],v=True)
+                project.remove_stopped(service_names=options['SERVICE'], v=True)
             else:
                 print("No stopped containers")
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -257,13 +257,13 @@ class TopLevelCommand(Command):
             -f, --force   Don't ask to confirm removal
             -v            Remove volumes associated with containers
         """
-        killed=False
+        killed = False
         if options['--kill']:
             print("Going to kill all containers")
             if options.get('--force') \
                     or yesno("Are you sure? [yN] ", default=False):
                         project.kill(service_names=options['SERVICE'], signal='SIGKILL')
-                        killed=True
+                        killed = True
             else:
                 print("No containers killed")
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -152,10 +152,21 @@ class TopLevelCommand(Command):
         Options:
             -s SIGNAL         SIGNAL to send to the container.
                               Default signal is SIGKILL.
+            --rm              Remove containers nd associated volumes forcefully
+                              after stopping them
         """
         signal = options.get('-s', 'SIGKILL')
 
         project.kill(service_names=options['SERVICE'], signal=signal)
+        if options['--rm']:
+            all_containers = project.containers(service_names=options['SERVICE'], stopped=True)
+            stopped_containers = [c for c in all_containers if not c.is_running]
+
+            if len(stopped_containers) > 0:
+                print("Going to remove", list_containers(stopped_containers))
+                project.remove_stopped(service_names=options['SERVICE'],v=True)
+            else:
+                print("No stopped containers")
 
     def logs(self, project, options):
         """


### PR DESCRIPTION
Most of the times, during development of a docker-compose.yml file, I found myself killing services and then removing the stopped containers immediately. To do this, I had to execute 2 docker-compose commands , first to kill the services and then to remove the containers and associated volumes. 
I think It would be very convenient if one command did the complete clean-up , viz., killing AND removing the stopped containers. 
So, I think it would be a great convenience option to have --rm in the kill command.