### PR TITLE
Update pip install instructions to be more reliable

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -60,7 +60,14 @@ To install Compose, do the following:
 
 ### Install using pip
 
-    $ sudo pip install -U docker-compose
+Compose can be installed from [pypi](https://pypi.python.org/pypi/docker-compose)
+using `pip`.  If you install using `pip` it is highly recommended that you use a
+[virtualenv](https://virtualenv.pypa.io/en/latest/) because many operating systems
+have python system packages that conflict with docker-compose dependencies. See
+the [virtualenv tutorial](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
+to get started.
+
+    $ pip install docker-compose
 
 
 ### Install as a container


### PR DESCRIPTION
Every week we get one or two reports of failures to install from pip (#2108, #1996, #2101, #1305, #1288, #1290 are some recent ones I was able to find without much effort).

We use some very common packages (six, requests) which are newer than the version installed on most systems.  This is always going to lead to problems.

I think we should suggest that people use a virtualenv to install with pip to prevent these issues.  If they're a less experienced python user it should be a better experience for them.

Fixes #1996 
Fixes #2101