### PR TITLE
Give the user a better error message when the yaml file is invalid

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -610,5 +610,6 @@ def load_yaml(filename):
     try:
         with open(filename, 'r') as fh:
             return yaml.safe_load(fh)
-    except IOError as e:
-        raise ConfigurationError(six.text_type(e))
+    except (IOError, yaml.YAMLError) as e:
+        error_name = getattr(e, '__module__', '') + '.' + e.__class__.__name__
+        raise ConfigurationError(u"{}: {}".format(error_name, e))

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 from operator import itemgetter
 
+import py
 import pytest
 
 from compose.config import config
@@ -348,6 +349,18 @@ class ConfigTest(unittest.TestCase):
                     'filename.yml'
                 )
             )
+
+    def test_load_yaml_with_yaml_error(self):
+        tmpdir = py.test.ensuretemp('invalid_yaml_test')
+        invalid_yaml_file = tmpdir.join('docker-compose.yml')
+        invalid_yaml_file.write("""
+            web:
+              this is bogus: ok: what
+        """)
+        with pytest.raises(ConfigurationError) as exc:
+            config.load_yaml(str(invalid_yaml_file))
+
+        assert 'line 3, column 32' in exc.exconly()
 
 
 class InterpolationTest(unittest.TestCase):


### PR DESCRIPTION
reported here: http://stackoverflow.com/questions/33114202/docker-compose-not-working-on-debian-8-2

Couldn't find an existing issue for it.

If there are yaml parsing errors the user would get a stacktrace, so the important details (line and column number with the error) were kind of hard to see.

This fixes the issue by removing the stacktrace and only printing the relevant error message:

```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "./examples/invalid-yaml/dc.yml", line 3, column 20
```
