### PR TITLE
Run on windows by bypassing dockerpty.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -67,6 +67,14 @@ def main():
     except NeedsBuildError as e:
         log.error("Service '%s' needs to be built, but --no-build was passed." % e.service.name)
         sys.exit(1)
+    except AttributeError as e:
+        if sys.platform == 'win32':
+            if str(e) == "'module' object has no attribute 'AF_UNIX'":
+                log.error('No docker host environment variables specified. '
+                          'Run docker-machine env --help for more info.')
+                sys.exit(1)
+        else:
+            raise
 
 
 def setup_logging():

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -8,7 +8,6 @@ import sys
 from inspect import getdoc
 from operator import attrgetter
 
-import dockerpty
 from docker.errors import APIError
 
 from .. import __version__
@@ -27,6 +26,9 @@ from .formatter import Formatter
 from .log_printer import LogPrinter
 from .utils import get_version_info
 from .utils import yesno
+
+if sys.platform != 'win32':
+    import dockerpty
 
 log = logging.getLogger(__name__)
 console_handler = logging.StreamHandler(sys.stderr)
@@ -393,6 +395,13 @@ class TopLevelCommand(Command):
         if options['-d']:
             service.start_container(container)
             print(container.name)
+        elif sys.platform == 'win32':
+            raise UserError(
+                'Only detached mode is supported on Windows. You must run '
+                'compose with the -d option. If you wish to help getting '
+                'terminal mode support working, PRs are welcome! We need to '
+                'replace dockerpty or remove its depedency on fcntl.'
+            )
         else:
             dockerpty.start(project.client, container.id, interactive=not options['-T'])
             exit_code = container.wait()

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,12 @@ install_requires = [
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',
     'docker-py >= 1.3.1, < 1.4',
-    'dockerpty >= 0.3.4, < 0.4',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',
 ]
+
+if (sys.platform != 'win32'):
+    install_requires.append('dockerpty >= 0.3.4, < 0.4')
 
 
 tests_require = [


### PR DESCRIPTION
This is a proposal for a way to implement windows support for compose in the near term. 

A primary blocker to support for running on windows in dockerpty's dependency on fcntl to lock the file descriptors for the pty streams. This is only used when docker-compose is ran in attached mode. This PR removes attached mode support on windows.  The assumption is that you could simply use docker itself to attach to the containers as a windows user. 

I have tested docker build, run, and up with some simple projects that do not use volumes and all seems to work as expected. 

The caveat here being that volumes on windows generally don't work well with vagrant, docker-machine, docker, and those same limitations apply to compose.

The upside to this simple patch is it allows me to use docker-compose to build and start environments as long as I am creating containers that do not depend on volumes. I'll be using it for local development and experimentation.

I'm not quite sure how to go about implementing tests. I'm not sure what is required from a CI perspective to get windows testing in place and how best to approach disambiguating the platform in tests and build pipeline. 

I'm happy to collaborate with anyone who is willing to work on this feature branch and help implement full windows support for compose, although my ability to work further it is will likely be limited to testing and debugging additional changes.  