### PR TITLE
Validate and interpolate extended services

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -179,6 +179,9 @@ class ServiceLoader(object):
                 self.filename
             )
 
+            self.extended_config_path = self.get_extended_config_path(
+                self.service_dict['extends']
+            )
 
     def detect_cycle(self, name):
         if self.signature(name) in self.already_seen:
@@ -215,11 +218,7 @@ class ServiceLoader(object):
         extends_options = self.service_dict['extends']
         service_name = self.service_dict['name']
 
-        if 'file' in extends_options:
-            extends_from_filename = extends_options['file']
-            other_config_path = expand_path(self.working_dir, extends_from_filename)
-        else:
-            other_config_path = self.filename
+        other_config_path = self.get_extended_config_path(extends_options)
 
         other_working_dir = os.path.dirname(other_config_path)
         other_already_seen = self.already_seen + [self.signature(service_name)]
@@ -251,6 +250,18 @@ class ServiceLoader(object):
         )
 
         return merge_service_dicts(other_service_dict, self.service_dict)
+
+    def get_extended_config_path(self, extends_options):
+        """
+        Service we are extending either has a value for 'file' set, which we
+        need to obtain a full path too or we are extending from a service
+        defined in our own file.
+        """
+        if 'file' in extends_options:
+            extends_from_filename = extends_options['file']
+            return expand_path(self.working_dir, extends_from_filename)
+
+        return self.filename
 
     def signature(self, name):
         return (self.filename, name)

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -152,7 +152,11 @@ def load(config_details):
 
 class ServiceLoader(object):
     def __init__(self, working_dir, filename=None, already_seen=None):
+        if working_dir is None:
+            raise Exception("No working_dir passed to ServiceLoader()")
+
         self.working_dir = os.path.abspath(working_dir)
+
         if filename:
             self.filename = os.path.abspath(filename)
         else:
@@ -175,9 +179,6 @@ class ServiceLoader(object):
             return service_dict
 
         extends_options = self.validate_extends_options(service_dict['name'], service_dict['extends'])
-
-        if self.working_dir is None:
-            raise Exception("No working_dir passed to ServiceLoader()")
 
         if 'file' in extends_options:
             extends_from_filename = extends_options['file']
@@ -319,9 +320,6 @@ def merge_environment(base, override):
 def get_env_files(options, working_dir=None):
     if 'env_file' not in options:
         return {}
-
-    if working_dir is None:
-        raise Exception("No working_dir passed to get_env_files()")
 
     env_files = options.get('env_file', [])
     if not isinstance(env_files, list):

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -184,7 +184,7 @@ class ServiceLoader(object):
             self.service_dict = self.resolve_extends()
 
         if not self.already_seen:
-            validate_against_service_schema(self.service_dict)
+            validate_against_service_schema(self.service_dict, self.service_name)
 
         return process_container_options(self.service_dict, working_dir=self.working_dir)
 

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -182,6 +182,8 @@ class ServiceLoader(object):
             self.extended_config_path = self.get_extended_config_path(
                 self.service_dict['extends']
             )
+            extended_config = load_yaml(self.extended_config_path)
+            validate_against_schema(extended_config)
 
     def detect_cycle(self, name):
         if self.signature(name) in self.already_seen:
@@ -217,10 +219,9 @@ class ServiceLoader(object):
 
         extends_options = self.service_dict['extends']
         service_name = self.service_dict['name']
+        other_config_path = self.extended_config_path
 
-        other_config_path = self.get_extended_config_path(extends_options)
-
-        other_working_dir = os.path.dirname(other_config_path)
+        other_working_dir = os.path.dirname(self.extended_config_path)
         other_already_seen = self.already_seen + [self.signature(service_name)]
 
         base_service = extends_options['service']

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -151,7 +151,7 @@ def load(config_details):
 
 
 class ServiceLoader(object):
-    def __init__(self, working_dir, filename=None, already_seen=None):
+    def __init__(self, working_dir, filename, already_seen=None):
         if working_dir is None:
             raise Exception("No working_dir passed to ServiceLoader()")
 

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -10,7 +10,8 @@ from .errors import CircularReference
 from .errors import ComposeFileNotFound
 from .errors import ConfigurationError
 from .interpolation import interpolate_environment_variables
