### PR TITLE
Clean orphan containers

### DIFF
--- a/docs/reference/clean.md
+++ b/docs/reference/clean.md
@@ -1,0 +1,33 @@
+<!--[metadata]>
++++
+title = "clean"
+description = "Kill and remove orphan containers."
+keywords = ["fig, composition, compose, docker, orchestration, cli, clean"]
+[menu.main]
+identifier="clean.compose"
+parent = "smn_compose_cli"
++++
+<![end-metadata]-->
+
+# clean
+
+```
+Usage: clean [options]
+
+Options:
+--keep          Do not remove containers.
+-f, --force     Don't ask to confirm removal
+```
+
+Kill and remove orphan containers.
+
+If any container from a previous version of docker-compose.yml is running,
+this container will be killed and removed.
+
+If the container is not running, it will be removed.
+
+Orphan containers are identified using labels.
+
+To prevent Compose from removing containers, use the `--keep` flag.
+
+    $ docker-compose clean --keep

--- a/docs/reference/docker-compose.md
+++ b/docs/reference/docker-compose.md
@@ -40,6 +40,7 @@ Commands:
   stop               Stop services
   unpause            Unpause services
   up                 Create and start containers
+  clean              Remove orphan containers
   migrate-to-labels  Recreate containers to add labels
   version            Show the Docker-Compose version information
 ```

--- a/docs/reference/ps.md
+++ b/docs/reference/ps.md
@@ -15,7 +15,8 @@ parent = "smn_compose_cli"
 Usage: ps [options] [SERVICE...]
 
 Options:
--q    Only display IDs
+-q          Only display IDs
+-a, --all   Display orphan containers
 ```
 
 Lists containers.

--- a/docs/reference/up.md
+++ b/docs/reference/up.md
@@ -27,6 +27,7 @@ Options:
 -t, --timeout TIMEOUT  Use this timeout in seconds for container shutdown
                        when attached or when containers are already
                        running. (default: 10)
+--clean                Kill orphan containers.
 ```
 
 Builds, (re)creates, starts, and attaches to containers for a service.
@@ -45,3 +46,5 @@ flag.
 
 If you want to force Compose to stop and recreate all containers, use the
 `--force-recreate` flag.
+
+You can kill all orphan containers using the `--clean` flag.

--- a/tests/fixtures/orphan-services/docker-compose.after.yml
+++ b/tests/fixtures/orphan-services/docker-compose.after.yml
@@ -1,0 +1,12 @@
+test1:
+    image: busybox
+    command: sleep 3600
+
+# Services are orphan now
+# test2:
+#     image: busybox
+#     command: sleep 3600
+#
+# test3:
+#     image: busybox
+#     command: "true"

--- a/tests/fixtures/orphan-services/docker-compose.before.yml
+++ b/tests/fixtures/orphan-services/docker-compose.before.yml
@@ -1,0 +1,11 @@
+test1:
+    image: busybox
+    command: sleep 3600
+
+test2:
+    image: busybox
+    command: sleep 3600
+
+test3:
+    image: busybox
+    command: "true"


### PR DESCRIPTION
This pull request adds to compose a `clean` command to clean-up orphaned containers when `docker-compose.yml` file is edited.

The first commit adds `clean` command which provides two options to stop and remove orphan containers. Using `--keep` only stop running orphaned containers, `--force` will kill and remove containers without confirmation.

`ps` gets the new flag `--all` to list orphaned containers, output can be filtered using service names. Service names will match orphan containers if `--all` flag is present.

`up` gets the new flag `--clean` to kill orphaned container. This flag will not remove orphaned containers, only `clean` command will.

The second commit adds unit tests about those changes.

Please tell me if any of my edits may alter any good practice about the project.

This is my very first participation on Github to a big project like compose. I really hope I didn't make any mistake in the pull request procedure. Please be indulgent if any :)

Fixes #1477 