### PR TITLE
Another release, another round of fixes to the release scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /dist
 /docs/_site
 /venv
+README.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,8 @@ include requirements.txt
 include requirements-dev.txt
 include tox.ini
 include *.md
+exclude README.md
+include README.rst
 include compose/config/*.json
 recursive-include contrib/completion *
 recursive-include tests *

--- a/project/RELEASE-PROCESS.md
+++ b/project/RELEASE-PROCESS.md
@@ -1,6 +1,14 @@
 Building a Compose release
 ==========================
 
+## Prerequisites
+
+The release scripts require the following tools installed on the host:
+
+* https://hub.github.com/
+* https://stedolan.github.io/jq/
+* http://pandoc.org/
+
 ## To get started with a new release
 
 Create a branch, update version, and add release notes by running `make-branch`
@@ -40,10 +48,10 @@ As part of this script you'll be asked to:
 
 ## To release a version (whether RC or stable)
 
-Check out the bump branch and run the `build-binary` script
+Check out the bump branch and run the `build-binaries` script
 
         git checkout bump-$VERSION
-        ./script/release/build-binary
+        ./script/release/build-binaries
 
 When prompted build the non-linux binaries and test them.
 

--- a/script/release/cherry-pick-pr
+++ b/script/release/cherry-pick-pr
@@ -22,7 +22,7 @@ EOM
 
 if [ -z "$(command -v hub 2> /dev/null)" ]; then
     >&2 echo "$0 requires https://hub.github.com/."
-    >&2 echo "Please install it and ake sure it is available on your \$PATH."
+    >&2 echo "Please install it and make sure it is available on your \$PATH."
     exit 2
 fi
 

--- a/script/release/push-release
+++ b/script/release/push-release
@@ -34,7 +34,9 @@ GITHUB_REPO=git@github.com:$REPO
 sha=$(git rev-parse HEAD)
 url=$API/$REPO/statuses/$sha
 build_status=$(curl -s $url | jq -r '.[0].state')
-if [[ "$build_status" != "success" ]]; then
+if [ -n "$SKIP_BUILD_CHECK" ]; then
+    echo "Skipping build status check..."
+elif [[ "$build_status" != "success" ]]; then
     >&2 echo "Build status is $build_status, but it should be success."
     exit -1
 fi
@@ -61,6 +63,7 @@ source venv-test/bin/activate
 pip install docker-compose==$VERSION
 docker-compose version
 deactivate
+rm -rf venv-test
 
 echo "Now publish the github release, and test the downloads."
 echo "Email maintainers@dockerproject.org and engineering@docker.com about the new release."

--- a/script/release/push-release
+++ b/script/release/push-release
@@ -21,10 +21,16 @@ VERSION="$(git config "branch.${BRANCH}.release")" || usage
 
 if [ -z "$(command -v jq 2> /dev/null)" ]; then
     >&2 echo "$0 requires https://stedolan.github.io/jq/"
-    >&2 echo "Please install it and ake sure it is available on your \$PATH."
+    >&2 echo "Please install it and make sure it is available on your \$PATH."
     exit 2
 fi
 
+
+if [ -z "$(command -v pandoc 2> /dev/null)" ]; then
+    >&2 echo "$0 requires http://pandoc.org/"
+    >&2 echo "Please install it and make sure it is available on your \$PATH."
+    exit 2
+fi
 
 API=https://api.github.com/repos
 REPO=docker/compose
@@ -45,12 +51,13 @@ echo "Tagging the release as $VERSION"
 git tag $VERSION
 git push $GITHUB_REPO $VERSION
 
-echo "Uploading sdist to pypi"
-python setup.py sdist
-
 echo "Uploading the docker image"
 docker push docker/compose:$VERSION
 
+echo "Uploading sdist to pypi"
+pandoc -f markdown -t rst README.md -o README.rst
+sed -i -e 's/logo.png?raw=true/https:\/\/github.com\/docker\/compose\/raw\/master\/logo.png?raw=true/' README.rst
+python setup.py sdist
 if [ "$(command -v twine 2> /dev/null)" ]; then
     twine upload ./dist/docker-compose-${VERSION}.tar.gz
 else

--- a/script/test-versions
+++ b/script/test-versions
@@ -28,10 +28,15 @@ for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"
 
   daemon_container="compose-dind-$version-$BUILD_NUMBER"
-  trap "docker rm -vf $daemon_container" EXIT
 
-  # TODO: remove when we stop testing against 1.7.x
-  daemon=$([[ "$version" == "1.7"* ]] && echo "-d" || echo "daemon")
+  function on_exit() {
+    if [[ "$?" != "0" ]]; then
+        docker logs "$daemon_container"
+    fi
+    docker rm -vf "$daemon_container"
+  }
+
+  trap "on_exit" EXIT
 
   docker run \
     -d \
@@ -39,7 +44,7 @@ for version in $DOCKER_VERSIONS; do
     --privileged \
     --volume="/var/lib/docker" \
     dockerswarm/dind:$version \
-    docker $daemon -H tcp://0.0.0.0:2375 $DOCKER_DAEMON_ARGS \
+    docker daemon -H tcp://0.0.0.0:2375 $DOCKER_DAEMON_ARGS \
 
   docker run \
     --rm \


### PR DESCRIPTION
* added a list of required software to the docs
* fixed reference to `build-binaries` script
* fixed some typos
* remove the temporary venv created to test the pypi release
* added a `SKIP_BUILD_CHECK` for when we don't have a green build on jenkins
* fixed the README on pypi by converting it to rst and fixing the image url before packaging up the sdist