### PR TITLE
Added ulimits to docker-compose

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -345,6 +345,16 @@ def validate_extended_service_dict(service_dict, filename, service):
                 "%s services with 'net: container' cannot be extended" % error_prefix)
 
 
+def validate_ulimits(ulimit_config):
+    for limit_name, soft_hard_values in six.iteritems(ulimit_config):
+        if isinstance(soft_hard_values, dict):
+            if not soft_hard_values['soft'] <= soft_hard_values['hard']:
+                raise ConfigurationError(
+                    "ulimit_config \"%s\" cannot contain a 'soft' value higher than 'hard' value" %
+                    ulimit_config
+                )
+
+
 def process_container_options(service_dict, working_dir=None):
     service_dict = service_dict.copy()
 
@@ -356,6 +366,9 @@ def process_container_options(service_dict, working_dir=None):
 
     if 'labels' in service_dict:
         service_dict['labels'] = parse_labels(service_dict['labels'])
+
+    if 'ulimits' in service_dict:
+        validate_ulimits(service_dict['ulimits'])
 
     return service_dict
 

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -116,6 +116,7 @@
         "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "stdin_open": {"type": "boolean"},
         "tty": {"type": "boolean"},
+        "ulimits": {"type": "object"},
         "user": {"type": "string"},
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -116,7 +116,25 @@
         "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "stdin_open": {"type": "boolean"},
         "tty": {"type": "boolean"},
-        "ulimits": {"type": "object"},
+        "ulimits": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-z]+$": {
+              "oneOf": [
+                {"type": "integer"},
+                {
+                  "type":"object",
+                  "properties": {
+                    "hard": {"type": "integer"},
+                    "soft": {"type": "integer"}
+                  },
+                  "required": ["soft", "hard"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        },
         "user": {"type": "string"},
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},

--- a/compose/service.py
+++ b/compose/service.py
@@ -1085,11 +1085,6 @@ def build_ulimits(ulimit_config):
         if isinstance(soft_hard_values, six.integer_types):
             ulimits.append({'name': limit_name, 'soft': soft_hard_values, 'hard': soft_hard_values})
         elif isinstance(soft_hard_values, dict):
-            if not soft_hard_values['soft'] <= soft_hard_values['hard']:
-                raise ConfigError(
-                    "ulimit_config \"%s\" cannot contain a 'soft' value higher than 'hard' value" %
-                    ulimit_config
-                )
             ulimit_dict = {'name': limit_name}
             ulimit_dict.update(soft_hard_values)
             ulimits.append(ulimit_dict)

--- a/compose/service.py
+++ b/compose/service.py
@@ -1078,26 +1078,19 @@ def parse_restart_spec(restart_config):
 
 
 def build_ulimits(ulimit_config):
-    valid_keys = set(['hard', 'soft'])
-
     if not ulimit_config:
         return None
     ulimits = []
     for limit_name, soft_hard_values in six.iteritems(ulimit_config):
         if isinstance(soft_hard_values, six.integer_types):
-            ulimits.append({'Name': limit_name, 'soft': soft_hard_values, 'hard': soft_hard_values})
+            ulimits.append({'name': limit_name, 'soft': soft_hard_values, 'hard': soft_hard_values})
         elif isinstance(soft_hard_values, dict):
-            if not set(soft_hard_values) == valid_keys:
-                raise ConfigError(
-                    "ulimit_config \"%s\" must contain both 'hard' and 'soft' as secondary keys, and nothing else" %
-                    ulimit_config
-                )
             if not soft_hard_values['soft'] <= soft_hard_values['hard']:
                 raise ConfigError(
                     "ulimit_config \"%s\" cannot contain a 'soft' value higher than 'hard' value" %
                     ulimit_config
                 )
-            ulimit_dict = {'Name': limit_name}
+            ulimit_dict = {'name': limit_name}
             ulimit_dict.update(soft_hard_values)
             ulimits.append(ulimit_dict)
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -1087,9 +1087,14 @@ def build_ulimits(ulimit_config):
         if isinstance(soft_hard_values, six.integer_types):
             ulimits.append({'Name': limit_name, 'soft': soft_hard_values, 'hard': soft_hard_values})
         elif isinstance(soft_hard_values, dict):
-            if not set(soft_hard_values) <= valid_keys:
+            if not set(soft_hard_values) == valid_keys:
                 raise ConfigError(
-                    "ulimit_config \"%s\" must contain only 'hard' and/or 'soft' as secondary keys" %
+                    "ulimit_config \"%s\" must contain both 'hard' and 'soft' as secondary keys, and nothing else" %
+                    ulimit_config
+                )
+            if not soft_hard_values['soft'] <= soft_hard_values['hard']:
+                raise ConfigError(
+                    "ulimit_config \"%s\" cannot contain a 'soft' value higher than 'hard' value" %
                     ulimit_config
                 )
             ulimit_dict = {'Name': limit_name}

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -348,6 +348,17 @@ Override the default labeling scheme for each container.
         - label:user:USER
         - label:role:ROLE
 
+### ulimits
+
+Override the default ulimits for a container. You can either use a number
+to set the hard and soft limits, or specify them in a dictionary.
+
+      ulimits:
+        nproc: 65535
+        nofile:
+          soft: 20000
+          hard: 40000
+
 ### volumes, volume\_driver
 
 Mount paths as volumes, optionally specifying a path on the host machine

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -162,36 +162,35 @@ class ServiceTest(DockerClientTestCase):
             {'www.example.com': '192.168.0.17',
              'api.example.com': '192.168.0.18'})
 
