### PR TITLE
Improve boolean warning message.

### DIFF
--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -57,9 +57,9 @@ def format_boolean_in_environment(instance):
     """
     if isinstance(instance, bool):
         log.warn(
-            "Warning: There is a boolean value, {0} in the 'environment' key.\n"
+            "Warning: There is a boolean value in the 'environment' key.\n"
             "Environment variables can only be strings.\nPlease add quotes to any boolean values to make them string "
-            "(eg, '{0}').\nThis warning will become an error in a future release. \r\n".format(instance)
+            "(eg, 'True', 'yes', 'N').\nThis warning will become an error in a future release. \r\n"
         )
     return True
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -319,7 +319,7 @@ class ConfigTest(unittest.TestCase):
 
     @mock.patch('compose.config.validation.log')
     def test_logs_warning_for_boolean_in_environment(self, mock_logging):
-        expected_warning_msg = "Warning: There is a boolean value, True in the 'environment' key."
+        expected_warning_msg = "Warning: There is a boolean value in the 'environment' key."
         config.load(
             build_config_details(
                 {'web': {


### PR DESCRIPTION
Including examples of more boolean types, eg yes/N as it's not
always immediately clear that they are treated as booleans by YAML.

As raised in https://github.com/docker/compose/issues/2146