### PR TITLE
Fix `build --pull` test flakes

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -15,6 +15,7 @@ from compose.cli.command import get_project
 from compose.cli.docker_client import docker_client
 from compose.container import Container
 from tests.integration.testcases import DockerClientTestCase
+from tests.integration.testcases import pull_busybox
 
 
 ProcessResult = namedtuple('ProcessResult', 'stdout stderr')
@@ -184,6 +185,8 @@ class CLITestCase(DockerClientTestCase):
         assert BUILD_PULL_TEXT not in result.stdout
 
     def test_build_pull(self):
+        # Make sure we have the latest busybox already
+        pull_busybox(self.client)
         self.base_dir = 'tests/fixtures/simple-dockerfile'
         self.dispatch(['build', 'simple'], None)
 
@@ -192,6 +195,8 @@ class CLITestCase(DockerClientTestCase):
         assert BUILD_PULL_TEXT in result.stdout
 
     def test_build_no_cache_pull(self):
+        # Make sure we have the latest busybox already
+        pull_busybox(self.client)
         self.base_dir = 'tests/fixtures/simple-dockerfile'
         self.dispatch(['build', 'simple'])
 

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from docker import errors
 from docker.utils import version_lt
 from pytest import skip
 
@@ -16,10 +15,7 @@ from compose.service import Service
 
 
 def pull_busybox(client):
-    try:
-        client.inspect_image('busybox:latest')
-    except errors.APIError:
-        client.pull('busybox:latest', stream=False)
+    client.pull('busybox:latest', stream=False)
 
 
 class DockerClientTestCase(unittest.TestCase):


### PR DESCRIPTION
These tests have flaked at least a couple times today. This should prevent it.

The test checks for the "already up to date" text.

Example failure: https://jenkins.dockerproject.org/job/Compose-PRs/1860/console