### PR TITLE
Choose API version automatically based on server

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -20,7 +20,7 @@ def docker_client():
         cert_path = os.path.join(os.environ.get('HOME', ''), '.docker')
 
     base_url = os.environ.get('DOCKER_HOST')
-    api_version = os.environ.get('COMPOSE_API_VERSION', '1.19')
+    api_version = os.environ.get('COMPOSE_API_VERSION', 'auto')
 
     tls_config = None
 


### PR DESCRIPTION
See [auto in docker-py Client API](http://docker-py.readthedocs.org/en/latest/api/index.html?highlight=auto).

If the user doesn't specify the API version, this uses 'auto' mode from docker-py, which detects the server version for you.