-from .validation import validate_against_schema
+from .validation import validate_against_fields_schema
+from .validation import validate_against_service_schema
 from .validation import validate_extended_service_exists
 from .validation import validate_extends_file_path
 from .validation import validate_service_names
@@ -139,7 +140,7 @@ def load(config_details):
     config, working_dir, filename = config_details
 
     processed_config = pre_process_config(config)
-    validate_against_schema(processed_config)
+    validate_against_fields_schema(processed_config)
 
     service_dicts = []
 
@@ -193,7 +194,7 @@ class ServiceLoader(object):
                 full_extended_config,
                 self.extended_config_path
             )
-            validate_against_schema(full_extended_config)
+            validate_against_fields_schema(full_extended_config)
 
             self.extended_config = full_extended_config[self.extended_service_name]
         else:
@@ -205,6 +206,10 @@ class ServiceLoader(object):
 
     def make_service_dict(self):
         self.service_dict = self.resolve_extends()
+
+        if not self.already_seen:
+            validate_against_service_schema(self.service_dict)
+
         return process_container_options(self.service_dict, working_dir=self.working_dir)
 
     def resolve_environment(self):

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -19,7 +19,12 @@
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "command": {"$ref": "#/definitions/string_or_list"},
         "container_name": {"type": "string"},
-        "cpu_shares": {"type": "string"},
+        "cpu_shares": {
+          "oneOf": [
+            {"type": "number"},
+            {"type": "string"}
+          ]
+        },
         "cpuset": {"type": "string"},
         "detach": {"type": "boolean"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
@@ -27,7 +32,7 @@
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "dockerfile": {"type": "string"},
         "domainname": {"type": "string"},
-        "entrypoint": {"type": "string"},
+        "entrypoint": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "env_file": {"$ref": "#/definitions/string_or_list"},
 
         "environment": {
@@ -75,7 +80,7 @@
         },
         "name": {"type": "string"},
         "net": {"type": "string"},
-        "pid": {"type": "string"},
+        "pid": {"type": ["string", "null"]},
 
         "ports": {
           "type": "array",
@@ -94,10 +99,10 @@
           "uniqueItems": true
         },
 
-        "privileged": {"type": "string"},
+        "privileged": {"type": "boolean"},
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},
-        "security_opt": {"type": "string"},
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "stdin_open": {"type": "string"},
         "tty": {"type": "string"},
         "user": {"type": "string"},

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -102,6 +102,7 @@
         "tty": {"type": "string"},
         "user": {"type": "string"},
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "working_dir": {"type": "string"}
       },

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -106,24 +106,6 @@
         "working_dir": {"type": "string"}
       },
 
-      "anyOf": [
-        {
-          "required": ["build"],
-          "not": {"required": ["image"]}
-        },
-        {
-          "required": ["image"],
-          "not": {"anyOf": [
-            {"required": ["build"]},
-            {"required": ["dockerfile"]}
-          ]}
-        },
-        {
-          "required": ["extends"],
-          "not": {"required": ["build", "image"]}
-        }
-      ],
-
       "dependencies": {
         "memswap_limit": ["mem_limit"]
       },

--- a/compose/config/service_schema.json
+++ b/compose/config/service_schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+
+  "properties": {
+      "name": {"type": "string"}
+  },
+
+  "required": ["name"],
+
+  "allOf": [
+    {"$ref": "fields_schema.json#/definitions/service"},
+    {"$ref": "#/definitions/service_constraints"}
+  ],
+
+  "definitions": {
+    "service_constraints": {
+      "anyOf": [
+        {
+          "required": ["build"],
+          "not": {"required": ["image"]}
+        },
+        {
+          "required": ["image"],
+          "not": {"anyOf": [
+            {"required": ["build"]},
+            {"required": ["dockerfile"]}
+          ]}
+        },
+        {
+          "required": ["extends"],
+          "not": {"required": ["build", "image"]}
+        }
+      ]
+    }
+  }
+
+}

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -66,6 +66,19 @@ def validate_top_level_object(func):
     return func_wrapper
 
 
