### PR TITLE
Extend compose files by allowing multiple files

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -51,22 +51,24 @@ class Command(DocoptCommand):
             handler(None, command_options)
             return
 
-        if 'FIG_FILE' in os.environ:
-            log.warn('The FIG_FILE environment variable is deprecated.')
-            log.warn('Please use COMPOSE_FILE instead.')
-
-        explicit_config_path = (
-            options.get('--file') or
-            os.environ.get('COMPOSE_FILE') or
-            os.environ.get('FIG_FILE'))
-
         project = get_project(
             self.base_dir,
-            explicit_config_path,
+            get_config_path(options.get('--file')),
             project_name=options.get('--project-name'),
             verbose=options.get('--verbose'))
 
         handler(project, command_options)
+
+
+def get_config_path(file_option):
+    if file_option:
+        return file_option
+
+    if 'FIG_FILE' in os.environ:
+        log.warn('The FIG_FILE environment variable is deprecated.')
+        log.warn('Please use COMPOSE_FILE instead.')
+
+    return [os.environ.get('COMPOSE_FILE') or os.environ.get('FIG_FILE')]
 
 
 def get_client(verbose=False):

--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -68,7 +68,8 @@ def get_config_path(file_option):
         log.warn('The FIG_FILE environment variable is deprecated.')
         log.warn('Please use COMPOSE_FILE instead.')
 
-    return [os.environ.get('COMPOSE_FILE') or os.environ.get('FIG_FILE')]
+    config_file = os.environ.get('COMPOSE_FILE') or os.environ.get('FIG_FILE')
+    return [config_file] if config_file else None
 
 
 def get_client(verbose=False):

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -96,7 +96,7 @@ class TopLevelCommand(Command):
     """Define and run multi-container applications with Docker.
 
     Usage:
-      docker-compose [options] [COMMAND] [ARGS...]
+      docker-compose [-f=<arg>...] [options] [COMMAND] [ARGS...]
       docker-compose -h|--help
 
     Options:

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -36,25 +36,6 @@ def yesno(prompt, default=None):
         return None
 
 
-def find_candidates_in_parent_dirs(filenames, path):
-    """
-    Given a directory path to start, looks for filenames in the
-    directory, and then each parent directory successively,
-    until found.
-
-    Returns tuple (candidates, path).
-    """
-    candidates = [filename for filename in filenames
-                  if os.path.exists(os.path.join(path, filename))]
-
-    if len(candidates) == 0:
-        parent_dir = os.path.join(path, '..')
-        if os.path.abspath(parent_dir) != os.path.abspath(path):
-            return find_candidates_in_parent_dirs(filenames, parent_dir)
-
-    return (candidates, path)
-
-
 def split_buffer(reader, separator):
     """
     Given a generator which yields strings and a separator string,

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -104,6 +104,8 @@ def find(base_dir, filenames):
         filenames = [os.path.join(base_dir, f) for f in filenames]
     else:
         filenames = get_default_config_files(base_dir)
+
+    log.debug("Using configuration files: {}".format(",".join(filenames)))
     return ConfigDetails(
         os.path.dirname(filenames[0]),
         [ConfigFile(f, load_yaml(f)) for f in filenames])

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -17,7 +17,6 @@ from .validation import validate_extended_service_exists
 from .validation import validate_extends_file_path
 from .validation import validate_service_names
 from .validation import validate_top_level_object
-from compose.cli.utils import find_candidates_in_parent_dirs
 
 
 DOCKER_CONFIG_KEYS = [
@@ -103,13 +102,13 @@ def find(base_dir, filenames):
     if filenames:
         filenames = [os.path.join(base_dir, f) for f in filenames]
     else:
-        filenames = [get_config_path(base_dir)]
+        filenames = get_default_config_path(base_dir)
     return ConfigDetails(
         os.path.dirname(filenames[0]),
         [ConfigFile(f, load_yaml(f)) for f in filenames])
 
 
-def get_config_path(base_dir):
+def get_default_config_path(base_dir):
     (candidates, path) = find_candidates_in_parent_dirs(SUPPORTED_FILENAMES, base_dir)
 
     if len(candidates) == 0:
@@ -131,6 +130,25 @@ def get_config_path(base_dir):
                  "Please rename your config file to docker-compose.yml\n" % winner)
 
     return os.path.join(path, winner)
