### PR TITLE
fix expose schema definition

### DIFF
--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -42,7 +42,11 @@
           ]
         },
 
-        "expose": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "expose": {
+          "type": "array",
+          "items": {"type": ["string", "number"]},
+          "uniqueItems": true
+        },
 
         "extends": {
           "type": "object",

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -239,6 +239,21 @@ class ConfigTest(unittest.TestCase):
                 )
             )
 
+    def test_valid_config_which_allows_two_type_definitions(self):
+        expose_values = [["8000"], [8000]]
+        for expose in expose_values:
+            service = config.load(
+                config.ConfigDetails(
+                    {'web': {
+                        'image': 'busybox',
+                        'expose': expose
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+            self.assertEqual(service[0]['expose'], expose)
+
 
 class InterpolationTest(unittest.TestCase):
     @mock.patch.dict(os.environ)


### PR DESCRIPTION
It was incorrectly defined in the schema that `expose` was an array of numbers, when it is valid to be either an array of numbers or an array of strings.

Signed-off-by: Mazz Mosley <mazz@houseofmnowster.com>