### PR TITLE
Allow dashes in environment variable names

### DIFF
--- a/compose/config/fields_schema.json
+++ b/compose/config/fields_schema.json
@@ -40,7 +40,7 @@
             {
               "type": "object",
               "patternProperties": {
-                "^[^-]+$": {
+                ".+": {
                   "type": ["string", "number", "boolean", "null"],
                   "format": "environment"
                 }

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -470,20 +470,18 @@ class ConfigTest(unittest.TestCase):
         self.assertTrue(mock_logging.warn.called)
         self.assertTrue(expected_warning_msg in mock_logging.warn.call_args[0][0])
 
-    def test_config_invalid_environment_dict_key_raises_validation_error(self):
-        expected_error_msg = "Service 'web' configuration key 'environment' contains unsupported option: '---'"
-
-        with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):
-            config.load(
-                build_config_details(
-                    {'web': {
-                        'image': 'busybox',
-                        'environment': {'---': 'nope'}
-                    }},
-                    'working_dir',
-                    'filename.yml'
-                )
+    def test_config_valid_environment_dict_key_contains_dashes(self):
+        services = config.load(
+            build_config_details(
+                {'web': {
+                    'image': 'busybox',
+                    'environment': {'SPRING_JPA_HIBERNATE_DDL-AUTO': 'none'}
+                }},
+                'working_dir',
+                'filename.yml'
             )
+        )
+        self.assertEqual(services[0]['environment']['SPRING_JPA_HIBERNATE_DDL-AUTO'], 'none')
 
     def test_load_yaml_with_yaml_error(self):
         tmpdir = py.test.ensuretemp('invalid_yaml_test')


### PR DESCRIPTION
See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html

> Environment variable names used by the utilities in the Shell and Utilities volume of POSIX.1-2008 consist solely of uppercase letters, digits, and the <underscore> ( '_' ) from the characters defined in Portable Character Set and do not begin with a digit. **Other characters may be permitted by an implementation; applications shall tolerate the presence of such names.**

Fixes #2370 