### PR TITLE
Attach to all containers when no service names are specified

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -583,8 +583,11 @@ class TopLevelCommand(Command):
 
 
 def build_log_printer(containers, service_names, monochrome):
+    if service_names:
+        containers = [c for c in containers if c.service in service_names]
+
     return LogPrinter(
-        [c for c in containers if c.service in service_names],
+        containers,
         attach_params={"logs": True},
         monochrome=monochrome)
 

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -113,7 +113,7 @@ class CLITestCase(DockerClientTestCase):
         output = mock_stdout.getvalue()
         self.assertNotIn(cache_indicator, output)
 
-    def test_up(self):
+    def test_up_detached(self):
         self.command.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')
         another = self.project.get_service('another')
@@ -121,10 +121,28 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(len(another.containers()), 1)
 
         # Ensure containers don't have stdin and stdout connected in -d mode
-        config = service.containers()[0].inspect()['Config']
-        self.assertFalse(config['AttachStderr'])
-        self.assertFalse(config['AttachStdout'])
-        self.assertFalse(config['AttachStdin'])
+        container, = service.containers()
+        self.assertFalse(container.get('Config.AttachStderr'))
+        self.assertFalse(container.get('Config.AttachStdout'))
+        self.assertFalse(container.get('Config.AttachStdin'))
+
+    def test_up_attached(self):
+        with mock.patch(
+            'compose.cli.main.attach_to_logs',
+            autospec=True
+        ) as mock_attach:
+            self.command.dispatch(['up'], None)
+            _, args, kwargs = mock_attach.mock_calls[0]
+            _project, log_printer, _names, _timeout = args
+
+        service = self.project.get_service('simple')
+        another = self.project.get_service('another')
+        self.assertEqual(len(service.containers()), 1)
+        self.assertEqual(len(another.containers()), 1)
+        self.assertEqual(
+            set(log_printer.containers),
+            set(self.project.containers())
+        )
 
     def test_up_with_links(self):
         self.command.base_dir = 'tests/fixtures/links-composefile'

--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -31,6 +31,16 @@ class CLIMainTestCase(unittest.TestCase):
         log_printer = build_log_printer(containers, service_names, True)
         self.assertEqual(log_printer.containers, containers[:3])
 
+    def test_build_log_printer_all_services(self):
+        containers = [
+            mock_container('web', 1),
+            mock_container('db', 1),
+            mock_container('other', 1),
+        ]
+        service_names = []
+        log_printer = build_log_printer(containers, service_names, True)
+        self.assertEqual(log_printer.containers, containers)
+
     def test_attach_to_logs(self):
         project = mock.create_autospec(Project)
         log_printer = mock.create_autospec(LogPrinter, containers=[])


### PR DESCRIPTION
Resolves #1961 and add a couple more tests to cover it