### PR TITLE
Export COMPOSE_FILE

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -40,7 +40,7 @@ For this reason, you'll probably want to define a separate Compose file, say
 Once you've got an alternate configuration file, make Compose use it
 by setting the `COMPOSE_FILE` environment variable:
 
-    $ COMPOSE_FILE=production.yml
+    $ export COMPOSE_FILE=production.yml
     $ docker-compose up -d
 
 > **Note:** You can also use the file for a one-off command without setting


### PR DESCRIPTION
The environment variable is not used by `docker-compose` without the `export` line..