### PR TITLE
Added support for cgroup_parent

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -21,6 +21,7 @@ from .validation import validate_top_level_object
 DOCKER_CONFIG_KEYS = [
     'cap_add',
     'cap_drop',
+    'cgroup_parent',
     'command',
     'cpu_shares',
     'cpuset',

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -17,6 +17,7 @@
         "build": {"type": "string"},
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup_parent": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/service.py
+++ b/compose/service.py
@@ -39,6 +39,7 @@ log = logging.getLogger(__name__)
 DOCKER_START_KEYS = [
     'cap_add',
     'cap_drop',
+    'cgroup_parent',
     'devices',
     'dns',
     'dns_search',
@@ -677,6 +678,7 @@ class Service(object):
         read_only = options.get('read_only', None)
 
         devices = options.get('devices', None)
+        cgroup_parent = options.get('cgroup_parent', None)
 
         return self.client.create_host_config(
             links=self._get_links(link_to_self=one_off),
@@ -698,7 +700,8 @@ class Service(object):
             read_only=read_only,
             pid_mode=pid,
             security_opt=security_opt,
-            ipc_mode=options.get('ipc')
+            ipc_mode=options.get('ipc'),
+            cgroup_parent=cgroup_parent
         )
 
     def build(self, no_cache=False, pull=False):

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -51,6 +51,12 @@ Override the default command.
 
     command: bundle exec thin -p 3000
 
+### cgroup_parent
+
+Specify an optional parent cgroup for the container.
+
+    cgroup_parent: m-executor-abcd
+
 ### container_name
 
 Specify a custom container name, rather than a generated default name.

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -331,6 +331,13 @@ class ServiceTest(unittest.TestCase):
         service.create_container(do_build=False)
         self.assertFalse(self.mock_client.build.called)
 
+    def test_create_container_no_build_cgroup_parent(self):
+        service = Service('foo', client=self.mock_client, build='.')
+        service.image = lambda: {'Id': 'abc123'}
+
+        service.create_container(do_build=False, cgroup_parent='test')
+        self.assertFalse(self.mock_client.build.called)
+
     def test_create_container_no_build_but_needs_build(self):
         service = Service('foo', client=self.mock_client, build='.')
         service.image = lambda *args, **kwargs: mock_get_image([])


### PR DESCRIPTION
This change adds cgroup-parent support to compose project. It allows
each service to specify a 'cgroup_parent' option.

Related:
1. docker/docker-py#716 (Enables this PR)
2. mohitsoni/compose-executor#3 (Depends on this PR)