### PR TITLE
Added csv option to ps

### DIFF
--- a/compose/cli/formatter.py
+++ b/compose/cli/formatter.py
@@ -23,3 +23,9 @@ class Formatter(object):
         table.set_chars(['-', '|', '+', '-'])
 
         return table.draw()
+
+    def csv(self, headers, rows):
+        csv = ";".join(headers)
+        for row in rows:
+            csv += "\n%s" % ";".join(row)
+        return csv

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -221,6 +221,7 @@ class TopLevelCommand(Command):
 
         Options:
             -q    Only display IDs
+            --csv    show status in row csv format
         """
         containers = sorted(
             project.containers(service_names=options['SERVICE'], stopped=True) +
@@ -248,7 +249,10 @@ class TopLevelCommand(Command):
                     container.human_readable_state,
                     container.human_readable_ports,
                 ])
-            print(Formatter().table(headers, rows))
+            if options['--csv']:
+                print(Formatter().csv(headers, rows))
+            else:
+                print(Formatter().table(headers, rows))
 
     def pull(self, project, options):
         """

--- a/docs/reference/ps.md
+++ b/docs/reference/ps.md
@@ -16,6 +16,7 @@ Usage: ps [options] [SERVICE...]
 
 Options:
 -q    Only display IDs
+--csv    show status in row csv format
 ```
 
 Lists containers.

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -69,6 +69,17 @@ class CLITestCase(DockerClientTestCase):
         self.assertNotIn('multiplecomposefiles_yetanother_1', output)
 
     @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_ps_default_composefile_csv_output(self, mock_stdout):
+        self.command.base_dir = 'tests/fixtures/multiple-composefiles'
+        self.command.dispatch(['up', '-d'], None)
+        self.command.dispatch(['ps', '--csv'], None)
+
+        output = mock_stdout.getvalue()
+        self.assertIn('multiplecomposefiles_simple_1;top;Up', output)
+        self.assertIn('multiplecomposefiles_another_1;top;Up', output)
+        self.assertNotIn('multiplecomposefiles_yetanother_1    top', output)
+
+    @mock.patch('sys.stdout', new_callable=StringIO)
     def test_ps_alternate_composefile(self, mock_stdout):
         config_path = os.path.abspath(
             'tests/fixtures/multiple-composefiles/compose2.yml')


### PR DESCRIPTION
In our use-case we process docker-compose ps output programatically.
It is easier to process csv format instead of table.