### PR TITLE
Use uname to build target name for different platforms

### DIFF
--- a/script/build-linux-inner
+++ b/script/build-linux-inner
@@ -2,7 +2,7 @@
 
 set -ex
 
-TARGET=dist/docker-compose-Linux-x86_64
+TARGET=dist/docker-compose-$(uname -s)-$(uname -m)
 VENV=/code/.tox/py27
 
 mkdir -p `pwd`/dist


### PR DESCRIPTION
In preparation to build docker-compose for Linux on ARM we should replace the fixed target name with the values from `uname -s` and `uname -m`.
