### PR TITLE
Bug fix: Use app's Gemfile.lock in Dockerfile

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -26,6 +26,7 @@ Dockerfile consists of:
     RUN mkdir /myapp
     WORKDIR /myapp
     ADD Gemfile /myapp/Gemfile
+    ADD Gemfile.lock /myapp/Gemfile.lock
     RUN bundle install
     ADD . /myapp
 


### PR DESCRIPTION
The Dockerfile should use the same Gemfile.lock as the app, to make sure the container gets the expected versions of gems installed.  Aside from wanting that in principle, without it you can get mysterious gem dependency errors.  Here's the scenario:

1. Suppose `Gemfile` includes `gem "some-active-gem", "~> 1.0"`
2. When developing the app, you run `bundle install`, which installs the latest version--let's say, 1.0.1-and records it in `Gemfile.lock`
3. Suppose the developers of `some-active-gem` then release v1.0.2
4. Now build the container: docker runs `bundle install`, which installs v1.0.2 and records it in `Gemfile.lock` -- and then docker "ADD"s the app worktree, which replaces the `Gemfile.lock` with the one from the worktree that lists v1.0.1.  
5. Now run your app and it fails with the error `Could not find some-active-gem-1.0.1 in any of the sources` which is a bit befuddling since you just saw it run bundle install so you expect all gem dependencies to be resolved properly.