### PR TITLE
Add flag for stops all containers if any container was stopped.

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -13,10 +13,11 @@ from compose.utils import split_buffer
 class LogPrinter(object):
     """Print logs from many containers to a single output stream."""
 
-    def __init__(self, containers, output=sys.stdout, monochrome=False):
+    def __init__(self, containers, output=sys.stdout, monochrome=False, cascade_stop=False):
         self.containers = containers
         self.output = utils.get_output_stream(output)
         self.monochrome = monochrome
+        self.cascade_stop = cascade_stop
 
     def run(self):
         if not self.containers:
@@ -24,7 +25,7 @@ class LogPrinter(object):
 
         prefix_width = max_name_width(self.containers)
         generators = list(self._make_log_generators(self.monochrome, prefix_width))
-        for line in Multiplexer(generators).loop():
+        for line in Multiplexer(generators, cascade_stop=self.cascade_stop).loop():
             self.output.write(line)
             self.output.flush()
 

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -20,8 +20,9 @@ class Multiplexer(object):
     parallel and yielding results as they come in.
     """
 
-    def __init__(self, iterators):
+    def __init__(self, iterators, cascade_stop=False):
         self.iterators = iterators
+        self.cascade_stop = cascade_stop
         self._num_running = len(iterators)
         self.queue = Queue()
 
@@ -36,7 +37,10 @@ class Multiplexer(object):
                     raise exception
 
                 if item is STOP:
-                    self._num_running -= 1
+                    if self.cascade_stop is True:
+                        break
+                    else:
+                        self._num_running -= 1
                 else:
                     yield item
             except Empty:

--- a/docs/reference/up.md
+++ b/docs/reference/up.md
@@ -15,18 +15,22 @@ parent = "smn_compose_cli"
 Usage: up [options] [SERVICE...]
 
 Options:
--d                     Detached mode: Run containers in the background,
-                       print new container names.
---no-color             Produce monochrome output.
---no-deps              Don't start linked services.
---force-recreate       Recreate containers even if their configuration and
-                       image haven't changed. Incompatible with --no-recreate.
---no-recreate          If containers already exist, don't recreate them.
-                       Incompatible with --force-recreate.
---no-build             Don't build an image, even if it's missing
--t, --timeout TIMEOUT  Use this timeout in seconds for container shutdown
-                       when attached or when containers are already
-                       running. (default: 10)
+-d                         Detached mode: Run containers in the background,
+                           print new container names.
+                           Incompatible with --abort-on-container-exit.
+--no-color                 Produce monochrome output.
+--no-deps                  Don't start linked services.
+--force-recreate           Recreate containers even if their configuration
+                           and image haven't changed.
+                           Incompatible with --no-recreate.
+--no-recreate              If containers already exist, don't recreate them.
+                           Incompatible with --force-recreate.
+--no-build                 Don't build an image, even if it's missing
+--abort-on-container-exit  Stops all containers if any container was stopped.
+                           Incompatible with -d.
+-t, --timeout TIMEOUT      Use this timeout in seconds for container shutdown
+                           when attached or when containers are already
+                           running. (default: 10)
 ```
 
 Builds, (re)creates, starts, and attaches to containers for a service.

--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -36,7 +36,7 @@ class CLIMainTestCase(unittest.TestCase):
             mock_container('another', 1),
         ]
         service_names = ['web', 'db']
-        log_printer = build_log_printer(containers, service_names, True)
+        log_printer = build_log_printer(containers, service_names, True, False)
         self.assertEqual(log_printer.containers, containers[:3])
 
     def test_build_log_printer_all_services(self):
@@ -46,7 +46,7 @@ class CLIMainTestCase(unittest.TestCase):
             mock_container('other', 1),
         ]
         service_names = []
-        log_printer = build_log_printer(containers, service_names, True)
+        log_printer = build_log_printer(containers, service_names, True, False)
         self.assertEqual(log_printer.containers, containers)
 
     def test_attach_to_logs(self):


### PR DESCRIPTION
Fixes #2474

The pull request [#1754](https://github.com/docker/compose/pull/1754) has changed the behavior of the commands `docker-compose up`.

I added the option `--cascade-stop` to return to the old behavior.