### PR TITLE
Remove mistaken field

### DIFF
--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -26,7 +26,6 @@
           ]
         },
         "cpuset": {"type": "string"},
-        "detach": {"type": "boolean"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
         "dns_search": {"$ref": "#/definitions/string_or_list"},


### PR DESCRIPTION
detach is a run param, not a config param. Oops, sorry!

Fixes https://github.com/docker/compose/issues/2007