### PR TITLE
Clean before doing a build

### DIFF
--- a/script/build-linux
+++ b/script/build-linux
@@ -2,6 +2,8 @@
 
 set -ex
 
+./script/clean
+
 TAG="docker-compose"
 docker build -t "$TAG" .
 docker run \

--- a/script/build-osx
+++ b/script/build-osx
@@ -3,7 +3,9 @@ set -ex
 
 PATH="/usr/local/bin:$PATH"
 
+./script/clean
 rm -rf venv
+
 virtualenv -p /usr/local/bin/python venv
 venv/bin/pip install -r requirements.txt
 venv/bin/pip install -r requirements-build.txt

--- a/script/clean
+++ b/script/clean
@@ -1,3 +1,6 @@
 #!/bin/sh
+set -e
+
 find . -type f -name '*.pyc' -delete
+find -name __pycache__ -delete
 rm -rf docs/_site build dist docker-compose.egg-info


### PR DESCRIPTION
While building the linux binary for the 1.4.1 release I ran into a bunch of failures. I finally tracked them down to the `./build` directory.

This change will force cleanup all cached files to make sure we don't accidentally include old files in the binaries.