### PR TITLE
Ps output in json

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
 import logging
 import re
 import signal
@@ -253,6 +254,7 @@ class TopLevelCommand(DocoptCommand):
 
         Options:
             -q    Only display IDs
+            --json    List containers in JSON format
         """
         containers = sorted(
             project.containers(service_names=options['SERVICE'], stopped=True) +
@@ -280,7 +282,10 @@ class TopLevelCommand(DocoptCommand):
                     container.human_readable_state,
                     container.human_readable_ports,
                 ])
-            print(Formatter().table(headers, rows))
+            if (options['--json']):
+                print(json.dumps(rows))
+            else:
+                print(Formatter().table(headers, rows))
 
     def pull(self, project, options):
         """

--- a/docs/reference/ps.md
+++ b/docs/reference/ps.md
@@ -16,6 +16,7 @@ Usage: ps [options] [SERVICE...]
 
 Options:
 -q    Only display IDs
+--json    List containers in JSON format
 ```
 
 Lists containers.

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -58,7 +58,19 @@ class CLITestCase(DockerClientTestCase):
             self.command.dispatch(['ps'], None)
         self.assertIn('simplecomposefile_simple_1', mock_stdout.getvalue())
 
-    def test_ps_default_composefile(self):
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_ps_json_output_when_service_is_empty(self, mock_stdout):
+        self.command.dispatch(['ps', '--json'], None)
+        self.assertIn('[]', mock_stdout.getvalue())
+
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_ps_json_output(self, mock_stdout):
+        self.command.dispatch(['up', '-d'], None)
+        self.command.dispatch(['ps', '--json'], None)
+        self.assertIn('["simplecomposefile_simple_1", "top", "Up", ""]', mock_stdout.getvalue())
+
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_ps_default_composefile(self, mock_stdout):
         self.command.base_dir = 'tests/fixtures/multiple-composefiles'
         with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
             self.command.dispatch(['up', '-d'], None)
@@ -69,7 +81,19 @@ class CLITestCase(DockerClientTestCase):
         self.assertIn('multiplecomposefiles_another_1', output)
         self.assertNotIn('multiplecomposefiles_yetanother_1', output)
 
-    def test_ps_alternate_composefile(self):
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_ps_json_output_with_multiple_services(self, mock_stdout):
+        self.command.base_dir = 'tests/fixtures/multiple-composefiles'
+        self.command.dispatch(['up', '-d'], None)
+        self.command.dispatch(['ps', '--json'], None)
+
+        output = mock_stdout.getvalue()
+        self.assertIn('["multiplecomposefiles_another_1", "top", "Up", ""]', output)
+        self.assertIn('["multiplecomposefiles_simple_1", "top", "Up", ""]', output)
+        self.assertNotIn('multiplecomposefiles_yetanother_1', output)
+
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_ps_alternate_composefile(self, mock_stdout):
         config_path = os.path.abspath(
             'tests/fixtures/multiple-composefiles/compose2.yml')
         self._project = get_project(self.command.base_dir, [config_path])


### PR DESCRIPTION
So in our environment we process docker-compose output programmatically.
It would be great if the output would be in machine readable format.
Previously I chose csv, but after @aanand comment I reworked the PR and made the ouput in json format.