### PR TITLE
Fix stacktrace when ctrl-c stops logs

### DIFF
--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from threading import Thread
 
+from six.moves import _thread as thread
+
 try:
     from Queue import Queue, Empty
 except ImportError:
@@ -38,6 +40,9 @@ class Multiplexer(object):
                     yield item
             except Empty:
                 pass
+            # See https://github.com/docker/compose/issues/189
+            except thread.error:
+                raise KeyboardInterrupt()
 
     def _init_readers(self):
         for iterator in self.iterators:


### PR DESCRIPTION
Fixes #189 

I had to test this manually with the binary, but I wasn't able to reproduce the error after this change.  Without the change I would get it ~80% of the runs (if I use the binary).

It's not pretty, but I'm not sure what else we can do about it.