### PR TITLE
Restore the dist volume mount for building linux binaries

### DIFF
--- a/script/build-linux
+++ b/script/build-linux
@@ -6,4 +6,7 @@ set -ex
 
 TAG="docker-compose"
 docker build -t "$TAG" .
-docker run --rm --entrypoint="script/build-linux-inner" "$TAG"
+docker run \
+    --rm --entrypoint="script/build-linux-inner" \
+    -v $(pwd)/dist:/code/dist \
+    "$TAG"


### PR DESCRIPTION
I removed the `/code` volume in #2065 so that we used the code from the image, but didn't realize we still needed `/code/dist` for the binary.