### PR TITLE
Added --force-rm to compose build.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -175,12 +175,14 @@ class TopLevelCommand(DocoptCommand):
         Usage: build [options] [SERVICE...]
 
         Options:
+            --force-rm  Always remove intermediate containers.
             --no-cache  Do not use cache when building the image.
             --pull      Always attempt to pull a newer version of the image.
         """
+        force_rm = bool(options.get('--force-rm', False))
         no_cache = bool(options.get('--no-cache', False))
         pull = bool(options.get('--pull', False))
-        project.build(service_names=options['SERVICE'], no_cache=no_cache, pull=pull)
+        project.build(service_names=options['SERVICE'], no_cache=no_cache, pull=pull, force_rm=force_rm)
 
     def help(self, project, options):
         """

--- a/compose/project.py
+++ b/compose/project.py
@@ -278,10 +278,10 @@ class Project(object):
         for service in self.get_services(service_names):
             service.restart(**options)
 
-    def build(self, service_names=None, no_cache=False, pull=False):
+    def build(self, service_names=None, no_cache=False, pull=False, force_rm=False):
         for service in self.get_services(service_names):
             if service.can_be_built():
-                service.build(no_cache, pull)
+                service.build(no_cache, pull, force_rm)
             else:
                 log.info('%s uses an image, skipping' % service.name)
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -704,7 +704,7 @@ class Service(object):
             cgroup_parent=cgroup_parent
         )
 
-    def build(self, no_cache=False, pull=False):
+    def build(self, no_cache=False, pull=False, force_rm=False):
         log.info('Building %s' % self.name)
 
         path = self.options['build']
@@ -718,6 +718,7 @@ class Service(object):
             tag=self.image_name,
             stream=True,
             rm=True,
+            forcerm=force_rm,
             pull=pull,
             nocache=no_cache,
             dockerfile=self.options.get('dockerfile', None),

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -93,7 +93,7 @@ __docker_compose_services_stopped() {
 _docker_compose_build() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --no-cache --pull" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --force-rm --no-cache --pull" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_from_build

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -192,6 +192,7 @@ __docker-compose_subcommand() {
         (build)
             _arguments \
                 $opts_help \
+                '--force-rm[Always remove intermediate containers.]' \
                 '--no-cache[Do not use cache when building the image]' \
                 '--pull[Always attempt to pull a newer version of the image.]' \
                 '*:services:__docker-compose_services_from_build' && ret=0

--- a/docs/reference/build.md
+++ b/docs/reference/build.md
@@ -15,6 +15,7 @@ parent = "smn_compose_cli"
 Usage: build [options] [SERVICE...]
 
 Options:
+--force-rm  Always remove intermediate containers.
 --no-cache  Do not use cache when building the image.
 --pull      Always attempt to pull a newer version of the image.
 ```

--- a/tests/fixtures/simple-failing-dockerfile/Dockerfile
+++ b/tests/fixtures/simple-failing-dockerfile/Dockerfile
@@ -1,0 +1,7 @@
+FROM busybox:latest
+LABEL com.docker.compose.test_image=true
+LABEL com.docker.compose.test_failing_image=true
+# With the following label the container wil be cleaned up automatically
+# Must be kept in sync with LABEL_PROJECT from compose/const.py
+LABEL com.docker.compose.project=composetest
+RUN exit 1

--- a/tests/fixtures/simple-failing-dockerfile/docker-compose.yml
+++ b/tests/fixtures/simple-failing-dockerfile/docker-compose.yml
@@ -1,0 +1,2 @@
+simple:
+  build: .

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -366,6 +366,7 @@ class ServiceTest(unittest.TestCase):
             stream=True,
             path='.',
             pull=False,
+            forcerm=False,
             nocache=False,
             rm=True,
         )


### PR DESCRIPTION
Fixes #2253 

It's a flag passed to docker build that removes the intermediate
containers left behind on fail builds.

Signed-off-by: Adrian Budau <budau.adi@gmail.com>