### PR TITLE
Rely on 'auto' for DEFAULT_API_VERSION

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -9,7 +9,7 @@ from ..const import HTTP_TIMEOUT
 log = logging.getLogger(__name__)
 
 
-DEFAULT_API_VERSION = '1.19'
+DEFAULT_API_VERSION = 'auto'
 
 
 def docker_client(version=None):


### PR DESCRIPTION
docker-py supports this directly