-    def test_build_ulimits(self):
-        # invalid options
-        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'not_soft_or_hard': 10000}}))
-        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'soft': 10000, 'hard': 10}}))
-        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'hard': 10000}}))
-        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'soft': 10000}}))
+    def sort_dicts_by_name(self, dictionary_list):
+        return sorted(dictionary_list, key=lambda k: k['name'])
 
-        # dictionaries
+    def test_build_ulimits_with_invalid_options(self):
+        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'soft': 10000, 'hard': 10}}))
+
+    def test_build_ulimits_with_integers(self):
         self.assertEqual(build_ulimits(
             {'nofile': {'soft': 10000, 'hard': 20000}}),
-            [{'Name': 'nofile', 'soft': 10000, 'hard': 20000}])
+            [{'name': 'nofile', 'soft': 10000, 'hard': 20000}])
+        self.assertEqual(self.sort_dicts_by_name(build_ulimits(
+            {'nofile': {'soft': 10000, 'hard': 20000}, 'nproc': {'soft': 65535, 'hard': 65535}})),
+            self.sort_dicts_by_name([{'name': 'nofile', 'soft': 10000, 'hard': 20000},
+                                     {'name': 'nproc', 'soft': 65535, 'hard': 65535}]))
+
+    def test_build_ulimits_with_dicts(self):
         self.assertEqual(build_ulimits(
-            {'nofile': {'soft': 10000, 'hard': 20000}, 'nproc': {'soft': 65535, 'hard': 65535}}),
-            [{'Name': 'nofile', 'soft': 10000, 'hard': 20000},
-             {'Name': 'nproc', 'soft': 65535, 'hard': 65535}])
-
-        # integers
-        self.assertEqual(build_extra_hosts(
             {'nofile': 20000}),
-            [{'Name': 'nofile', 'soft': 20000, 'hard': 20000}])
-        self.assertEqual(build_extra_hosts(
-            {'nofile': 20000, 'nproc': 65535}),
-            [{'Name': 'nofile', 'soft': 20000, 'hard': 20000},
-             {'Name': 'nproc', 'soft': 65535, 'hard': 65535}])
+            [{'name': 'nofile', 'soft': 20000, 'hard': 20000}])
+        self.assertEqual(self.sort_dicts_by_name(build_ulimits(
+            {'nofile': 20000, 'nproc': 65535})),
+            self.sort_dicts_by_name([{'name': 'nofile', 'soft': 20000, 'hard': 20000},
+                                     {'name': 'nproc', 'soft': 65535, 'hard': 65535}]))
 
-        # mix of dictionaries and integers
-        self.assertEqual(build_extra_hosts(
-            {'nproc': 65535, 'nofile': {'soft': 10000, 'hard': 20000}}),
-            [{'Name': 'nofile', 'soft': 10000, 'hard': 20000},
-             {'Name': 'nproc', 'soft': 65535, 'hard': 65535}])
+    def test_build_ulimits_with_integers_and_dicts(self):
+        self.assertEqual(self.sort_dicts_by_name(build_ulimits(
+            {'nproc': 65535, 'nofile': {'soft': 10000, 'hard': 20000}})),
+            self.sort_dicts_by_name([{'name': 'nofile', 'soft': 10000, 'hard': 20000},
+                                     {'name': 'nproc', 'soft': 65535, 'hard': 65535}]))
 
     def test_create_container_with_extra_hosts_list(self):
         extra_hosts = ['somehost:162.242.195.82', 'otherhost:50.31.209.229']

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -165,17 +165,14 @@ class ServiceTest(DockerClientTestCase):
     def test_build_ulimits(self):
         # invalid options
         self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'not_soft_or_hard': 10000}}))
