### PR TITLE
Change default `log_driver` value

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -657,7 +657,7 @@ class Service(object):
         cap_add = options.get('cap_add', None)
         cap_drop = options.get('cap_drop', None)
         log_config = LogConfig(
-            type=options.get('log_driver', 'json-file'),
+            type=options.get('log_driver', ""),
             config=options.get('log_opt', None)
         )
         pid = options.get('pid', None)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -864,7 +864,10 @@ class ServiceTest(DockerClientTestCase):
 
     def test_log_drive_invalid(self):
         service = self.create_service('web', log_driver='xxx')
-        self.assertRaises(APIError, lambda: create_and_start_container(service))
+        expected_error_msg = "logger: no log driver named 'xxx' is registered"
+
+        with self.assertRaisesRegexp(APIError, expected_error_msg):
+            create_and_start_container(service)
 
     def test_log_drive_empty_default_jsonfile(self):
         service = self.create_service('web')


### PR DESCRIPTION
If `log_driver` is not set in our .yml don't set a default of 'json-file', as this overrides daemon level config options as per issue: https://github.com/docker/compose/issues/1863

Send an empty string and let docker figure out it's default/read from it's global settings.

Fixes https://github.com/docker/compose/issues/1863