### PR TITLE
Improve oneOf schema validation messaging

### DIFF
--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -24,12 +24,7 @@
           ]
         },
         "container_name": {"type": "string"},
-        "cpu_shares": {
-          "oneOf": [
-            {"type": "number"},
-            {"type": "string"}
-          ]
-        },
+        "cpu_shares": {"type": ["number", "string"]},
         "cpuset": {"type": "string"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
@@ -74,18 +69,8 @@
         "log_opt": {"type": "object"},
 
         "mac_address": {"type": "string"},
-        "mem_limit": {
-          "oneOf": [
-            {"type": "number"},
-            {"type": "string"}
-          ]
-        },
-        "memswap_limit": {
-          "oneOf": [
-            {"type": "number"},
-            {"type": "string"}
-          ]
-        },
+        "mem_limit": {"type": ["number", "string"]},
+        "memswap_limit": {"type": ["number", "string"]},
         "name": {"type": "string"},
         "net": {"type": "string"},
         "pid": {"type": ["string", "null"]},

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -269,6 +269,21 @@ class ConfigTest(unittest.TestCase):
             )
             self.assertEqual(service[0]['entrypoint'], entrypoint)
 
+    def test_validation_message_for_invalid_type_when_multiple_types_allowed(self):
+        expected_error_msg = "Service 'web' configuration key 'mem_limit' contains an invalid type, it should be a number or a string"
+
+        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
+            config.load(
+                config.ConfigDetails(
+                    {'web': {
+                        'image': 'busybox',
+                        'mem_limit': ['incorrect']
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+
 
 class InterpolationTest(unittest.TestCase):
     @mock.patch.dict(os.environ)

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -183,7 +183,8 @@ class ConfigTest(unittest.TestCase):
             )
 
     def test_invalid_list_of_strings_format(self):
-        expected_error_msg = "'command' contains an invalid type, valid types are string or array"
+        expected_error_msg = "Service 'web' configuration key 'command' contains 1"
+        expected_error_msg += ", which is an invalid type, it should be a string"
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
                 config.ConfigDetails(
@@ -222,7 +223,7 @@ class ConfigTest(unittest.TestCase):
             )
 
     def test_config_extra_hosts_list_of_dicts_validation_error(self):
-        expected_error_msg = "Service 'web' configuration key 'extra_hosts' contains an invalid type"
+        expected_error_msg = "key 'extra_hosts' contains {'somehost': '162.242.195.82'}, which is an invalid type, it should be a string"
 
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(


### PR DESCRIPTION
Refactor to do a bit more work to provide finer grained error messages when a oneOf schema ValidationError occurs.

Closes https://github.com/docker/compose/issues/2002

