### PR TITLE
Expose the CLI reference pages a bit better from the index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -222,3 +222,14 @@ like-minded individuals, we have a number of open channels for communication.
 * To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/compose/pulls).
 
 For more information and resources, please visit the [Getting Help project page](https://docs.docker.com/project/get-help/).
+
+## Where to go next
+
+- [Installing Compose](install.md)
+- [Get started with Django](django.md)
+- [Get started with Rails](rails.md)
+- [Get started with Wordpress](wordpress.md)
+- [Command line reference](/reference)
+- [Yaml file reference](yml.md)
+- [Compose environment variables](env.md)
+- [Compose command line completion](completion.md)

--- a/docs/reference/docker-compose.md
+++ b/docs/reference/docker-compose.md
@@ -55,3 +55,8 @@ used all paths in the configuration are relative to the current working
 directory.
 
 Each configuration can has a project name. If you supply a `-p` flag, you can specify a project name. If you don't specify the flag, Compose uses the current directory name.
+
+## Where to go next
+
+* [CLI environment variables](overview.md)
+* [Command line reference](index.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -27,3 +27,8 @@ The following pages describe the usage information for the [docker-compose](/ref
 * [rm](/reference/rm.md)
 * [scale](/reference/scale.md)
 * [stop](/reference/stop.md)
+
+## Where to go next
+
+* [CLI environment variables](overview.md)
+* [docker-compose Command](docker-compose.md)

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -31,6 +31,26 @@ Setting this is optional. If you do not set this, the `COMPOSE_PROJECT_NAME` def
 
 Specify the file containing the compose configuration. If not provided, Compose looks for a file named  `docker-compose.yml` in the current directory and then each parent directory in succession until a file by that name is found.
 
+### COMPOSE\_API\_VERSION
+
+The Docker API only supports requests from clients which report a specific
+version. If you receive a `client and server don't have same version error` using
+`docker-compose`, you can workaround this error by setting this environment
+variable. Set the version value to match the server version.
+
+Setting this variable is intended as a workaround for situations where you need
+to run temporarily with a mismatch between the client and server version. For
+example, if you can upgrade the client but need to wait to upgrade the server.
+
+Running with this variable set and a known mismatch does prevent some Docker
+features from working properly. The exact features that fail would depend on the
+Docker client and server versions. For this reason, running with this variable
+set is only intended as a workaround and it is not officially supported.
+
+If you run into problems running with this set, resolve the mismatch through
+upgrade and remove this setting to see if your problems resolve before notifying
+support.
+
 ### DOCKER\_HOST
 
 Sets the URL of the `docker` daemon. As with the Docker client, defaults to `unix:///var/run/docker.sock`.

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -14,6 +14,13 @@ weight=-2
 
 This section describes the subcommands you can use with the `docker-compose` command.  You can run subcommand against one or more services. To run against a specific service, you supply the service name from your compose configuration. If you do not specify the service name, the command runs against all the services in your configuration.
 
+
+## Commands
+
+* [docker-compose Command](docker-compose.md)
+* [CLI Reference](index.md)
+
+
 ## Environment Variables
 
 Several environment variables are available for you to configure the Docker Compose command-line behaviour.
@@ -68,11 +75,6 @@ Configures the path to the `ca.pem`, `cert.pem`, and `key.pem` files used for TL
 
 Configures the time (in seconds) a request to the Docker daemon is allowed to hang before Compose considers
 it failed. Defaults to 60 seconds.
-
-
-
-
-
 
 
 ## Compose documentation


### PR DESCRIPTION

I noticed while reading over our docs that it was really hard for me to find the environment variables and command reference.  I think this change will make the situation better by cross-linking the reference pages to each other, and by adding a "where to go next" section to the overview page.

Also adds docs for a missing cli environment variable.