### PR TITLE
Support TLS without Verification

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -19,6 +19,16 @@ def docker_client():
 
     tls_config = None
 
+    if os.environ.get('DOCKER_TLS', '') != '':
+        parts = base_url.split('://', 1)
+        base_url = '%s://%s' % ('https', parts[1])
+
+        tls_config = tls.TLSConfig(
+            ssl_version=ssl.PROTOCOL_TLSv1,
+            verify=False,
+            assert_hostname=False
+        )
+
     if os.environ.get('DOCKER_TLS_VERIFY', '') != '':
         parts = base_url.split('://', 1)
         base_url = '%s://%s' % ('https', parts[1])


### PR DESCRIPTION
It is possible for the docker daemon to be run with TLS without `--tlsverify`, example is `docker -H tcp://192.168.100.100:2376 --tls ps` 

This PR allows it so that if you specify `DOCKER_TLS` as non empty env var, that the connection will get setup to not verify the connection.

Signed-off-by: Erik Kristensen <erik@erikkristensen.com>