### PR TITLE
Allow setting a one-off container name

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -308,6 +308,7 @@ class TopLevelCommand(Command):
             --allow-insecure-ssl  Deprecated - no effect.
             -d                    Detached mode: Run container in the background, print
                                   new container name.
+            --name NAME           Assign a name to the container
             --entrypoint CMD      Override the entrypoint of the image.
             -e KEY=VAL            Set an environment variable (can be used multiple times)
             -u, --user=""         Run as specified username or uid
@@ -373,6 +374,9 @@ class TopLevelCommand(Command):
                 'Service port mapping and manual port mapping '
                 'can not be used togather'
             )
+
+        if options['--name']:
+            container_options['name'] = options['--name']
 
         try:
             container = service.create_container(

--- a/compose/service.py
+++ b/compose/service.py
@@ -586,7 +586,7 @@ class Service(object):
 
         if self.custom_container_name() and not one_off:
             container_options['name'] = self.custom_container_name()
-        else:
+        elif not container_options.get('name'):
             container_options['name'] = self.get_container_name(number, one_off)
 
         if add_config_hash:

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -313,7 +313,7 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual('moto=bobo', container.environment['allo'])
 
     @mock.patch('dockerpty.start')
-    def test_run_service_without_map_ports(self, __):
+    def test_run_service_without_map_ports(self, _):
         # create one off container
         self.command.base_dir = 'tests/fixtures/ports-composefile'
         self.command.dispatch(['run', '-d', 'simple'], None)
@@ -331,7 +331,7 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(port_assigned, None)
 
     @mock.patch('dockerpty.start')
-    def test_run_service_with_map_ports(self, __):
+    def test_run_service_with_map_ports(self, _):
 
         # create one off container
         self.command.base_dir = 'tests/fixtures/ports-composefile'
@@ -354,7 +354,7 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(port_range[1], "0.0.0.0:49154")
 
     @mock.patch('dockerpty.start')
-    def test_run_service_with_explicitly_maped_ports(self, __):
+    def test_run_service_with_explicitly_maped_ports(self, _):
 
         # create one off container
         self.command.base_dir = 'tests/fixtures/ports-composefile'
@@ -373,7 +373,7 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(port_full, "0.0.0.0:30001")
 
     @mock.patch('dockerpty.start')
-    def test_run_service_with_explicitly_maped_ip_ports(self, __):
+    def test_run_service_with_explicitly_maped_ip_ports(self, _):
 
         # create one off container
         self.command.base_dir = 'tests/fixtures/ports-composefile'

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -391,6 +391,16 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(port_short, "127.0.0.1:30000")
         self.assertEqual(port_full, "127.0.0.1:30001")
 
+    @mock.patch('dockerpty.start')
+    def test_run_with_custom_name(self, _):
+        self.command.base_dir = 'tests/fixtures/environment-composefile'
+        name = 'the-container-name'
+        self.command.dispatch(['run', '--name', name, 'service'], None)
+
+        service = self.project.get_service('service')
+        container, = service.containers(stopped=True, one_off=True)
+        self.assertEqual(container.name, name)
+
     def test_rm(self):
         service = self.project.get_service('simple')
         service.create_container()

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -112,6 +112,7 @@ class CLITestCase(unittest.TestCase):
             '--service-ports': None,
             '--publish': [],
             '--rm': None,
+            '--name': None,
         })
 
         _, _, call_kwargs = mock_client.create_container.mock_calls[0]
@@ -141,6 +142,7 @@ class CLITestCase(unittest.TestCase):
             '--service-ports': None,
             '--publish': [],
             '--rm': None,
+            '--name': None,
         })
         _, _, call_kwargs = mock_client.create_container.mock_calls[0]
         self.assertEquals(call_kwargs['host_config']['RestartPolicy']['Name'], 'always')
@@ -166,6 +168,7 @@ class CLITestCase(unittest.TestCase):
             '--service-ports': None,
             '--publish': [],
             '--rm': True,
+            '--name': None,
         })
         _, _, call_kwargs = mock_client.create_container.mock_calls[0]
         self.assertFalse('RestartPolicy' in call_kwargs['host_config'])
@@ -195,4 +198,5 @@ class CLITestCase(unittest.TestCase):
                 '--service-ports': True,
                 '--publish': ['80:80'],
                 '--rm': None,
+                '--name': None,
             })

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -150,6 +150,19 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(opts['hostname'], 'name.sub', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
 
+    def test_get_container_create_options_with_name_option(self):
+        service = Service(
+            'foo',
+            image='foo',
+            client=self.mock_client,
+            container_name='foo1')
+        name = 'the_new_name'
+        opts = service._get_container_create_options(
+            {'name': name},
+            1,
+            one_off=True)
+        self.assertEqual(opts['name'], name)
+
     def test_get_container_not_found(self):
         self.mock_client.containers.return_value = []
         service = Service('foo', client=self.mock_client, image='foo')

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -99,14 +99,12 @@ class ServiceTest(unittest.TestCase):
 
     def test_split_domainname_none(self):
         service = Service('foo', image='foo', hostname='name', client=self.mock_client)
-        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'image': 'foo'}, 1)
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertFalse('domainname' in opts, 'domainname')
 
     def test_memory_swap_limit(self):
         service = Service(name='foo', image='foo', hostname='name', client=self.mock_client, mem_limit=1000000000, memswap_limit=2000000000)
-        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'some': 'overrides'}, 1)
         self.assertEqual(opts['host_config']['MemorySwap'], 2000000000)
         self.assertEqual(opts['host_config']['Memory'], 1000000000)
@@ -114,7 +112,6 @@ class ServiceTest(unittest.TestCase):
     def test_log_opt(self):
         log_opt = {'syslog-address': 'tcp://192.168.0.42:123'}
         service = Service(name='foo', image='foo', hostname='name', client=self.mock_client, log_driver='syslog', log_opt=log_opt)
-        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'some': 'overrides'}, 1)
 
         self.assertIsInstance(opts['host_config']['LogConfig'], LogConfig)
@@ -127,7 +124,6 @@ class ServiceTest(unittest.TestCase):
             hostname='name.domain.tld',
             image='foo',
             client=self.mock_client)
-        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'image': 'foo'}, 1)
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
@@ -139,7 +135,6 @@ class ServiceTest(unittest.TestCase):
             image='foo',
             domainname='domain.tld',
             client=self.mock_client)
-        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'image': 'foo'}, 1)
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')
@@ -151,7 +146,6 @@ class ServiceTest(unittest.TestCase):
             domainname='domain.tld',
             image='foo',
             client=self.mock_client)
-        self.mock_client.containers.return_value = []
         opts = service._get_container_create_options({'image': 'foo'}, 1)
         self.assertEqual(opts['hostname'], 'name.sub', 'hostname')
         self.assertEqual(opts['domainname'], 'domain.tld', 'domainname')


### PR DESCRIPTION
In #1755 we removed the custom name from one-off containers, which left them with the default name.

This adds a `--name` param to `docker-compose run` to name the container