### PR TITLE
Stop using deprecated `create_host_config` from utils

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -11,7 +11,6 @@ from operator import attrgetter
 import enum
 import six
 from docker.errors import APIError
-from docker.utils import create_host_config
 from docker.utils import LogConfig
 from docker.utils.ports import build_port_bindings
 from docker.utils.ports import split_port
@@ -678,7 +677,7 @@ class Service(object):
 
         devices = options.get('devices', None)
 
-        return create_host_config(
+        return self.client.create_host_config(
             links=self._get_links(link_to_self=one_off),
             port_bindings=port_bindings,
             binds=options.get('binds'),

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -813,6 +813,13 @@ class ServiceTest(DockerClientTestCase):
         for k, v in {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''}.items():
             self.assertEqual(env[k], v)
 
+    def test_with_high_enough_api_version_we_get_default_network_mode(self):
+        # TODO: remove this test once minimum docker version is 1.8.x
+        with mock.patch.object(self.client, '_version', '1.20'):
+            service = self.create_service('web')
+            service_config = service._get_container_host_config({})
+            self.assertEquals(service_config['NetworkMode'], 'default')
+
     def test_labels(self):
         labels_dict = {
             'com.example.description': "Accounting webapp",

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -144,8 +144,11 @@ class CLITestCase(unittest.TestCase):
             '--rm': None,
             '--name': None,
         })
-        _, _, call_kwargs = mock_client.create_container.mock_calls[0]
-        self.assertEquals(call_kwargs['host_config']['RestartPolicy']['Name'], 'always')
+
+        self.assertEquals(
+            mock_client.create_host_config.call_args[1]['restart_policy']['Name'],
+            'always'
+        )
 
         command = TopLevelCommand()
         mock_client = mock.create_autospec(docker.Client)
@@ -170,8 +173,10 @@ class CLITestCase(unittest.TestCase):
             '--rm': True,
             '--name': None,
         })
-        _, _, call_kwargs = mock_client.create_container.mock_calls[0]
-        self.assertFalse('RestartPolicy' in call_kwargs['host_config'])
+
+        self.assertFalse(
+            mock_client.create_host_config.call_args[1].get('restart_policy')
+        )
 
     def test_command_manula_and_service_ports_together(self):
         command = TopLevelCommand()

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -543,13 +543,13 @@ class ServiceVolumesTest(unittest.TestCase):
             }
         }
 
-        create_options = service._get_container_create_options(
+        service._get_container_create_options(
             override_options={},
             number=1,
         )
 
         self.assertEqual(
-            set(create_options['host_config']['Binds']),
+            set(self.mock_client.create_host_config.call_args[1]['binds']),
             set([
                 '/host/path:/data1:rw',
                 '/host/path:/data2:rw',
@@ -581,14 +581,14 @@ class ServiceVolumesTest(unittest.TestCase):
             },
         }
 
-        create_options = service._get_container_create_options(
+        service._get_container_create_options(
             override_options={},
             number=1,
             previous_container=Container(self.mock_client, {'Id': '123123123'}),
         )
 
         self.assertEqual(
-            create_options['host_config']['Binds'],
+            self.mock_client.create_host_config.call_args[1]['binds'],
             ['/mnt/sda1/host/path:/data:rw'],
         )
 
@@ -613,4 +613,4 @@ class ServiceVolumesTest(unittest.TestCase):
         ).create_container()
 
         self.assertEqual(len(create_calls), 1)
-        self.assertEqual(create_calls[0][1]['host_config']['Binds'], volumes)
+        self.assertEqual(self.mock_client.create_host_config.call_args[1]['binds'], volumes)


### PR DESCRIPTION
To ensure backwards compatibility that `network_mode` gets set to  `default` when we have an api version high enough we need to use `docker.client.create_host_config` and not the deprecated `docker.utils.create_host_config`.