### PR TITLE
docker-compose events

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -256,8 +256,10 @@ class TopLevelCommand(DocoptCommand):
             --json      Output events as a stream of json objects
         """
         def format_event(event):
-            return ("{time}: service={service} event={event} "
-                    "container={container} image={image}").format(**event)
+            attributes = ["%s=%s" % item for item in event['attributes'].items()]
+            return ("{time} {type} {action} {id} ({attrs})").format(
+                attrs=", ".join(sorted(attributes)),
+                **event)
 
         def json_format_event(event):
             event['time'] = event['time'].isoformat()
@@ -266,6 +268,7 @@ class TopLevelCommand(DocoptCommand):
         for event in project.events():
             formatter = json_format_event if options['--json'] else format_event
             print(formatter(event))
+            sys.stdout.flush()
 
     def help(self, project, options):
         """

--- a/compose/const.py
+++ b/compose/const.py
@@ -6,6 +6,7 @@ import sys
 
 DEFAULT_TIMEOUT = 10
 HTTP_TIMEOUT = int(os.environ.get('COMPOSE_HTTP_TIMEOUT', os.environ.get('DOCKER_CLIENT_TIMEOUT', 60)))
+IMAGE_EVENTS = ['delete', 'import', 'pull', 'push', 'tag', 'untag']
 IS_WINDOWS_PLATFORM = (sys.platform == "win32")
 LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
 LABEL_ONE_OFF = 'com.docker.compose.oneoff'

--- a/compose/project.py
+++ b/compose/project.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import datetime
 import logging
 from functools import reduce
 
@@ -11,6 +12,7 @@ from . import parallel
 from .config import ConfigurationError
 from .config.sort_services import get_service_name_from_net
 from .const import DEFAULT_TIMEOUT
+from .const import IMAGE_EVENTS
 from .const import LABEL_ONE_OFF
 from .const import LABEL_PROJECT
 from .const import LABEL_SERVICE
@@ -20,6 +22,7 @@ from .service import ConvergenceStrategy
 from .service import Net
 from .service import Service
 from .service import ServiceNet
+from .utils import microseconds_from_time_nano
 from .volume import Volume
 
 
@@ -267,7 +270,40 @@ class Project(object):
         plans = self._get_convergence_plans(services, strategy)
 
         for service in services:
