### PR TITLE
Rename "yml reference" to "Compose file reference"

### DIFF
--- a/docs/completion.md
+++ b/docs/completion.md
@@ -65,4 +65,4 @@ Enjoy working with Compose faster and with less typos!
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -65,4 +65,4 @@ Enjoy working with Compose faster and with less typos!
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -3,6 +3,7 @@
 title = "Compose file reference"
 description = "Compose file reference"
 keywords = ["fig, composition, compose, docker"]
+aliases = ["/compose/yml"]
 [menu.main]
 parent="smn_compose_ref"
 +++

--- a/docs/django.md
+++ b/docs/django.md
@@ -164,4 +164,4 @@ In this section, you set up the database connection for Django.
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/django.md
+++ b/docs/django.md
@@ -164,4 +164,4 @@ In this section, you set up the database connection for Django.
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [YAML file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/env.md
+++ b/docs/env.md
@@ -42,4 +42,4 @@ Fully qualified container name, e.g. `DB_1_NAME=/myapp_web_1/myapp_db_1`
 - [User guide](index.md)
 - [Installing Compose](install.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/env.md
+++ b/docs/env.md
@@ -42,4 +42,4 @@ Fully qualified container name, e.g. `DB_1_NAME=/myapp_web_1/myapp_db_1`
 - [User guide](index.md)
 - [Installing Compose](install.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/extends.md
+++ b/docs/extends.md
@@ -359,4 +359,4 @@ locally-defined bindings taking precedence:
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/extends.md
+++ b/docs/extends.md
@@ -359,4 +359,4 @@ locally-defined bindings taking precedence:
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Compose has commands for managing the whole lifecycle of your application:
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)
 
 ## Quick start
 
@@ -196,7 +196,7 @@ At this point, you have seen the basics of how Compose works.
 - Next, try the quick start guide for [Django](django.md),
   [Rails](rails.md), or [WordPress](wordpress.md).
 - See the reference guides for complete details on the [commands](./reference/index.md), the
-  [configuration file](yml.md) and [environment variables](env.md).
+  [configuration file](compose-file.md) and [environment variables](env.md).
 
 ## Release Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Compose has commands for managing the whole lifecycle of your application:
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)
 
 ## Quick start
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,4 +130,4 @@ To uninstall Docker Compose if you installed using `pip`:
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,4 +130,4 @@ To uninstall Docker Compose if you installed using `pip`:
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/production.md
+++ b/docs/production.md
@@ -90,4 +90,4 @@ guide</a>.
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/production.md
+++ b/docs/production.md
@@ -90,4 +90,4 @@ guide</a>.
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -129,4 +129,4 @@ That's it. Your app should now be running on port 3000 on your Docker daemon. If
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -129,4 +129,4 @@ That's it. Your app should now be running on port 3000 on your Docker daemon. If
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -81,4 +81,4 @@ it failed. Defaults to 60 seconds.
 
 - [User guide](../index.md)
 - [Installing Compose](../install.md)
-- [Compose file reference](../yml.md)
+- [Compose file reference](../compose-file.md)

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -81,4 +81,4 @@ it failed. Defaults to 60 seconds.
 
 - [User guide](../index.md)
 - [Installing Compose](../install.md)
-- [Yaml file reference](../yml.md)
+- [Compose file reference](../yml.md)

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -99,4 +99,4 @@ database containers. If you're using [Docker Machine](https://docs.docker.com/ma
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Yaml file reference](yml.md)
+- [Compose file reference](yml.md)

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -99,4 +99,4 @@ database containers. If you're using [Docker Machine](https://docs.docker.com/ma
 - [Get started with Rails](rails.md)
 - [Get started with WordPress](wordpress.md)
 - [Command line reference](./reference/index.md)
-- [Compose file reference](yml.md)
+- [Compose file reference](compose-file.md)

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -1,15 +1,19 @@
 <!--[metadata]>
 +++
-title = "docker-compose.yml reference"
-description = "docker-compose.yml reference"
-keywords = ["fig, composition, compose,  docker"]
+title = "Compose file reference"
+description = "Compose file reference"
+keywords = ["fig, composition, compose, docker"]
 [menu.main]
 parent="smn_compose_ref"
 +++
 <![end-metadata]-->
 
 
-# docker-compose.yml reference
+# Compose file reference
+
+The compose file is a [YAML](http://yaml.org/) file where all the top level
+keys are the name of a service, and the values are the service definition.
+The default path for a compose file is `./docker-compose.yml`.
 
 Each service defined in `docker-compose.yml` must specify exactly one of
 `image` or `build`. Other keys are optional, and are analogous to their

--- a/docs/yml.md
+++ b/docs/yml.md
@@ -334,7 +334,7 @@ Override the default labeling scheme for each container.
         - label:user:USER
         - label:role:ROLE
 
-### volumes
+### volumes, volume\_driver
 
 Mount paths as volumes, optionally specifying a path on the host machine
 (`HOST:CONTAINER`), or an access mode (`HOST:CONTAINER:ro`).
@@ -348,8 +348,18 @@ You can mount a relative path on the host, which will expand relative to
 the directory of the Compose configuration file being used. Relative paths
 should always begin with `.` or `..`.
 
+If you use a volume name (instead of a volume path), you may also specify
+a `volume_driver`.
+
+    volume_driver: mydriver
+
+
 > Note: No path expansion will be done if you have also specified a
 > `volume_driver`.
+
+See [Docker Volumes](https://docs.docker.com/userguide/dockervolumes/) and
+[Volume Plugins](https://docs.docker.com/extend/plugins_volume/) for more
+information.
 
 ### volumes_from
 
@@ -361,7 +371,7 @@ specifying read-only access(``ro``) or read-write(``rw``).
      - container_name
      - service_name:rw
 
-### cpu\_shares, cpuset, domainname, entrypoint, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, privileged, read\_only, restart, stdin\_open, tty, user, volume\_driver, working\_dir
+### cpu\_shares, cpuset, domainname, entrypoint, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, privileged, read\_only, restart, stdin\_open, tty, user, working\_dir
 
 Each of these is a single value, analogous to its
 [docker run](https://docs.docker.com/reference/run/) counterpart.
@@ -387,8 +397,6 @@ Each of these is a single value, analogous to its
     read_only: true
     stdin_open: true
     tty: true
-
-    volume_driver: mydriver
 
 ## Variable substitution
 


### PR DESCRIPTION
I think we should start referring to the configuration file as the "Compose file". 

1) We're talking about formalizing the spec (#2089), so it would be good to starting referring to it by a proper name early
2) Calling it the "yml file" I think puts the focus on the wrong thing. Technically compose works with json files as well (because yml is just a superset of json). 
3) This reference doc includes the docs for variable substitution now (which is not related to yml)

I haven't renamed the document so that we don't break any links. I'm not sure if there is any way to alias or redirect from the old url.

I also made a small change to the `volume_driver` section. I think it would be good to start splitting out this catch-all section, so I started with one small change.

cc @moxiegirl 