### PR TITLE
Use inspect network to query for an existing network

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -5,6 +5,7 @@ import logging
 from functools import reduce
 
 from docker.errors import APIError
+from docker.errors import NotFound
 
 from .config import ConfigurationError
 from .config import get_service_name_from_net
@@ -363,10 +364,10 @@ class Project(object):
         return [c for c in containers if matches_service_names(c)]
 
     def get_network(self):
-        networks = self.client.networks(names=[self.name])
-        if networks:
-            return networks[0]
-        return None
+        try:
+            return self.client.inspect_network(self.name)
+        except NotFound:
+            return None
 
     def ensure_network_exists(self):
         # TODO: recreate network if driver has changed?

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -187,7 +187,7 @@ class CLITestCase(DockerClientTestCase):
         )
 
     def test_up_without_networking(self):
-        self.require_engine_version("1.9")
+        self.require_api_version('1.21')
 
         self.command.base_dir = 'tests/fixtures/links-composefile'
         self.command.dispatch(['up', '-d'], None)
@@ -205,7 +205,7 @@ class CLITestCase(DockerClientTestCase):
         self.assertTrue(web_container.get('HostConfig.Links'))
 
     def test_up_with_networking(self):
-        self.require_engine_version("1.9")
+        self.require_api_version('1.21')
 
         self.command.base_dir = 'tests/fixtures/links-composefile'
         self.command.dispatch(['--x-networking', 'up', '-d'], None)

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -98,14 +98,14 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(db._get_volumes_from(), [data_container.id + ':rw'])
 
     def test_get_network_does_not_exist(self):
-        self.require_engine_version("1.9")
+        self.require_api_version('1.21')
         client = docker_client(version='1.21')
 
         project = Project('composetest', [], client)
         assert project.get_network() is None
 
     def test_get_network(self):
-        self.require_engine_version("1.9")
+        self.require_api_version('1.21')
         client = docker_client(version='1.21')
 
         network_name = 'network_does_exist'

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from .testcases import DockerClientTestCase
+from compose.cli.docker_client import docker_client
 from compose.config import config
 from compose.const import LABEL_PROJECT
 from compose.container import Container
@@ -95,6 +96,22 @@ class ProjectTest(DockerClientTestCase):
         )
         db = project.get_service('db')
         self.assertEqual(db._get_volumes_from(), [data_container.id + ':rw'])
+
+    def test_get_network_does_not_exist(self):
+        self.require_engine_version("1.9")
+        client = docker_client(version='1.21')
+
+        project = Project('composetest', [], client)
+        assert project.get_network() is None
+
+    def test_get_network(self):
+        self.require_engine_version("1.9")
+        client = docker_client(version='1.21')
+
+        network_name = 'network_does_exist'
+        project = Project(network_name, [], client)
+        client.create_network(network_name)
+        assert project.get_network()['name'] == network_name
 
     def test_net_from_service(self):
         project = Project.from_dicts(

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -76,11 +76,7 @@ class DockerClientTestCase(unittest.TestCase):
         build_output = self.client.build(*args, **kwargs)
         stream_output(build_output, open('/dev/null', 'w'))
 
-    def require_engine_version(self, minimum):
-        # Drop '-dev' or '-rcN' suffix
-        engine = self.client.version()['Version'].split('-', 1)[0]
-        if version_lt(engine, minimum):
-            skip(
-                "Engine version is too low ({} < {})"
-                .format(engine, minimum)
-            )
+    def require_api_version(self, minimum):
+        api_version = self.client.version()['ApiVersion']
+        if version_lt(api_version, minimum):
+            skip("API version is too low ({} < {})".format(api_version, minimum))


### PR DESCRIPTION
And more tests for get_network()

Also changed the version check to use an api version:
* because the tests have to reference the api version anyway to do inspection
* using an engine version breaks against swarm, and we want to be able to run against swarm