-            service.execute_convergence_plan(plans[service.name], do_build, detached=True, start=False)
+            service.execute_convergence_plan(
+                plans[service.name],
+                do_build,
+                detached=True,
+                start=False)
+
+    def events(self):
+        def build_container_event(event, container):
+            time = datetime.datetime.fromtimestamp(event['time'])
+            time = time.replace(
+                microsecond=microseconds_from_time_nano(event['timeNano']))
+            return {
+                'service': container.service,
+                'event': event['status'],
+                'container': container.id,
+                'image': event['from'],
+                'time': time,
+            }
+
+        service_names = set(self.service_names)
+        for event in self.client.events(
+            filters={'label': self.labels()},
+            decode=True
+        ):
+            if event['status'] in IMAGE_EVENTS:
+                # We don't receive any image events because labels aren't applied
+                # to images
+                continue
+
+            # TODO: get labels from the API v1.22 , see github issue 2618
+            container = Container.from_id(self.client, event['id'])
+            if container.service not in service_names:
+                continue
+            yield build_container_event(event, container)
 
     def up(self,
            service_names=None,

--- a/compose/project.py
+++ b/compose/project.py
@@ -282,11 +282,15 @@ class Project(object):
             time = time.replace(
                 microsecond=microseconds_from_time_nano(event['timeNano']))
             return {
-                'service': container.service,
-                'event': event['status'],
-                'container': container.id,
-                'image': event['from'],
                 'time': time,
+                'type': 'container',
+                'action': event['status'],
+                'id': container.id,
+                'service': container.service,
+                'attributes': {
+                    'name': container.name,
+                    'image': event['from'],
+                }
             }
 
         service_names = set(self.service_names)

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -88,3 +88,7 @@ def json_hash(obj):
     h = hashlib.sha256()
     h.update(dump.encode('utf8'))
     return h.hexdigest()
+
+
+def microseconds_from_time_nano(time_nano):
+    return int(time_nano % 1000000000 / 1000)

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -1,0 +1,34 @@
+<!--[metadata]>
++++
+title = "events"
+description = "Receive real time events from containers."
+keywords = ["fig, composition, compose, docker, orchestration, cli, events"]
+[menu.main]
+identifier="events.compose"
+parent = "smn_compose_cli"
++++
+<![end-metadata]-->
+
+# events
+
+```
+Usage: events [options] [SERVICE...]
+
+Options:
+    --json      Output events as a stream of json objects
+```
+
+Stream container events for every container in the project.
+
+With the `--json` flag, a json object will be printed one per line with the
+format:
+
+```
+{
+    "service": "web",
+    "event": "create",
+    "container": "213cf75fc39a",
+    "image": "alpine:edge",
+    "time": "2015-11-20T18:01:03.615550",
+}
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,19 +14,20 @@ parent = "smn_compose_ref"
 The following pages describe the usage information for the [docker-compose](docker-compose.md) subcommands. You can also see this information by running `docker-compose [SUBCOMMAND] --help` from the command line.
 
 * [build](build.md)
+* [events](events.md)
 * [help](help.md)
 * [kill](kill.md)
-* [ps](ps.md)
-* [restart](restart.md)
-* [run](run.md)
-* [start](start.md)
-* [up](up.md)
 * [logs](logs.md)
 * [port](port.md)
+* [ps](ps.md)
 * [pull](pull.md)
+* [restart](restart.md)
 * [rm](rm.md)
+* [run](run.md)
 * [scale](scale.md)
+* [start](start.md)
 * [stop](stop.md)
+* [up](up.md)
 
 ## Where to go next
 

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -238,12 +238,19 @@ class ProjectTest(unittest.TestCase):
 
         def get_container(cid):
             if cid == 'abcde':
-                labels = {LABEL_SERVICE: 'web'}
+                name = 'web'
+                labels = {LABEL_SERVICE: name}
             elif cid == 'ababa':
-                labels = {LABEL_SERVICE: 'db'}
+                name = 'db'
+                labels = {LABEL_SERVICE: name}
             else:
                 labels = {}
-            return {'Id': cid, 'Config': {'Labels': labels}}
+                name = ''
+            return {
+                'Id': cid,
+                'Config': {'Labels': labels},
+                'Name': '/project_%s_1' % name,
+            }
 
         self.mock_client.inspect_container.side_effect = get_container
 
@@ -254,24 +261,36 @@ class ProjectTest(unittest.TestCase):
         assert not list(events)
         assert events_list == [
             {
+                'type': 'container',
                 'service': 'web',
-                'event': 'create',
-                'container': 'abcde',
-                'image': 'example/image',
+                'action': 'create',
+                'id': 'abcde',
+                'attributes': {
+                    'name': 'project_web_1',
+                    'image': 'example/image',
+                },
                 'time': dt_with_microseconds(1420092061, 2),
             },
             {
+                'type': 'container',
                 'service': 'web',
-                'event': 'attach',
-                'container': 'abcde',
-                'image': 'example/image',
+                'action': 'attach',
+                'id': 'abcde',
+                'attributes': {
+                    'name': 'project_web_1',
+                    'image': 'example/image',
+                },
                 'time': dt_with_microseconds(1420092061, 3),
             },
             {
+                'type': 'container',
                 'service': 'db',
-                'event': 'create',
-                'container': 'ababa',
-                'image': 'example/db',
+                'action': 'create',
+                'id': 'ababa',
+                'attributes': {
+                    'name': 'project_db_1',
+                    'image': 'example/db',
+                },
                 'time': dt_with_microseconds(1420092061, 4),
             },
         ]


### PR DESCRIPTION
Fixes #1510 

Adds a new command `events` for tailing the event stream for containers in the composition.

The event fields match the new api fields being introduced in 1.10 (https://github.com/docker/docker/pull/18888/)

This gist shows an example of using these events to create event hooks in under 20 lines of bash:
https://gist.github.com/dnephin/c56b479810f863527e90

Any suggestion on where this can be included in the docs?