### PR TITLE
Remove .git from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 *.egg-info
 .coverage
-.git
 .tox
 build
 coverage-html


### PR DESCRIPTION
Hello,

I have read the guideline how to contribute to compose, but when I tried to execute tests, pre-commit failed. So tests didn't have chance to run at all.
This was because tests run in a container in which the code was added but .git directory was on the exclude list, but pre-commit needs it.