### PR TITLE
Remove uniqueness constraint for command

### DIFF
--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -17,7 +17,12 @@
         "build": {"type": "string"},
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "command": {"$ref": "#/definitions/string_or_list"},
+        "command": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
         "container_name": {"type": "string"},
         "cpu_shares": {
           "oneOf": [

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -183,7 +183,7 @@ class ConfigTest(unittest.TestCase):
             )
 
     def test_invalid_list_of_strings_format(self):
-        expected_error_msg = "'command' contains an invalid type, valid types are string or list of strings"
+        expected_error_msg = "'command' contains an invalid type, valid types are string or array"
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
                 config.ConfigDetails(


### PR DESCRIPTION
The command value can be a list, which would be a Unix command-line
invocation broken up into individual values, thus needing the ability to
have non unique values.
