### PR TITLE
Set the terminal title to what Docker-Compose is currently doing

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -115,6 +115,7 @@ class TopLevelCommand(Command):
       help               Get help on a command
       kill               Kill containers
       logs               View output from containers
+      pause              Pause services
       port               Print the public port for a port binding
       ps                 List containers
       pull               Pulls service images
@@ -124,6 +125,7 @@ class TopLevelCommand(Command):
       scale              Set number of containers for a service
       start              Start services
       stop               Stop services
+      unpause            Unpause services
       up                 Create and start containers
       migrate-to-labels  Recreate containers to add labels
       version            Show the Docker-Compose version information

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -30,6 +30,7 @@ from .formatter import Formatter
 from .log_printer import LogPrinter
 from .utils import get_version_info
 from .utils import yesno
+from .utils import set_term_title, get_term_title
 
 log = logging.getLogger(__name__)
 console_handler = logging.StreamHandler(sys.stderr)
@@ -42,6 +43,7 @@ It will be removed in a future version of Compose.
 
 def main():
     setup_logging()
+    prev_title = get_term_title()
     try:
         command = TopLevelCommand()
         command.sys_dispatch()
@@ -74,6 +76,9 @@ def main():
             "If you encounter this issue regularly because of slow network conditions, consider setting "
             "COMPOSE_HTTP_TIMEOUT to a higher value (current value: %s)." % HTTP_TIMEOUT
         )
+    finally:
+        # Clean up term title
+        set_term_title(prev_title)
 
 
 def setup_logging():

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import os
 import platform
+import sys
 import ssl
 import subprocess
 
@@ -107,3 +108,16 @@ def get_version_info(scope):
             + "OpenSSL version: %s" % ssl.OPENSSL_VERSION
     else:
         raise RuntimeError('passed unallowed value to `cli.utils.get_version_info`')
+
+def get_term_title():
+    # Haha this is difficult apparently.
+    out = subprocess.check_output(['xprop',  '-id', os.getenv("WINDOWID"), "WM_NAME"])
+    title = out.split('=')[1].strip().split('"')[1]
+    return title
+
+def set_term_title(title):
+    sys.stdout.write(b'\33]0;%s\a' % title)
+
+def title_and_log(logger, status):
+    set_term_title("docker-compose: %s" % status)
+    logger.info(status)

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -109,6 +109,8 @@ def get_version_info(scope):
     else:
         raise RuntimeError('passed unallowed value to `cli.utils.get_version_info`')
 
+
+
 def get_term_title():
     # Haha this is difficult apparently.
     out = subprocess.check_output(['xprop',  '-id', os.getenv("WINDOWID"), "WM_NAME"])
@@ -116,8 +118,11 @@ def get_term_title():
     return title
 
 def set_term_title(title):
+    # ref https://github.com/ipython/ipython/blob/master/IPython/utils/terminal.py
+    # For windows https://stackoverflow.com/questions/7387276/set-windows-command-line-terminal-title-in-python
     sys.stdout.write(b'\33]0;%s\a' % title)
 
 def title_and_log(logger, status):
+    "Convenience function takes the logger and a status and sets terminal title."
     set_term_title("docker-compose: %s" % status)
     logger.info(status)

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -32,7 +32,7 @@
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "dockerfile": {"type": "string"},
         "domainname": {"type": "string"},
