### PR TITLE
WIP: Add appveyor config for testing on windows and building windows binary

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+
+install:
+  - "SET PATH=C:\\Python27-x64;C:\\Python27-x64\\Scripts;%PATH%"
+  - "python --version"
+  - "pip install tox==2.1.1"
+
+
+# Build the binary after tests
+build: false
+
+test_script:
+  - "tox -e py27,py34 -- tests/unit"
+
+after_test:
+  - ps: ".\\script\\build-windows.ps1"


### PR DESCRIPTION
The unit tests are failing and I suspect that the `build-windows.ps1` isn't working quite yet.

Once merged we'll have to enable the project on appveyor, currently setup on my fork: https://ci.appveyor.com/project/dnephin/compose

Linking some references here for when I get back to it:
- https://packaging.python.org/en/latest/appveyor/
- https://github.com/ogrisel/python-appveyor-demo
- http://www.appveyor.com/docs/appveyor-yml
- http://www.appveyor.com/docs/build-configuration
