### PR TITLE
Refactor process_error and include a filename as part of the validation error messages

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -229,9 +229,9 @@ def load(config_details):
 
 
 def process_config_file(config_file, service_name=None):
-    validate_top_level_object(config_file.config)
+    validate_top_level_object(config_file)
     processed_config = interpolate_environment_variables(config_file.config)
-    validate_against_fields_schema(processed_config)
+    validate_against_fields_schema(processed_config, config_file.filename)
 
     if service_name and service_name not in processed_config:
         raise ConfigurationError(

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -65,7 +65,6 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'dockerfile',
     'expose',
     'external_links',
-    'name',
 ]
 
 

--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -2,15 +2,18 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "type": "object",
+  "id": "fields_schema.json",
 
   "patternProperties": {
     "^[a-zA-Z0-9._-]+$": {
       "$ref": "#/definitions/service"
     }
   },
+  "additionalProperties": false,
 
   "definitions": {
     "service": {
+      "id": "#/definitions/service",
       "type": "object",
 
       "properties": {
@@ -167,6 +170,5 @@
       ]
     }
 
-  },
-  "additionalProperties": false
+  }
 }

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -18,13 +18,6 @@ def interpolate_environment_variables(config):
 
 
 def process_service(service_name, service_dict, mapping):
-    if not isinstance(service_dict, dict):
-        raise ConfigurationError(
-            'Service "%s" doesn\'t have any configuration options. '
-            'All top level keys in your docker-compose.yml must map '
-            'to a dictionary of configuration options.' % service_name
-        )
-
     return dict(
         (key, interpolate_value(service_name, key, val, mapping))
         for (key, val) in service_dict.items()

--- a/compose/config/service_schema.json
+++ b/compose/config/service_schema.json
@@ -1,15 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "service_schema.json",
 
   "type": "object",
 
   "allOf": [
     {"$ref": "fields_schema.json#/definitions/service"},
-    {"$ref": "#/definitions/service_constraints"}
+    {"$ref": "#/definitions/constraints"}
   ],
 
   "definitions": {
-    "service_constraints": {
+    "constraints": {
+      "id": "#/definitions/constraints",
       "anyOf": [
         {
           "required": ["build"],
@@ -21,13 +23,8 @@
             {"required": ["build"]},
             {"required": ["dockerfile"]}
           ]}
-        },
-        {
-          "required": ["extends"],
-          "not": {"required": ["build", "image"]}
         }
       ]
     }
   }
