### PR TITLE
Fix flaky test

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -358,7 +358,7 @@ def parse_environment(environment):
         return dict(split_env(e) for e in environment)
 
     if isinstance(environment, dict):
-        return environment
+        return dict(environment)
 
     raise ConfigurationError(
         "environment \"%s\" must be a list or mapping," %

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -695,7 +695,7 @@ class ServiceTest(DockerClientTestCase):
         Test that calling scale on a service that has a custom container name
         results in warning output.
         """
-        service = self.create_service('web', container_name='custom-container')
+        service = self.create_service('app', container_name='custom-container')
         self.assertEqual(service.custom_container_name(), 'custom-container')
 
         service.scale(3)

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -199,7 +199,6 @@ class ServiceStateTest(DockerClientTestCase):
 
         self.assertEqual([c.is_running for c in containers], [False, True])
 
-        web = self.create_service('web', **options)
         self.assertEqual(
             ('start', containers[0:1]),
             web.convergence_plan(),

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -33,6 +33,9 @@ class DockerClientTestCase(unittest.TestCase):
 
         options = ServiceLoader(working_dir='.').make_service_dict(name, kwargs)
 
+        labels = options.setdefault('labels', {})
+        labels['com.docker.compose.test-name'] = self.id()
+
         return Service(
             project='composetest',
             client=self.client,


### PR DESCRIPTION
Branched from #1939
Resolves #1922 

This works around the problem of containers not being removed correctly by using a different name for the service.  Also adds a new label to all containers so that if we end up with test pollution we can track the container back to the test that created it.

This is definitely just a workaround, but I think the root issue is actually a race condition in the docker engine so will take much longer to fix.  I don't like having every branch fail our test suite. So I'd like to push this workaround, since the failure isn't directly related to compose itself.