### PR TITLE
Logs are available for all log drivers except for none.

### DIFF
--- a/compose/container.py
+++ b/compose/container.py
@@ -145,7 +145,7 @@ class Container(object):
     @property
     def has_api_logs(self):
         log_type = self.log_driver
-        return not log_type or log_type == 'json-file'
+        return not log_type or log_type != 'none'
 
     def attach_log_stream(self):
         """A log stream can only be attached if the container uses a json-file


### PR DESCRIPTION
When I implemented #2020 I think I was confused about how these log drivers worked.  It turns out we can't get logs from other drivers, but attach does work!

This was reported on the docker-user@ mailing list.