+
+
+def find_candidates_in_parent_dirs(filenames, path):
+    """
+    Given a directory path to start, looks for filenames in the
+    directory, and then each parent directory successively,
+    until found.
+
+    Returns tuple (candidates, path).
+    """
+    candidates = [filename for filename in filenames
+                  if os.path.exists(os.path.join(path, filename))]
+
+    if len(candidates) == 0:
+        parent_dir = os.path.join(path, '..')
+        if os.path.abspath(parent_dir) != os.path.abspath(path):
+            return find_candidates_in_parent_dirs(filenames, parent_dir)
+
+    return (candidates, path)
 
 
 @validate_top_level_object

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -77,6 +77,7 @@ SUPPORTED_FILENAMES = [
     'fig.yaml',
 ]
 
+DEFAULT_OVERRIDE_FILENAME = 'docker-compose.override.yml'
 
 PATH_START_CHARS = [
     '/',
@@ -102,16 +103,16 @@ def find(base_dir, filenames):
     if filenames:
         filenames = [os.path.join(base_dir, f) for f in filenames]
     else:
-        filenames = get_default_config_path(base_dir)
+        filenames = get_default_config_files(base_dir)
     return ConfigDetails(
         os.path.dirname(filenames[0]),
         [ConfigFile(f, load_yaml(f)) for f in filenames])
 
 
-def get_default_config_path(base_dir):
+def get_default_config_files(base_dir):
     (candidates, path) = find_candidates_in_parent_dirs(SUPPORTED_FILENAMES, base_dir)
 
-    if len(candidates) == 0:
+    if not candidates:
         raise ComposeFileNotFound(SUPPORTED_FILENAMES)
 
     winner = candidates[0]
@@ -129,7 +130,12 @@ def get_default_config_path(base_dir):
         log.warn("%s is deprecated and will not be supported in future. "
                  "Please rename your config file to docker-compose.yml\n" % winner)
 
-    return os.path.join(path, winner)
+    return [os.path.join(path, winner)] + get_default_override_file(path)
+
+
+def get_default_override_file(path):
+    override_filename = os.path.join(path, DEFAULT_OVERRIDE_FILENAME)
+    return [override_filename] if os.path.exists(override_filename) else []
 
 
 def find_candidates_in_parent_dirs(filenames, path):
@@ -143,7 +149,7 @@ def find_candidates_in_parent_dirs(filenames, path):
     candidates = [filename for filename in filenames
                   if os.path.exists(os.path.join(path, filename))]
 
-    if len(candidates) == 0:
+    if not candidates:
         parent_dir = os.path.join(path, '..')
         if os.path.abspath(parent_dir) != os.path.abspath(path):
             return find_candidates_in_parent_dirs(filenames, parent_dir)

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -166,14 +166,16 @@ def load(config_details):
             for name in set(base) | set(override)
         }
 
-    def combine_configs(override, base):
+    def combine_configs(base, override):
         service_dicts = load_file(base.filename, base.config)
         if not override:
             return service_dicts
 
-        return merge_service_dicts(base.config, override.config)
+        return ConfigFile(
+            override.filename,
+            merge_services(base.config, override.config))
 
-    return reduce(combine_configs, configs, None)
+    return reduce(combine_configs, configs + [None])
 
 
 class ServiceLoader(object):

--- a/docs/reference/docker-compose.md
+++ b/docs/reference/docker-compose.md
@@ -14,7 +14,7 @@ weight=-2
 
 ```
 Usage:
-  docker-compose [options] [COMMAND] [ARGS...]
+  docker-compose [-f=<arg>...] [options] [COMMAND] [ARGS...]
   docker-compose -h|--help
 
 Options:
@@ -41,20 +41,62 @@ Commands:
   unpause            Unpause services
   up                 Create and start containers
   migrate-to-labels  Recreate containers to add labels
+  version            Show the Docker-Compose version information
 ```
 
-The Docker Compose binary. You use this command to build and manage multiple services in Docker containers.
+The Docker Compose binary. You use this command to build and manage multiple
+services in Docker containers.
 
-Use the `-f` flag to specify the location of a Compose configuration file. This
-flag is optional. If you don't provide this flag. Compose looks for a file named
-`docker-compose.yml` in the  working directory. If the file is not found,
-Compose looks in each parent directory successively, until it finds the file.
+Use the `-f` flag to specify the location of a Compose configuration file. You
+can supply multiple `-f` configuration files. When you supply multiple files,
+Compose combines them into a single configuration. Compose builds the
+configuration in the order you supply the files. Subsequent files override and
+add to their successors.
 
