### PR TITLE
Fix check for tags in release script `make-branch`

### DIFF
--- a/script/release/make-branch
+++ b/script/release/make-branch
@@ -46,7 +46,7 @@ if [ -z "$REMOTE" ]; then
 fi
 
 # handle the difference between a branch and a tag
-if [ -z "$(git name-rev $BASE_VERSION | grep tags)" ]; then
+if [ -z "$(git name-rev --tags $BASE_VERSION | grep tags)" ]; then
     BASE_VERSION=$REMOTE/$BASE_VERSION
 fi
 


### PR DESCRIPTION
Ran into another bug while starting to cherry-pick some branches into rc2.

I'm not sure if this worked if there isn't a branch with the same name, but if there is a branch with the same name it fails without the `--tags`.  This is only a problem when we're branching from a git tag (which is why I didn't see it in the previous round of fixes).