### PR TITLE
Add more github label areas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,4 @@
   sha: 3d86483455ab5bd06cc1069fdd5ac57be5463f10
   hooks:
     - id: reorder-python-imports
+      language_version: 'python2.7'

--- a/project/ISSUE-TRIAGE.md
+++ b/project/ISSUE-TRIAGE.md
@@ -20,13 +20,15 @@ The following labels are provided in additional to the standard labels:
 
 Most issues should fit into one of the following functional areas:
 
-| Area        |
-|-------------|
-| area/build  |
-| area/cli    |
-| area/config |
-| area/logs   |
-| area/run    |
-| area/scale  |
-| area/tests  |
-| area/up     |
+| Area           |
+|----------------|
+| area/build     |
+| area/cli       |
+| area/config    |
+| area/logs      |
+| area/packaging |
+| area/run       |
+| area/scale     |
+| area/tests     |
+| area/up        |
+| area/volumes   |


### PR DESCRIPTION
Adds `area/volumes` and `area/packaging`, since those are two rather large areas that aren't covered by the existing ones.

Also set a fixed python  version for the import ordering hook. Otherwise developers who run this with python3 will see `enum` re-ordered.