### PR TITLE
Fix error message and class name from Boot2Docker to DockerMachine

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -41,7 +41,7 @@ class Command(DocoptCommand):
                 else:
                     raise errors.DockerNotFoundGeneric()
             elif call_silently(['which', 'boot2docker']) == 0:
-                raise errors.ConnectionErrorBoot2Docker()
+                raise errors.ConnectionErrorDockerMachine()
             else:
                 raise errors.ConnectionErrorGeneric(self.get_client().base_url)
 

--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -40,10 +40,10 @@ class DockerNotFoundGeneric(UserError):
         """)
 
 
-class ConnectionErrorBoot2Docker(UserError):
+class ConnectionErrorDockerMachine(UserError):
     def __init__(self):
-        super(ConnectionErrorBoot2Docker, self).__init__("""
-        Couldn't connect to Docker daemon - you might need to run `boot2docker up`.
+        super(ConnectionErrorDockerMachine, self).__init__("""
+        Couldn't connect to Docker daemon - you might need to run `docker-machine start default`.
         """)
 
 


### PR DESCRIPTION
When I tried to run `docker-compose build` I get the error message "Couldn't connect to Docker daemon - you might need to run boot2docker up". But now the daemon uses `docker-machine` by default and not `boot2docker`.