### PR TITLE
Remove trailing white space from docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -206,7 +206,7 @@ At this point, you have seen the basics of how Compose works.
 
 ## Release Notes
 
-To see a detailed list of changes for past and current releases of Docker 
+To see a detailed list of changes for past and current releases of Docker
 Compose, please refer to the [CHANGELOG](https://github.com/docker/compose/blob/master/CHANGELOG.md).
 
 ## Getting help


### PR DESCRIPTION
Not sure how this got past the pre-commit hooks before being merged, but I've fixed it.

Signed-off-by: Mazz Mosley <mazz@houseofmnowster.com>