### PR TITLE
Use py.test as a test runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN pip install -r requirements-dev.txt
 RUN pip install tox==2.1.1
 
 ADD . /code/
-RUN python setup.py install
+RUN pip install --no-deps -e /code
 
 RUN chown -R user /code/
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,1 @@
+git+https://github.com/pyinstaller/pyinstaller.git@12e40471c77f588ea5be352f7219c873ddaae056#egg=pyinstaller

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 coverage==3.7.1
-flake8==2.3.0
-mock >= 1.0.1
-nose==1.3.4
-pep8==1.6.1
+mock>=1.0.1
+pytest==2.7.2
+pytest-cov==2.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 coverage==3.7.1
 flake8==2.3.0
-git+https://github.com/pyinstaller/pyinstaller.git@12e40471c77f588ea5be352f7219c873ddaae056#egg=pyinstaller
 mock >= 1.0.1
 nose==1.3.4
 pep8==1.6.1

--- a/script/build-linux
+++ b/script/build-linux
@@ -6,7 +6,6 @@ TAG="docker-compose"
 docker build -t "$TAG" .
 docker run \
   --rm \
-  --user=user \
   --volume="$(pwd):/code" \
   --entrypoint="script/build-linux-inner" \
   "$TAG"

--- a/script/build-linux-inner
+++ b/script/build-linux-inner
@@ -2,9 +2,12 @@
 
 set -ex
 
+TARGET=dist/docker-compose-Linux-x86_64
+
 mkdir -p `pwd`/dist
 chmod 777 `pwd`/dist
 
-pyinstaller -F bin/docker-compose
-mv dist/docker-compose dist/docker-compose-Linux-x86_64
-dist/docker-compose-Linux-x86_64 version
+pip install -r requirements-build.txt
+su -c "pyinstaller -F bin/docker-compose" user
+mv dist/docker-compose $TARGET
+$TARGET version

--- a/script/build-osx
+++ b/script/build-osx
@@ -6,7 +6,7 @@ PATH="/usr/local/bin:$PATH"
 rm -rf venv
 virtualenv -p /usr/local/bin/python venv
 venv/bin/pip install -r requirements.txt
-venv/bin/pip install -r requirements-dev.txt
+venv/bin/pip install -r requirements-build.txt
 venv/bin/pip install .
 venv/bin/pyinstaller -F bin/docker-compose
 mv dist/docker-compose dist/docker-compose-Darwin-x86_64

--- a/script/ci
+++ b/script/ci
@@ -13,4 +13,4 @@ export DOCKER_DAEMON_ARGS="--storage-driver=overlay"
 . script/test-versions
 
 >&2 echo "Building Linux binary"
-su -c script/build-linux-inner user
+. script/build-linux-inner

--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,10 @@ install_requires = [
 
 
 tests_require = [
-    'nose',
-    'flake8',
+    'pytest',
 ]
 
 
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
 if sys.version_info[:1] < (3,):
     tests_require.append('mock >= 1.0.1')
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,14 @@ passenv =
 setenv =
     HOME=/tmp
 deps =
-    -rrequirements.txt
+    -rrequirements-dev.txt
 commands =
-    nosetests -v --with-coverage --cover-branches --cover-package=compose --cover-erase --cover-html-dir=coverage-html --cover-html {posargs}
-    flake8 compose tests setup.py
+    py.test -v \
+        --cov=compose \
+        --cov-report html \
+        --cov-report term \
+        --cov-config=tox.ini \
+        {posargs}
 
 [testenv:pre-commit]
 skip_install = True
@@ -21,16 +25,16 @@ commands =
     pre-commit install
     pre-commit run --all-files
 
-[testenv:py27]
-deps =
-    {[testenv]deps}
-    -rrequirements-dev.txt
+# Coverage configuration
+[run]
+branch = True
 
-[testenv:py34]
-deps =
-    {[testenv]deps}
-    flake8
-    nose
+[report]
+show_missing = true
+
+[html]
+directory = coverage-html
+# end coverage configuration
 
 [flake8]
 # Allow really long lines for now


### PR DESCRIPTION
I split out the "build" dependencies from the "test" dependencies to cleanup tox.ini a bit. pyinstaller doesn't install under python3.

I verified that the coverage report is still in the right place.