### PR TITLE
Publish master builds to bintray

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@
     - id: check-docstring-first
     - id: check-merge-conflict
     - id: check-yaml
+    - id: check-json
     - id: debug-statements
     - id: end-of-file-fixer
     - id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,13 @@ install: ./script/travis/install
 script:
   - ./script/travis/ci
   - ./script/travis/build-binary
+
+before_deploy:
+  - "./script/travis/render-bintray-config.py < ./script/travis/bintray.json.tmpl > ./bintray.json"
+
+deploy:
+  provider: bintray
+  user: docker-compose-roleuser
+  key: '$BINTRAY_API_KEY'
+  file: ./bintray.json
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+matrix:
+  include:
+    - os: linux
+    - os: osx
+      language: generic
+
+
+install: ./script/travis/install
+
+script:
+  - ./script/travis/ci
+  - ./script/travis/build-binary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,19 @@ install:
 # Build the binary after tests
 build: false
 
+environment:
+  BINTRAY_USER: "docker-compose-roleuser"
+  BINTRAY_PATH: "docker-compose/master/windows/master/docker-compose-Windows-x86_64.exe"
+
 test_script:
   - "tox -e py27,py34 -- tests/unit"
-
-after_test:
   - ps: ".\\script\\build-windows.ps1"
+
+deploy_script:
+  - "curl -sS
+        -u \"%BINTRAY_USER%:%BINTRAY_API_KEY%\"
+        -X PUT \"https://api.bintray.com/content/%BINTRAY_PATH%?override=1&publish=1\"
+        --data-binary @dist\\docker-compose-Windows-x86_64.exe"
 
 artifacts:
   - path: .\dist\docker-compose-Windows-x86_64.exe

--- a/docs/install.md
+++ b/docs/install.md
@@ -71,6 +71,13 @@ To install compose as a container run:
     $ curl -L https://github.com/docker/compose/releases/download/1.5.0/run.sh > /usr/local/bin/docker-compose
     $ chmod +x /usr/local/bin/docker-compose
 
+## Master builds
+
+If you're interested in trying out a pre-release build you can download a
+binary from https://dl.bintray.com/docker-compose/master/. Pre-release
+builds allow you to try out new features before they are released, but may
+be less stable.
+
 
 ## Upgrading
 

--- a/script/build-image
+++ b/script/build-image
@@ -13,4 +13,3 @@ VERSION="$(python setup.py --version)"
 python setup.py sdist
 cp dist/docker-compose-$VERSION.tar.gz dist/docker-compose-release.tar.gz
 docker build -t docker/compose:$TAG -f Dockerfile.run .
-

--- a/script/build-linux
+++ b/script/build-linux
@@ -5,7 +5,7 @@ set -ex
 ./script/clean
 
 TAG="docker-compose"
-docker build -t "$TAG" .
+docker build -t "$TAG" . | tail -n 200
 docker run \
     --rm --entrypoint="script/build-linux-inner" \
     -v $(pwd)/dist:/code/dist \

--- a/script/build-osx
+++ b/script/build-osx
@@ -3,7 +3,6 @@ set -ex
 
 PATH="/usr/local/bin:$PATH"
 
-./script/clean
 rm -rf venv
 
 virtualenv -p /usr/local/bin/python venv

--- a/script/build-windows.ps1
+++ b/script/build-windows.ps1
@@ -29,7 +29,6 @@
 #        .\script\build-windows.ps1
 
 $ErrorActionPreference = "Stop"
-Set-PSDebug -trace 1
 
 # Remove virtualenv
 if (Test-Path venv) {

--- a/script/prepare-osx
+++ b/script/prepare-osx
@@ -24,7 +24,7 @@ if !(which brew); then
   ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
-brew update
+brew update > /dev/null
 
 if !(python_version | grep "$desired_python_version"); then
   if brew list | grep python; then

--- a/script/travis/bintray.json.tmpl
+++ b/script/travis/bintray.json.tmpl
@@ -1,0 +1,29 @@
+{
+    "package": {
+        "name": "${TRAVIS_OS_NAME}",
+        "repo": "master",
+        "subject": "docker-compose",
+        "desc": "Automated build of master branch from travis ci.",
+        "website_url": "https://github.com/docker/compose",
+        "issue_tracker_url": "https://github.com/docker/compose/issues",
+        "vcs_url": "https://github.com/docker/compose.git",
+        "licenses": ["Apache-2.0"]
+    },
+
+    "version": {
+        "name": "master",
+        "desc": "Automated build of the master branch.",
+        "released": "${DATE}",
+        "vcs_tag": "master"
+    },
+
+    "files": [
+        {
+            "includePattern": "dist/(.*)",
+            "excludePattern": ".*\.tar.gz",
+            "uploadPattern": "$1",
+            "matrixParams": { "override": 1 }
+        }
+    ],
+    "publish": true
+}

--- a/script/travis/build-binary
+++ b/script/travis/build-binary
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     script/build-linux
-    # TODO: add script/build-image
+    script/build-image master
+    # TODO: requires auth
+    # docker push docker/compose:master
 else
     script/prepare-osx
     script/build-osx

--- a/script/travis/build-binary
+++ b/script/travis/build-binary
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    script/build-linux
+    # TODO: add script/build-image
+else
+    script/prepare-osx
+    script/build-osx
+fi

--- a/script/travis/ci
+++ b/script/travis/ci
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    tox -e py27,py34 -- tests/unit
+else
+    # TODO: we could also install py34 and test against it
+    python -m tox -e py27 -- tests/unit
+fi

--- a/script/travis/install
+++ b/script/travis/install
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    pip install tox==2.1.1
+else
+    pip install --user tox==2.1.1
+fi

--- a/script/travis/render-bintray-config.py
+++ b/script/travis/render-bintray-config.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import datetime
+import os.path
+import sys
+
+os.environ['DATE'] = str(datetime.date.today())
+
+for line in sys.stdin:
+    print os.path.expandvars(line),


### PR DESCRIPTION
Implements #1070 

Using travis-ci we can publish builds to bintray at https://dl.bintray.com/docker-compose/master/

The deploy step only runs on the master branch (by default). We can look to get it setup to work on tags as well, if we are interested in using this for scheduled releases as well.

Also added the bintray upload to appveyor config. The appveyor deploy scripts runs on any branch, but never on pull requests.

In both cases the API key is hidden to anyone submitting a PR, so there's no risk of a malicious PR exposing it. The API key is configured from the web UI of travis-ci and appveyor.