### PR TITLE
Image and build together

### DIFF
--- a/compose/config/service_schema_v2.json
+++ b/compose/config/service_schema_v2.json
@@ -167,17 +167,8 @@
     "constraints": {
       "id": "#/definitions/constraints",
       "anyOf": [
-        {
-          "required": ["build"],
-          "not": {"required": ["image"]}
-        },
-        {
-          "required": ["image"],
-          "not": {"anyOf": [
-            {"required": ["build"]},
-            {"required": ["dockerfile"]}
-          ]}
-        }
+          {"required": ["build"]},
+          {"required": ["image"]}
       ]
     }
   }

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -151,6 +151,7 @@ def handle_error_for_schema_with_id(error, service_name):
             VALID_NAME_CHARS)
 
     if schema_id == '#/definitions/constraints':
+        # TODO: only applies to v1
         if 'image' in error.instance and 'build' in error.instance:
             return (
                 "Service '{}' has both an image and build path specified. "
@@ -159,7 +160,8 @@ def handle_error_for_schema_with_id(error, service_name):
         if 'image' not in error.instance and 'build' not in error.instance:
             return (
                 "Service '{}' has neither an image nor a build path "
-                "specified. Exactly one must be provided.".format(service_name))
+                "specified. At least one must be provided.".format(service_name))
+        # TODO: only applies to v1
         if 'image' in error.instance and 'dockerfile' in error.instance:
             return (
                 "Service '{}' has both an image and alternate Dockerfile. "

--- a/compose/project.py
+++ b/compose/project.py
@@ -344,8 +344,8 @@ class Project(object):
             updated_dependencies = [
                 name
                 for name in service.get_dependency_names()
-                if name in plans
-                and plans[name].action in ('recreate', 'create')
+                if name in plans and
+                plans[name].action in ('recreate', 'create')
             ]
 
             if updated_dependencies and strategy.allows_recreate:

--- a/compose/service.py
+++ b/compose/service.py
@@ -535,9 +535,9 @@ class Service(object):
         # unqualified hostname and a domainname unless domainname
         # was also given explicitly. This matches the behavior of
         # the official Docker CLI in that scenario.
-        if ('hostname' in container_options
-                and 'domainname' not in container_options
-                and '.' in container_options['hostname']):
+        if ('hostname' in container_options and
+                'domainname' not in container_options and
+                '.' in container_options['hostname']):
             parts = container_options['hostname'].partition('.')
             container_options['hostname'] = parts[0]
             container_options['domainname'] = parts[2]

--- a/compose/service.py
+++ b/compose/service.py
@@ -275,10 +275,7 @@ class Service(object):
 
     @property
     def image_name(self):
-        if self.can_be_built():
-            return self.full_name
-        else:
-            return self.options['image']
+        return self.options.get('image', '{s.project}_{s.name}'.format(s=self))
 
     def convergence_plan(self, strategy=ConvergenceStrategy.changed):
         containers = self.containers(stopped=True)
@@ -664,13 +661,6 @@ class Service(object):
 
     def can_be_built(self):
         return 'build' in self.options
-
-    @property
-    def full_name(self):
-        """
-        The tag to give to images built for this service.
-        """
-        return '%s_%s' % (self.project, self.name)
 
     def labels(self, one_off=False):
         return [

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -491,7 +491,7 @@ class ServiceTest(DockerClientTestCase):
             f.write("FROM busybox\n")
 
         self.create_service('web', build=base_dir).build()
-        self.assertEqual(len(self.client.images(name='composetest_web')), 1)
+        assert self.client.inspect_image('composetest_web')
 
     def test_build_non_ascii_filename(self):
         base_dir = tempfile.mkdtemp()
@@ -504,7 +504,19 @@ class ServiceTest(DockerClientTestCase):
             f.write("hello world\n")
 
         self.create_service('web', build=text_type(base_dir)).build()
-        self.assertEqual(len(self.client.images(name='composetest_web')), 1)
+        assert self.client.inspect_image('composetest_web')
+
+    def test_build_with_image_name(self):
+        base_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, base_dir)
+
+        with open(os.path.join(base_dir, 'Dockerfile'), 'w') as f:
+            f.write("FROM busybox\n")
+
+        image_name = 'examples/composetest:latest'
+        self.addCleanup(self.client.remove_image, image_name)
+        self.create_service('web', build=base_dir, image=image_name).build()
+        assert self.client.inspect_image(image_name)
 
     def test_build_with_git_url(self):
         build_url = "https://github.com/dnephin/docker-build-from-url.git"

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -492,6 +492,15 @@ class ServiceTest(unittest.TestCase):
             use_networking=True)
         self.assertEqual(service._get_links(link_to_self=True), [])
 
+    def test_image_name_from_config(self):
+        image_name = 'example/web:latest'
+        service = Service('foo', image=image_name)
+        assert service.image_name == image_name
+
+    def test_image_name_default(self):
+        service = Service('foo', project='testing')
+        assert service.image_name == 'testing_foo'
+
 
 def sort_by_name(dictionary_list):
     return sorted(dictionary_list, key=lambda k: k['name'])


### PR DESCRIPTION
Fixes #2092 

Allow both `image` and `build` in a service config, and use `image` as the image name when building, if it exists.