+def validate_extends_file_path(service_name, extends_options, filename):
+    """
+    The service to be extended must either be defined in the config key 'file',
+    or within 'filename'.
+    """
+    error_prefix = "Invalid 'extends' configuration for %s:" % service_name
+
+    if 'file' not in extends_options and filename is None:
+        raise ConfigurationError(
+            "%s you need to specify a 'file', e.g. 'file: something.yml'" % error_prefix
+        )
+
+
 def get_unsupported_config_msg(service_name, error_key):
     msg = "Unsupported config option for '{}' service: '{}'".format(service_name, error_key)
     if error_key in DOCKER_CONFIG_HINTS:

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -79,6 +79,14 @@ def validate_extends_file_path(service_name, extends_options, filename):
         )
 
 
+def validate_extended_service_exists(extended_service_name, full_extended_config, extended_config_path):
+    if extended_service_name not in full_extended_config:
+        msg = (
+            "Cannot extend service '%s' in %s: Service not found"
+        ) % (extended_service_name, extended_config_path)
+        raise ConfigurationError(msg)
+
+
 def get_unsupported_config_msg(service_name, error_key):
     msg = "Unsupported config option for '{}' service: '{}'".format(service_name, error_key)
     if error_key in DOCKER_CONFIG_HINTS:

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -125,7 +125,7 @@ def process_errors(errors):
 
     for error in errors:
         # handle root level errors
-        if len(error.path) == 0:
+        if len(error.path) == 0 and not error.instance.get('name'):
             if error.validator == 'type':
                 msg = "Top level object needs to be a dictionary. Check your .yml file that you have defined a service at the top level."
                 root_msgs.append(msg)
@@ -137,11 +137,13 @@ def process_errors(errors):
                 root_msgs.append(_clean_error_message(error.message))
 
         else:
-            # handle service level errors
-            service_name = error.path[0]
-
-            # pop the service name off our path
-            error.path.popleft()
+            try:
+                # field_schema errors will have service name on the path
+                service_name = error.path[0]
+                error.path.popleft()
+            except IndexError:
+                # service_schema errors will have the name in the instance
+                service_name = error.instance.get('name')
 
             if error.validator == 'additionalProperties':
                 invalid_config_key = _parse_key_from_error_msg(error)

--- a/tests/fixtures/extends/invalid-links.yml
+++ b/tests/fixtures/extends/invalid-links.yml
@@ -1,0 +1,9 @@
+myweb:
+  build: '.'
+  extends:
+    service: web
+  command: top
+web:
+  build: '.'
+  links:
+    - "mydb:db"

--- a/tests/fixtures/extends/invalid-net.yml
+++ b/tests/fixtures/extends/invalid-net.yml
@@ -1,0 +1,8 @@
+myweb:
+  build: '.'
+  extends:
+    service: web
+  command: top
+web:
+  build: '.'
+  net: "container:db"

--- a/tests/fixtures/extends/invalid-volumes.yml
+++ b/tests/fixtures/extends/invalid-volumes.yml
@@ -1,0 +1,9 @@
+myweb:
+  build: '.'
+  extends:
+    service: web
+  command: top
+web:
+  build: '.'
+  volumes_from:
+    - "db"

--- a/tests/fixtures/extends/service-with-invalid-schema.yml
+++ b/tests/fixtures/extends/service-with-invalid-schema.yml
@@ -1,5 +1,4 @@
 myweb:
   extends:
+    file: valid-composite-extends.yml
     service: web
-web:
-  command: top

--- a/tests/fixtures/extends/service-with-invalid-schema.yml
+++ b/tests/fixtures/extends/service-with-invalid-schema.yml
@@ -1,0 +1,5 @@
+myweb:
+  extends:
+    service: web
+web:
+  command: top

--- a/tests/fixtures/extends/service-with-valid-composite-extends.yml
+++ b/tests/fixtures/extends/service-with-valid-composite-extends.yml
@@ -1,0 +1,5 @@
+myweb:
+  build: '.'
+  extends:
+    file: 'valid-composite-extends.yml'
+    service: web

--- a/tests/fixtures/extends/valid-common-config.yml
+++ b/tests/fixtures/extends/valid-common-config.yml
@@ -1,0 +1,6 @@
+myweb:
+  build: '.'
+  extends:
+    file: valid-common.yml
+    service: common-config
+  command: top

