### PR TITLE
Fix compose up with other log drivers

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -193,7 +193,7 @@ class TopLevelCommand(Command):
 
         monochrome = options['--no-color']
         print("Attaching to", list_containers(containers))
-        LogPrinter(containers, attach_params={'logs': True}, monochrome=monochrome).run()
+        LogPrinter(containers, monochrome=monochrome).run()
 
     def pause(self, project, options):
         """
@@ -602,11 +602,7 @@ def convergence_strategy_from_opts(options):
 def build_log_printer(containers, service_names, monochrome):
     if service_names:
         containers = [c for c in containers if c.service in service_names]
-
-    return LogPrinter(
-        containers,
-        attach_params={"logs": True},
-        monochrome=monochrome)
+    return LogPrinter(containers, monochrome=monochrome)
 
 
 def attach_to_logs(project, log_printer, service_names, timeout):

--- a/compose/container.py
+++ b/compose/container.py
@@ -137,6 +137,15 @@ class Container(object):
     def is_paused(self):
         return self.get('State.Paused')
 
+    @property
+    def log_driver(self):
+        return self.get('HostConfig.LogConfig.Type')
+
+    @property
+    def has_api_logs(self):
+        log_type = self.log_driver
+        return not log_type or log_type == 'json-file'
+
     def get(self, key):
         """Return a value from the container or None if the value is not set.
 

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -289,17 +289,22 @@ Because Docker container names must be unique, you cannot scale a service
 beyond 1 container if you have specified a custom name. Attempting to do so
 results in an error.
 
-### log driver
+### log_driver
 
-Specify a logging driver for the service's containers, as with the ``--log-driver`` option for docker run ([documented here](http://docs.docker.com/reference/run/#logging-drivers-log-driver)).
-
-Allowed values are currently ``json-file``, ``syslog`` and ``none``. The list will change over time as more drivers are added to the Docker engine.
+Specify a logging driver for the service's containers, as with the ``--log-driver``
+option for docker run ([documented here](https://docs.docker.com/reference/logging/overview/)).
 
 The default value is json-file.
 
     log_driver: "json-file"
     log_driver: "syslog"
     log_driver: "none"
+
+> **Note:** Only the `json-file` driver makes the logs available directly from
+> `docker-compose up` and `docker-compose logs`. Using any other driver will not
+> print any logs.
+
+### log_opt
 
 Specify logging options with `log_opt` for the logging driver, as with the ``--log-opt`` option for `docker run`.
 

--- a/tests/unit/cli/log_printer_test.py
+++ b/tests/unit/cli/log_printer_test.py
@@ -1,20 +1,31 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import os
-
+import mock
 import six
 
 from compose.cli.log_printer import LogPrinter
+from compose.cli.log_printer import wait_on_exit
+from compose.container import Container
 from tests import unittest
+
+
+def build_mock_container(reader):
+    return mock.Mock(
+        spec=Container,
+        name='myapp_web_1',
+        name_without_project='web_1',
+        has_api_logs=True,
+        attach=reader,
+        wait=mock.Mock(return_value=0),
+    )
 
 
 class LogPrinterTest(unittest.TestCase):
     def get_default_output(self, monochrome=False):
         def reader(*args, **kwargs):
             yield b"hello\nworld"
-
-        container = MockContainer(reader)
+        container = build_mock_container(reader)
         output = run_log_printer([container], monochrome=monochrome)
         return output
 
@@ -38,37 +49,39 @@ class LogPrinterTest(unittest.TestCase):
         def reader(*args, **kwargs):
             yield glyph.encode('utf-8') + b'\n'
 
-        container = MockContainer(reader)
+        container = build_mock_container(reader)
         output = run_log_printer([container])
         if six.PY2:
             output = output.decode('utf-8')
 
         self.assertIn(glyph, output)
 
+    def test_wait_on_exit(self):
+        exit_status = 3
+        mock_container = mock.Mock(
+            spec=Container,
+            name='cname',
+            wait=mock.Mock(return_value=exit_status))
+
+        expected = '{} exited with code {}\n'.format(mock_container.name, exit_status)
+        self.assertEqual(expected, wait_on_exit(mock_container))
+
+    def test_generator_with_no_logs(self):
+        mock_container = mock.Mock(
+            spec=Container,
+            has_api_logs=False,
+            log_driver='none',
+            name_without_project='web_1',
+            wait=mock.Mock(return_value=0))
+
+        output = run_log_printer([mock_container])
+        self.assertIn(
+            "WARNING: no logs are available with the 'none' log driver\n",
+            output
+        )
+
 
 def run_log_printer(containers, monochrome=False):
-    r, w = os.pipe()
-    reader, writer = os.fdopen(r, 'r'), os.fdopen(w, 'w')
-    printer = LogPrinter(containers, output=writer, monochrome=monochrome)
-    printer.run()
-    writer.close()
-    return reader.read()
-
-
-class MockContainer(object):
-    def __init__(self, reader):
-        self._reader = reader
-
-    @property
-    def name(self):
-        return 'myapp_web_1'
-
-    @property
-    def name_without_project(self):
-        return 'web_1'
-
-    def attach(self, *args, **kwargs):
-        return self._reader()
-
-    def wait(self, *args, **kwargs):
-        return 0
+    output = six.StringIO()
+    LogPrinter(containers, output=output, monochrome=monochrome).run()
+    return output.getvalue()


### PR DESCRIPTION
Fixes #1947

Update the docs to say that custom log drivers make it impossible to view the logs.

Update log printing to print a reasonable warning when an alternative log_driver is set.

Also some refactoring in the last commit.