### PR TITLE
fix problem with bash completion in old bash

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -17,6 +17,12 @@
 #    . ~/.docker-compose-completion.sh
 
 
+# suppress trailing whitespace
+__docker_compose_nospace() {
+	# compopt is not available in ancient bash versions
+	type compopt &>/dev/null && compopt -o nospace
+}
+
 # For compatibility reasons, Compose and therefore its completion supports several
 # stack compositon files as listed here, in descending priority.
 # Support for these filenames might be dropped in some future version.
@@ -255,7 +261,7 @@ _docker_compose_run() {
 	case "$prev" in
 		-e)
 			COMPREPLY=( $( compgen -e -- "$cur" ) )
-			compopt -o nospace
+			__docker_compose_nospace
 			return
 			;;
 		--entrypoint|--name|--user|-u)
@@ -291,7 +297,7 @@ _docker_compose_scale() {
 			;;
 		*)
 			COMPREPLY=( $(compgen -S "=" -W "$(___docker_compose_all_services_in_compose_file)" -- "$cur") )
-			compopt -o nospace
+			__docker_compose_nospace
 			;;
 	esac
 }


### PR DESCRIPTION
There is a problem with bash completion running in old bash versions. These versions are still shipped with current MacBooks. See #16348 for the corresponding Docker issue and its details.

As docker-compose bash completion also uses the problematic bash feature, this PR applies the same fix as used in Docker, see #16348.

Steps to reproduce the problem:
On a MacBook, completion of `docker-compose run -e` will result in

    docker-compose run -e bash: compopt: command not found

Likewise, completion of `docker-compose scale` will yield

    docker-compose scale bash: compopt: command not found