### PR TITLE
Limit log memory usage for huge logs

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -24,7 +24,7 @@ class LogPrinter(object):
 
         prefix_width = max_name_width(self.containers)
         generators = list(self._make_log_generators(self.monochrome, prefix_width))
-        for line in Multiplexer(generators).loop():
+        for line in Multiplexer(generators, 10).loop():
             self.output.write(line)
             self.output.flush()
 

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -19,10 +19,10 @@ class Multiplexer(object):
     parallel and yielding results as they come in.
     """
 
-    def __init__(self, iterators):
+    def __init__(self, iterators, max_queue_size=-1):
         self.iterators = iterators
         self._num_running = len(iterators)
-        self.queue = Queue()
+        self.queue = Queue(maxsize=max_queue_size)
 
     def loop(self):
         self._init_readers()


### PR DESCRIPTION
When using the log command logs with lots of logs, dockek-compose will accumulate logs in memory faster than they can be streamed on sys.stdout

Add an optional maximum queue size in Multiplexer to make incommingstreams block

With this patch, I've reduced the memory usage of `docker-compose logs` for my current containers from 250Mb to ~ 40Mb