### PR TITLE
Revert networking-related changes to getting started guides

### DIFF
--- a/docs/django.md
+++ b/docs/django.md
@@ -64,8 +64,9 @@ and a `docker-compose.yml` file.
 
     The `docker-compose.yml` file describes the services that make your app. In
     this example those services are a web server and database.  The compose file
-    also describes which Docker images these services use, any volumes they might
-    need mounted inside the containers, and any ports they might
+    also describes which Docker images these services use, how they link
+    together, any volumes they might need mounted inside the containers.
+    Finally, the `docker-compose.yml` file describes which ports these services
     expose. See the [`docker-compose.yml` reference](yml.md) for more
     information on how this file works.
 
@@ -80,6 +81,8 @@ and a `docker-compose.yml` file.
             - .:/code
           ports:
             - "8000:8000"
+          links:
+            - db
 
     This file defines two services: The `db` service and the `web` service.
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -37,7 +37,7 @@ Next, create a bootstrap `Gemfile` which just loads Rails. It'll be overwritten 
     source 'https://rubygems.org'
     gem 'rails', '4.2.0'
 
-Finally, `docker-compose.yml` is where the magic happens. This file describes the services that comprise your app (a database and a web app), how to get each one's Docker image (the database just runs on a pre-made PostgreSQL image, and the web app is built from the current directory), and the configuration needed to expose the web app's port.
+Finally, `docker-compose.yml` is where the magic happens. This file describes the services that comprise your app (a database and a web app), how to get each one's Docker image (the database just runs on a pre-made PostgreSQL image, and the web app is built from the current directory), and the configuration needed to link them together and expose the web app's port.
 
     db:
       image: postgres
@@ -48,6 +48,8 @@ Finally, `docker-compose.yml` is where the magic happens. This file describes th
         - .:/myapp
       ports:
         - "3000:3000"
+      links:
+        - db
 
 ### Build the project
 

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -46,6 +46,8 @@ and a separate MySQL instance:
       command: php -S 0.0.0.0:8000 -t /code
       ports:
         - "8000:8000"
+      links:
+        - db
       volumes:
         - .:/code
     db:


### PR DESCRIPTION
While networking support is still experimental and behind a flag, we should leave the getting started guides as they are.