### PR TITLE
Don't set the hostname to the service name with networking.

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -599,9 +599,6 @@ class Service(object):
             container_options['hostname'] = parts[0]
             container_options['domainname'] = parts[2]
 
-        if 'hostname' not in container_options and self.use_networking:
-            container_options['hostname'] = self.name
-
         if 'ports' in container_options or 'expose' in self.options:
             ports = []
             all_ports = container_options.get('ports', []) + self.options.get('expose', [])

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -205,7 +205,6 @@ class CLITestCase(DockerClientTestCase):
             containers = service.containers()
             self.assertEqual(len(containers), 1)
             self.assertIn(containers[0].id, network['Containers'])
-            self.assertEqual(containers[0].get('Config.Hostname'), service.name)
 
         web_container = self.project.get_service('web').containers()[0]
         self.assertFalse(web_container.get('HostConfig.Links'))

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -213,16 +213,6 @@ class ServiceTest(unittest.TestCase):
         opts = service._get_container_create_options({'image': 'foo'}, 1)
         self.assertIsNone(opts.get('hostname'))
 
-    def test_hostname_defaults_to_service_name_when_using_networking(self):
-        service = Service(
-            'foo',
-            image='foo',
-            use_networking=True,
-            client=self.mock_client,
-        )
-        opts = service._get_container_create_options({'image': 'foo'}, 1)
-        self.assertEqual(opts['hostname'], 'foo')
-
     def test_get_container_create_options_with_name_option(self):
         service = Service(
             'foo',


### PR DESCRIPTION
Fixes #2327

Since it's not being used for anything, I think we can undo this part of the networking experiment. When we get alias support there should be some other mechanism we can use to set the aliases.

cc @aanand @vieux 