### PR TITLE
Disallow booleans in environment

### DIFF
--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -36,7 +36,15 @@
 
         "environment": {
           "oneOf": [
-            {"type": "object"},
+            {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9_]+$": {
+                  "type": ["string", "number"]
+                }
+              },
+              "additionalProperties": false
+            },
             {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
           ]
         },

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -39,7 +39,7 @@
             {
               "type": "object",
               "patternProperties": {
-                "^[a-zA-Z0-9_]+$": {
+                "^[^-]+$": {
                   "type": ["string", "number", "boolean"],
                   "format": "environment"
                 }

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -40,7 +40,8 @@
               "type": "object",
               "patternProperties": {
                 "^[a-zA-Z0-9_]+$": {
-                  "type": ["string", "number"]
+                  "type": ["string", "number", "boolean"],
+                  "format": "environment"
                 }
               },
               "additionalProperties": false

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -184,17 +184,21 @@ Mount all of the volumes from another service or container.
 
 ### environment
 
-Add environment variables. You can use either an array or a dictionary.
+Add environment variables. You can use either an array or a dictionary. Any
+boolean values; true, false, yes no, need to be enclosed in quotes to ensure
+they are not converted to True or False by the YML parser.
 
 Environment variables with only a key are resolved to their values on the
 machine Compose is running on, which can be helpful for secret or host-specific values.
 
     environment:
       RACK_ENV: development
+      SHOW: 'true'
       SESSION_SECRET:
 
     environment:
       - RACK_ENV=development
+      - SHOW=true
       - SESSION_SECRET
 
 ### env_file

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -287,6 +287,21 @@ class ConfigTest(unittest.TestCase):
         self.assertTrue(mock_logging.warn.called)
         self.assertTrue(expected_warning_msg in mock_logging.warn.call_args[0][0])
 
+    def test_config_invalid_environment_dict_key_raises_validation_error(self):
+        expected_error_msg = "Service 'web' configuration key 'environment' contains an invalid type"
+
+        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
+            config.load(
+                config.ConfigDetails(
+                    {'web': {
+                        'image': 'busybox',
+                        'environment': {'---': 'nope'}
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+
 
 class InterpolationTest(unittest.TestCase):
     @mock.patch.dict(os.environ)

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -270,15 +270,15 @@ class ConfigTest(unittest.TestCase):
             )
             self.assertEqual(service[0]['entrypoint'], entrypoint)
 
-    def test_validation_message_for_invalid_type_when_multiple_types_allowed(self):
-        expected_error_msg = "Service 'web' configuration key 'mem_limit' contains an invalid type, it should be a number or a string"
+    def test_config_environment_contains_boolean_validation_error(self):
+        expected_error_msg = "Service 'web' configuration key 'environment' contains an invalid type"
 
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
                 config.ConfigDetails(
                     {'web': {
                         'image': 'busybox',
-                        'mem_limit': ['incorrect']
+                        'environment': {'SHOW_STUFF': True}
                     }},
                     'working_dir',
                     'filename.yml'

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -270,20 +270,22 @@ class ConfigTest(unittest.TestCase):
             )
             self.assertEqual(service[0]['entrypoint'], entrypoint)
 
-    def test_config_environment_contains_boolean_validation_error(self):
-        expected_error_msg = "Service 'web' configuration key 'environment' contains an invalid type"
-
-        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
-            config.load(
-                config.ConfigDetails(
-                    {'web': {
-                        'image': 'busybox',
-                        'environment': {'SHOW_STUFF': True}
-                    }},
-                    'working_dir',
-                    'filename.yml'
-                )
+    @mock.patch('compose.config.validation.log')
+    def test_logs_warning_for_boolean_in_environment(self, mock_logging):
+        expected_warning_msg = "Warning: There is a boolean value, True in the 'environment' key."
+        config.load(
+            config.ConfigDetails(
+                {'web': {
+                    'image': 'busybox',
+                    'environment': {'SHOW_STUFF': True}
+                }},
+                'working_dir',
+                'filename.yml'
             )
+        )
+
+        self.assertTrue(mock_logging.warn.called)
+        self.assertTrue(expected_warning_msg in mock_logging.warn.call_args[0][0])
 
 
 class InterpolationTest(unittest.TestCase):


### PR DESCRIPTION
This change will force people to put boolean values in quotes, thus ensuring
that the value gets passed through as intended.

Fixes #1788