### PR TITLE
Update service config_dict computation to include volumes_from mode

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -502,7 +502,9 @@ class Service(object):
             'image_id': self.image()['Id'],
             'links': self.get_link_names(),
             'net': self.net.id,
-            'volumes_from': self.get_volumes_from_names(),
+            'volumes_from': [
+                (v.source.name, v.mode) for v in self.volumes_from if isinstance(v.source, Service)
+            ],
         }
 
     def get_dependency_names(self):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -410,7 +410,7 @@ class ServiceTest(unittest.TestCase):
             'options': {'image': 'example.com/foo'},
             'links': [('one', 'one')],
             'net': 'other',
-            'volumes_from': ['two'],
+            'volumes_from': [('two', 'rw')],
         }
         self.assertEqual(config_dict, expected)
 


### PR DESCRIPTION
Ensure config_hash is updated when volumes_from mode is changed, and service is recreated on next up as a result.

Fixes #2322 