### PR TITLE
Properly validate files when multiple files are used

### DIFF
--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import sys
-from functools import wraps
 
 import six
 from docker.utils.ports import split_port
@@ -65,27 +64,21 @@ def format_boolean_in_environment(instance):
     return True
 
 
-def validate_service_names(func):
-    @wraps(func)
-    def func_wrapper(config):
-        for service_name in config.keys():
-            if type(service_name) is int:
-                raise ConfigurationError(
-                    "Service name: {} needs to be a string, eg '{}'".format(service_name, service_name)
-                )
-        return func(config)
-    return func_wrapper
-
-
-def validate_top_level_object(func):
-    @wraps(func)
-    def func_wrapper(config):
-        if not isinstance(config, dict):
+def validate_service_names(config):
+    for service_name in config.keys():
+        if not isinstance(service_name, six.string_types):
             raise ConfigurationError(
-                "Top level object needs to be a dictionary. Check your .yml file that you have defined a service at the top level."
-            )
-        return func(config)
-    return func_wrapper
+                "Service name: {} needs to be a string, eg '{}'".format(
+                    service_name,
+                    service_name))
+
+
+def validate_top_level_object(config):
+    if not isinstance(config, dict):
+        raise ConfigurationError(
+            "Top level object needs to be a dictionary. Check your .yml file "
+            "that you have defined a service at the top level.")
+    validate_service_names(config)
 
 
 def validate_extends_file_path(service_name, extends_options, filename):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -134,6 +134,28 @@ class ConfigTest(unittest.TestCase):
         ]
         self.assertEqual(service_sort(service_dicts), service_sort(expected))
 
+    def test_load_with_multiple_files_and_empty_override(self):
+        base_file = config.ConfigFile(
+            'base.yaml',
+            {'web': {'image': 'example/web'}})
+        override_file = config.ConfigFile('override.yaml', None)
+        details = config.ConfigDetails('.', [base_file, override_file])
+
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(details)
+        assert 'Top level object needs to be a dictionary' in exc.exconly()
+
+    def test_load_with_multiple_files_and_empty_base(self):
+        base_file = config.ConfigFile('base.yaml', None)
+        override_file = config.ConfigFile(
+            'override.yaml',
+            {'web': {'image': 'example/web'}})
+        details = config.ConfigDetails('.', [base_file, override_file])
+
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(details)
+        assert 'Top level object needs to be a dictionary' in exc.exconly()
+
     def test_config_valid_service_names(self):
         for valid_name in ['_', '-', '.__.', '_what-up.', 'what_.up----', 'whatup']:
             config.load(


### PR DESCRIPTION
Fixes #2203 

Removed the single-use decorators so the functionality can be used directly as a function.
