### PR TITLE
Allow using `docker-compose.yml.dist`

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -71,6 +71,7 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
 
 SUPPORTED_FILENAMES = [
     'docker-compose.yml',
+    'docker-compose.yml.dist',
     'docker-compose.yaml',
     'fig.yml',
     'fig.yaml',
@@ -109,7 +110,7 @@ def get_config_path(base_dir):
 
     winner = candidates[0]
 
-    if len(candidates) > 1:
+    if len(candidates) > 1 and not (len(candidates) == 2 and candidates[1].endswith('.dist')):
         log.warn("Found multiple config files with supported names: %s", ", ".join(candidates))
         log.warn("Using %s\n", winner)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -206,7 +206,7 @@ At this point, you have seen the basics of how Compose works.
 
 ## Release Notes
 
-To see a detailed list of changes for past and current releases of Docker 
+To see a detailed list of changes for past and current releases of Docker
 Compose, please refer to the [CHANGELOG](https://github.com/docker/compose/blob/master/CHANGELOG.md).
 
 ## Getting help

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -1059,6 +1059,7 @@ class GetConfigPathTestCase(unittest.TestCase):
 
     files = [
         'docker-compose.yml',
+        'docker-compose.yml.dist',
         'docker-compose.yaml',
         'fig.yml',
         'fig.yaml',
@@ -1067,9 +1068,10 @@ class GetConfigPathTestCase(unittest.TestCase):
     def test_get_config_path_default_file_in_basedir(self):
         files = self.files
         self.assertEqual('docker-compose.yml', get_config_filename_for_files(files[0:]))
-        self.assertEqual('docker-compose.yaml', get_config_filename_for_files(files[1:]))
-        self.assertEqual('fig.yml', get_config_filename_for_files(files[2:]))
-        self.assertEqual('fig.yaml', get_config_filename_for_files(files[3:]))
+        self.assertEqual('docker-compose.yml.dist', get_config_filename_for_files(files[1:]))
+        self.assertEqual('docker-compose.yaml', get_config_filename_for_files(files[2:]))
+        self.assertEqual('fig.yml', get_config_filename_for_files(files[3:]))
+        self.assertEqual('fig.yaml', get_config_filename_for_files(files[4:]))
         with self.assertRaises(config.ComposeFileNotFound):
             get_config_filename_for_files([])
 
@@ -1081,9 +1083,10 @@ class GetConfigPathTestCase(unittest.TestCase):
             return get_config_filename_for_files(files, subdir=True)
 
         self.assertEqual('docker-compose.yml', get_config_in_subdir(files[0:]))
-        self.assertEqual('docker-compose.yaml', get_config_in_subdir(files[1:]))
-        self.assertEqual('fig.yml', get_config_in_subdir(files[2:]))
-        self.assertEqual('fig.yaml', get_config_in_subdir(files[3:]))
+        self.assertEqual('docker-compose.yml.dist', get_config_in_subdir(files[1:]))
+        self.assertEqual('docker-compose.yaml', get_config_in_subdir(files[2:]))
+        self.assertEqual('fig.yml', get_config_in_subdir(files[3:]))
+        self.assertEqual('fig.yaml', get_config_in_subdir(files[4:]))
         with self.assertRaises(config.ComposeFileNotFound):
             get_config_in_subdir([])
 


### PR DESCRIPTION
Having one `docker-compose.yml` file in a project can sometime lead to conflicts with others developers as we all need to adapt it to our needs (ports, volumes, environments, etc..).

With this PR, I suggest to allow compose to look at `docker-compose.yml.dist` if `docker-compose.yml` does not exist.
So the `.dist` file can be added to the VCS of the project, but can still be overrided by creating the file `docker-compose.yml` (excluded in the VCS).

This strategy is used for example by [phpunit](https://phpunit.de)
