### PR TITLE
Set log level to DEBUG when `--verbose` is passed

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -25,6 +25,7 @@ from .log_printer import LogPrinter
 from .utils import yesno, get_version_info
 
 log = logging.getLogger(__name__)
+console_handler = logging.StreamHandler(sys.stderr)
 
 INSECURE_SSL_WARNING = """
 Warning: --allow-insecure-ssl is deprecated and has no effect.
@@ -63,9 +64,6 @@ def main():
 
 
 def setup_logging():
-    console_handler = logging.StreamHandler(sys.stderr)
-    console_handler.setFormatter(logging.Formatter())
-    console_handler.setLevel(logging.INFO)
     root_logger = logging.getLogger()
     root_logger.addHandler(console_handler)
     root_logger.setLevel(logging.DEBUG)
@@ -117,6 +115,16 @@ class TopLevelCommand(Command):
         options = super(TopLevelCommand, self).docopt_options()
         options['version'] = get_version_info('compose')
         return options
+
+    def perform_command(self, options, *args, **kwargs):
+        if options.get('--verbose'):
+            console_handler.setFormatter(logging.Formatter('%(name)s.%(funcName)s: %(message)s'))
+            console_handler.setLevel(logging.DEBUG)
+        else:
+            console_handler.setFormatter(logging.Formatter())
+            console_handler.setLevel(logging.INFO)
+
+        return super(TopLevelCommand, self).perform_command(options, *args, **kwargs)
 
     def build(self, project, options):
         """


### PR DESCRIPTION
In combination with https://github.com/docker/docker-py/pull/728, this should help us when working with users to debug registry authentication issues.

I'm not wild about the implementation (overriding a `Command` method in its only subclass) but it was the simplest way I could see. Alternative suggestions welcome.

```
$ docker-compose --verbose pull
docker.auth.auth.load_config: Trying /Users/aanand/.docker/config.json
docker.auth.auth.load_config: Found 'auths' section
docker.auth.auth.parse_auth: Found entry (registry=u'quay.io', username=u'aanand')
docker.auth.auth.parse_auth: Found entry (registry=u'https://index.docker.io/v1/', username=u'aanand')
compose.cli.command.get_client: Compose version 1.5.0dev
compose.cli.command.get_client: Docker base_url: https://192.168.99.100:2376
compose.cli.command.get_client: Docker version: KernelVersion=4.0.9-boot2docker, Os=linux, BuildTime=Thu Aug 13 02:49:29 UTC 2015, ApiVersion=1.20, Version=1.8.1, GitCommit=d12ea79, Arch=amd64, GoVersion=go1.4.2
compose.service.pull: Pulling redis (redis:latest)...
compose.cli.verbose_proxy.proxy_callable: docker pull <- ('redis', tag=u'latest', stream=True)
docker.client.pull: Looking for auth config
docker.auth.auth.resolve_authconfig: Looking for auth entry for 'index.docker.io'
docker.auth.auth.resolve_authconfig: Found u'https://index.docker.io/v1/'
docker.client.pull: Found auth config
compose.cli.verbose_proxy.proxy_callable: docker pull -> <generator object _stream_helper at 0x110b63690>
latest: Pulling from library/redis
...
```