+        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'soft': 10000, 'hard': 10}}))
+        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'hard': 10000}}))
+        self.assertRaises(ConfigError, lambda: build_ulimits({'nofile': {'soft': 10000}}))
 
         # dictionaries
         self.assertEqual(build_ulimits(
             {'nofile': {'soft': 10000, 'hard': 20000}}),
             [{'Name': 'nofile', 'soft': 10000, 'hard': 20000}])
-        self.assertEqual(build_ulimits(
-            {'nofile': {'hard': 20000}}),
-            [{'Name': 'nofile', 'hard': 20000}])
-        self.assertEqual(build_ulimits(
-            {'nofile': {'soft': 10000}}),
-            [{'Name': 'nofile', 'soft': 10000}])
         self.assertEqual(build_ulimits(
             {'nofile': {'soft': 10000, 'hard': 20000}, 'nproc': {'soft': 65535, 'hard': 65535}}),
             [{'Name': 'nofile', 'soft': 10000, 'hard': 20000},

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -388,6 +388,26 @@ class ConfigTest(unittest.TestCase):
                 )
             )
 
+    def test_config_ulimits_soft_greater_than_hard_error(self):
+        expected_error_msg = "cannot contain a 'soft' value higher than 'hard' value"
+
+        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
+            config.load(
+                build_config_details(
+                    {'web': {
+                        'image': 'busybox',
+                        'ulimits': {
+                            'nofile': {
+                                "soft": 10000,
+                                "hard": 1000
+                            }
+                        }
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+
     def test_valid_config_which_allows_two_type_definitions(self):
         expose_values = [["8000"], [8000]]
         for expose in expose_values:

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -348,6 +348,46 @@ class ConfigTest(unittest.TestCase):
                 )
             )
 
+    def test_config_ulimits_invalid_keys_validation_error(self):
+        expected_error_msg = "Service 'web' configuration key 'ulimits' contains unsupported option: 'not_soft_or_hard'"
+
+        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
+            config.load(
+                build_config_details(
+                    {'web': {
+                        'image': 'busybox',
+                        'ulimits': {
+                            'nofile': {
+                                "not_soft_or_hard": 100,
+                                "soft": 10000,
+                                "hard": 20000,
+                            }
+                        }
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+
+    def test_config_ulimits_required_keys_validation_error(self):
+        expected_error_msg = "Service 'web' configuration key 'ulimits' u?'hard' is a required property"
+
+        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
+            config.load(
+                build_config_details(
+                    {'web': {
+                        'image': 'busybox',
+                        'ulimits': {
+                            'nofile': {
+                                "soft": 10000,
+                            }
+                        }
+                    }},
+                    'working_dir',
+                    'filename.yml'
+                )
+            )
+
     def test_valid_config_which_allows_two_type_definitions(self):
         expose_values = [["8000"], [8000]]
         for expose in expose_values:


### PR DESCRIPTION
I added ulimits functionality as outlined in #1322, but I have a few style concerns.

### How to handle error checking

As far as I could tell, this was the most nested config option, so I wasn't sure the appropriate amount of type checking to put into the function. You will currently get a docker-compose level error if you put in something that isn't a dict for the first level, or a dict or an int for the second level. It also handles putting in a key other than `soft` or `hard`. However, if you put in something like

```
ulimits:
  nofile:
    soft: ThisIsAnError
    hard: 60000
```

You get an error from docker-py, not docker-compose, that states `ValueError: Ulimit.soft must be an integer`.

### Should we handle `soft:hard` style of setting limits?

This isn't exposed in docker-py at all, but should we add the ability to say
```
ulimits:
  nofile: "8096:16192"
```

It's relatively easy to do, but I was worried about continuing to build up this relatively small feature. I'm not sure if docker-compose wants the kitchen sink when it comes to options.

If either of these should be changed, let me know and I can fix ASAP.