### PR TITLE
Fixing matrix include so `os: linux` goes to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@ sudo: required
 
 language: python
 
-services:
-  - docker
-
 matrix:
   include:
     - os: linux
+      services:
+      - docker
     - os: osx
       language: generic
-
 
 install: ./script/travis/install
 


### PR DESCRIPTION
Fixes issue reported in https://github.com/travis-ci/travis-ci/issues/5142