### PR TITLE
WIP: Upgrade to api 1.20

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -9,7 +9,7 @@ from ..const import HTTP_TIMEOUT
 log = logging.getLogger(__name__)
 
 
-DEFAULT_API_VERSION = '1.19'
+DEFAULT_API_VERSION = '1.20'
 
 
 def docker_client(version=None):

--- a/compose/container.py
+++ b/compose/container.py
@@ -171,6 +171,12 @@ class Container(object):
         port = self.ports.get("%s/%s" % (port, protocol))
         return "{HostIp}:{HostPort}".format(**port[0]) if port else None
 
+    def get_mount(self, mount_dest):
+        for mount in self.get('Mounts'):
+            if mount['Destination'] == mount_dest:
+                return mount
+        return None
+
     def start(self, **options):
         return self.client.start(self.id, **options)
 

--- a/compose/container.py
+++ b/compose/container.py
@@ -222,16 +222,6 @@ class Container(object):
         self.has_been_inspected = True
         return self.dictionary
 
-    # TODO: only used by tests, move to test module
-    def links(self):
-        links = []
-        for container in self.client.containers():
-            for name in container['Names']:
-                bits = name.split('/')
-                if len(bits) > 2 and bits[1] == self.name:
-                    links.append(bits[2])
-        return links
-
     def attach(self, *args, **kwargs):
         return self.client.attach(self.id, *args, **kwargs)
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -839,7 +839,13 @@ def get_container_data_volumes(container, volumes_option):
     a mapping of volume bindings for those volumes.
     """
     volumes = []
-    container_volumes = container.get('Volumes') or {}
+    volumes_option = volumes_option or []
+
+    container_mounts = dict(
+        (mount['Destination'], mount)
+        for mount in container.get('Mounts') or {}
+    )
+
     image_volumes = [
         VolumeSpec.parse(volume)
         for volume in
@@ -851,13 +857,13 @@ def get_container_data_volumes(container, volumes_option):
         if volume.external:
             continue
 
-        volume_path = container_volumes.get(volume.internal)
+        mount = container_mounts.get(volume.internal)
         # New volume, doesn't exist in the old container
-        if not volume_path:
+        if not mount:
             continue
 
         # Copy existing volume from old container
-        volume = volume._replace(external=volume_path)
+        volume = volume._replace(external=mount['Source'])
         volumes.append(volume)
 
     return volumes

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -16,6 +16,7 @@ from compose.cli.command import get_project
 from compose.cli.docker_client import docker_client
 from compose.container import Container
 from tests.integration.testcases import DockerClientTestCase
+from tests.integration.testcases import get_links
 from tests.integration.testcases import pull_busybox
 
 
@@ -847,7 +848,7 @@ class CLITestCase(DockerClientTestCase):
 
         web, other, db = containers
         self.assertEqual(web.human_readable_command, 'top')
-        self.assertTrue({'db', 'other'} <= set(web.links()))
+        self.assertTrue({'db', 'other'} <= set(get_links(web)))
         self.assertEqual(db.human_readable_command, 'top')
         self.assertEqual(other.human_readable_command, 'top')
 
@@ -869,7 +870,9 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(len(containers), 2)
         web = containers[1]
 
-        self.assertEqual(set(web.links()), set(['db', 'mydb_1', 'extends_mydb_1']))
+        self.assertEqual(
+            set(get_links(web)),
+            set(['db', 'mydb_1', 'extends_mydb_1']))
 
         expected_env = set([
             "FOO=1",

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -809,7 +809,7 @@ class CLITestCase(DockerClientTestCase):
         self.dispatch(['up', '-d'], None)
 
         container = self.project.containers(stopped=True)[0]
-        actual_host_path = container.get('Volumes')['/container-path']
+        actual_host_path = container.get_mount('/container-path')['Source']
         components = actual_host_path.split('/')
         assert components[-2:] == ['home-dir', 'my-volume']
 

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -275,7 +275,6 @@ class ProjectTest(DockerClientTestCase):
 
         db_container = [c for c in project.containers() if 'db' in c.name][0]
         self.assertEqual(db_container.id, old_db_id)
-        mount, = db_container.get('Mounts')
         self.assertEqual(
             db_container.get_mount('/var/db')['Source'],
             db_volume_path)

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -266,15 +266,19 @@ class ProjectTest(DockerClientTestCase):
         project.up(['db'])
         self.assertEqual(len(project.containers()), 1)
         old_db_id = project.containers()[0].id
-        db_volume_path = project.containers()[0].inspect()['Volumes']['/var/db']
+
+        container, = project.containers()
+        db_volume_path = container.get_mount('/var/db')['Source']
 
         project.up(strategy=ConvergenceStrategy.never)
         self.assertEqual(len(project.containers()), 2)
 
         db_container = [c for c in project.containers() if 'db' in c.name][0]
         self.assertEqual(db_container.id, old_db_id)
-        self.assertEqual(db_container.inspect()['Volumes']['/var/db'],
-                         db_volume_path)
+        mount, = db_container.get('Mounts')
+        self.assertEqual(
+            db_container.get_mount('/var/db')['Source'],
+            db_volume_path)
 
     def test_project_up_with_no_recreate_stopped(self):
         web = self.create_service('web')
@@ -289,8 +293,9 @@ class ProjectTest(DockerClientTestCase):
         old_containers = project.containers(stopped=True)
 
         self.assertEqual(len(old_containers), 1)
-        old_db_id = old_containers[0].id
-        db_volume_path = old_containers[0].inspect()['Volumes']['/var/db']
+        old_container, = old_containers
+        old_db_id = old_container.id
+        db_volume_path = old_container.get_mount('/var/db')['Source']
 
         project.up(strategy=ConvergenceStrategy.never)
 
@@ -300,8 +305,9 @@ class ProjectTest(DockerClientTestCase):
 
         db_container = [c for c in new_containers if 'db' in c.name][0]
         self.assertEqual(db_container.id, old_db_id)
-        self.assertEqual(db_container.inspect()['Volumes']['/var/db'],
-                         db_volume_path)
+        self.assertEqual(
+            db_container.get_mount('/var/db')['Source'],
+            db_volume_path)
 
     def test_project_up_without_all_services(self):
         console = self.create_service('console')

--- a/tests/integration/resilience_test.py
+++ b/tests/integration/resilience_test.py
@@ -18,12 +18,12 @@ class ResilienceTest(DockerClientTestCase):
 
         container = self.db.create_container()
         container.start()
-        self.host_path = container.get('Volumes')['/var/db']
+        self.host_path = container.get_mount('/var/db')['Source']
 
     def test_successful_recreate(self):
         self.project.up(strategy=ConvergenceStrategy.always)
         container = self.db.containers()[0]
-        self.assertEqual(container.get('Volumes')['/var/db'], self.host_path)
+        self.assertEqual(container.get_mount('/var/db')['Source'], self.host_path)
 
     def test_create_failure(self):
         with mock.patch('compose.service.Service.create_container', crash):
@@ -32,7 +32,7 @@ class ResilienceTest(DockerClientTestCase):
 
         self.project.up()
         container = self.db.containers()[0]
-        self.assertEqual(container.get('Volumes')['/var/db'], self.host_path)
+        self.assertEqual(container.get_mount('/var/db')['Source'], self.host_path)
 
     def test_start_failure(self):
         with mock.patch('compose.container.Container.start', crash):
@@ -41,7 +41,7 @@ class ResilienceTest(DockerClientTestCase):
 
         self.project.up()
         container = self.db.containers()[0]
-        self.assertEqual(container.get('Volumes')['/var/db'], self.host_path)
+        self.assertEqual(container.get_mount('/var/db')['Source'], self.host_path)
 
 
 class Crash(Exception):

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -306,7 +306,8 @@ class ServiceTest(DockerClientTestCase):
             ConvergencePlan('recreate', [old_container]))
 
         self.assertEqual(
-            [mount['Destination'] for mount in new_container.get('Mounts')], ['/data']
+            [mount['Destination'] for mount in new_container.get('Mounts')],
+            ['/data']
         )
         self.assertEqual(new_container.get_mount('/data')['Source'], volume_path)
 
@@ -317,8 +318,11 @@ class ServiceTest(DockerClientTestCase):
         )
 
         old_container = create_and_start_container(service)
-        self.assertEqual(list(old_container.get('Volumes').keys()), ['/data'])
-        volume_path = old_container.get('Volumes')['/data']
+        self.assertEqual(
+            [mount['Destination'] for mount in old_container.get('Mounts')],
+            ['/data']
+        )
+        volume_path = old_container.get_mount('/data')['Source']
 
         service.options['volumes'] = [VolumeSpec.parse('/tmp:/data')]
 
@@ -332,8 +336,11 @@ class ServiceTest(DockerClientTestCase):
             "Service \"db\" is using volume \"/data\" from the previous container",
             args[0])
 
-        self.assertEqual(list(new_container.get('Volumes')), ['/data'])
-        self.assertEqual(new_container.get('Volumes')['/data'], volume_path)
+        self.assertEqual(
+            [mount['Destination'] for mount in new_container.get('Mounts')],
+            ['/data']
+        )
+        self.assertEqual(new_container.get_mount('/data')['Source'], volume_path)
 
     def test_start_container_passes_through_options(self):
         db = self.create_service('db')

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -12,6 +12,7 @@ from six import text_type
 
 from .. import mock
 from .testcases import DockerClientTestCase
+from .testcases import get_links
 from .testcases import pull_busybox
 from compose import __version__
 from compose.config.types import VolumeFromSpec
@@ -88,7 +89,7 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('db', volumes=[VolumeSpec.parse('/var/db')])
         container = service.create_container()
         container.start()
-        self.assertIsNotNone(container.get_mount('/var/db'))
+        assert container.get_mount('/var/db')
 
     def test_create_container_with_volume_driver(self):
         service = self.create_service('db', volume_driver='foodriver')
@@ -152,7 +153,7 @@ class ServiceTest(DockerClientTestCase):
             volumes=[VolumeSpec(host_path, container_path, 'rw')])
         container = service.create_container()
         container.start()
-        self.assertIsNotNone(container.get_mount(container_path))
+        assert container.get_mount(container_path)
 
         # Match the last component ("host-path"), because boot2docker symlinks /tmp
         actual_host_path = container.get_mount(container_path)['Source']
@@ -361,7 +362,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(web)
 
         self.assertEqual(
-            set(web.containers()[0].links()),
+            set(get_links(web.containers()[0])),
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',
@@ -377,7 +378,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(web)
 
         self.assertEqual(
-            set(web.containers()[0].links()),
+            set(get_links(web.containers()[0])),
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',
@@ -395,7 +396,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(web)
 
         self.assertEqual(
-            set(web.containers()[0].links()),
+            set(get_links(web.containers()[0])),
             set([
                 'composetest_db_1',
                 'composetest_db_2',
@@ -409,7 +410,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(db)
 
         c = create_and_start_container(db)
-        self.assertEqual(set(c.links()), set([]))
+        self.assertEqual(set(get_links(c)), set([]))
 
     def test_start_one_off_container_creates_links_to_its_own_service(self):
         db = self.create_service('db')
@@ -420,7 +421,7 @@ class ServiceTest(DockerClientTestCase):
         c = create_and_start_container(db, one_off=True)
 
         self.assertEqual(
-            set(c.links()),
+            set(get_links(c)),
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import py
 
 from .testcases import DockerClientTestCase
+from .testcases import get_links
 from compose.config import config
 from compose.project import Project
 from compose.service import ConvergenceStrategy
@@ -186,8 +187,8 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         web, = [c for c in containers if c.service == 'web']
         nginx, = [c for c in containers if c.service == 'nginx']
 
-        self.assertEqual(web.links(), ['composetest_db_1', 'db', 'db_1'])
-        self.assertEqual(nginx.links(), ['composetest_web_1', 'web', 'web_1'])
+        self.assertEqual(set(get_links(web)), {'composetest_db_1', 'db', 'db_1'})
+        self.assertEqual(set(get_links(nginx)), {'composetest_web_1', 'web', 'web_1'})
 
 
 class ServiceStateTest(DockerClientTestCase):

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -25,8 +25,7 @@ class DockerClientTestCase(unittest.TestCase):
         for c in self.client.containers(
                 all=True,
                 filters={'label': '%s=composetest' % LABEL_PROJECT}):
-            self.client.kill(c['Id'])
-            self.client.remove_container(c['Id'])
+            self.client.remove_container(c['Id'], force=True)
         for i in self.client.images(
                 filters={'label': 'com.docker.compose.test_image'}):
             self.client.remove_image(i)

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -16,6 +16,16 @@ def pull_busybox(client):
     client.pull('busybox:latest', stream=False)
 
 
+def get_links(container):
+    links = container.get('HostConfig.Links') or []
+
+    def format_link(link):
+        _, alias = link.split(':')
+        return alias.split('/')[-1]
+
+    return [format_link(link) for link in links]
+
+
 class DockerClientTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -234,6 +234,7 @@ class ServiceTest(unittest.TestCase):
         prev_container = mock.Mock(
             id='ababab',
             image_config={'ContainerConfig': {}})
+        prev_container.get.return_value = None
 
         opts = service._get_container_create_options(
             {},
@@ -573,6 +574,10 @@ class NetTestCase(unittest.TestCase):
         self.assertEqual(net.id, service_name)
         self.assertEqual(net.mode, None)
         self.assertEqual(net.service_name, service_name)
+
+
+def build_mount(destination, source, mode='rw'):
+    return {'Source': source, 'Destination': destination, 'Mode': mode}
 
 
 class ServiceVolumesTest(unittest.TestCase):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -600,12 +600,33 @@ class ServiceVolumesTest(unittest.TestCase):
         }
         container = Container(self.mock_client, {
             'Image': 'ababab',
-            'Volumes': {
-                '/host/volume': '/host/volume',
-                '/existing/volume': '/var/lib/docker/aaaaaaaa',
-                '/removed/volume': '/var/lib/docker/bbbbbbbb',
-                '/mnt/image/data': '/var/lib/docker/cccccccc',
-            },
+            'Mounts': [
+                {
+                    'Source': '/host/volume',
+                    'Destination': '/host/volume',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'hostvolume',
+                }, {
+                    'Source': '/var/lib/docker/aaaaaaaa',
+                    'Destination': '/existing/volume',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'existingvolume',
+                }, {
+                    'Source': '/var/lib/docker/bbbbbbbb',
+                    'Destination': '/removed/volume',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'removedvolume',
+                }, {
+                    'Source': '/var/lib/docker/cccccccc',
+                    'Destination': '/mnt/image/data',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'imagedata',
+                },
+            ]
         }, has_been_inspected=True)
 
         expected = [
@@ -630,7 +651,13 @@ class ServiceVolumesTest(unittest.TestCase):
 
         intermediate_container = Container(self.mock_client, {
             'Image': 'ababab',
-            'Volumes': {'/existing/volume': '/var/lib/docker/aaaaaaaa'},
+            'Mounts': [{
+                'Source': '/var/lib/docker/aaaaaaaa',
+                'Destination': '/existing/volume',
+                'Mode': '',
+                'RW': True,
+                'Name': 'existingvolume',
+            }],
         }, has_been_inspected=True)
 
         expected = [
@@ -693,9 +720,16 @@ class ServiceVolumesTest(unittest.TestCase):
         self.mock_client.inspect_container.return_value = {
             'Id': '123123123',
             'Image': 'ababab',
-            'Volumes': {
-                '/data': '/mnt/sda1/host/path',
-            },
+            'Mounts': [
+                {
+                    'Destination': '/data',
+                    'Source': '/mnt/sda1/host/path',
+                    'Mode': '',
+                    'RW': True,
+                    'Driver': 'local',
+                    'Name': 'abcdefff1234'
+                },
+            ]
         }
 
         service._get_container_create_options(


### PR DESCRIPTION
**Don't merge** I'd like to wait until we're done with the 1.5.0 release so that we don't run into conflicts while cherry-picking.  Opening the PR now to verify against jenkins that the work is done.

Fixes #2131 

Upgrade our tests and api interaction to be compatible with api version 1.20.
