### PR TITLE
Allow env_file to format lines as `export FOO=bar`

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -409,6 +409,8 @@ def env_vars_from_file(filename):
     for line in open(filename, 'r'):
         line = line.strip()
         if line and not line.startswith('#'):
+            if line.startswith('export '):
+                line = line.replace('export ', '', 1)
             k, v = split_env(line)
             env[k] = v
     return env

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -214,7 +214,8 @@ Environment variables specified in `environment` override these values.
       - /opt/secrets.env
 
 Compose expects each line in an env file to be in `VAR=VAL` format. Lines
-beginning with `#` (i.e. comments) are ignored, as are blank lines.
+beginning with `#` (i.e. comments) are ignored, as are blank lines. Lines may
+start with `export` so that you can source the file in bash.
 
     # Set Rails/Rack environment
     RACK_ENV=development

--- a/tests/fixtures/env/export.env
+++ b/tests/fixtures/env/export.env
@@ -1,0 +1,1 @@
+export HELLO=1

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -719,6 +719,17 @@ class EnvTest(unittest.TestCase):
             {'ONE': '2', 'TWO': '1', 'THREE': '3', 'FOO': 'baz', 'DOO': 'dah'},
         )
 
+    def test_env_with_export(self):
+        service_dict = make_service_dict(
+            'foo',
+            {'build': '.', 'env_file': 'export.env'},
+            'tests/fixtures/env',
+        )
+        self.assertEqual(
+            service_dict['environment'],
+            {'HELLO': '1'}
+        )
+
     def test_env_nonexistent_file(self):
         options = {'env_file': 'nonexistent.env'}
         self.assertRaises(


### PR DESCRIPTION
Take it or leave it, but I thought it might be cool to allow the env_file to be formatted like a file that you could source in bash, for mixed development environments (some docker, some native).  Inspired by https://github.com/bkeepers/dotenv, which allows this.