### PR TITLE
Remove service.start_container()

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -448,7 +448,7 @@ class TopLevelCommand(DocoptCommand):
             raise e
 
         if detach:
-            service.start_container(container)
+            container.start()
             print(container.name)
         else:
             dockerpty.start(project.client, container.id, interactive=not options['-T'])

--- a/compose/service.py
+++ b/compose/service.py
@@ -406,7 +406,7 @@ class Service(object):
             if should_attach_logs:
                 container.attach_log_stream()
 
-            self.start_container(container)
+            container.start()
 
             return [container]
 
@@ -457,21 +457,16 @@ class Service(object):
         )
         if attach_logs:
             new_container.attach_log_stream()
-        self.start_container(new_container)
+        new_container.start()
         container.remove()
         return new_container
 
     def start_container_if_stopped(self, container, attach_logs=False):
-        if container.is_running:
-            return container
-        else:
+        if not container.is_running:
             log.info("Starting %s" % container.name)
             if attach_logs:
                 container.attach_log_stream()
-            return self.start_container(container)
-
-    def start_container(self, container):
-        container.start()
+            container.start()
         return container
 
     def remove_duplicate_containers(self, timeout=DEFAULT_TIMEOUT):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -557,7 +557,7 @@ class CLITestCase(DockerClientTestCase):
     def test_restart(self):
         service = self.project.get_service('simple')
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         started_at = container.dictionary['State']['StartedAt']
         self.dispatch(['restart', '-t', '1'], None)
         container.inspect()

--- a/tests/integration/resilience_test.py
+++ b/tests/integration/resilience_test.py
@@ -13,7 +13,7 @@ class ResilienceTest(DockerClientTestCase):
         self.project = Project('composetest', [self.db], self.client)
 
         container = self.db.create_container()
-        self.db.start_container(container)
+        container.start()
         self.host_path = container.get('Volumes')['/var/db']
 
     def test_successful_recreate(self):
@@ -31,7 +31,7 @@ class ResilienceTest(DockerClientTestCase):
         self.assertEqual(container.get('Volumes')['/var/db'], self.host_path)
 
     def test_start_failure(self):
-        with mock.patch('compose.service.Service.start_container', crash):
+        with mock.patch('compose.container.Container.start', crash):
             with self.assertRaises(Crash):
                 self.project.up(strategy=ConvergenceStrategy.always)
 

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -30,7 +30,8 @@ from compose.service import VolumeFromSpec
 
 def create_and_start_container(service, **override_options):
     container = service.create_container(**override_options)
-    return service.start_container(container)
+    container.start()
+    return container
 
 
 class ServiceTest(DockerClientTestCase):
@@ -115,19 +116,19 @@ class ServiceTest(DockerClientTestCase):
     def test_create_container_with_unspecified_volume(self):
         service = self.create_service('db', volumes=['/var/db'])
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertIn('/var/db', container.get('Volumes'))
 
     def test_create_container_with_volume_driver(self):
         service = self.create_service('db', volume_driver='foodriver')
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual('foodriver', container.get('Config.VolumeDriver'))
 
     def test_create_container_with_cpu_shares(self):
         service = self.create_service('db', cpu_shares=73)
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual(container.get('HostConfig.CpuShares'), 73)
 
     def test_build_extra_hosts(self):
@@ -165,7 +166,7 @@ class ServiceTest(DockerClientTestCase):
         extra_hosts = ['somehost:162.242.195.82', 'otherhost:50.31.209.229']
         service = self.create_service('db', extra_hosts=extra_hosts)
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual(set(container.get('HostConfig.ExtraHosts')), set(extra_hosts))
 
     def test_create_container_with_extra_hosts_dicts(self):
@@ -173,33 +174,33 @@ class ServiceTest(DockerClientTestCase):
         extra_hosts_list = ['somehost:162.242.195.82', 'otherhost:50.31.209.229']
         service = self.create_service('db', extra_hosts=extra_hosts)
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual(set(container.get('HostConfig.ExtraHosts')), set(extra_hosts_list))
 
     def test_create_container_with_cpu_set(self):
         service = self.create_service('db', cpuset='0')
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual(container.get('HostConfig.CpusetCpus'), '0')
 
     def test_create_container_with_read_only_root_fs(self):
         read_only = True
         service = self.create_service('db', read_only=read_only)
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual(container.get('HostConfig.ReadonlyRootfs'), read_only, container.get('HostConfig'))
 
     def test_create_container_with_security_opt(self):
         security_opt = ['label:disable']
         service = self.create_service('db', security_opt=security_opt)
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual(set(container.get('HostConfig.SecurityOpt')), set(security_opt))
 
     def test_create_container_with_mac_address(self):
         service = self.create_service('db', mac_address='02:42:ac:11:65:43')
         container = service.create_container()
-        service.start_container(container)
+        container.start()
         self.assertEqual(container.inspect()['Config']['MacAddress'], '02:42:ac:11:65:43')
 
     def test_create_container_with_specified_volume(self):
@@ -208,7 +209,7 @@ class ServiceTest(DockerClientTestCase):
 
         service = self.create_service('db', volumes=['%s:%s' % (host_path, container_path)])
         container = service.create_container()
-        service.start_container(container)
+        container.start()
 
         volumes = container.inspect()['Volumes']
         self.assertIn(container_path, volumes)
@@ -281,7 +282,7 @@ class ServiceTest(DockerClientTestCase):
             ]
         )
         host_container = host_service.create_container()
-        host_service.start_container(host_container)
+        host_container.start()
         self.assertIn(volume_container_1.id + ':rw',
                       host_container.get('HostConfig.VolumesFrom'))
         self.assertIn(volume_container_2.id + ':rw',
@@ -300,7 +301,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(old_container.get('Config.Cmd'), ['-d', '1'])
         self.assertIn('FOO=1', old_container.get('Config.Env'))
         self.assertEqual(old_container.name, 'composetest_db_1')
-        service.start_container(old_container)
+        old_container.start()
         old_container.inspect()  # reload volume data
         volume_path = old_container.get('Volumes')['/etc']
 


### PR DESCRIPTION
It has been an unnecessary wrapper around container.start() for a little while now, so we can call it directly.
