### PR TITLE
bash completion for networking options

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -105,11 +105,15 @@ _docker_compose_docker_compose() {
 		--project-name|-p)
 			return
 			;;
+		--x-network-driver)
+			COMPREPLY=( $( compgen -W "bridge host none overlay" -- "$cur" ) )
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help -h --verbose --version -v --file -f --project-name -p" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--file -f --help -h --project-name -p --verbose --version -v --x-networking --x-network-driver" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "${commands[*]}" -- "$cur" ) )
@@ -409,6 +413,9 @@ _docker_compose() {
 			--project-name|p)
 				(( counter++ ))
 				compose_project="${words[$counter]}"
+				;;
+			--x-network-driver)
+				(( counter++ ))
 				;;
 			-*)
 				;;


### PR DESCRIPTION
This adds completion support for `--x-networking` and `--x-network-options`.
ref: #2191
Thanks @sdurrheimer for the ping.

Please schedule this for 1.5.0 as the feature is present in that release.