-        "entrypoint": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "entrypoint": {"$ref": "#/definitions/string_or_list"},
         "env_file": {"$ref": "#/definitions/string_or_list"},
 
         "environment": {

--- a/compose/container.py
+++ b/compose/container.py
@@ -6,6 +6,7 @@ from functools import reduce
 import six
 
 from .const import LABEL_CONTAINER_NUMBER
+from .const import LABEL_PROJECT
 from .const import LABEL_SERVICE
 
 
@@ -70,7 +71,12 @@ class Container(object):
 
     @property
     def name_without_project(self):
-        return '{0}_{1}'.format(self.service, self.number)
+        project = self.labels.get(LABEL_PROJECT)
+
+        if self.name.startswith('{0}_{1}'.format(project, self.service)):
+            return '{0}_{1}'.format(self.service, self.number)
+        else:
+            return self.name
 
     @property
     def number(self):

--- a/compose/service.py
+++ b/compose/service.py
@@ -159,27 +159,32 @@ class Service(object):
     # TODO: remove these functions, project takes care of starting/stopping,
     def stop(self, **options):
         for c in self.containers():
-            log.info("Stopping %s..." % c.name)
+            status = "Stopping %s..." % c.name
+            title_and_log(log, status)
             c.stop(**options)
 
     def pause(self, **options):
         for c in self.containers(filters={'status': 'running'}):
-            log.info("Pausing %s..." % c.name)
+            status = "Pausing %s..." % c.name
+            title_and_log(log, status)
             c.pause(**options)
 
     def unpause(self, **options):
         for c in self.containers(filters={'status': 'paused'}):
-            log.info("Unpausing %s..." % c.name)
+            status = "Unpausing %s..." % c.name
+            title_and_log(log, status)
             c.unpause()
 
     def kill(self, **options):
         for c in self.containers():
-            log.info("Killing %s..." % c.name)
+            status = "Killing %s..." % c.nam
+            title_and_log(log, status)
             c.kill(**options)
 
     def restart(self, **options):
         for c in self.containers():
-            log.info("Restarting %s..." % c.name)
+            status = "Restarting %s..." % c.name
+            title_and_log(log, status)
             c.restart(**options)
 
     # end TODO
@@ -305,7 +310,8 @@ class Service(object):
         )
 
         if 'name' in container_options and not quiet:
-            log.info("Creating %s..." % container_options['name'])
+            status = "Creating %s..." % container_options['name']
+            title_and_log(log, status)
 
         return Container.create(self.client, **container_options)
 
@@ -436,7 +442,8 @@ class Service(object):
         volumes can be copied to the new container, before the original
         container is removed.
         """
-        log.info("Recreating %s..." % container.name)
+        status = "Recreating %s..." % container.name
+        title_and_log(log, status)
         try:
             container.stop(timeout=timeout)
         except APIError as e:
@@ -466,7 +473,8 @@ class Service(object):
         if container.is_running:
             return container
         else:
-            log.info("Starting %s..." % container.name)
+            status = "Starting %s..." % container.name
+            title_and_log(log, status)
             return self.start_container(container)
 
     def start_container(self, container):
@@ -475,7 +483,8 @@ class Service(object):
 
     def remove_duplicate_containers(self, timeout=DEFAULT_TIMEOUT):
         for c in self.duplicate_containers():
-            log.info('Removing %s...' % c.name)
+            status = 'Removing %s...' % c.name
+            title_and_log(log, status)
             c.stop(timeout=timeout)
             c.remove()
 
@@ -775,7 +784,8 @@ class Service(object):
 
         repo, tag, separator = parse_repository_tag(self.options['image'])
         tag = tag or 'latest'
-        log.info('Pulling %s (%s%s%s)...' % (self.name, repo, separator, tag))
+        status = 'Pulling %s (%s%s%s)...' % (self.name, repo, separator, tag)
+        title_and_log(log, status)
         output = self.client.pull(
             repo,
             tag=tag,

--- a/compose/service.py
+++ b/compose/service.py
@@ -159,32 +159,27 @@ class Service(object):
     # TODO: remove these functions, project takes care of starting/stopping,
     def stop(self, **options):
         for c in self.containers():
-            status = "Stopping %s..." % c.name
-            title_and_log(log, status)
+            log.info("Stopping %s" % c.name)
             c.stop(**options)
 
     def pause(self, **options):
         for c in self.containers(filters={'status': 'running'}):
-            status = "Pausing %s..." % c.name
-            title_and_log(log, status)
+            log.info("Pausing %s" % c.name)
             c.pause(**options)
 
     def unpause(self, **options):
         for c in self.containers(filters={'status': 'paused'}):
-            status = "Unpausing %s..." % c.name
-            title_and_log(log, status)
+            log.info("Unpausing %s" % c.name)
             c.unpause()
 
     def kill(self, **options):
         for c in self.containers():
-            status = "Killing %s..." % c.nam
-            title_and_log(log, status)
+            log.info("Killing %s" % c.name)
             c.kill(**options)
 
     def restart(self, **options):
         for c in self.containers():
-            status = "Restarting %s..." % c.name
-            title_and_log(log, status)
+            log.info("Restarting %s" % c.name)
             c.restart(**options)
 
     # end TODO
@@ -310,8 +305,7 @@ class Service(object):
         )
 
         if 'name' in container_options and not quiet:
-            status = "Creating %s..." % container_options['name']
-            title_and_log(log, status)
+            log.info("Creating %s" % container_options['name'])
 
         return Container.create(self.client, **container_options)
 
@@ -442,8 +436,7 @@ class Service(object):
         volumes can be copied to the new container, before the original
         container is removed.
         """
