### PR TITLE
Use "unicode_literals" in all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,12 @@
     - id: requirements-txt-fixer
     - id: trailing-whitespace
 - repo: git://github.com/asottile/reorder_python_imports
-  sha: 3d86483455ab5bd06cc1069fdd5ac57be5463f10
+  sha: v0.1.0
   hooks:
     - id: reorder-python-imports
       language_version: 'python2.7'
+      args:
+        - --add-import
+        - from __future__ import absolute_import
+        - --add-import
+        - from __future__ import unicode_literals

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 __version__ = '1.6.0dev'

--- a/compose/__main__.py
+++ b/compose/__main__.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from compose.cli.main import main
 
 main()

--- a/compose/cli/colors.py
+++ b/compose/cli/colors.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 NAMES = [
     'grey',

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import logging
 import os
 

--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from textwrap import dedent
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 from threading import Thread
 

--- a/compose/cli/verbose_proxy.py
+++ b/compose/cli/verbose_proxy.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import functools
 import logging
 import pprint

--- a/compose/config/__init__.py
+++ b/compose/config/__init__.py
@@ -1,4 +1,7 @@
 # flake8: noqa
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from .config import ConfigurationError
 from .config import DOCKER_CONFIG_KEYS
 from .config import find

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import codecs
 import logging

--- a/compose/config/errors.py
+++ b/compose/config/errors.py
@@ -1,3 +1,7 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
 class ConfigurationError(Exception):
     def __init__(self, msg):
         self.msg = msg

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import logging
 import os
 from string import Template

--- a/compose/config/sort_services.py
+++ b/compose/config/sort_services.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from compose.config.errors import DependencyError
 
 

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import json
 import logging
 import os

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -254,7 +254,8 @@ def _parse_oneof_validator(error):
             )
             return "{}contains {}, which is an invalid type, it should be {}".format(
                 invalid_config_key,
-                context.instance,
+                # Always print the json repr of the invalid value
+                json.dumps(context.instance),
                 _parse_valid_types_from_validator(context.validator_value))
 
         if context.validator == 'uniqueItems':

--- a/compose/const.py
+++ b/compose/const.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import os
 import sys
 

--- a/compose/progress_stream.py
+++ b/compose/progress_stream.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from compose import utils
 
 

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import codecs
 import hashlib
 import json

--- a/compose/volume.py
+++ b/compose/volume.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 

--- a/script/travis/render-bintray-config.py
+++ b/script/travis/render-bintray-config.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import datetime
 import os.path

--- a/script/travis/render-bintray-config.py
+++ b/script/travis/render-bintray-config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import datetime

--- a/script/versions.py
+++ b/script/versions.py
@@ -21,7 +21,9 @@ For example, if the list of versions is:
 `default` would return `1.7.1` and
 `recent -n 3` would return `1.8.0-rc2 1.7.1 1.6.2`
 """
+from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import argparse
 import itertools

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import sys
 
 if sys.version_info >= (2, 7):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import os
 import shlex

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import random

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -2,6 +2,7 @@
 Integration tests which cover state convergence (aka smart recreate) performed
 by `docker-compose up`.
 """
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import py

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from docker.errors import DockerException

--- a/tests/unit/cli/command_test.py
+++ b/tests/unit/cli/command_test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import pytest
 from requests.exceptions import ConnectionError

--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import logging
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -552,7 +552,9 @@ class ConfigTest(unittest.TestCase):
             )
 
     def test_config_extra_hosts_list_of_dicts_validation_error(self):
-        expected_error_msg = "key 'extra_hosts' contains {'somehost': '162.242.195.82'}, which is an invalid type, it should be a string"
+        expected_error_msg = (
+            "key 'extra_hosts' contains {\"somehost\": \"162.242.195.82\"}, "
+            "which is an invalid type, it should be a string")
 
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
+from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import shutil

--- a/tests/unit/config/sort_services_test.py
+++ b/tests/unit/config/sort_services_test.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from compose.config.errors import DependencyError
 from compose.config.sort_services import sort_service_dicts
 from compose.config.types import VolumeFromSpec

--- a/tests/unit/config/types_test.py
+++ b/tests/unit/config/types_test.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import pytest
 
 from compose.config.errors import ConfigurationError

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import docker

--- a/tests/unit/interpolation_test.py
+++ b/tests/unit/interpolation_test.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import unittest
 
 from compose.config.interpolation import BlankDefaultDict as bddict

--- a/tests/unit/multiplexer_test.py
+++ b/tests/unit/multiplexer_test.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 import unittest
 
 from compose.cli.multiplexer import Multiplexer

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import docker

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from compose import utils


### PR DESCRIPTION
Based on #2306 because docopt fails when given unicode strings as args.

We recently fixed a bunch of unicode bugs, many of which were fixed by just using a unicode literal.  To prevent any regressions in this area, we can force python2 to use unicode literals.

I've also added a pre-commit check that will add this import to new files for us (it actually did all the work to add the missing imports in this PR!).

The second commit fixes a test that broke with this change (because the new repr would include the `u''` prefix on the string repr.  Since we're printing out a value from the config, I think using a json reprinstead of the python repr is more correct.  We could also use the yaml repr, but that is harder to read in a condensed error message (and will pretty often be the same as the json repr).