### PR TITLE
Defining default value for log driver.

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -658,7 +658,7 @@ class Service(object):
         cap_add = options.get('cap_add', None)
         cap_drop = options.get('cap_drop', None)
         log_config = LogConfig(
-            type=options.get('log_driver', ""),
+            type=options.get('log_driver', "json-file"),
             config=options.get('log_opt', None)
         )
         pid = options.get('pid', None)


### PR DESCRIPTION
Defining default value for log driver. For the available options I chose
json-file to improve the compability across different OS enviromnents.

This configuration was causing an error I reported in #2135.