### PR TITLE
Fix error when compose can't connect to docker

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -38,10 +38,10 @@ def friendly_error_message():
                 raise errors.DockerNotFoundUbuntu()
             else:
                 raise errors.DockerNotFoundGeneric()
-        elif call_silently(['which', 'boot2docker']) == 0:
+        elif call_silently(['which', 'docker-machine']) == 0:
             raise errors.ConnectionErrorDockerMachine()
         else:
-            raise errors.ConnectionErrorGeneric(self.get_client().base_url)
+            raise errors.ConnectionErrorGeneric(get_client().base_url)
 
 
 def project_from_options(base_dir, options):

--- a/compose/cli/docopt_command.py
+++ b/compose/cli/docopt_command.py
@@ -25,9 +25,6 @@ class DocoptCommand(object):
     def dispatch(self, argv, global_options):
         self.perform_command(*self.parse(argv, global_options))
 
-    def perform_command(self, options, handler, command_options):
-        handler(command_options)
-
     def parse(self, argv, global_options):
         options = docopt_full_help(getdoc(self), argv, **self.docopt_options())
         command = options['COMMAND']

--- a/tests/unit/cli/command_test.py
+++ b/tests/unit/cli/command_test.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+import pytest
+from requests.exceptions import ConnectionError
+
+from compose.cli import errors
+from compose.cli.command import friendly_error_message
+from tests import mock
+from tests import unittest
+
+
+class FriendlyErrorMessageTestCase(unittest.TestCase):
+
+    def test_dispatch_generic_connection_error(self):
+        with pytest.raises(errors.ConnectionErrorGeneric):
+            with mock.patch(
+                'compose.cli.command.call_silently',
+                autospec=True,
+                side_effect=[0, 1]
+            ):
+                with friendly_error_message():
+                    raise ConnectionError()


### PR DESCRIPTION
Fixes #2133

I had to do some refactoring to make it possible to unit test this fix.  This is a change I've wanted to do for a long time now, and I realize that with some of my recent changes it was really easy to accomplish.

`Command` never really felt like it should be part of the class hierarchy. It had a completely separate set of responsibilities.  This refactor removes the intermediate base class, and moved the last few calls to be just functions.

Now when you trace the calls from `main()` you don't have to jump back and forth between the 3 classes in the inheritance hierarchy.  `DocoptCommand` starts the dispatch, and then hands it off to `TopLevelCommand` with a single entry point between them (`perform_command()`).