### PR TITLE
Lowercase windows drive letter

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -943,23 +943,21 @@ def build_volume_binding(volume_spec):
 
 
 def normalize_paths_for_engine(external_path, internal_path):
-    """
-    Windows paths, c:\my\path\shiny, need to be changed to be compatible with
+    """Windows paths, c:\my\path\shiny, need to be changed to be compatible with
     the Engine. Volume paths are expected to be linux style /c/my/path/shiny/
     """
-    if IS_WINDOWS_PLATFORM:
-        if external_path:
-            drive, tail = os.path.splitdrive(external_path)
-
-            if drive:
-                reformatted_drive = "/{}".format(drive.lower().replace(":", ""))
-                external_path = reformatted_drive + tail
-
-            external_path = "/".join(external_path.split("\\"))
-
-        return external_path, "/".join(internal_path.split("\\"))
-    else:
+    if not IS_WINDOWS_PLATFORM:
         return external_path, internal_path
+
+    if external_path:
+        drive, tail = os.path.splitdrive(external_path)
+
+        if drive:
+            external_path = '/' + drive.lower().rstrip(':') + tail
+
+        external_path = external_path.replace('\\', '/')
+
+    return external_path, internal_path.replace('\\', '/')
 
 
 def parse_volume_spec(volume_config):

--- a/compose/service.py
+++ b/compose/service.py
@@ -952,7 +952,7 @@ def normalize_paths_for_engine(external_path, internal_path):
             drive, tail = os.path.splitdrive(external_path)
 
             if drive:
-                reformatted_drive = "/{}".format(drive.replace(":", ""))
+                reformatted_drive = "/{}".format(drive.lower().replace(":", ""))
                 external_path = reformatted_drive + tail
 
             external_path = "/".join(external_path.split("\\"))

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -537,8 +537,8 @@ class VolumeConfigTest(unittest.TestCase):
         self.assertEqual(d['volumes'], ['/var/lib/data:/data'])
 
     def test_absolute_windows_path_does_not_expand(self):
-        d = make_service_dict('foo', {'build': '.', 'volumes': ['C:\\data:/data']}, working_dir='.')
-        self.assertEqual(d['volumes'], ['C:\\data:/data'])
+        d = make_service_dict('foo', {'build': '.', 'volumes': ['c:\\data:/data']}, working_dir='.')
+        self.assertEqual(d['volumes'], ['c:\\data:/data'])
 
     @pytest.mark.skipif(IS_WINDOWS_PLATFORM, reason='posix paths')
     def test_relative_path_does_expand_posix(self):
@@ -553,14 +553,14 @@ class VolumeConfigTest(unittest.TestCase):
 
     @pytest.mark.skipif(not IS_WINDOWS_PLATFORM, reason='windows paths')
     def test_relative_path_does_expand_windows(self):
-        d = make_service_dict('foo', {'build': '.', 'volumes': ['./data:/data']}, working_dir='C:\\Users\\me\\myproject')
-        self.assertEqual(d['volumes'], ['C:\\Users\\me\\myproject\\data:/data'])
+        d = make_service_dict('foo', {'build': '.', 'volumes': ['./data:/data']}, working_dir='c:\\Users\\me\\myproject')
+        self.assertEqual(d['volumes'], ['c:\\Users\\me\\myproject\\data:/data'])
 
-        d = make_service_dict('foo', {'build': '.', 'volumes': ['.:/data']}, working_dir='C:\\Users\\me\\myproject')
-        self.assertEqual(d['volumes'], ['C:\\Users\\me\\myproject:/data'])
+        d = make_service_dict('foo', {'build': '.', 'volumes': ['.:/data']}, working_dir='c:\\Users\\me\\myproject')
+        self.assertEqual(d['volumes'], ['c:\\Users\\me\\myproject:/data'])
 
-        d = make_service_dict('foo', {'build': '.', 'volumes': ['../otherproject:/data']}, working_dir='C:\\Users\\me\\myproject')
-        self.assertEqual(d['volumes'], ['C:\\Users\\me\\otherproject:/data'])
+        d = make_service_dict('foo', {'build': '.', 'volumes': ['../otherproject:/data']}, working_dir='c:\\Users\\me\\myproject')
+        self.assertEqual(d['volumes'], ['c:\\Users\\me\\otherproject:/data'])
 
     @mock.patch.dict(os.environ)
     def test_home_directory_with_driver_does_not_expand(self):


### PR DESCRIPTION
Fixes #2198 (I think)

`os.path.splitdrive()` was giving us uppercase letters, but `docker-machine` creates a path with a lowercase `/c/`.  It's also possible that a user could specify an absolute path with uppercase drive.  

This change forces the drive to lowercase.

The second commit includes a small refactor.