### PR TITLE
Fix a test case that assumes busybox image id

### DIFF
--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -12,6 +12,7 @@ from six import text_type
 
 from .. import mock
 from .testcases import DockerClientTestCase
+from .testcases import pull_busybox
 from compose import __version__
 from compose.const import LABEL_CONTAINER_NUMBER
 from compose.const import LABEL_ONE_OFF
@@ -549,8 +550,10 @@ class ServiceTest(DockerClientTestCase):
         })
 
     def test_create_with_image_id(self):
-        # Image id for the current busybox:latest
-        service = self.create_service('foo', image='8c2e06607696')
+        # Get image id for the current busybox:latest
+        pull_busybox(self.client)
+        image_id = self.client.inspect_image('busybox:latest')['Id'][:12]
+        service = self.create_service('foo', image=image_id)
         service.create_container()
 
     def test_scale(self):

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -1,12 +1,21 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from docker import errors
+
 from .. import unittest
 from compose.cli.docker_client import docker_client
 from compose.config.config import ServiceLoader
 from compose.const import LABEL_PROJECT
 from compose.progress_stream import stream_output
 from compose.service import Service
+
+
+def pull_busybox(client):
+    try:
+        client.inspect_image('busybox:latest')
+    except errors.APIError:
+        client.pull('busybox:latest', stream=False)
 
 
 class DockerClientTestCase(unittest.TestCase):


### PR DESCRIPTION
Using the old busybox image id was causing failures in the 1.4.2 release branch, and it probably fails on master as well for any host that has updated busybox (and removed the old layers).