-
 }

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -307,7 +307,10 @@ def _validate_against_schema(config, schema_filename, format_checker=[], service
         schema = json.load(schema_fh)
 
     resolver = RefResolver(resolver_full_path, schema)
-    validation_output = Draft4Validator(schema, resolver=resolver, format_checker=FormatChecker(format_checker))
+    validation_output = Draft4Validator(
+        schema,
+        resolver=resolver,
+        format_checker=FormatChecker(format_checker))
 
     errors = [error for error in sorted(validation_output.iter_errors(config), key=str)]
     if errors:

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -867,7 +867,7 @@ class MemoryOptionsTest(unittest.TestCase):
         a mem_limit
         """
         expected_error_msg = (
-            "Invalid 'memswap_limit' configuration for 'foo' service: when "
+            "Service 'foo' configuration key 'memswap_limit' is invalid: when "
             "defining 'memswap_limit' you must set 'mem_limit' as well"
         )
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -78,14 +78,12 @@ class ConfigTest(unittest.TestCase):
 
     def test_config_invalid_service_names(self):
         for invalid_name in ['?not?allowed', ' ', '', '!', '/', '\xe2']:
-            with pytest.raises(ConfigurationError):
-                config.load(
-                    build_config_details(
-                        {invalid_name: {'image': 'busybox'}},
-                        'working_dir',
-                        'filename.yml'
-                    )
-                )
+            with pytest.raises(ConfigurationError) as exc:
+                config.load(build_config_details(
+                    {invalid_name: {'image': 'busybox'}},
+                    'working_dir',
+                    'filename.yml'))
+            assert 'Invalid service name \'%s\'' % invalid_name in exc.exconly()
 
     def test_load_with_invalid_field_name(self):
         config_details = build_config_details(
@@ -95,6 +93,16 @@ class ConfigTest(unittest.TestCase):
         with pytest.raises(ConfigurationError) as exc:
             config.load(config_details)
         error_msg = "Unsupported config option for 'web' service: 'name'"
+        assert error_msg in exc.exconly()
+
+    def test_load_invalid_service_definition(self):
+        config_details = build_config_details(
+            {'web': 'wrong'},
+            'working_dir',
+            'filename.yml')
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(config_details)
+        error_msg = "Service \"web\" doesn\'t have any configuration options"
         assert error_msg in exc.exconly()
 
     def test_config_integer_service_name_raise_validation_error(self):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -94,6 +94,7 @@ class ConfigTest(unittest.TestCase):
             config.load(config_details)
         error_msg = "Unsupported config option for 'web' service: 'name'"
         assert error_msg in exc.exconly()
+        assert "Validation failed in file 'filename.yml'" in exc.exconly()
 
     def test_load_invalid_service_definition(self):
         config_details = build_config_details(
@@ -102,11 +103,12 @@ class ConfigTest(unittest.TestCase):
             'filename.yml')
         with pytest.raises(ConfigurationError) as exc:
             config.load(config_details)
-        error_msg = "Service \"web\" doesn\'t have any configuration options"
+        error_msg = "service 'web' doesn't have any configuration options"
         assert error_msg in exc.exconly()
 
     def test_config_integer_service_name_raise_validation_error(self):
-        expected_error_msg = "Service name: 1 needs to be a string, eg '1'"
+        expected_error_msg = ("In file 'filename.yml' service name: 1 needs to "
+                              "be a string, eg '1'")
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
                 build_config_details(
@@ -156,25 +158,26 @@ class ConfigTest(unittest.TestCase):
 
     def test_load_with_multiple_files_and_empty_override(self):
         base_file = config.ConfigFile(
-            'base.yaml',
+            'base.yml',
             {'web': {'image': 'example/web'}})
-        override_file = config.ConfigFile('override.yaml', None)
+        override_file = config.ConfigFile('override.yml', None)
         details = config.ConfigDetails('.', [base_file, override_file])
 
         with pytest.raises(ConfigurationError) as exc:
             config.load(details)
-        assert 'Top level object needs to be a dictionary' in exc.exconly()
+        error_msg = "Top level object in 'override.yml' needs to be an object"
+        assert error_msg in exc.exconly()
 
     def test_load_with_multiple_files_and_empty_base(self):
-        base_file = config.ConfigFile('base.yaml', None)
+        base_file = config.ConfigFile('base.yml', None)
         override_file = config.ConfigFile(
-            'override.yaml',
+            'override.yml',
             {'web': {'image': 'example/web'}})
         details = config.ConfigDetails('.', [base_file, override_file])
 
         with pytest.raises(ConfigurationError) as exc:
             config.load(details)
-        assert 'Top level object needs to be a dictionary' in exc.exconly()
+        assert "Top level object in 'base.yml' needs to be an object" in exc.exconly()
 
     def test_load_with_multiple_files_and_extends_in_override_file(self):
         base_file = config.ConfigFile(
@@ -225,17 +228,17 @@ class ConfigTest(unittest.TestCase):
 
         with pytest.raises(ConfigurationError) as exc:
             config.load(details)
-        assert 'Service "bogus" doesn\'t have any configuration' in exc.exconly()
+        assert "service 'bogus' doesn't have any configuration" in exc.exconly()
+        assert "In file 'override.yaml'" in exc.exconly()
 
     def test_config_valid_service_names(self):
         for valid_name in ['_', '-', '.__.', '_what-up.', 'what_.up----', 'whatup']:
-            config.load(
+            services = config.load(
                 build_config_details(
                     {valid_name: {'image': 'busybox'}},
                     'tests/fixtures/extends',
-                    'common.yml'
-                )
-            )
+                    'common.yml'))
+            assert services[0]['name'] == valid_name
 
     def test_config_invalid_ports_format_validation(self):
         expected_error_msg = "Service 'web' configuration key 'ports' contains an invalid type"
@@ -300,7 +303,8 @@ class ConfigTest(unittest.TestCase):
             )
 
     def test_invalid_config_not_a_dictionary(self):
-        expected_error_msg = "Top level object needs to be a dictionary."
+        expected_error_msg = ("Top level object in 'filename.yml' needs to be "
+                              "an object.")
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
             config.load(
                 build_config_details(
@@ -382,12 +386,13 @@ class ConfigTest(unittest.TestCase):
             )
 
     def test_config_ulimits_invalid_keys_validation_error(self):
-        expected_error_msg = "Service 'web' configuration key 'ulimits' contains unsupported option: 'not_soft_or_hard'"
+        expected = ("Service 'web' configuration key 'ulimits' 'nofile' contains "
+                    "unsupported option: 'not_soft_or_hard'")
 
-        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
-            config.load(
-                build_config_details(
-                    {'web': {
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(build_config_details(
+                {
+                    'web': {
                         'image': 'busybox',
                         'ulimits': {
                             'nofile': {
@@ -396,50 +401,43 @@ class ConfigTest(unittest.TestCase):
                                 "hard": 20000,
                             }
                         }
-                    }},
-                    'working_dir',
-                    'filename.yml'
-                )
-            )
+                    }
+                },
+                'working_dir',
+                'filename.yml'))
+        assert expected in exc.exconly()
 
     def test_config_ulimits_required_keys_validation_error(self):
-        expected_error_msg = "Service 'web' configuration key 'ulimits' u?'hard' is a required property"
 
-        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
-            config.load(
-                build_config_details(
-                    {'web': {
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(build_config_details(
+                {
+                    'web': {
                         'image': 'busybox',
-                        'ulimits': {
-                            'nofile': {
-                                "soft": 10000,
-                            }
-                        }
-                    }},
-                    'working_dir',
-                    'filename.yml'
-                )
-            )
+                        'ulimits': {'nofile': {"soft": 10000}}
+                    }
+                },
+                'working_dir',
+                'filename.yml'))
+        assert "Service 'web' configuration key 'ulimits' 'nofile'" in exc.exconly()
+        assert "'hard' is a required property" in exc.exconly()
 
     def test_config_ulimits_soft_greater_than_hard_error(self):
-        expected_error_msg = "cannot contain a 'soft' value higher than 'hard' value"
+        expected = "cannot contain a 'soft' value higher than 'hard' value"
 
-        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
-            config.load(
-                build_config_details(
-                    {'web': {
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(build_config_details(
+                {
+                    'web': {
                         'image': 'busybox',
                         'ulimits': {
-                            'nofile': {
-                                "soft": 10000,
-                                "hard": 1000
-                            }
+                            'nofile': {"soft": 10000, "hard": 1000}
                         }
-                    }},
-                    'working_dir',
-                    'filename.yml'
-                )
-            )
+                    }
+                },
+                'working_dir',
+                'filename.yml'))
+        assert expected in exc.exconly()
 
     def test_valid_config_which_allows_two_type_definitions(self):
         expose_values = [["8000"], [8000]]

--- a/tox.ini
+++ b/tox.ini
@@ -43,4 +43,6 @@ directory = coverage-html
 [flake8]
 # Allow really long lines for now
 max-line-length = 140
+# Set this high for now
+max-complexity = 20
 exclude = compose/packages


### PR DESCRIPTION
Fixes #2323 

The refactoring started as a way to reduce the complexity of `process_errors()`. It started as a function with cyclomatic complexity of 26! I refactored it into a few smaller functions, each of which is under a cyclomatic complexity of 8.

Part of the refactoring included adding ids to some of the schemas. We were guessing at which schema was being validated by arbitrary hints (the type of path). By using a schema id we're much less likely to break these validation messages in the future, as we add new schemas and sub-schemas.

The last commit adds filenames to validation messages, and adjusts the tests to match.