-        status = "Recreating %s..." % container.name
-        title_and_log(log, status)
+        log.info("Recreating %s" % container.name)
         try:
             container.stop(timeout=timeout)
         except APIError as e:
@@ -473,8 +466,7 @@ class Service(object):
         if container.is_running:
             return container
         else:
-            status = "Starting %s..." % container.name
-            title_and_log(log, status)
+            log.info("Starting %s" % container.name)
             return self.start_container(container)
 
     def start_container(self, container):
@@ -483,8 +475,7 @@ class Service(object):
 
     def remove_duplicate_containers(self, timeout=DEFAULT_TIMEOUT):
         for c in self.duplicate_containers():
-            status = 'Removing %s...' % c.name
-            title_and_log(log, status)
+            log.info('Removing %s' % c.name)
             c.stop(timeout=timeout)
             c.remove()
 
@@ -711,8 +702,8 @@ class Service(object):
         )
 
     def build(self, no_cache=False):
-        status = 'Building %s...' % self.name
-        title_and_log(log, status)
+        log.info('Building %s' % self.name)
+
         path = self.options['build']
         # python2 os.path() doesn't support unicode, so we need to encode it to
         # a byte string

--- a/compose/service.py
+++ b/compose/service.py
@@ -33,6 +33,7 @@ from .progress_stream import stream_output
 from .progress_stream import StreamOutputError
 from .utils import json_hash
 from .utils import parallel_execute
+from compose.cli.utils import title_and_log
 
 log = logging.getLogger(__name__)
 
@@ -701,8 +702,8 @@ class Service(object):
         )
 
     def build(self, no_cache=False):
-        log.info('Building %s...' % self.name)
-
+        status = 'Building %s...' % self.name
+        title_and_log(log, status)
         path = self.options['build']
         # python2 os.path() doesn't support unicode, so we need to encode it to
         # a byte string

--- a/compose/service.py
+++ b/compose/service.py
@@ -159,27 +159,32 @@ class Service(object):
     # TODO: remove these functions, project takes care of starting/stopping,
     def stop(self, **options):
         for c in self.containers():
-            log.info("Stopping %s" % c.name)
+            status = "Stopping %s" % c.name
+            title_and_log(log, status)
             c.stop(**options)
 
     def pause(self, **options):
         for c in self.containers(filters={'status': 'running'}):
-            log.info("Pausing %s" % c.name)
+            status = "Pausing %s" % c.name
+            title_and_log(log, status)
             c.pause(**options)
 
     def unpause(self, **options):
         for c in self.containers(filters={'status': 'paused'}):
-            log.info("Unpausing %s" % c.name)
+            status = "Unpausing %s" % c.name
+            title_and_log(log, status)
             c.unpause()
 
     def kill(self, **options):
         for c in self.containers():
-            log.info("Killing %s" % c.name)
+            status = "Killing %s" % c.nam
+            title_and_log(log, status)
             c.kill(**options)
 
     def restart(self, **options):
         for c in self.containers():
