### PR TITLE
Pass all DOCKER_ env vars to py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ usedevelop=True
 passenv =
     LD_LIBRARY_PATH
     DOCKER_HOST
+    DOCKER_CERT_PATH
+    DOCKER_TLS_VERIFY
 setenv =
     HOME=/tmp
 deps =


### PR DESCRIPTION
This ensures that `tox` will run against SSL-protected Docker daemons.