### PR TITLE
Add support for declaring named volumes in compose files

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -80,12 +80,13 @@ def get_project(base_dir, config_path=None, project_name=None, verbose=False,
     config_details = config.find(base_dir, config_path)
 
     api_version = '1.21' if use_networking else None
-    return Project.from_dicts(
+    return Project.from_config(
         get_project_name(config_details.working_dir, project_name),
         config.load(config_details),
         get_client(verbose=verbose, version=api_version),
         use_networking=use_networking,
-        network_driver=network_driver)
+        network_driver=network_driver
+    )
 
 
 def get_project_name(working_dir, project_name=None):

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -8,8 +8,7 @@ from ..const import HTTP_TIMEOUT
 
 log = logging.getLogger(__name__)
 
-
-DEFAULT_API_VERSION = '1.20'
+DEFAULT_API_VERSION = '1.21'
 
 
 def docker_client(version=None):

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -9,7 +9,7 @@ from ..const import HTTP_TIMEOUT
 log = logging.getLogger(__name__)
 
 
-DEFAULT_API_VERSION = '1.19'
+DEFAULT_API_VERSION = '1.20'
 
 
 def docker_client(version=None):

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -211,11 +211,11 @@ class TopLevelCommand(DocoptCommand):
             return
 
         if options['--services']:
-            print('\n'.join(service['name'] for service in compose_config))
+            print('\n'.join(service['name'] for service in compose_config.services))
             return
 
         compose_config = dict(
-            (service.pop('name'), service) for service in compose_config)
+            (service.pop('name'), service) for service in compose_config.services)
         print(yaml.dump(
             compose_config,
             default_flow_style=False,

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -315,7 +315,7 @@ def load_services(working_dir, config_files, version):
     return build_services(config_file)
 
 
-def process_config_file(config_file, service_name=None, version=None):
+def process_config_file(config_file, version, service_name=None):
     validate_top_level_service_objects(config_file, version)
     processed_config = interpolate_environment_variables(config_file.config, version)
     validate_against_fields_schema(
@@ -364,7 +364,7 @@ class ServiceExtendsResolver(object):
 
         extended_file = process_config_file(
             ConfigFile.from_filename(config_path),
-            service_name=service_name, version=self.version
+            version=self.version, service_name=service_name
         )
         service_config = extended_file.config[service_name]
         return config_path, service_config, service_name

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -117,6 +117,17 @@ class ConfigFile(namedtuple('_ConfigFile', 'filename config')):
         return cls(filename, load_yaml(filename))
 
 
+class Config(namedtuple('_Config', 'version services volumes')):
+    """
+    :param version: configuration version
+    :type  version: int
+    :param services: List of service description dictionaries
+    :type  services: :class:`list`
+    :param volumes: List of volume description dictionaries
+    :type  volumes: :class:`list`
+    """
+
+
 class ServiceConfig(namedtuple('_ServiceConfig', 'working_dir filename name config')):
 
     @classmethod
@@ -146,6 +157,24 @@ def find(base_dir, filenames):
     return ConfigDetails(
         os.path.dirname(filenames[0]),
         [ConfigFile.from_filename(f) for f in filenames])
+
+
+def get_config_version(config_details):
+    def get_version(config):
+        validate_top_level_object(config)
+        return config.config.get('version')
+    main_file = config_details.config_files[0]
+    version = get_version(main_file)
+    for next_file in config_details.config_files[1:]:
+        next_file_version = get_version(next_file)
+        if version != next_file_version:
+            raise ConfigurationError(
+                "Version mismatch: main file {0} specifies version {1} but "
+                "extension file {2} uses version {3}".format(
+                    main_file.filename, version, next_file.filename, next_file_version
+                )
+            )
+    return version
 
 
 def get_default_config_files(base_dir):
@@ -194,10 +223,46 @@ def load(config_details):
 
     Return a fully interpolated, extended and validated configuration.
     """
+    version = get_config_version(config_details)
+    processed_files = []
+    for config_file in config_details.config_files:
+        processed_files.append(
+            process_config_file(config_file, version=version)
+        )
+    config_details = config_details._replace(config_files=processed_files)
 
+    if not version or isinstance(version, dict):
+        service_dicts = load_services(
+            config_details.working_dir, config_details.config_files
+        )
+        volumes = {}
+    elif version == 2:
+        config_files = [
+            ConfigFile(f.filename, f.config.get('services', {}))
+            for f in config_details.config_files
+        ]
+        service_dicts = load_services(
+            config_details.working_dir, config_files
+        )
+        volumes = load_volumes(config_details.config_files)
+    else:
+        raise ConfigurationError('Invalid config version provided: {0}'.format(version))
+
+    return Config(version, service_dicts, volumes)
+
+
+def load_volumes(config_files):
+    volumes = {}
+    for config_file in config_files:
+        for name, volume_config in config_file.config.get('volumes', {}).items():
+            volumes.update({name: volume_config})
+    return volumes
+
+
+def load_services(working_dir, config_files):
     def build_service(filename, service_name, service_dict):
         service_config = ServiceConfig.with_abs_paths(
-            config_details.working_dir,
+            working_dir,
             filename,
             service_name,
             service_dict)
@@ -227,20 +292,20 @@ def load(config_details):
             for name in all_service_names
         }
 
-    config_file = process_config_file(config_details.config_files[0])
-    for next_file in config_details.config_files[1:]:
-        next_file = process_config_file(next_file)
-
+    config_file = config_files[0]
+    for next_file in config_files[1:]:
         config = merge_services(config_file.config, next_file.config)
         config_file = config_file._replace(config=config)
 
     return build_services(config_file)
 
 
-def process_config_file(config_file, service_name=None):
+def process_config_file(config_file, service_name=None, version=None):
     validate_top_level_object(config_file)
     processed_config = interpolate_environment_variables(config_file.config)
-    validate_against_fields_schema(processed_config, config_file.filename)
+    validate_against_fields_schema(
+        processed_config, config_file.filename, version
+    )
 
     if service_name and service_name not in processed_config:
         raise ConfigurationError(

--- a/compose/config/fields_schema_v1.json
+++ b/compose/config/fields_schema_v1.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
 
   "type": "object",
-  "id": "fields_schema.json",
+  "id": "fields_schema_v1.json",
 
   "patternProperties": {
     "^[a-zA-Z0-9._-]+$": {

--- a/compose/config/fields_schema_v2.json
+++ b/compose/config/fields_schema_v2.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+  "properties": {
+    "version": {
+      "enum": [2]
+    },
+    "services": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "fields_schema.json#/definitions/service"
+        }
+      }
+    },
+    "volumes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/volume"
+        }
+      }
+    }
+  },
+
+  "definitions": {
+    "volume": {
+      "type": "object",
+      "properties": {
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["boolean", "string", "number"]}
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/compose/config/fields_schema_v2.json
+++ b/compose/config/fields_schema_v2.json
@@ -1,38 +1,44 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-
   "type": "object",
+  "id": "fields_schema_v2.json",
+
   "properties": {
     "version": {
       "enum": [2]
     },
     "services": {
+      "id": "#/properties/services",
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9._-]+$": {
-          "$ref": "fields_schema.json#/definitions/service"
+          "$ref": "fields_schema_v1.json#/definitions/service"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "volumes": {
+      "id": "#/properties/volumes",
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9._-]+$": {
           "$ref": "#/definitions/volume"
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
 
   "definitions": {
     "volume": {
+      "id": "#/definitions/volume",
       "type": "object",
       "properties": {
         "driver": {"type": "string"},
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {"type": ["boolean", "string", "number"]}
+            "^.+$": {"type": ["string", "number"]}
           },
           "additionalProperties": false
         }

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -8,19 +8,13 @@ from .errors import ConfigurationError
 log = logging.getLogger(__name__)
 
 
-def interpolate_environment_variables(config, version):
+def interpolate_environment_variables(service_dicts):
     mapping = BlankDefaultDict(os.environ)
-    service_dicts = config if version == 1 else config.get('services', {})
 
-    interpolated = dict(
+    return dict(
         (service_name, process_service(service_name, service_dict, mapping))
         for (service_name, service_dict) in service_dicts.items()
     )
-    if version == 1:
-        return interpolated
-    result = dict(config)
-    result.update({'services': interpolated})
-    return result
 
 
 def process_service(service_name, service_dict, mapping):

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -8,13 +8,19 @@ from .errors import ConfigurationError
 log = logging.getLogger(__name__)
 
 
-def interpolate_environment_variables(config):
+def interpolate_environment_variables(config, version):
     mapping = BlankDefaultDict(os.environ)
+    service_dicts = config if version == 1 else config.get('services', {})
 
-    return dict(
+    interpolated = dict(
         (service_name, process_service(service_name, service_dict, mapping))
-        for (service_name, service_dict) in config.items()
+        for (service_name, service_dict) in service_dicts.items()
     )
+    if version == 1:
+        return interpolated
+    result = dict(config)
+    result.update({'services': interpolated})
+    return result
 
 
 def process_service(service_name, service_dict, mapping):

--- a/compose/config/service_schema.json
+++ b/compose/config/service_schema.json
@@ -5,7 +5,7 @@
   "type": "object",
 
   "allOf": [
-    {"$ref": "fields_schema.json#/definitions/service"},
+    {"$ref": "fields_schema_v1.json#/definitions/service"},
     {"$ref": "#/definitions/constraints"}
   ],
 

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -74,19 +74,18 @@ def format_boolean_in_environment(instance):
     return True
 
 
-def validate_top_level_service_objects(config_file, version):
+def validate_top_level_service_objects(filename, service_dicts):
     """Perform some high level validation of the service name and value.
 
     This validation must happen before interpolation, which must happen
     before the rest of validation, which is why it's separate from the
     rest of the service validation.
     """
-    service_dicts = config_file.config if version == 1 else config_file.config.get('services', {})
     for service_name, service_dict in service_dicts.items():
         if not isinstance(service_name, six.string_types):
             raise ConfigurationError(
                 "In file '{}' service name: {} needs to be a string, eg '{}'".format(
-                    config_file.filename,
+                    filename,
                     service_name,
                     service_name))
 
@@ -95,8 +94,9 @@ def validate_top_level_service_objects(config_file, version):
                 "In file '{}' service '{}' doesn\'t have any configuration options. "
                 "All top level keys in your docker-compose.yml must map "
                 "to a dictionary of configuration options.".format(
-                    config_file.filename,
-                    service_name))
+                    filename, service_name
+                )
+            )
 
 
 def validate_top_level_object(config_file):

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -281,11 +281,14 @@ def process_errors(errors, service_name=None):
     return '\n'.join(format_error_message(error, service_name) for error in errors)
 
 
-def validate_against_fields_schema(config, filename):
+def validate_against_fields_schema(config, filename, version=None):
+    schema_filename = "fields_schema.json"
+    if version:
+        schema_filename = "fields_schema_v{0}.json".format(version)
     _validate_against_schema(
         config,
-        "fields_schema.json",
-        format_checker=["ports", "expose", "bool-value-in-mapping"],
+        schema_filename,
+        format_checker=["ports", "environment", "bool-value-in-mapping"],
         filename=filename)
 
 

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -290,7 +290,7 @@ def validate_against_fields_schema(config, filename, version):
     _validate_against_schema(
         config,
         schema_filename,
-        format_checker=["ports", "environment", "bool-value-in-mapping"],
+        format_checker=["ports", "expose", "bool-value-in-mapping"],
         filename=filename)
 
 

--- a/compose/const.py
+++ b/compose/const.py
@@ -10,3 +10,4 @@ LABEL_PROJECT = 'com.docker.compose.project'
 LABEL_SERVICE = 'com.docker.compose.service'
 LABEL_VERSION = 'com.docker.compose.version'
 LABEL_CONFIG_HASH = 'com.docker.compose.config-hash'
+COMPOSEFILE_VERSIONS = (1, 2)

--- a/compose/container.py
+++ b/compose/container.py
@@ -228,16 +228,6 @@ class Container(object):
         self.has_been_inspected = True
         return self.dictionary
 
-    # TODO: only used by tests, move to test module
-    def links(self):
-        links = []
-        for container in self.client.containers():
-            for name in container['Names']:
-                bits = name.split('/')
-                if len(bits) > 2 and bits[1] == self.name:
-                    links.append(bits[2])
-        return links
-
     def attach(self, *args, **kwargs):
         return self.client.attach(self.id, *args, **kwargs)
 

--- a/compose/container.py
+++ b/compose/container.py
@@ -177,6 +177,12 @@ class Container(object):
         port = self.ports.get("%s/%s" % (port, protocol))
         return "{HostIp}:{HostPort}".format(**port[0]) if port else None
 
+    def get_mount(self, mount_dest):
+        for mount in self.get('Mounts'):
+            if mount['Destination'] == mount_dest:
+                return mount
+        return None
+
     def start(self, **options):
         return self.client.start(self.id, **options)
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -236,6 +236,18 @@ class Project(object):
             raise ConfigurationError(
                 'Volume %s specifies nonexistent driver %s' % (volume.name, volume.driver)
             )
+        except APIError as e:
+            if 'Choose a different volume name' in str(e):
+                raise ConfigurationError(
+                    'Configuration for volume {0} specifies driver {1}, but '
+                    'a volume with the same name uses a different driver '
+                    '({3}). If you wish to use the new configuration, please '
+                    'remove the existing volume "{2}" first:\n'
+                    '$ docker volume rm {2}'.format(
+                        volume.name, volume.driver, volume.full_name,
+                        volume.inspect()['Driver']
+                    )
+                )
 
     def restart(self, service_names=None, **options):
         containers = self.containers(service_names, stopped=True)

--- a/compose/project.py
+++ b/compose/project.py
@@ -234,7 +234,7 @@ class Project(object):
                 volume.create()
         except NotFound:
             raise ConfigurationError(
-                'Volume %s sepcifies nonexistent driver %s' % (volume.name, volume.driver)
+                'Volume %s specifies nonexistent driver %s' % (volume.name, volume.driver)
             )
 
     def restart(self, service_names=None, **options):

--- a/compose/service.py
+++ b/compose/service.py
@@ -868,6 +868,7 @@ def get_container_data_volumes(container, volumes_option):
             continue
 
         mount = container_mounts.get(volume.internal)
+
         # New volume, doesn't exist in the old container
         if not mount:
             continue

--- a/compose/service.py
+++ b/compose/service.py
@@ -849,7 +849,13 @@ def get_container_data_volumes(container, volumes_option):
     a mapping of volume bindings for those volumes.
     """
     volumes = []
-    container_volumes = container.get('Volumes') or {}
+    volumes_option = volumes_option or []
+
+    container_mounts = dict(
+        (mount['Destination'], mount)
+        for mount in container.get('Mounts') or {}
+    )
+
     image_volumes = [
         VolumeSpec.parse(volume)
         for volume in
@@ -861,13 +867,13 @@ def get_container_data_volumes(container, volumes_option):
         if volume.external:
             continue
 
-        volume_path = container_volumes.get(volume.internal)
+        mount = container_mounts.get(volume.internal)
         # New volume, doesn't exist in the old container
-        if not volume_path:
+        if not mount:
             continue
 
         # Copy existing volume from old container
-        volume = volume._replace(external=volume_path)
+        volume = volume._replace(external=mount['Source'])
         volumes.append(volume)
 
     return volumes

--- a/compose/volume.py
+++ b/compose/volume.py
@@ -10,10 +10,16 @@ class Volume(object):
         self.driver_opts = driver_opts
 
     def create(self):
-        return self.client.create_volume(self.name, self.driver, self.driver_opts)
+        return self.client.create_volume(
+            self.full_name, self.driver, self.driver_opts
+        )
 
     def remove(self):
-        return self.client.remove_volume(self.name)
+        return self.client.remove_volume(self.full_name)
 
     def inspect(self):
-        return self.client.inspect_volume(self.name)
+        return self.client.inspect_volume(self.full_name)
+
+    @property
+    def full_name(self):
+        return '{0}_{1}'.format(self.project, self.name)

--- a/compose/volume.py
+++ b/compose/volume.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+
+class Volume(object):
+    def __init__(self, client, project, name, driver=None, driver_opts=None):
+        self.client = client
+        self.project = project
+        self.name = name
+        self.driver = driver
+        self.driver_opts = driver_opts
+
+    def create(self):
+        return self.client.create_volume(self.name, self.driver, self.driver_opts)
+
+    def remove(self):
+        return self.client.remove_volume(self.name)
+
+    def inspect(self):
+        return self.client.inspect_volume(self.name)

--- a/docker-compose.spec
+++ b/docker-compose.spec
@@ -18,8 +18,13 @@ exe = EXE(pyz,
           a.datas,
           [
             (
-                'compose/config/fields_schema.json',
-                'compose/config/fields_schema.json',
+                'compose/config/fields_schema_v1.json',
+                'compose/config/fields_schema_v1.json',
+                'DATA'
+            ),
+            (
+                'compose/config/fields_schema_v2.json',
+                'compose/config/fields_schema_v2.json',
                 'DATA'
             ),
             (
@@ -33,6 +38,7 @@ exe = EXE(pyz,
                 'DATA'
             )
           ],
+
           name='docker-compose',
           debug=False,
           strip=None,

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -24,6 +24,64 @@ As with `docker run`, options specified in the Dockerfile (e.g., `CMD`,
 `EXPOSE`, `VOLUME`, `ENV`) are respected by default - you don't need to
 specify them again in `docker-compose.yml`.
 
+## Versioning
+
+It is possible to use different versions of the `compose.yml` format.
+Below are the formats currently supported by compose.
+
+
+### Version 1
+
+Compose files that do not declare a version are considered "version 1". In
+those files, all the [services](#service-configuration-reference) are declared
+at the root of the document.
+
+Version 1 files do not support the declaration of
+named [volumes](#volume-configuration-reference)
+
+Example:
+
+    web:
+      build: .
+      ports:
+       - "5000:5000"
+      volumes:
+       - .:/code
+       - logvolume01:/var/log
+      links:
+       - redis
+    redis:
+      image: redis
+
+
+### Version 2
+
+Compose files using the version 2 syntax must indicate the version number at
+the root of the document. All [services](#service-configuration-reference)
+must be declared under the `services` key.
+Named [volumes](#volume-configuration-reference) must be declared under the
+`volumes` key.
+
+Example:
+
+    version: 2
+    services:
+      web:
+        build: .
+        ports:
+         - "5000:5000"
+        volumes:
+         - .:/code
+         - logvolume01:/var/log
+        links:
+         - redis
+      redis:
+        image: redis
+    volumes:
+      logvolume01:
+        driver: default
+
+
 ## Service configuration reference
 
 This section contains a list of all configuration options supported by a service
@@ -412,6 +470,34 @@ Each of these is a single value, analogous to its
     read_only: true
     stdin_open: true
     tty: true
+
+
+## Volume configuration reference
+
+While it is possible to declare volumes on the fly as part of the service
+declaration, this section allows you to create named volumes that can be
+reused across multiple services (without relying on `volumes_from`), and are
+easily retrieved and inspected using the docker command line or API.
+See the [docker volume](http://docs.docker.com/reference/commandline/volume/)
+subcommand documentation for more information.
+
+### driver
+
+Specify which volume driver should be used for this volume. Defaults to
+`local`. An exception will be raised if the driver is not available.
+
+      driver: foobar
+
+### driver_opts
+
+Specify a list of options as key-value pairs to pass to the driver for this
+volume. Those options are driver dependent - consult the driver's
+documentation for more information. Optional.
+
+      driver_opts:
+        foo: "bar"
+        baz: 1
+
 
 ## Variable substitution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,16 +31,22 @@ they can be run together in an isolated environment.
 
 A `docker-compose.yml` looks like this:
 
-    web:
-      build: .
-      ports:
-       - "5000:5000"
-      volumes:
-       - .:/code
-      links:
-       - redis
-    redis:
-      image: redis
+    version: 2
+    services:
+      web:
+        build: .
+        ports:
+         - "5000:5000"
+        volumes:
+         - .:/code
+         - logvolume01:/var/log
+        links:
+         - redis
+      redis:
+        image: redis
+    volumes:
+      logvolume01:
+        driver: default
 
 For more information about the Compose file, see the
 [Compose file reference](compose-file.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
--e git://github.com/docker/docker-py.git@881e24c231ab9921eb0cbd475e85706137983f89#egg=docker-py
 PyYAML==3.11
-# docker-py==1.5.1
+docker-py==1.6.0
 dockerpty==0.3.4
 docopt==0.6.1
 enum34==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+-e git://github.com/docker/docker-py.git@881e24c231ab9921eb0cbd475e85706137983f89#egg=docker-py
 PyYAML==3.11
-docker-py==1.5.0
+# docker-py==1.5.1
 dockerpty==0.3.4
 docopt==0.6.1
 enum34==1.0.4

--- a/script/test-versions
+++ b/script/test-versions
@@ -18,7 +18,7 @@ get_versions="docker run --rm
 if [ "$DOCKER_VERSIONS" == "" ]; then
   DOCKER_VERSIONS="$($get_versions default)"
 elif [ "$DOCKER_VERSIONS" == "all" ]; then
-  DOCKER_VERSIONS="$($get_versions recent -n 2)"
+  DOCKER_VERSIONS="$($get_versions recent -n 1)"
 fi
 
 

--- a/script/test-versions
+++ b/script/test-versions
@@ -18,6 +18,7 @@ get_versions="docker run --rm
 if [ "$DOCKER_VERSIONS" == "" ]; then
   DOCKER_VERSIONS="$($get_versions default)"
 elif [ "$DOCKER_VERSIONS" == "all" ]; then
+  # TODO: `-n 2` when engine 1.10 releases
   DOCKER_VERSIONS="$($get_versions recent -n 1)"
 fi
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -16,6 +16,7 @@ from compose.cli.command import get_project
 from compose.cli.docker_client import docker_client
 from compose.container import Container
 from tests.integration.testcases import DockerClientTestCase
+from tests.integration.testcases import get_links
 from tests.integration.testcases import pull_busybox
 
 
@@ -909,7 +910,7 @@ class CLITestCase(DockerClientTestCase):
 
         web, other, db = containers
         self.assertEqual(web.human_readable_command, 'top')
-        self.assertTrue({'db', 'other'} <= set(web.links()))
+        self.assertTrue({'db', 'other'} <= set(get_links(web)))
         self.assertEqual(db.human_readable_command, 'top')
         self.assertEqual(other.human_readable_command, 'top')
 
@@ -931,7 +932,9 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(len(containers), 2)
         web = containers[1]
 
-        self.assertEqual(set(web.links()), set(['db', 'mydb_1', 'extends_mydb_1']))
+        self.assertEqual(
+            set(get_links(web)),
+            set(['db', 'mydb_1', 'extends_mydb_1']))
 
         expected_env = set([
             "FOO=1",

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -871,7 +871,7 @@ class CLITestCase(DockerClientTestCase):
         self.dispatch(['up', '-d'], None)
 
         container = self.project.containers(stopped=True)[0]
-        actual_host_path = container.get('Volumes')['/container-path']
+        actual_host_path = container.get_mount('/container-path')['Source']
         components = actual_host_path.split('/')
         assert components[-2:] == ['home-dir', 'my-volume']
 

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import random
+
 from .testcases import DockerClientTestCase
 from compose.cli.docker_client import docker_client
 from compose.config import config
@@ -508,3 +510,81 @@ class ProjectTest(DockerClientTestCase):
         project.up()
         service = project.get_service('web')
         self.assertEqual(len(service.containers()), 1)
+
+    def test_project_up_volumes(self):
+        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        config_data = config.Config(
+            2, [{
+                'name': 'web',
+                'image': 'busybox:latest',
+                'command': 'top'
+            }], {vol_name: {'driver': 'local'}}
+        )
+
+        project = Project.from_config(
+            name='composetest',
+            config_data=config_data, client=self.client
+        )
+        project.up()
+        self.assertEqual(len(project.containers()), 1)
+
+        volume_data = self.client.inspect_volume(vol_name)
+        self.assertEqual(volume_data['Name'], vol_name)
+        self.assertEqual(volume_data['Driver'], 'local')
+
+    def test_initialize_volumes(self):
+        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        config_data = config.Config(
+            2, [{
+                'name': 'web',
+                'image': 'busybox:latest',
+                'command': 'top'
+            }], {vol_name: {}}
+        )
+
+        project = Project.from_config(
+            name='composetest',
+            config_data=config_data, client=self.client
+        )
+        project.initialize_volumes()
+
+        volume_data = self.client.inspect_volume(vol_name)
+        self.assertEqual(volume_data['Name'], vol_name)
+        self.assertEqual(volume_data['Driver'], 'local')
+
+    def test_project_up_implicit_volume_driver(self):
+        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        config_data = config.Config(
+            2, [{
+                'name': 'web',
+                'image': 'busybox:latest',
+                'command': 'top'
+            }], {vol_name: {}}
+        )
+
+        project = Project.from_config(
+            name='composetest',
+            config_data=config_data, client=self.client
+        )
+        project.up()
+
+        volume_data = self.client.inspect_volume(vol_name)
+        self.assertEqual(volume_data['Name'], vol_name)
+        self.assertEqual(volume_data['Driver'], 'local')
+
+    def test_project_up_invalid_volume_driver(self):
+        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        config_data = config.Config(
+            2, [{
+                'name': 'web',
+                'image': 'busybox:latest',
+                'command': 'top'
+            }], {vol_name: {'driver': 'foobar'}}
+        )
+
+        project = Project.from_config(
+            name='composetest',
+            config_data=config_data, client=self.client
+        )
+        with self.assertRaises(config.ConfigurationError):
+            project.initialize_volumes()

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -69,9 +69,9 @@ class ProjectTest(DockerClientTestCase):
                 'volumes_from': ['data'],
             },
         })
-        project = Project.from_dicts(
+        project = Project.from_config(
             name='composetest',
-            service_dicts=service_dicts,
+            config_data=service_dicts,
             client=self.client,
         )
         db = project.get_service('db')
@@ -86,9 +86,9 @@ class ProjectTest(DockerClientTestCase):
             name='composetest_data_container',
             labels={LABEL_PROJECT: 'composetest'},
         )
-        project = Project.from_dicts(
+        project = Project.from_config(
             name='composetest',
-            service_dicts=build_service_dicts({
+            config_data=build_service_dicts({
                 'db': {
                     'image': 'busybox:latest',
                     'volumes_from': ['composetest_data_container'],
@@ -117,9 +117,9 @@ class ProjectTest(DockerClientTestCase):
         assert project.get_network()['Name'] == network_name
 
     def test_net_from_service(self):
-        project = Project.from_dicts(
+        project = Project.from_config(
             name='composetest',
-            service_dicts=build_service_dicts({
+            config_data=build_service_dicts({
                 'net': {
                     'image': 'busybox:latest',
                     'command': ["top"]
@@ -149,9 +149,9 @@ class ProjectTest(DockerClientTestCase):
         )
         net_container.start()
 
-        project = Project.from_dicts(
+        project = Project.from_config(
             name='composetest',
-            service_dicts=build_service_dicts({
+            config_data=build_service_dicts({
                 'web': {
                     'image': 'busybox:latest',
                     'net': 'container:composetest_net_container'
@@ -331,7 +331,6 @@ class ProjectTest(DockerClientTestCase):
         project.up(['db'])
         self.assertEqual(len(project.containers()), 1)
         old_db_id = project.containers()[0].id
-
         container, = project.containers()
         db_volume_path = container.get_mount('/var/db')['Source']
 
@@ -401,9 +400,9 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(console.containers()), 0)
 
     def test_project_up_starts_depends(self):
-        project = Project.from_dicts(
+        project = Project.from_config(
             name='composetest',
-            service_dicts=build_service_dicts({
+            config_data=build_service_dicts({
                 'console': {
                     'image': 'busybox:latest',
                     'command': ["top"],
@@ -436,9 +435,9 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(project.get_service('console').containers()), 0)
 
     def test_project_up_with_no_deps(self):
-        project = Project.from_dicts(
+        project = Project.from_config(
             name='composetest',
-            service_dicts=build_service_dicts({
+            config_data=build_service_dicts({
                 'console': {
                     'image': 'busybox:latest',
                     'command': ["top"],

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -340,7 +340,6 @@ class ProjectTest(DockerClientTestCase):
 
         db_container = [c for c in project.containers() if 'db' in c.name][0]
         self.assertEqual(db_container.id, old_db_id)
-        mount, = db_container.get('Mounts')
         self.assertEqual(
             db_container.get_mount('/var/db')['Source'],
             db_volume_path)

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -513,6 +513,7 @@ class ProjectTest(DockerClientTestCase):
 
     def test_project_up_volumes(self):
         vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        full_vol_name = 'composetest_{0}'.format(vol_name)
         config_data = config.Config(
             2, [{
                 'name': 'web',
@@ -528,12 +529,13 @@ class ProjectTest(DockerClientTestCase):
         project.up()
         self.assertEqual(len(project.containers()), 1)
 
-        volume_data = self.client.inspect_volume(vol_name)
-        self.assertEqual(volume_data['Name'], vol_name)
+        volume_data = self.client.inspect_volume(full_vol_name)
+        self.assertEqual(volume_data['Name'], full_vol_name)
         self.assertEqual(volume_data['Driver'], 'local')
 
     def test_initialize_volumes(self):
         vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        full_vol_name = 'composetest_{0}'.format(vol_name)
         config_data = config.Config(
             2, [{
                 'name': 'web',
@@ -548,12 +550,13 @@ class ProjectTest(DockerClientTestCase):
         )
         project.initialize_volumes()
 
-        volume_data = self.client.inspect_volume(vol_name)
-        self.assertEqual(volume_data['Name'], vol_name)
+        volume_data = self.client.inspect_volume(full_vol_name)
+        self.assertEqual(volume_data['Name'], full_vol_name)
         self.assertEqual(volume_data['Driver'], 'local')
 
     def test_project_up_implicit_volume_driver(self):
         vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        full_vol_name = 'composetest_{0}'.format(vol_name)
         config_data = config.Config(
             2, [{
                 'name': 'web',
@@ -568,12 +571,13 @@ class ProjectTest(DockerClientTestCase):
         )
         project.up()
 
-        volume_data = self.client.inspect_volume(vol_name)
-        self.assertEqual(volume_data['Name'], vol_name)
+        volume_data = self.client.inspect_volume(full_vol_name)
+        self.assertEqual(volume_data['Name'], full_vol_name)
         self.assertEqual(volume_data['Driver'], 'local')
 
     def test_project_up_invalid_volume_driver(self):
         vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+
         config_data = config.Config(
             2, [{
                 'name': 'web',

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -512,14 +512,14 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(len(service.containers()), 1)
 
     def test_project_up_volumes(self):
-        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        vol_name = '{0:x}'.format(random.getrandbits(32))
         full_vol_name = 'composetest_{0}'.format(vol_name)
         config_data = config.Config(
-            2, [{
+            version=2, services=[{
                 'name': 'web',
                 'image': 'busybox:latest',
                 'command': 'top'
-            }], {vol_name: {'driver': 'local'}}
+            }], volumes={vol_name: {'driver': 'local'}}
         )
 
         project = Project.from_config(
@@ -534,14 +534,14 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(volume_data['Driver'], 'local')
 
     def test_initialize_volumes(self):
-        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        vol_name = '{0:x}'.format(random.getrandbits(32))
         full_vol_name = 'composetest_{0}'.format(vol_name)
         config_data = config.Config(
-            2, [{
+            version=2, services=[{
                 'name': 'web',
                 'image': 'busybox:latest',
                 'command': 'top'
-            }], {vol_name: {}}
+            }], volumes={vol_name: {}}
         )
 
         project = Project.from_config(
@@ -555,14 +555,14 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(volume_data['Driver'], 'local')
 
     def test_project_up_implicit_volume_driver(self):
-        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        vol_name = '{0:x}'.format(random.getrandbits(32))
         full_vol_name = 'composetest_{0}'.format(vol_name)
         config_data = config.Config(
-            2, [{
+            version=2, services=[{
                 'name': 'web',
                 'image': 'busybox:latest',
                 'command': 'top'
-            }], {vol_name: {}}
+            }], volumes={vol_name: {}}
         )
 
         project = Project.from_config(
@@ -576,7 +576,7 @@ class ProjectTest(DockerClientTestCase):
         self.assertEqual(volume_data['Driver'], 'local')
 
     def test_project_up_invalid_volume_driver(self):
-        vol_name = 'composetests_{0:x}'.format(random.getrandbits(32))
+        vol_name = '{0:x}'.format(random.getrandbits(32))
 
         config_data = config.Config(
             2, [{

--- a/tests/integration/resilience_test.py
+++ b/tests/integration/resilience_test.py
@@ -18,12 +18,12 @@ class ResilienceTest(DockerClientTestCase):
 
         container = self.db.create_container()
         container.start()
-        self.host_path = container.get('Volumes')['/var/db']
+        self.host_path = container.get_mount('/var/db')['Source']
 
     def test_successful_recreate(self):
         self.project.up(strategy=ConvergenceStrategy.always)
         container = self.db.containers()[0]
-        self.assertEqual(container.get('Volumes')['/var/db'], self.host_path)
+        self.assertEqual(container.get_mount('/var/db')['Source'], self.host_path)
 
     def test_create_failure(self):
         with mock.patch('compose.service.Service.create_container', crash):
@@ -32,7 +32,7 @@ class ResilienceTest(DockerClientTestCase):
 
         self.project.up()
         container = self.db.containers()[0]
-        self.assertEqual(container.get('Volumes')['/var/db'], self.host_path)
+        self.assertEqual(container.get_mount('/var/db')['Source'], self.host_path)
 
     def test_start_failure(self):
         with mock.patch('compose.container.Container.start', crash):
@@ -41,7 +41,7 @@ class ResilienceTest(DockerClientTestCase):
 
         self.project.up()
         container = self.db.containers()[0]
-        self.assertEqual(container.get('Volumes')['/var/db'], self.host_path)
+        self.assertEqual(container.get_mount('/var/db')['Source'], self.host_path)
 
 
 class Crash(Exception):

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -163,6 +163,7 @@ class ServiceTest(DockerClientTestCase):
 
         # Match the last component ("host-path"), because boot2docker symlinks /tmp
         actual_host_path = container.get_mount(container_path)['Source']
+
         self.assertTrue(path.basename(actual_host_path) == path.basename(host_path),
                         msg=("Last component differs: %s, %s" % (actual_host_path, host_path)))
 

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -312,7 +312,8 @@ class ServiceTest(DockerClientTestCase):
             ConvergencePlan('recreate', [old_container]))
 
         self.assertEqual(
-            [mount['Destination'] for mount in new_container.get('Mounts')], ['/data']
+            [mount['Destination'] for mount in new_container.get('Mounts')],
+            ['/data']
         )
         self.assertEqual(new_container.get_mount('/data')['Source'], volume_path)
 
@@ -323,8 +324,11 @@ class ServiceTest(DockerClientTestCase):
         )
 
         old_container = create_and_start_container(service)
-        self.assertEqual(list(old_container.get('Volumes').keys()), ['/data'])
-        volume_path = old_container.get('Volumes')['/data']
+        self.assertEqual(
+            [mount['Destination'] for mount in old_container.get('Mounts')],
+            ['/data']
+        )
+        volume_path = old_container.get_mount('/data')['Source']
 
         service.options['volumes'] = [VolumeSpec.parse('/tmp:/data')]
 
@@ -338,8 +342,11 @@ class ServiceTest(DockerClientTestCase):
             "Service \"db\" is using volume \"/data\" from the previous container",
             args[0])
 
-        self.assertEqual(list(new_container.get('Volumes')), ['/data'])
-        self.assertEqual(new_container.get('Volumes')['/data'], volume_path)
+        self.assertEqual(
+            [mount['Destination'] for mount in new_container.get('Mounts')],
+            ['/data']
+        )
+        self.assertEqual(new_container.get_mount('/data')['Source'], volume_path)
 
     def test_execute_convergence_plan_without_start(self):
         service = self.create_service(

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -12,6 +12,7 @@ from six import text_type
 
 from .. import mock
 from .testcases import DockerClientTestCase
+from .testcases import get_links
 from .testcases import pull_busybox
 from compose import __version__
 from compose.config.types import VolumeFromSpec
@@ -88,7 +89,7 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('db', volumes=[VolumeSpec.parse('/var/db')])
         container = service.create_container()
         container.start()
-        self.assertIsNotNone(container.get_mount('/var/db'))
+        assert container.get_mount('/var/db')
 
     def test_create_container_with_volume_driver(self):
         service = self.create_service('db', volume_driver='foodriver')
@@ -158,7 +159,7 @@ class ServiceTest(DockerClientTestCase):
             volumes=[VolumeSpec(host_path, container_path, 'rw')])
         container = service.create_container()
         container.start()
-        self.assertIsNotNone(container.get_mount(container_path))
+        assert container.get_mount(container_path)
 
         # Match the last component ("host-path"), because boot2docker symlinks /tmp
         actual_host_path = container.get_mount(container_path)['Source']
@@ -385,7 +386,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(web)
 
         self.assertEqual(
-            set(web.containers()[0].links()),
+            set(get_links(web.containers()[0])),
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',
@@ -401,7 +402,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(web)
 
         self.assertEqual(
-            set(web.containers()[0].links()),
+            set(get_links(web.containers()[0])),
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',
@@ -419,7 +420,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(web)
 
         self.assertEqual(
-            set(web.containers()[0].links()),
+            set(get_links(web.containers()[0])),
             set([
                 'composetest_db_1',
                 'composetest_db_2',
@@ -433,7 +434,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(db)
 
         c = create_and_start_container(db)
-        self.assertEqual(set(c.links()), set([]))
+        self.assertEqual(set(get_links(c)), set([]))
 
     def test_start_one_off_container_creates_links_to_its_own_service(self):
         db = self.create_service('db')
@@ -444,7 +445,7 @@ class ServiceTest(DockerClientTestCase):
         c = create_and_start_container(db, one_off=True)
 
         self.assertEqual(
-            set(c.links()),
+            set(get_links(c)),
             set([
                 'composetest_db_1', 'db_1',
                 'composetest_db_2', 'db_2',

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -88,13 +88,13 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('db', volumes=[VolumeSpec.parse('/var/db')])
         container = service.create_container()
         container.start()
-        self.assertIn('/var/db', container.get('Volumes'))
+        self.assertIsNotNone(container.get_mount('/var/db'))
 
     def test_create_container_with_volume_driver(self):
         service = self.create_service('db', volume_driver='foodriver')
         container = service.create_container()
         container.start()
-        self.assertEqual('foodriver', container.get('Config.VolumeDriver'))
+        self.assertEqual('foodriver', container.get('HostConfig.VolumeDriver'))
 
     def test_create_container_with_cpu_shares(self):
         service = self.create_service('db', cpu_shares=73)
@@ -158,12 +158,10 @@ class ServiceTest(DockerClientTestCase):
             volumes=[VolumeSpec(host_path, container_path, 'rw')])
         container = service.create_container()
         container.start()
-
-        volumes = container.inspect()['Volumes']
-        self.assertIn(container_path, volumes)
+        self.assertIsNotNone(container.get_mount(container_path))
 
         # Match the last component ("host-path"), because boot2docker symlinks /tmp
-        actual_host_path = volumes[container_path]
+        actual_host_path = container.get_mount(container_path)['Source']
         self.assertTrue(path.basename(actual_host_path) == path.basename(host_path),
                         msg=("Last component differs: %s, %s" % (actual_host_path, host_path)))
 
@@ -173,10 +171,10 @@ class ServiceTest(DockerClientTestCase):
         """
         service = self.create_service('data', volumes=[VolumeSpec.parse('/data/')])
         old_container = create_and_start_container(service)
-        volume_path = old_container.get('Volumes')['/data']
+        volume_path = old_container.get_mount('/data')['Source']
 
         new_container = service.recreate_container(old_container)
-        self.assertEqual(new_container.get('Volumes')['/data'], volume_path)
+        self.assertEqual(new_container.get_mount('/data')['Source'], volume_path)
 
     def test_duplicate_volume_trailing_slash(self):
         """
@@ -250,7 +248,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(old_container.name, 'composetest_db_1')
         old_container.start()
         old_container.inspect()  # reload volume data
-        volume_path = old_container.get('Volumes')['/etc']
+        volume_path = old_container.get_mount('/etc')['Source']
 
         num_containers_before = len(self.client.containers(all=True))
 
@@ -262,7 +260,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(new_container.get('Config.Cmd'), ['-d', '1'])
         self.assertIn('FOO=2', new_container.get('Config.Env'))
         self.assertEqual(new_container.name, 'composetest_db_1')
-        self.assertEqual(new_container.get('Volumes')['/etc'], volume_path)
+        self.assertEqual(new_container.get_mount('/etc')['Source'], volume_path)
         self.assertIn(
             'affinity:container==%s' % old_container.id,
             new_container.get('Config.Env'))
@@ -305,14 +303,18 @@ class ServiceTest(DockerClientTestCase):
         )
 
         old_container = create_and_start_container(service)
-        self.assertEqual(list(old_container.get('Volumes').keys()), ['/data'])
-        volume_path = old_container.get('Volumes')['/data']
+        self.assertEqual(
+            [mount['Destination'] for mount in old_container.get('Mounts')], ['/data']
+        )
+        volume_path = old_container.get_mount('/data')['Source']
 
         new_container, = service.execute_convergence_plan(
             ConvergencePlan('recreate', [old_container]))
 
-        self.assertEqual(list(new_container.get('Volumes')), ['/data'])
-        self.assertEqual(new_container.get('Volumes')['/data'], volume_path)
+        self.assertEqual(
+            [mount['Destination'] for mount in new_container.get('Mounts')], ['/data']
+        )
+        self.assertEqual(new_container.get_mount('/data')['Source'], volume_path)
 
     def test_execute_convergence_plan_when_image_volume_masks_config(self):
         service = self.create_service(

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import py
 
 from .testcases import DockerClientTestCase
+from .testcases import get_links
 from compose.config import config
 from compose.project import Project
 from compose.service import ConvergenceStrategy
@@ -186,8 +187,8 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         web, = [c for c in containers if c.service == 'web']
         nginx, = [c for c in containers if c.service == 'nginx']
 
-        self.assertEqual(web.links(), ['composetest_db_1', 'db', 'db_1'])
-        self.assertEqual(nginx.links(), ['composetest_web_1', 'web', 'web_1'])
+        self.assertEqual(set(get_links(web)), {'composetest_db_1', 'db', 'db_1'})
+        self.assertEqual(set(get_links(nginx)), {'composetest_web_1', 'web', 'web_1'})
 
 
 class ServiceStateTest(DockerClientTestCase):

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -26,10 +26,10 @@ class ProjectTestCase(DockerClientTestCase):
         details = config.ConfigDetails(
             'working_dir',
             [config.ConfigFile(None, cfg)])
-        return Project.from_dicts(
+        return Project.from_config(
             name='composetest',
             client=self.client,
-            service_dicts=config.load(details))
+            config_data=config.load(details))
 
 
 class BasicProjectTest(ProjectTestCase):

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -25,8 +25,7 @@ class DockerClientTestCase(unittest.TestCase):
         for c in self.client.containers(
                 all=True,
                 filters={'label': '%s=composetest' % LABEL_PROJECT}):
-            self.client.kill(c['Id'])
-            self.client.remove_container(c['Id'])
+            self.client.remove_container(c['Id'], force=True)
         for i in self.client.images(
                 filters={'label': 'com.docker.compose.test_image'}):
             self.client.remove_image(i)

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -41,7 +41,7 @@ class DockerClientTestCase(unittest.TestCase):
             self.client.remove_image(i)
         volumes = self.client.volumes().get('Volumes') or []
         for v in volumes:
-            if 'composetests_' in v['Name']:
+            if 'composetest_' in v['Name']:
                 self.client.remove_volume(v['Name'])
 
     def create_service(self, name, **kwargs):

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -16,6 +16,16 @@ def pull_busybox(client):
     client.pull('busybox:latest', stream=False)
 
 
+def get_links(container):
+    links = container.get('HostConfig.Links') or []
+
+    def format_link(link):
+        _, alias = link.split(':')
+        return alias.split('/')[-1]
+
+    return [format_link(link) for link in links]
+
+
 class DockerClientTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -39,6 +39,10 @@ class DockerClientTestCase(unittest.TestCase):
         for i in self.client.images(
                 filters={'label': 'com.docker.compose.test_image'}):
             self.client.remove_image(i)
+        volumes = self.client.volumes().get('Volumes') or []
+        for v in volumes:
+            if 'composetests_' in v['Name']:
+                self.client.remove_volume(v['Name'])
 
     def create_service(self, name, **kwargs):
         if 'image' not in kwargs and 'build' not in kwargs:

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals
+
+from docker.errors import DockerException
+
+from .testcases import DockerClientTestCase
+from compose.volume import Volume
+
+
+class VolumeTest(DockerClientTestCase):
+    def setUp(self):
+        self.tmp_volumes = []
+
+    def tearDown(self):
+        for volume in self.tmp_volumes:
+            try:
+                self.client.remove_volume(volume.full_name)
+            except DockerException:
+                pass
+
+    def create_volume(self, name, driver=None, opts=None):
+        vol = Volume(
+            self.client, 'composetest', name, driver=driver, driver_opts=opts
+        )
+        self.tmp_volumes.append(vol)
+        return vol
+
+    def test_create_volume(self):
+        vol = self.create_volume('volume01')
+        vol.create()
+        info = self.client.inspect_volume(vol.full_name)
+        assert info['Name'] == vol.full_name
+
+    def test_recreate_existing_volume(self):
+        vol = self.create_volume('volume01')
+
+        vol.create()
+        info = self.client.inspect_volume(vol.full_name)
+        assert info['Name'] == vol.full_name
+
+        vol.create()
+        info = self.client.inspect_volume(vol.full_name)
+        assert info['Name'] == vol.full_name
+
+    def test_inspect_volume(self):
+        vol = self.create_volume('volume01')
+        vol.create()
+        info = vol.inspect()
+        assert info['Name'] == vol.full_name
+
+    def test_remove_volume(self):
+        vol = Volume(self.client, 'composetest', 'volume01')
+        vol.create()
+        vol.remove()
+        volumes = self.client.volumes()['Volumes']
+        assert len([v for v in volumes if v['Name'] == vol.full_name]) == 0

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -286,6 +286,18 @@ class ConfigTest(unittest.TestCase):
         error_msg = "Top level object in 'override.yml' needs to be an object"
         assert error_msg in exc.exconly()
 
+    def test_load_with_multiple_files_and_empty_override_v2(self):
+        base_file = config.ConfigFile(
+            'base.yml',
+            {'version': 2, 'services': {'web': {'image': 'example/web'}}})
+        override_file = config.ConfigFile('override.yml', None)
+        details = config.ConfigDetails('.', [base_file, override_file])
+
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(details)
+        error_msg = "Top level object in 'override.yml' needs to be an object"
+        assert error_msg in exc.exconly()
+
     def test_load_with_multiple_files_and_empty_base(self):
         base_file = config.ConfigFile('base.yml', None)
         override_file = config.ConfigFile(
@@ -293,6 +305,17 @@ class ConfigTest(unittest.TestCase):
             {'web': {'image': 'example/web'}})
         details = config.ConfigDetails('.', [base_file, override_file])
 
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(details)
+        assert "Top level object in 'base.yml' needs to be an object" in exc.exconly()
+
+    def test_load_with_multiple_files_and_empty_base_v2(self):
+        base_file = config.ConfigFile('base.yml', None)
+        override_file = config.ConfigFile(
+            'override.tml',
+            {'version': 2, 'services': {'web': {'image': 'example/web'}}}
+        )
+        details = config.ConfigDetails('.', [base_file, override_file])
         with pytest.raises(ConfigurationError) as exc:
             config.load(details)
         assert "Top level object in 'base.yml' needs to be an object" in exc.exconly()

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -702,7 +702,7 @@ class ConfigTest(unittest.TestCase):
                 'dns_search': 'domain.local',
             }
         }))
-        assert actual == [
+        assert actual.services == [
             {
                 'name': 'web',
                 'image': 'alpine',

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -35,29 +35,6 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual(project.get_service('db').name, 'db')
         self.assertEqual(project.get_service('db').options['image'], 'busybox:latest')
 
-    def test_from_dict_sorts_in_dependency_order(self):
-        project = Project.from_config('composetest', Config(None, [
-            {
-                'name': 'web',
-                'image': 'busybox:latest',
-                'links': ['db'],
-            },
-            {
-                'name': 'db',
-                'image': 'busybox:latest',
-                'volumes_from': ['volume']
-            },
-            {
-                'name': 'volume',
-                'image': 'busybox:latest',
-                'volumes': ['/tmp'],
-            }
-        ], None), None)
-
-        self.assertEqual(project.services[0].name, 'volume')
-        self.assertEqual(project.services[1].name, 'db')
-        self.assertEqual(project.services[2].name, 'web')
-
     def test_from_config(self):
         dicts = Config(None, [
             {

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -234,6 +234,7 @@ class ServiceTest(unittest.TestCase):
         prev_container = mock.Mock(
             id='ababab',
             image_config={'ContainerConfig': {}})
+        prev_container.get.return_value = None
 
         opts = service._get_container_create_options(
             {},
@@ -573,6 +574,10 @@ class NetTestCase(unittest.TestCase):
         self.assertEqual(net.id, service_name)
         self.assertEqual(net.mode, None)
         self.assertEqual(net.service_name, service_name)
+
+
+def build_mount(destination, source, mode='rw'):
+    return {'Source': source, 'Destination': destination, 'Mode': mode}
 
 
 class ServiceVolumesTest(unittest.TestCase):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -600,12 +600,33 @@ class ServiceVolumesTest(unittest.TestCase):
         }
         container = Container(self.mock_client, {
             'Image': 'ababab',
-            'Volumes': {
-                '/host/volume': '/host/volume',
-                '/existing/volume': '/var/lib/docker/aaaaaaaa',
-                '/removed/volume': '/var/lib/docker/bbbbbbbb',
-                '/mnt/image/data': '/var/lib/docker/cccccccc',
-            },
+            'Mounts': [
+                {
+                    'Source': '/host/volume',
+                    'Destination': '/host/volume',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'hostvolume',
+                }, {
+                    'Source': '/var/lib/docker/aaaaaaaa',
+                    'Destination': '/existing/volume',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'existingvolume',
+                }, {
+                    'Source': '/var/lib/docker/bbbbbbbb',
+                    'Destination': '/removed/volume',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'removedvolume',
+                }, {
+                    'Source': '/var/lib/docker/cccccccc',
+                    'Destination': '/mnt/image/data',
+                    'Mode': '',
+                    'RW': True,
+                    'Name': 'imagedata',
+                },
+            ]
         }, has_been_inspected=True)
 
         expected = [
@@ -630,7 +651,13 @@ class ServiceVolumesTest(unittest.TestCase):
 
         intermediate_container = Container(self.mock_client, {
             'Image': 'ababab',
-            'Volumes': {'/existing/volume': '/var/lib/docker/aaaaaaaa'},
+            'Mounts': [{
+                'Source': '/var/lib/docker/aaaaaaaa',
+                'Destination': '/existing/volume',
+                'Mode': '',
+                'RW': True,
+                'Name': 'existingvolume',
+            }],
         }, has_been_inspected=True)
 
         expected = [
@@ -693,9 +720,16 @@ class ServiceVolumesTest(unittest.TestCase):
         self.mock_client.inspect_container.return_value = {
             'Id': '123123123',
             'Image': 'ababab',
-            'Volumes': {
-                '/data': '/mnt/sda1/host/path',
-            },
+            'Mounts': [
+                {
+                    'Destination': '/data',
+                    'Source': '/mnt/sda1/host/path',
+                    'Mode': '',
+                    'RW': True,
+                    'Driver': 'local',
+                    'Name': 'abcdefff1234'
+                },
+            ]
         }
 
         service._get_container_create_options(


### PR DESCRIPTION
* Bump default API version to 1.21 (required for named volume management)
* Introduce new, versioned compose file format while maintaining support
  for current (legacy) format
* Test updates to reflect changes made to the internal API

Fixes #2110, replaces #2113 

WIP:
- [x] Tests
- [x] Documentation