### PR TITLE
Fix `docker-compose logs` on python3

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -57,7 +57,7 @@ class LogPrinter(object):
     def _make_log_generator(self, container, color_fn):
         prefix = color_fn(self._generate_prefix(container))
         # Attach to container before log printer starts running
-        line_generator = split_buffer(self._attach(container), '\n')
+        line_generator = split_buffer(self._attach(container), u'\n')
 
         for line in line_generator:
             yield prefix + line

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -7,6 +7,7 @@ import platform
 import ssl
 import subprocess
 
+import six
 from docker import version as docker_py_version
 from six.moves import input
 
@@ -63,11 +64,11 @@ def split_buffer(reader, separator):
     separator, except for the last one if none was found on the end
     of the input.
     """
-    buffered = str('')
-    separator = str(separator)
+    buffered = six.text_type('')
+    separator = six.text_type(separator)
 
     for data in reader:
-        buffered += data
+        buffered += data.decode('utf-8')
         while True:
             index = buffered.find(separator)
             if index == -1:

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import datetime
 import os
 import platform
 import ssl
@@ -34,39 +33,6 @@ def yesno(prompt, default=None):
         return default
     else:
         return None
-
-
-# http://stackoverflow.com/a/5164027
-def prettydate(d):
-    diff = datetime.datetime.utcnow() - d
-    s = diff.seconds
-    if diff.days > 7 or diff.days < 0:
-        return d.strftime('%d %b %y')
-    elif diff.days == 1:
-        return '1 day ago'
-    elif diff.days > 1:
-        return '{0} days ago'.format(diff.days)
-    elif s <= 1:
-        return 'just now'
-    elif s < 60:
-        return '{0} seconds ago'.format(s)
-    elif s < 120:
-        return '1 minute ago'
-    elif s < 3600:
-        return '{0} minutes ago'.format(s / 60)
-    elif s < 7200:
-        return '1 hour ago'
-    else:
-        return '{0} hours ago'.format(s / 3600)
-
-
-def mkdir(path, permissions=0o700):
-    if not os.path.exists(path):
-        os.mkdir(path)
-
-    os.chmod(path, permissions)
-
-    return path
 
 
 def find_candidates_in_parent_dirs(filenames, path):

--- a/tests/unit/cli/log_printer_test.py
+++ b/tests/unit/cli/log_printer_test.py
@@ -5,8 +5,8 @@ import os
 
 import six
 
-from .. import unittest
 from compose.cli.log_printer import LogPrinter
+from tests import unittest
 
 
 class LogPrinterTest(unittest.TestCase):

--- a/tests/unit/cli/log_printer_test.py
+++ b/tests/unit/cli/log_printer_test.py
@@ -12,7 +12,7 @@ from tests import unittest
 class LogPrinterTest(unittest.TestCase):
     def get_default_output(self, monochrome=False):
         def reader(*args, **kwargs):
-            yield "hello\nworld"
+            yield b"hello\nworld"
 
         container = MockContainer(reader)
         output = run_log_printer([container], monochrome=monochrome)
@@ -36,11 +36,10 @@ class LogPrinterTest(unittest.TestCase):
         glyph = u'\u2022'
 
         def reader(*args, **kwargs):
-            yield glyph + '\n'
+            yield glyph.encode('utf-8') + b'\n'
 
         container = MockContainer(reader)
         output = run_log_printer([container])
-
         if six.PY2:
             output = output.decode('utf-8')
 

--- a/tests/unit/split_buffer_test.py
+++ b/tests/unit/split_buffer_test.py
@@ -8,33 +8,33 @@ from compose.cli.utils import split_buffer
 class SplitBufferTest(unittest.TestCase):
     def test_single_line_chunks(self):
         def reader():
-            yield 'abc\n'
-            yield 'def\n'
-            yield 'ghi\n'
+            yield b'abc\n'
+            yield b'def\n'
+            yield b'ghi\n'
 
         self.assert_produces(reader, ['abc\n', 'def\n', 'ghi\n'])
 
     def test_no_end_separator(self):
         def reader():
-            yield 'abc\n'
-            yield 'def\n'
-            yield 'ghi'
+            yield b'abc\n'
+            yield b'def\n'
+            yield b'ghi'
 
         self.assert_produces(reader, ['abc\n', 'def\n', 'ghi'])
 
     def test_multiple_line_chunk(self):
         def reader():
-            yield 'abc\ndef\nghi'
+            yield b'abc\ndef\nghi'
 
         self.assert_produces(reader, ['abc\n', 'def\n', 'ghi'])
 
     def test_chunked_line(self):
         def reader():
-            yield 'a'
-            yield 'b'
-            yield 'c'
-            yield '\n'
-            yield 'd'
+            yield b'a'
+            yield b'b'
+            yield b'c'
+            yield b'\n'
+            yield b'd'
 
         self.assert_produces(reader, ['abc\n', 'd'])
 
@@ -42,12 +42,12 @@ class SplitBufferTest(unittest.TestCase):
         string = u"a\u2022c\n"
 
         def reader():
-            yield string
+            yield string.encode('utf-8')
 
         self.assert_produces(reader, [string])
 
     def assert_produces(self, reader, expectations):
-        split = split_buffer(reader(), '\n')
+        split = split_buffer(reader(), u'\n')
 
         for (actual, expected) in zip(split, expectations):
             self.assertEqual(type(actual), type(expected))


### PR DESCRIPTION
I think this is the last incompatibility with python3. Thanks to @funkyfuture  and @ouziel-slama for calling out this issue a while ago and opening PRs against my branch.

I've updated the unit tests for this function to properly reflect the types we're getting back from `docker-py`. In both py2 and py3 it returns bytes objects, so now our unittests do the same, and we convert everything to unicode in `split_buffer()`.

Includes a couple other cleanup commits for moving a test file to match the naming convention, remove two functions from `utils.py` that are not used anywhere.