--- a/tests/fixtures/extends/valid-common.yml
+++ b/tests/fixtures/extends/valid-common.yml
@@ -1,0 +1,3 @@
+common-config:
+  environment:
+    - FOO=1

--- a/tests/fixtures/extends/valid-composite-extends.yml
+++ b/tests/fixtures/extends/valid-composite-extends.yml
@@ -1,0 +1,2 @@
+web:
+  command: top

--- a/tests/fixtures/extends/valid-interpolation-2.yml
+++ b/tests/fixtures/extends/valid-interpolation-2.yml
@@ -1,0 +1,3 @@
+web:
+  build: '.'
+  hostname: "host-${HOSTNAME_VALUE}"

--- a/tests/fixtures/extends/valid-interpolation.yml
+++ b/tests/fixtures/extends/valid-interpolation.yml
@@ -1,0 +1,5 @@
+myweb:
+  extends:
+    service: web
+    file: valid-interpolation-2.yml
+  command: top

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -165,16 +165,6 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(set(container.get('HostConfig.ExtraHosts')), set(extra_hosts))
 
-    def test_create_container_with_extra_hosts_string(self):
-        extra_hosts = 'somehost:162.242.195.82'
-        service = self.create_service('db', extra_hosts=extra_hosts)
-        self.assertRaises(ConfigError, lambda: service.create_container())
-
-    def test_create_container_with_extra_hosts_list_of_dicts(self):
-        extra_hosts = [{'somehost': '162.242.195.82'}, {'otherhost': '50.31.209.229'}]
-        service = self.create_service('db', extra_hosts=extra_hosts)
-        self.assertRaises(ConfigError, lambda: service.create_container())
-
     def test_create_container_with_extra_hosts_dicts(self):
         extra_hosts = {'somehost': '162.242.195.82', 'otherhost': '50.31.209.229'}
         extra_hosts_list = ['somehost:162.242.195.82', 'otherhost:50.31.209.229']
@@ -515,7 +505,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(container['HostConfig']['Privileged'], True)
 
     def test_expose_does_not_publish_ports(self):
-        service = self.create_service('web', expose=[8000])
+        service = self.create_service('web', expose=["8000"])
         container = create_and_start_container(service).inspect()
         self.assertEqual(container['NetworkSettings']['Ports'], {'8000/tcp': None})
 

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -31,7 +31,7 @@ class DockerClientTestCase(unittest.TestCase):
         if 'command' not in kwargs:
             kwargs['command'] = ["top"]
 
-        options = ServiceLoader(working_dir='.').make_service_dict(name, kwargs)
+        options = ServiceLoader(working_dir='.', filename=None).make_service_dict(name, kwargs)
 
         labels = options.setdefault('labels', {})
         labels['com.docker.compose.test-name'] = self.id()

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -31,7 +31,7 @@ class DockerClientTestCase(unittest.TestCase):
         if 'command' not in kwargs:
             kwargs['command'] = ["top"]
 
-        options = ServiceLoader(working_dir='.', filename=None).make_service_dict(name, kwargs)
+        options = ServiceLoader(working_dir='.', filename=None, service_name=name, service_dict=kwargs).make_service_dict()
 
         labels = options.setdefault('labels', {})
         labels['com.docker.compose.test-name'] = self.id()

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -31,10 +31,28 @@ class DockerClientTestCase(unittest.TestCase):
         if 'command' not in kwargs:
             kwargs['command'] = ["top"]
 
+        links = kwargs.get('links', None)
+        volumes_from = kwargs.get('volumes_from', None)
+        net = kwargs.get('net', None)
+
+        workaround_options = ['links', 'volumes_from', 'net']
+        for key in workaround_options:
+            try:
+                del kwargs[key]
+            except KeyError:
+                pass
+
         options = ServiceLoader(working_dir='.', filename=None, service_name=name, service_dict=kwargs).make_service_dict()
 
         labels = options.setdefault('labels', {})
         labels['com.docker.compose.test-name'] = self.id()
