### PR TITLE
log_opt: change address to syslog-address

### DIFF
--- a/compose/config/schema.json
+++ b/compose/config/schema.json
@@ -56,16 +56,9 @@
         "image": {"type": "string"},
         "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+
         "log_driver": {"type": "string"},
-
-        "log_opt": {
-          "type": "object",
-
-          "properties": {
-            "syslog-address": {"type": "string"}
-          },
-          "required": ["syslog-address"]
-        },
+        "log_opt": {"type": "object"},
 
         "mac_address": {"type": "string"},
         "mem_limit": {

--- a/compose/config/schema.json
+++ b/compose/config/schema.json
@@ -62,9 +62,9 @@
           "type": "object",
 
           "properties": {
-            "address": {"type": "string"}
+            "syslog-address": {"type": "string"}
           },
-          "required": ["address"]
+          "required": ["syslog-address"]
         },
 
         "mac_address": {"type": "string"},

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -301,7 +301,7 @@ Logging options are key value pairs. An example of `syslog` options:
 
     log_driver: "syslog"
     log_opt:
-      address: "tcp://192.168.0.42:123"
+      syslog-address: "tcp://192.168.0.42:123"
 
 ### net
 

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -113,7 +113,7 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(opts['host_config']['Memory'], 1000000000)
 
     def test_log_opt(self):
-        log_opt = {'address': 'tcp://192.168.0.42:123'}
+        log_opt = {'syslog-address': 'tcp://192.168.0.42:123'}
         service = Service(name='foo', image='foo', hostname='name', client=self.mock_client, log_driver='syslog', log_opt=log_opt)
         self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'some': 'overrides'}, 1)


### PR DESCRIPTION
The documentation for `log_opt` stated to use `address` but that gives an error.

If I use `syslog-address` everything works as expected.

Also, see #1816 which is closed...

Not sure if I am missing something obviously, but this error cost me a couple of hours ;)