### PR TITLE
Fix parallel output

### DIFF
--- a/compose/utils.py
+++ b/compose/utils.py
@@ -164,7 +164,7 @@ def write_out_msg(stream, lines, msg_index, msg, status="done"):
         stream.write("%c[%dA" % (27, diff))
         # erase
         stream.write("%c[2K\r" % 27)
-        stream.write("{} {} ... {}\n".format(msg, obj_index, status))
+        stream.write("{} {} ... {}\r".format(msg, obj_index, status))
         # move back down
         stream.write("%c[%dB" % (27, diff))
     else:


### PR DESCRIPTION
We were outputting an extra line, which in *some* cases, on *some* terminals, was causing the output of parallel actions to get messed up.

In particular, it would happen when the terminal had just been cleared or hadn't yet filled up with a screen's worth of text.

Closes #1904.