### PR TITLE
Allow to extend service using shorthand notation. Closes #1989

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -275,15 +275,19 @@ class ServiceLoader(object):
         self.service_dict['environment'] = env
 
     def validate_and_construct_extends(self):
+        extends = self.service_dict['extends']
+        if not isinstance(extends, dict):
+            extends = {'service': extends}
+
         validate_extends_file_path(
             self.service_name,
-            self.service_dict['extends'],
+            extends,
             self.filename
         )
         self.extended_config_path = self.get_extended_config_path(
-            self.service_dict['extends']
+            extends
         )
-        self.extended_service_name = self.service_dict['extends']['service']
+        self.extended_service_name = extends['service']
 
         full_extended_config = pre_process_config(
             load_yaml(self.extended_config_path)

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -57,14 +57,21 @@
         },
 
         "extends": {
-          "type": "object",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
 
-          "properties": {
-            "service": {"type": "string"},
-            "file": {"type": "string"}
-          },
-          "required": ["service"],
-          "additionalProperties": false
+              "properties": {
+                "service": {"type": "string"},
+                "file": {"type": "string"}
+              },
+              "required": ["service"],
+              "additionalProperties": false
+            }
+          ]
         },
 
         "extra_hosts": {"$ref": "#/definitions/list_or_dict"},

--- a/tests/fixtures/extends/verbose-and-shorthand.yml
+++ b/tests/fixtures/extends/verbose-and-shorthand.yml
@@ -1,0 +1,15 @@
+base:
+  image: busybox
+  environment:
+    - "BAR=1"
+
+verbose:
+  extends:
+    service: base
+  environment:
+    - "FOO=1"
+
+shorthand:
+  extends: base
+  environment:
+    - "FOO=2"

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1115,6 +1115,26 @@ class ExtendsTest(unittest.TestCase):
         dicts = load_from_filename('tests/fixtures/extends/valid-common-config.yml')
         self.assertEqual(dicts[0]['environment'], {'FOO': '1'})
 
+    def test_extended_service_with_verbose_and_shorthand_way(self):
+        services = load_from_filename('tests/fixtures/extends/verbose-and-shorthand.yml')
+        self.assertEqual(service_sort(services), service_sort([
+            {
+                'name': 'base',
+                'image': 'busybox',
+                'environment': {'BAR': '1'},
+            },
+            {
+                'name': 'verbose',
+                'image': 'busybox',
+                'environment': {'BAR': '1', 'FOO': '1'},
+            },
+            {
+                'name': 'shorthand',
+                'image': 'busybox',
+                'environment': {'BAR': '1', 'FOO': '2'},
+            },
+        ]))
+
 
 @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
 class ExpandPathTest(unittest.TestCase):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -335,7 +335,7 @@ class ConfigTest(unittest.TestCase):
         self.assertTrue(expected_warning_msg in mock_logging.warn.call_args[0][0])
 
     def test_config_invalid_environment_dict_key_raises_validation_error(self):
-        expected_error_msg = "Service 'web' configuration key 'environment' contains an invalid type"
+        expected_error_msg = "Service 'web' configuration key 'environment' contains unsupported option: '---'"
 
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
@@ -957,7 +957,10 @@ class ExtendsTest(unittest.TestCase):
             )
 
     def test_extends_validation_invalid_key(self):
-        expected_error_msg = "Unsupported config option for 'web' service: 'rogue_key'"
+        expected_error_msg = (
+            "Service 'web' configuration key 'extends' "
+            "contains unsupported option: 'rogue_key'"
+        )
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
                 build_config_details(
@@ -977,7 +980,10 @@ class ExtendsTest(unittest.TestCase):
             )
 
     def test_extends_validation_sub_property_key(self):
-        expected_error_msg = "Service 'web' configuration key 'extends' 'file' contains an invalid type"
+        expected_error_msg = (
+            "Service 'web' configuration key 'extends' 'file' contains 1, "
+            "which is an invalid type, it should be a string"
+        )
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
                 build_config_details(


### PR DESCRIPTION
I looked at using a shorthand notation to extend a service (Issue #1989)
Seams to be working ok, but validation errors got more generic. Can someone advise how to make them as specific as they where before?

Signed-off-by: Karol Duleba <mr.fuxi@gmail.com>