### PR TITLE
Bash completion for `docker-compose scale --timeout`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -280,11 +280,14 @@ _docker_compose_scale() {
 			COMPREPLY=("$cur")
 			return
 			;;
+		--timeout|-t)
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --timeout -t" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $(compgen -S "=" -W "$(___docker_compose_all_services_in_compose_file)" -- "$cur") )

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -278,16 +278,17 @@ _docker_compose_scale() {
 	case "$prev" in
 		=)
 			COMPREPLY=("$cur")
-			;;
-		*)
-			COMPREPLY=( $(compgen -S "=" -W "$(___docker_compose_all_services_in_compose_file)" -- "$cur") )
-			compopt -o nospace
+			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $(compgen -S "=" -W "$(___docker_compose_all_services_in_compose_file)" -- "$cur") )
+			compopt -o nospace
 			;;
 	esac
 }

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -223,7 +223,7 @@ _docker_compose_pull() {
 
 _docker_compose_restart() {
 	case "$prev" in
-		-t | --timeout)
+		--timeout|-t)
 			return
 			;;
 	esac
@@ -311,7 +311,7 @@ _docker_compose_start() {
 
 _docker_compose_stop() {
 	case "$prev" in
-		-t | --timeout)
+		--timeout|-t)
 			return
 			;;
 	esac
@@ -341,7 +341,7 @@ _docker_compose_unpause() {
 
 _docker_compose_up() {
 	case "$prev" in
-		-t | --timeout)
+		--timeout|-t)
 			return
 			;;
 	esac
@@ -402,11 +402,11 @@ _docker_compose() {
 	local compose_file compose_project
 	while [ $counter -lt $cword ]; do
 		case "${words[$counter]}" in
-			-f|--file)
+			--file|-f)
 				(( counter++ ))
 				compose_file="${words[$counter]}"
 				;;
-			-p|--project-name)
+			--project-name|p)
 				(( counter++ ))
 				compose_project="${words[$counter]}"
 				;;


### PR DESCRIPTION
A fix, an added feature and a cosmetic refactoring.
See individual commit messages.

The fix from 7e22719090bf33012c5cd327cc70ebd965cd923f is a minor one, there's no need to include it in 1.4.1.