### PR TITLE
Fix env_file and environment when used with extends

### DIFF
--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -46,7 +46,8 @@ class DockerClientTestCase(unittest.TestCase):
 
         service_config = ServiceConfig('.', None, name, kwargs)
         options = process_service(service_config)
-        options['environment'] = resolve_environment('.', kwargs)
+        options['environment'] = resolve_environment(
+            service_config._replace(config=options))
         labels = options.setdefault('labels', {})
         labels['com.docker.compose.test-name'] = self.id()
 


### PR DESCRIPTION
Fixes #2408
Fixes #2416

This was a regression in 1.5.1. See issues for the symptoms. The problem was that `service_dict` was being overridden if there was an `extends` key.

This change moves `resolve_environment()` so that it happens with related changes to the config.