### PR TITLE
 Handle unexpected errors, but don't ignore background threads

### DIFF
--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -638,8 +638,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertTrue(service.containers()[0].is_running)
         self.assertIn("ERROR: for 2  Boom", mock_stdout.getvalue())
 
-    @mock.patch('sys.stdout', new_callable=StringIO)
-    def test_scale_with_api_returns_unexpected_exception(self, mock_stdout):
+    def test_scale_with_api_returns_unexpected_exception(self):
         """
         Test that when scaling if the API returns an error, that is not of type
         APIError, that error is re-raised.
@@ -650,7 +649,8 @@ class ServiceTest(DockerClientTestCase):
 
         with mock.patch(
             'compose.container.Container.create',
-                side_effect=ValueError("BOOM")):
+            side_effect=ValueError("BOOM")
+        ):
             with self.assertRaises(ValueError):
                 service.scale(3)
 


### PR DESCRIPTION
Fixes #1955 

See the issue for description of the problem.

This does change the behaviour of `parallel_execute()` with unexpected exceptions (prints error instead of raises the exception). In order to handle this properly and still raise an exception a much larger refactor would be necessary (to attempt to join or kill unfinished threads), so I went with this change instead.

Let me know if you feel it's important to raise the unexpected exception and I can take another pass.