### PR TITLE
Build the windows binary on appveyor, and disable some unit tests on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 
+version: '{branch}-{build}'
+
 install:
   - "SET PATH=C:\\Python27-x64;C:\\Python27-x64\\Scripts;%PATH%"
   - "python --version"
-  - "pip install tox==2.1.1"
-
+  - "pip install tox==2.1.1 virtualenv==13.1.2"
 
 # Build the binary after tests
 build: false
@@ -13,3 +14,7 @@ test_script:
 
 after_test:
   - ps: ".\\script\\build-windows.ps1"
+
+artifacts:
+  - path: .\dist\docker-compose-Windows-x86_64.exe
+    name: "Compose Windows binary"

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -16,6 +16,7 @@ from .. import legacy
 from ..config import parse_environment
 from ..const import DEFAULT_TIMEOUT
 from ..const import HTTP_TIMEOUT
+from ..const import IS_WINDOWS_PLATFORM
 from ..progress_stream import StreamOutputError
 from ..project import ConfigurationError
 from ..project import NoSuchService
@@ -30,9 +31,8 @@ from .log_printer import LogPrinter
 from .utils import get_version_info
 from .utils import yesno
 
-WINDOWS = (sys.platform == 'win32')
 
-if not WINDOWS:
+if not IS_WINDOWS_PLATFORM:
     import dockerpty
 
 log = logging.getLogger(__name__)
@@ -343,7 +343,7 @@ class TopLevelCommand(Command):
 
         detach = options['-d']
 
-        if WINDOWS and not detach:
+        if IS_WINDOWS_PLATFORM and not detach:
             raise UserError(
                 "Interactive mode is not yet supported on Windows.\n"
                 "Please pass the -d flag when using `docker-compose run`."

--- a/compose/const.py
+++ b/compose/const.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 DEFAULT_TIMEOUT = 10
 LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
@@ -8,3 +9,4 @@ LABEL_SERVICE = 'com.docker.compose.service'
 LABEL_VERSION = 'com.docker.compose.version'
 LABEL_CONFIG_HASH = 'com.docker.compose.config-hash'
 HTTP_TIMEOUT = int(os.environ.get('COMPOSE_HTTP_TIMEOUT', os.environ.get('DOCKER_CLIENT_TIMEOUT', 60)))
+IS_WINDOWS_PLATFORM = (sys.platform == 'win32')

--- a/script/build-osx
+++ b/script/build-osx
@@ -9,7 +9,7 @@ rm -rf venv
 virtualenv -p /usr/local/bin/python venv
 venv/bin/pip install -r requirements.txt
 venv/bin/pip install -r requirements-build.txt
-venv/bin/pip install .
+venv/bin/pip install --no-deps .
 venv/bin/pyinstaller docker-compose.spec
 mv dist/docker-compose dist/docker-compose-Darwin-x86_64
 dist/docker-compose-Darwin-x86_64 version

--- a/script/build-windows.ps1
+++ b/script/build-windows.ps1
@@ -13,12 +13,21 @@ Get-ChildItem -Recurse -Include *.pyc | foreach ($_) { Remove-Item $_.FullName }
 virtualenv .\venv
 
 # Install dependencies
-.\venv\Scripts\easy_install "http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win32-py2.7.exe/download"
+.\venv\Scripts\pip install pypiwin32==219
 .\venv\Scripts\pip install -r requirements.txt
-.\venv\Scripts\pip install -r requirements-build.txt
-.\venv\Scripts\pip install .
+.\venv\Scripts\pip install --no-deps .
+
+# TODO: pip warns when installing from a git sha, so we need to set ErrorAction to
+# 'Continue'.  See
+# https://github.com/pypa/pip/blob/fbc4b7ae5fee00f95bce9ba4b887b22681327bb1/pip/vcs/git.py#L77
+# This can be removed once pyinstaller 3.x is released and we upgrade 
+$ErrorActionPreference = "Continue"
+.\venv\Scripts\pip install --allow-external pyinstaller -r requirements-build.txt
 
 # Build binary
+# pyinstaller has lots of warnings, so we need to run with ErrorAction = Continue
 .\venv\Scripts\pyinstaller .\docker-compose.spec
+$ErrorActionPreference = "Stop"
+
 Move-Item -Force .\dist\docker-compose .\dist\docker-compose-Windows-x86_64.exe
 .\dist\docker-compose-Windows-x86_64.exe --version

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -5,6 +5,7 @@ import os
 
 import docker
 import py
+import pytest
 
 from .. import mock
 from .. import unittest
@@ -13,6 +14,7 @@ from compose.cli.command import get_project_name
 from compose.cli.docopt_command import NoSuchCommand
 from compose.cli.errors import UserError
 from compose.cli.main import TopLevelCommand
+from compose.const import IS_WINDOWS_PLATFORM
 from compose.service import Service
 
 
@@ -81,6 +83,7 @@ class CLITestCase(unittest.TestCase):
         with self.assertRaises(NoSuchCommand):
             TopLevelCommand().dispatch(['help', 'nonexistent'], None)
 
+    @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason="requires dockerpty")
     @mock.patch('compose.cli.main.dockerpty', autospec=True)
     def test_run_with_environment_merged_with_options_list(self, mock_dockerpty):
         command = TopLevelCommand()

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -5,8 +5,11 @@ import shutil
 import tempfile
 from operator import itemgetter
 
