### PR TITLE
Use official python docker images instead of compiling python manually

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
-FROM debian:wheezy
+FROM python:2.7.10-wheezy
 
 RUN set -ex; \
     apt-get update -qq; \
     apt-get install -y \
-        gcc \
-        make \
-        zlib1g \
-        zlib1g-dev \
-        libssl-dev \
         git \
         apt-transport-https \
         ca-certificates \
@@ -17,37 +12,6 @@ RUN set -ex; \
         libsqlite3-dev \
     ; \
     rm -rf /var/lib/apt/lists/*
-
-# Build Python 2.7.9 from source
-RUN set -ex; \
-    curl -LO https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz; \
-    tar -xzf Python-2.7.9.tgz; \
-    cd Python-2.7.9; \
-    ./configure --enable-shared; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf /Python-2.7.9; \
-    rm Python-2.7.9.tgz
-
-# Make libpython findable
-ENV LD_LIBRARY_PATH /usr/local/lib
-
-# Install setuptools
-RUN set -ex; \
-    curl -LO https://bootstrap.pypa.io/ez_setup.py; \
-    python ez_setup.py; \
-    rm ez_setup.py
-
-# Install pip
-RUN set -ex; \
-    curl -LO https://pypi.python.org/packages/source/p/pip/pip-7.0.1.tar.gz; \
-    tar -xzf pip-7.0.1.tar.gz; \
-    cd pip-7.0.1; \
-    python setup.py install; \
-    cd ..; \
-    rm -rf pip-7.0.1; \
-    rm pip-7.0.1.tar.gz
 
 ENV ALL_DOCKER_VERSIONS 1.7.1 1.8.1
 


### PR DESCRIPTION
I'm one of those developers that gets impatient waiting for feedback from a build server.  It seems like every time I've submitted or update a PR on compose I need to wait for docker build, and cache doesn't seem to get leveraged. On 6/1/2015 @aanand introduced manual compilation of python 2.7.9 to suppress some unsecure TLS warnings. The compile take several minutes. This change updates the docker file to use the official python:2.7.10-wheezy container to eliminate the compile time. 