### PR TITLE
Use more robust download URL for completions

### DIFF
--- a/docs/completion.md
+++ b/docs/completion.md
@@ -23,7 +23,7 @@ On a Mac, install with `brew install bash-completion`
 
 Place the completion script in `/etc/bash_completion.d/` (`/usr/local/etc/bash_completion.d/` on a Mac), using e.g.
 
-     curl -L https://raw.githubusercontent.com/docker/compose/$(docker-compose --version | awk 'NR==1{print $NF}')/contrib/completion/bash/docker-compose > /etc/bash_completion.d/docker-compose
+     curl -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/bash/docker-compose > /etc/bash_completion.d/docker-compose
 
 Completion will be available upon next login.
 
@@ -32,7 +32,7 @@ Completion will be available upon next login.
 Place the completion script in your `/path/to/zsh/completion`, using e.g. `~/.zsh/completion/`
 
     mkdir -p ~/.zsh/completion
-    curl -L https://raw.githubusercontent.com/docker/compose/$(docker-compose --version | awk 'NR==1{print $NF}')/contrib/completion/zsh/_docker-compose > ~/.zsh/completion/_docker-compose
+    curl -L https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/zsh/_docker-compose > ~/.zsh/completion/_docker-compose
 
 Include the directory in your `$fpath`, e.g. by adding in `~/.zshrc`
 


### PR DESCRIPTION
The download URLs for the bash and zsh completions are currently computed by parsing the output of `docker-compose --version`. This is ugly and error-prone, see #2417 for an example (though compatibility was preserved in that case).

With `docker-compose version --short` in place, we now have a more robust way of getting the version string.