+import pytest
+
 from compose.config import config
 from compose.config.errors import ConfigurationError
+from compose.const import IS_WINDOWS_PLATFORM
 from tests import mock
 from tests import unittest
 
@@ -92,6 +95,7 @@ class ConfigTest(unittest.TestCase):
                 )
             )
 
+    @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
     def test_load_with_multiple_files(self):
         base_file = config.ConfigFile(
             'base.yaml',
@@ -410,6 +414,7 @@ class InterpolationTest(unittest.TestCase):
         self.assertIn('in service "web"', cm.exception.msg)
         self.assertIn('"${"', cm.exception.msg)
 
+    @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
     @mock.patch.dict(os.environ)
     def test_volume_binding_with_environment_variable(self):
         os.environ['VOLUME_PATH'] = '/host/path'
@@ -422,6 +427,7 @@ class InterpolationTest(unittest.TestCase):
         )[0]
         self.assertEqual(d['volumes'], ['/host/path:/container/path'])
 
+    @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
     @mock.patch.dict(os.environ)
     def test_volume_binding_with_home(self):
         os.environ['HOME'] = '/home/user'
@@ -817,6 +823,7 @@ class EnvTest(unittest.TestCase):
             {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
         )
 
+    @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
     @mock.patch.dict(os.environ)
     def test_resolve_path(self):
         os.environ['HOSTENV'] = '/tmp'
@@ -1073,6 +1080,7 @@ class ExtendsTest(unittest.TestCase):
         for service in service_dicts:
             self.assertTrue(service['hostname'], expected_interpolated_value)
 
+    @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
     def test_volume_path(self):
         dicts = load_from_filename('tests/fixtures/volume-path/docker-compose.yml')
 
@@ -1108,6 +1116,7 @@ class ExtendsTest(unittest.TestCase):
         self.assertEqual(dicts[0]['environment'], {'FOO': '1'})
 
 
+@pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
 class ExpandPathTest(unittest.TestCase):
     working_dir = '/home/user/somedir'
 
@@ -1129,6 +1138,7 @@ class ExpandPathTest(unittest.TestCase):
         self.assertEqual(result, user_path + 'otherdir/somefile')
 
 
+@pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
 class BuildPathTest(unittest.TestCase):
     def setUp(self):
         self.abs_context_path = os.path.join(os.getcwd(), 'tests/fixtures/build-ctx')

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import docker
+import pytest
 
 from .. import mock
 from .. import unittest
+from compose.const import IS_WINDOWS_PLATFORM
 from compose.const import LABEL_CONFIG_HASH
 from compose.const import LABEL_ONE_OFF
 from compose.const import LABEL_PROJECT
@@ -439,6 +441,7 @@ def mock_get_image(images):
         raise NoSuchImageError()
 
 
+@pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
 class ServiceVolumesTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
https://ci.appveyor.com/project/dnephin/compose/build/windows-19

This will let me enable AppVeyor on the docker/compose repo. The binary is available as an artifact of the build.

A few of the failing unit tests are disabled on windows, we can re-enable them as we fix them.

cc @mnowster 