### PR TITLE
Replace underscores with hyphens in a container name

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -853,7 +853,7 @@ def build_container_name(project, service, number, one_off=False):
     bits = [project, service]
     if one_off:
         bits.append('run')
-    return '_'.join(bits + [str(number)])
+    return '-'.join(bits + [str(number)])
 
 
 # Images


### PR DESCRIPTION
This PR replaces underscores with hyphens when used as separators in a container name. 
The use of hyphens is important when the container name coincides with the hostname of the container: indeed underscores produce invalid hostnames (see [restrictions on valid hostnames](https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names)).