### PR TITLE
Added support for IPC namespaces, fixes GH-1689

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -36,6 +36,7 @@ DOCKER_CONFIG_KEYS = [
     'extra_hosts',
     'hostname',
     'image',
+    'ipc',
     'labels',
     'links',
     'mac_address',

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -59,6 +59,7 @@
         "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "hostname": {"type": "string"},
         "image": {"type": "string"},
+        "ipc": {"type": "string"},
         "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -44,6 +44,7 @@ DOCKER_START_KEYS = [
     'dns_search',
     'env_file',
     'extra_hosts',
+    'ipc',
     'read_only',
     'net',
     'log_driver',
@@ -696,7 +697,8 @@ class Service(object):
             extra_hosts=extra_hosts,
             read_only=read_only,
             pid_mode=pid,
-            security_opt=security_opt
+            security_opt=security_opt,
+            ipc_mode=options.get('ipc')
         )
 
     def build(self, no_cache=False):

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -373,7 +373,7 @@ Override the default labeling scheme for each container.
         - label:user:USER
         - label:role:ROLE
 
-### working\_dir, entrypoint, user, hostname, domainname, mac\_address, mem\_limit, memswap\_limit, privileged, restart, stdin\_open, tty, cpu\_shares, cpuset, read\_only, volume\_driver
+### working\_dir, entrypoint, user, hostname, domainname, mac\_address, mem\_limit, memswap\_limit, privileged, ipc, restart, stdin\_open, tty, cpu\_shares, cpuset, read\_only, volume\_driver
 
 Each of these is a single value, analogous to its
 [docker run](https://docs.docker.com/reference/run/) counterpart.
@@ -393,6 +393,8 @@ Each of these is a single value, analogous to its
     mem_limit: 1000000000
     memswap_limit: 2000000000
     privileged: true
+
+    ipc: host
 
     restart: always
 


### PR DESCRIPTION
Wasn't sure about the protocol regarding tests for minor changes like this, but there are no edge cases regarding the IPC setting - it's None, or a string, nothing more.

Signed-off-by: Lachlan Pease <predatory.kangaroo@gmail.com>