-Use a `-` as the filename to read configuration file from stdin. When stdin is
-used all paths in the configuration are relative to the current working
-directory.
+For example, consider this command line:
 
-Each configuration can has a project name. If you supply a `-p` flag, you can specify a project name. If you don't specify the flag, Compose uses the current directory name.
+```
+$ docker-compose -f docker-compose.yml -f docker-compose.admin.yml run backup_db`
+```
+
+The `docker-compose.yml` file might specify a `webapp` service.
+
+```
+webapp:
+  image: examples/web
+  ports:
+    - "8000:8000"
+  volumes:
+    - "/data"
+```
+
+If the `docker-compose.admin.yml` also specifies this same service, any matching
+fields will override the previous file. New values, add to the `webapp` service
+configuration.
+
+```
+webapp:
+  build: .
+  environment:
+    - DEBUG=1
+```
+
+Use a `-f` with `-` (dash) as the filename to read the configuration from
+stdin. When stdin is used all paths in the configuration are
+relative to the current working directory.
+
+The `-f` flag is optional. If you don't provide this flag on the command line,
+Compose traverses the working directory and its subdirectories looking for a
+`docker-compose.yml` and a `docker-compose.override.yml` file. You must supply
+at least the `docker-compose.yml` file. If both files are present, Compose
+combines the two files into a single configuration. The configuration in the
+`docker-compose.override.yml` file is applied over and in addition to the values
+in the `docker-compose.yml` file.
+
+Each configuration has a project name. If you supply a `-p` flag, you can
+specify a project name. If you don't specify the flag, Compose uses the current
+directory name.
+
 
 ## Where to go next
 

--- a/tests/fixtures/override-files/docker-compose.override.yml
+++ b/tests/fixtures/override-files/docker-compose.override.yml
@@ -1,0 +1,6 @@
+
+web:
+    command: "top"
+
+db:
+    command: "top"

--- a/tests/fixtures/override-files/docker-compose.yml
+++ b/tests/fixtures/override-files/docker-compose.yml
@@ -1,0 +1,10 @@
+
+web:
+    image: busybox:latest
+    command: "sleep 200"
+    links:
+        - db
+
+db:
+    image: busybox:latest
+    command: "sleep 200"

--- a/tests/fixtures/override-files/extra.yml
+++ b/tests/fixtures/override-files/extra.yml
@@ -1,0 +1,9 @@
+
+web:
+    links:
+        - db
+        - other
+
+other:
+    image: busybox:latest
+    command: "top"

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -9,6 +9,7 @@ from six import StringIO
 
 from .. import mock
 from .testcases import DockerClientTestCase
+from compose.cli.command import get_project
 from compose.cli.errors import UserError
 from compose.cli.main import TopLevelCommand
 from compose.project import NoSuchService
@@ -38,7 +39,7 @@ class CLITestCase(DockerClientTestCase):
         if hasattr(self, '_project'):
             return self._project
 
-        return self.command.get_project()
+        return get_project(self.command.base_dir)
 
     def test_help(self):
         old_base_dir = self.command.base_dir
@@ -72,7 +73,7 @@ class CLITestCase(DockerClientTestCase):
     def test_ps_alternate_composefile(self, mock_stdout):
         config_path = os.path.abspath(
             'tests/fixtures/multiple-composefiles/compose2.yml')
-        self._project = self.command.get_project(config_path)
+        self._project = get_project(self.command.base_dir, [config_path])
 
         self.command.base_dir = 'tests/fixtures/multiple-composefiles'
         self.command.dispatch(['-f', 'compose2.yml', 'up', '-d'], None)
@@ -571,7 +572,7 @@ class CLITestCase(DockerClientTestCase):
     def test_env_file_relative_to_compose_file(self):
         config_path = os.path.abspath('tests/fixtures/env-file/docker-compose.yml')
         self.command.dispatch(['-f', config_path, 'up', '-d'], None)
-        self._project = self.command.get_project(config_path)
+        self._project = get_project(self.command.base_dir, [config_path])
 
         containers = self.project.containers(stopped=True)
         self.assertEqual(len(containers), 1)

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from .testcases import DockerClientTestCase
-from compose import config
+from compose.config import config
 from compose.const import LABEL_PROJECT
 from compose.container import Container
 from compose.project import Project
@@ -9,7 +9,10 @@ from compose.service import ConvergenceStrategy
 
 
 def build_service_dicts(service_config):
-    return config.load(config.ConfigDetails(service_config, 'working_dir', None))
+    return config.load(
+        config.ConfigDetails(
+            'working_dir',
+            [config.ConfigFile(None, service_config)]))
 
 
 class ProjectTest(DockerClientTestCase):

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 
 from .testcases import DockerClientTestCase
-from compose import config
+from compose.config import config
 from compose.const import LABEL_CONFIG_HASH
 from compose.project import Project
 from compose.service import ConvergenceStrategy
@@ -24,11 +24,13 @@ class ProjectTestCase(DockerClientTestCase):
         return set(project.containers(stopped=True))
 
     def make_project(self, cfg):
+        details = config.ConfigDetails(
+            'working_dir',
+            [config.ConfigFile(None, cfg)])
         return Project.from_dicts(
             name='composetest',
             client=self.client,
-            service_dicts=config.load(config.ConfigDetails(cfg, 'working_dir', None))
-        )
+            service_dicts=config.load(details))
 
 
 class BasicProjectTest(ProjectTestCase):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1167,7 +1167,7 @@ class BuildPathTest(unittest.TestCase):
         self.assertEquals(service_dict, [{'name': 'foo', 'build': self.abs_context_path}])
 
 
-class GetConfigPathTestCase(unittest.TestCase):
+class GetDefaultConfigFilesTestCase(unittest.TestCase):
 
     files = [
         'docker-compose.yml',
@@ -1177,25 +1177,21 @@ class GetConfigPathTestCase(unittest.TestCase):
     ]
 
     def test_get_config_path_default_file_in_basedir(self):
-        files = self.files
-        self.assertEqual('docker-compose.yml', get_config_filename_for_files(files[0:]))
-        self.assertEqual('docker-compose.yaml', get_config_filename_for_files(files[1:]))
-        self.assertEqual('fig.yml', get_config_filename_for_files(files[2:]))
-        self.assertEqual('fig.yaml', get_config_filename_for_files(files[3:]))
+        for index, filename in enumerate(self.files):
+            self.assertEqual(
+                filename,
+                get_config_filename_for_files(self.files[index:]))
         with self.assertRaises(config.ComposeFileNotFound):
             get_config_filename_for_files([])
 
     def test_get_config_path_default_file_in_parent_dir(self):
         """Test with files placed in the subdir"""
-        files = self.files
 
         def get_config_in_subdir(files):
             return get_config_filename_for_files(files, subdir=True)
 
-        self.assertEqual('docker-compose.yml', get_config_in_subdir(files[0:]))
-        self.assertEqual('docker-compose.yaml', get_config_in_subdir(files[1:]))
-        self.assertEqual('fig.yml', get_config_in_subdir(files[2:]))
-        self.assertEqual('fig.yaml', get_config_in_subdir(files[3:]))
+        for index, filename in enumerate(self.files):
+            self.assertEqual(filename, get_config_in_subdir(self.files[index:]))
         with self.assertRaises(config.ComposeFileNotFound):
             get_config_in_subdir([])
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1213,6 +1213,7 @@ def get_config_filename_for_files(filenames, subdir=None):
             base_dir = tempfile.mkdtemp(dir=project_dir)
         else:
             base_dir = project_dir
-        return os.path.basename(config.get_config_path(base_dir))
+        filename, = config.get_default_config_files(base_dir)
+        return os.path.basename(filename)
     finally:
         shutil.rmtree(project_dir)

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -280,7 +280,7 @@ class ConfigTest(unittest.TestCase):
     def test_logs_warning_for_boolean_in_environment(self, mock_logging):
         expected_warning_msg = "Warning: There is a boolean value, True in the 'environment' key."
         config.load(
-            config.ConfigDetails(
+            build_config_details(
                 {'web': {
                     'image': 'busybox',
                     'environment': {'SHOW_STUFF': True}
@@ -298,7 +298,7 @@ class ConfigTest(unittest.TestCase):
 
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
-                config.ConfigDetails(
+                build_config_details(
                     {'web': {
                         'image': 'busybox',
                         'environment': {'---': 'nope'}


### PR DESCRIPTION
Resolves #1987

Add support for  specifying multiple `-f` arguments to `docker-compose`. Multiple files are merged onto each other to allow users to customize the composition for different environments.

The default overrides file is `docker-compose.override.yml` which is applied over the default `docker-compose.yml` if it exists.
