### PR TITLE
Fix mutation of service.options 

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -358,7 +358,7 @@ def parse_environment(environment):
         return dict(split_env(e) for e in environment)
 
     if isinstance(environment, dict):
-        return environment
+        return dict(environment)
 
     raise ConfigurationError(
         "environment \"%s\" must be a list or mapping," %


### PR DESCRIPTION
Resolves #1804

When a label or environment variable is specified in the config `self.options` was being mutated, which causes the config hash to change during `scale()`, so each container would have a different config_hash even if they all had the same config.

This really makes me wish python had an immutable dict. Debugging and testing this took way longer than it would have with immutable types.