+
+        if links:
+            options['links'] = links
+        if volumes_from:
+            options['volumes_from'] = volumes_from
+        if net:
+            options['net'] = net
 
         return Service(
             project='composetest',

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -866,12 +866,17 @@ class ExtendsTest(unittest.TestCase):
 
         self.assertEquals(len(service), 1)
         self.assertIsInstance(service[0], dict)
+        self.assertEquals(service[0]['command'], "/bin/true")
 
     def test_extended_service_with_invalid_config(self):
         expected_error_msg = "Service 'myweb' has neither an image nor a build path specified"
 
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             load_from_filename('tests/fixtures/extends/service-with-invalid-schema.yml')
+
+    def test_extended_service_with_valid_config(self):
+        service = load_from_filename('tests/fixtures/extends/service-with-valid-composite-extends.yml')
+        self.assertEquals(service[0]['command'], "top")
 
     def test_extends_file_defaults_to_self(self):
         """
@@ -954,6 +959,10 @@ class ExtendsTest(unittest.TestCase):
         err_msg = r'''Cannot extend service 'foo' in .*: Service not found'''
         with self.assertRaisesRegexp(ConfigurationError, err_msg):
             load_from_filename('tests/fixtures/extends/nonexistent-service.yml')
+
+    def test_partial_service_config_in_extends_is_still_valid(self):
+        dicts = load_from_filename('tests/fixtures/extends/valid-common-config.yml')
+        self.assertEqual(dicts[0]['environment'], {'FOO': '1'})
 
 
 class BuildPathTest(unittest.TestCase):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -914,6 +914,17 @@ class ExtendsTest(unittest.TestCase):
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             load_from_filename('tests/fixtures/extends/invalid-net.yml')
 
+    @mock.patch.dict(os.environ)
+    def test_valid_interpolation_in_extended_service(self):
+        os.environ.update(
+            HOSTNAME_VALUE="penguin",
+        )
+        expected_interpolated_value = "host-penguin"
+
+        service_dicts = load_from_filename('tests/fixtures/extends/valid-interpolation.yml')
+        for service in service_dicts:
+            self.assertTrue(service['hostname'], expected_interpolated_value)
+
     def test_volume_path(self):
         dicts = load_from_filename('tests/fixtures/volume-path/docker-compose.yml')
 

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -15,7 +15,11 @@ def make_service_dict(name, service_dict, working_dir, filename=None):
     """
     Test helper function to construct a ServiceLoader
     """
-    return config.ServiceLoader(working_dir=working_dir, filename=filename).make_service_dict(name, service_dict)
+    return config.ServiceLoader(
+        working_dir=working_dir,
+        filename=filename,
+        service_name=name,
+        service_dict=service_dict).make_service_dict()
 
 
 def service_sort(services):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -11,11 +11,11 @@ from compose.config import config
 from compose.config.errors import ConfigurationError
 
 
-def make_service_dict(name, service_dict, working_dir):
+def make_service_dict(name, service_dict, working_dir, filename=None):
     """
     Test helper function to construct a ServiceLoader
     """
-    return config.ServiceLoader(working_dir=working_dir).make_service_dict(name, service_dict)
+    return config.ServiceLoader(working_dir=working_dir, filename=filename).make_service_dict(name, service_dict)
 
 
 def service_sort(services):


### PR DESCRIPTION
In order to run interpolation and schema validation against a service that we want to extend, I did some re-factoring, which ultimately made it easier and clearer to then be able to perform those functions.

The `resolve_extends` has always been a bit of an overloaded function, it previously was doing more than what the word resolve meant to me. It was constructing, validating, logic, validating then constructing. Rather than insert more complexity into an already complex function, I've done some refactoring which ultimately I feel helps tighten up the design a bit.

Ultimately, this now splits validation into two parts, an initial field validation, which we run when we call `Config.load` and a second validation, of service schema validation, when we call `make_service_dict`. I've also moved some functions to be within the class, as they provide no benefit living outside of it and it helps clear up the intent of the scope of that functionality. Internal workings of the ServiceLoader.

I'm not stating that this is perfect code but it does achieve our goal of the feature, some of the code has been improved while I'm there and gives us some room to think about how we might iterate on this in the future. It highlights some design approaches too, which there is never only one true answer for.

*Note*: Please note the commit messages, don't just look at the giant diff. It'll help demonstrate how I de-constructed this problem and why I've chosen to improve/move some things around.

:sparkles: :ok_woman: 

Fixes https://github.com/docker/compose/issues/1909