### PR TITLE
Docs changes, fixed some links, removed older links, etc

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,11 +1,6 @@
 FROM docs/base:latest
 MAINTAINER Mary Anthony <mary@docker.com> (@moxiegirl)
 
-# To get the git info for this repo
-COPY . /src
-
-COPY . /docs/content/compose/
-
 RUN svn checkout https://github.com/docker/docker/trunk/docs /docs/content/docker
 RUN svn checkout https://github.com/docker/swarm/trunk/docs /docs/content/swarm
 RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/machine
@@ -13,6 +8,10 @@ RUN svn checkout https://github.com/docker/distribution/trunk/docs /docs/content
 RUN svn checkout https://github.com/docker/tutorials/trunk/docs /docs/content/tutorials
 RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content
 
+# To get the git info for this repo
+COPY . /src
+
+COPY . /docs/content/compose/
 
 # Sed to process GitHub Markdown
 # 1-2 Remove comment code from metadata block

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -66,4 +66,3 @@ Enjoy working with Compose faster and with less typos!
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -1,6 +1,6 @@
 <!--[metadata]>
 +++
-title = "Command Completion"
+title = "Command-line Completion"
 description = "Compose CLI reference"
 keywords = ["fig, composition, compose, docker, orchestration, cli,  reference"]
 [menu.main]
@@ -9,7 +9,7 @@ weight=3
 +++
 <![end-metadata]-->
 
-# Command Completion
+# Command-line Completion
 
 Compose comes with [command completion](http://en.wikipedia.org/wiki/Command-line_completion)
 for the bash and zsh shell.

--- a/docs/django.md
+++ b/docs/django.md
@@ -131,5 +131,3 @@ example, run `docker-compose up` and in another terminal run:
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)

--- a/docs/env.md
+++ b/docs/env.md
@@ -41,9 +41,5 @@ Fully qualified container name, e.g. `DB_1_NAME=/myapp_web_1/myapp_db_1`
 
 - [User guide](/)
 - [Installing Compose](install.md)
-- [Get started with Django](django.md)
-- [Get started with Rails](rails.md)
-- [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose command line completion](completion.md)

--- a/docs/extends.md
+++ b/docs/extends.md
@@ -360,4 +360,3 @@ locally-defined bindings taking precedence:
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose command line completion](completion.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,8 +55,6 @@ Compose has commands for managing the whole lifecycle of your application:
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)
 
 ## Quick start
 
@@ -218,14 +216,3 @@ like-minded individuals, we have a number of open channels for communication.
 * To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/compose/pulls).
 
 For more information and resources, please visit the [Getting Help project page](https://docs.docker.com/project/get-help/).
-
-## Where to go next
-
-- [Installing Compose](install.md)
-- [Get started with Django](django.md)
-- [Get started with Rails](rails.md)
-- [Get started with WordPress](wordpress.md)
-- [Command line reference](/reference)
-- [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -205,13 +205,14 @@ Compose, please refer to the [CHANGELOG](https://github.com/docker/compose/blob/
 
 ## Getting help
 
-Docker Compose is still in its infancy and under active development. If you need
-help, would like to contribute, or simply want to talk about the project with
-like-minded individuals, we have a number of open channels for communication.
+Docker Compose is under active development. If you need help, would like to
+contribute, or simply want to talk about the project with like-minded
+individuals, we have a number of open channels for communication.
 
 * To report bugs or file feature requests: please use the [issue tracker on Github](https://github.com/docker/compose/issues).
 
-* To talk about the project with people in real time: please join the `#docker-compose` channel on IRC.
+* To talk about the project with people in real time: please join the
+  `#docker-compose` channel on freenode IRC.
 
 * To contribute code or documentation changes: please submit a [pull request on Github](https://github.com/docker/compose/pulls).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -117,5 +117,3 @@ To uninstall Docker Compose if you installed using `pip`:
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)

--- a/docs/production.md
+++ b/docs/production.md
@@ -91,5 +91,3 @@ guide</a>.
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -129,5 +129,3 @@ That's it. Your app should now be running on port 3000 on your Docker daemon. If
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)

--- a/docs/reference/docker-compose.md
+++ b/docs/reference/docker-compose.md
@@ -100,5 +100,5 @@ directory name.
 
 ## Where to go next
 
-* [CLI environment variables](overview.md)
-* [Command line reference](index.md)
+* [CLI environment variables](/reference/overview.md)
+* [Command line reference](/reference)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -30,5 +30,5 @@ The following pages describe the usage information for the [docker-compose](/ref
 
 ## Where to go next
 
-* [CLI environment variables](overview.md)
-* [docker-compose Command](docker-compose.md)
+* [CLI environment variables](/reference/overview)
+* [docker-compose Command](/reference/docker-compose)

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -17,8 +17,8 @@ This section describes the subcommands you can use with the `docker-compose` com
 
 ## Commands
 
-* [docker-compose Command](docker-compose.md)
-* [CLI Reference](index.md)
+* [docker-compose Command](/reference/docker-compose.md)
+* [CLI Reference](/reference)
 
 
 ## Environment Variables

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -81,9 +81,4 @@ it failed. Defaults to 60 seconds.
 
 - [User guide](/)
 - [Installing Compose](install.md)
-- [Get started with Django](django.md)
-- [Get started with Rails](rails.md)
-- [Get started with WordPress](wordpress.md)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -100,5 +100,3 @@ database containers. If you're using [Docker Machine](https://docs.docker.com/ma
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
 - [Yaml file reference](yml.md)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -418,5 +418,3 @@ dollar sign (`$$`).
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](/reference)
-- [Compose environment variables](env.md)
-- [Compose command line completion](completion.md)


### PR DESCRIPTION
This is a collection of small docs changes. Each commit should be well isolated from the others.

cc @moxiegirl 

* Moved `COPY` to the end of the `Dockerfile` so that rebuilding doesn't re-download all the external repos. It makes it much faster to re-run `make -C docs`. Is this change ok for the larger docs build?
* I removed some links from the footer menu on most pages. 
 * The "environment variable" page is basically deprecated, so I don't think we want to link to it from everywhere.
 * The "Command completion" doc is only really useful during installation, and we already link to it from the install docs.
 * The reference section doesn't really need a link back to the getting started guides. I think these guides are only really useful when someone is "getting started" with compose. Once they're hitting the reference section it's not going to be useful for them.
* Fixed cross-section links in the reference section