### PR TITLE
Allow entrypoint to be a list or string

### DIFF
--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -32,7 +32,7 @@
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "dockerfile": {"type": "string"},
         "domainname": {"type": "string"},
-        "entrypoint": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "entrypoint": {"$ref": "#/definitions/string_or_list"},
         "env_file": {"$ref": "#/definitions/string_or_list"},
 
         "environment": {

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -254,6 +254,21 @@ class ConfigTest(unittest.TestCase):
             )
             self.assertEqual(service[0]['expose'], expose)
 
+    def test_valid_config_oneof_string_or_list(self):
+        entrypoint_values = [["sh"], "sh"]
+        for entrypoint in entrypoint_values:
+            service = config.load(
+                config.ConfigDetails(
+                    {'web': {
+                        'image': 'busybox',
+                        'entrypoint': entrypoint
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+            self.assertEqual(service[0]['entrypoint'], entrypoint)
+
 
 class InterpolationTest(unittest.TestCase):
     @mock.patch.dict(os.environ)


### PR DESCRIPTION
Previously it was set to only allow a list.

Fixes https://github.com/docker/compose/issues/1997