### PR TITLE
Bump requests to 2.7 to fix the ResponseNotReady() error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ docker-py==1.3.1
 dockerpty==0.3.4
 docopt==0.6.1
 jsonschema==2.5.1
-requests==2.6.1
+requests==2.7.0
 six==1.7.3
 texttable==0.8.2
 websocket-client==0.32.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def find_version(*file_paths):
 install_requires = [
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.6.1, < 2.7',
+    'requests >= 2.6.1, < 2.8',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',
     'docker-py >= 1.3.1, < 1.4',

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
         --cov-report html \
         --cov-report term \
         --cov-config=tox.ini \
-        {posargs}
+        {posargs:tests}
 
 [testenv:pre-commit]
 skip_install = True


### PR DESCRIPTION
We've seen the occasional 

```
requests.exceptions.ConnectionError: ('Connection aborted.', ResponseNotReady('Request-sent',))
```

in #1783 and I've seen it a few times running against a `docker-machine` virtualbox.

This is fixed in `requests == 2.7` https://github.com/kennethreitz/requests/issues/2579

I also noticed that tox was missing a default posargs, which caused it to run  tests against other virtualenvs (jenkins isn't effected because there wouldn't be any on jenkins).