### PR TITLE
Proposal: Run not one-off

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -351,6 +351,8 @@ class TopLevelCommand(DocoptCommand):
             -p, --publish=[]      Publish a container's port(s) to the host
             --service-ports       Run command with the service's ports enabled and mapped
                                   to the host.
+            --not-one-off         Run the container as part of the composition,
+                                  not as a one-off container.
             -T                    Disable pseudo-tty allocation. By default `docker-compose run`
                                   allocates a TTY.
         """
@@ -423,7 +425,7 @@ class TopLevelCommand(DocoptCommand):
         try:
             container = service.create_container(
                 quiet=True,
-                one_off=True,
+                one_off=not options['--not-one-off'],
                 **container_options
             )
         except APIError as e:


### PR DESCRIPTION
(opening this PR to discuss, still needs tests)

There have been a couple occasions where it would have been useful to use `docker-compose run` to start a container, but have that container labeled and named as if it were a regular container (created by `up`), not a "one-off" container.  

Scenario 1 is using `docker-compose` with a process supervisor or init system. If you wanted to use a single `docker-compose.yml` for the entire system, but you wanted the supervisor to handle each service as a separate process, you could use `docker-compose run --no-deps --not-one-off` to start each container.  You could start them all at once (in parallel) , and as dependencies becomes available, the services would eventually stop failing and go into the `up` state.

Scenario 2 was more of a workaround for another issue, but in https://github.com/docker/compose/issues/1532#issuecomment-140015148 but may still be useful even after that issue is fixed.