-            log.info("Restarting %s" % c.name)
+            status = "Restarting %s" % c.name
+            title_and_log(log, status)
             c.restart(**options)
 
     # end TODO
@@ -305,7 +310,8 @@ class Service(object):
         )
 
         if 'name' in container_options and not quiet:
-            log.info("Creating %s" % container_options['name'])
+            status = "Creating %s" % container_options['name']
+            title_and_log(log, status)
 
         return Container.create(self.client, **container_options)
 
@@ -436,7 +442,8 @@ class Service(object):
         volumes can be copied to the new container, before the original
         container is removed.
         """
-        log.info("Recreating %s" % container.name)
+        status = "Recreating %s" % container.name
+        title_and_log(log, status)
         try:
             container.stop(timeout=timeout)
         except APIError as e:
@@ -466,7 +473,8 @@ class Service(object):
         if container.is_running:
             return container
         else:
-            log.info("Starting %s" % container.name)
+            status = "Starting %s" % container.name
+            title_and_log(log, status)
             return self.start_container(container)
 
     def start_container(self, container):
@@ -475,7 +483,8 @@ class Service(object):
 
     def remove_duplicate_containers(self, timeout=DEFAULT_TIMEOUT):
         for c in self.duplicate_containers():
-            log.info('Removing %s' % c.name)
+            status = 'Removing %s' % c.name
+            title_and_log(log, status)
             c.stop(timeout=timeout)
             c.remove()
 
@@ -702,8 +711,8 @@ class Service(object):
         )
 
     def build(self, no_cache=False):
-        log.info('Building %s' % self.name)
-
+        status = 'Building %s' % self.name
+        title_and_log(log, status)
         path = self.options['build']
         # python2 os.path() doesn't support unicode, so we need to encode it to
         # a byte string

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -90,13 +90,13 @@ def write_out_msg(stream, lines, msg_index, msg, status="done"):
         stream.write("%c[%dA" % (27, diff))
         # erase
         stream.write("%c[2K\r" % 27)
-        stream.write("{} {}... {}\n".format(msg, obj_index, status))
+        stream.write("{} {} ... {}\n".format(msg, obj_index, status))
         # move back down
         stream.write("%c[%dB" % (27, diff))
     else:
         diff = 0
         lines.append(obj_index)
-        stream.write("{} {}... \r\n".format(msg, obj_index))
+        stream.write("{} {} ... \r\n".format(msg, obj_index))
 
     stream.flush()
 

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -254,6 +254,21 @@ class ConfigTest(unittest.TestCase):
             )
             self.assertEqual(service[0]['expose'], expose)
 
+    def test_valid_config_oneof_string_or_list(self):
+        entrypoint_values = [["sh"], "sh"]
+        for entrypoint in entrypoint_values:
+            service = config.load(
+                config.ConfigDetails(
+                    {'web': {
+                        'image': 'busybox',
+                        'entrypoint': entrypoint
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+            self.assertEqual(service[0]['entrypoint'], entrypoint)
+
 
 class InterpolationTest(unittest.TestCase):
     @mock.patch.dict(os.environ)

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -83,8 +83,14 @@ class ContainerTest(unittest.TestCase):
         self.assertEqual(container.name, "composetest_db_1")
 
     def test_name_without_project(self):
+        self.container_dict['Name'] = "/composetest_web_7"
         container = Container(None, self.container_dict, has_been_inspected=True)
         self.assertEqual(container.name_without_project, "web_7")
+
+    def test_name_without_project_custom_container_name(self):
+        self.container_dict['Name'] = "/custom_name_of_container"
+        container = Container(None, self.container_dict, has_been_inspected=True)
+        self.assertEqual(container.name_without_project, "custom_name_of_container")
 
     def test_inspect_if_not_inspected(self):
         mock_client = mock.create_autospec(docker.Client)


### PR DESCRIPTION
I find it difficult when my builds generate a lot of output to track exactly whats going on. So I hunted down the xterm title control sequences and xprop method to store the current title so we clean up after ourselves in case the shell does not automatically (zsh/oh-my-zsh seems to).