### PR TITLE
Removed unneeded newlines on docker-compose pull with no tty

### DIFF
--- a/tests/unit/progress_stream_test.py
+++ b/tests/unit/progress_stream_test.py
@@ -34,3 +34,34 @@ class ProgressStreamTestCase(unittest.TestCase):
         ]
         events = progress_stream.stream_output(output, StringIO())
         self.assertEqual(len(events), 1)
+
+    def test_stream_output_progress_event_tty(self):
+        events = [
+            b'{"status": "Already exists", "progressDetail": {}, "id": "8d05e3af52b0"}'
+        ]
+
+        class TTYStringIO(StringIO):
+            def isatty(self):
+                return True
+
+        output = TTYStringIO()
+        events = progress_stream.stream_output(events, output)
+        self.assertTrue(len(output.getvalue()) > 0)
+
+    def test_stream_output_progress_event_no_tty(self):
+        events = [
+            b'{"status": "Already exists", "progressDetail": {}, "id": "8d05e3af52b0"}'
+        ]
+        output = StringIO()
+
+        events = progress_stream.stream_output(events, output)
+        self.assertEqual(len(output.getvalue()), 0)
+
+    def test_stream_output_no_progress_event_no_tty(self):
+        events = [
+            b'{"status": "Pulling from library/xy", "id": "latest"}'
+        ]
+        output = StringIO()
+
+        events = progress_stream.stream_output(events, output)
+        self.assertTrue(len(output.getvalue()) > 0)


### PR DESCRIPTION
"docker-compose pull &> test.log" would print a lot of newlines, this pull request fixes this.

old output:

    (env)lodur:compose yves$ docker-compose -f ../../../../../../compose.yaml pull  &> test.log
    (env)lodur:compose yves$ cat test.log 
    Pulling redis (redis:latest)...
    latest: Pulling from library/redis
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    
    Digest: sha256:cef5e2b2218eec7f2619bc115e69207c2a222d265ca6dc8e8f97b5a454f3510b
    Status: Image is up to date for redis:latest

new output:

    (env)lodur:compose yves$ docker-compose -f ../../../../../../compose.yaml pull  &> test.log
    (env)lodur:compose yves$ cat test.log 
    Pulling redis (redis:latest)...
    latest: Pulling from library/redis
    Digest: sha256:cef5e2b2218eec7f2619bc115e69207c2a222d265ca6dc8e8f97b5a454f3510b
    Status: Image is up to date for redis:latest