### PR TITLE
Fix running one-off containers with --x-networking

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -539,6 +539,9 @@ class Service(object):
         return 1 if not numbers else max(numbers) + 1
 
     def _get_links(self, link_to_self):
+        if self.use_networking:
+            return []
+
         links = []
         for service, link_name in self.links:
             for container in service.containers():

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -499,6 +499,14 @@ class ServiceTest(unittest.TestCase):
             ports=["127.0.0.1:1000-2000:2000-3000"])
         self.assertEqual(service.specifies_host_port(), True)
 
+    def test_get_links_with_networking(self):
+        service = Service(
+            'foo',
+            image='foo',
+            links=[(Service('one'), 'one')],
+            use_networking=True)
+        self.assertEqual(service._get_links(link_to_self=True), [])
+
 
 class NetTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Found this while debugging #2248 

We need to disable linking to self when we run with networking enabled.

`run` sets up links from the one-off container to the "canonical" container, which breaks when used with `--x-networking`. The link to the canonical container it's not something the user has asked for, it's just something we do automatically.

In this case it seems appropriate to not create the link at all, since it will work the same way without the link.