### PR TITLE
Fix #1958. Remove release notes for old version of Docker Compose.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -206,17 +206,8 @@ At this point, you have seen the basics of how Compose works.
 
 ## Release Notes
 
-### Version 1.2.0 (April 7, 2015)
-
-For complete information on this release, see the [1.2.0 Milestone project page](https://github.com/docker/compose/wiki/1.2.0-Milestone-Project-Page).
-In addition to bug fixes and refinements, this release adds the following:
-
-* The `extends` keyword, which adds the ability to extend services by sharing  common configurations. For details, see
-[PR #1088](https://github.com/docker/compose/pull/1088).
-
-* Better integration with Swarm. Swarm will now schedule inter-dependent
-containers on the same host. For details, see
-[PR #972](https://github.com/docker/compose/pull/972).
+To see a detailed list of changes for past and current releases of Docker 
+Compose, please refer to the [CHANGELOG](https://github.com/docker/compose/blob/master/CHANGELOG.md).
 
 ## Getting help
 


### PR DESCRIPTION
Cherry picking index.md update

Replace by link to the latest CHANGELOG in GitHub.

Signed-off-by: Charles Chan <charleswhchan@users.noreply.github.com>
(cherry picked from commit 000bf1c16a1e2181d4b6b2a580692ed3f48231c0)