### PR TITLE
Only allocate a tty if we detect one

### DIFF
--- a/script/run.sh
+++ b/script/run.sh
@@ -43,5 +43,11 @@ if [ -n "$HOME" ]; then
     VOLUMES="$VOLUMES -v $HOME:$HOME"
 fi
 
+# Only allocate tty if we detect one
+if [ -t 1 ]; then
+    DOCKER_RUN_OPTIONS="-ti"
+else
+    DOCKER_RUN_OPTIONS="-i"
+fi
 
-exec docker run --rm -ti $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w $(pwd) $IMAGE $@
+exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w $(pwd) $IMAGE $@


### PR DESCRIPTION
I was in the situation where I need to run `docker-compose` in CI environment (Bamboo specifically) and was running into problems where the `docker-compose` command would fail with the message:

    cannot enable tty mode on non tty input

Upon SSHing into the machine to investigate the problem I found that I could run the commands just fine.  I discovered that the `-t` flag to `docker` was causing the issue.  The change conditionally applies the `-t` flag if a TTY is detected. 

My TTY check comes from http://stackoverflow.com/a/911213/283844.

If there's a better way of resolving this issue then feel free to close this PR.  I won't be offended! :)

---

Following the contributors guidelines:

* Tests: I don't believe there are tests available at this level.  Happy to write them if they should exist.
* Documentation: I don't believe any change in documentation is required.
* Signed off: The commit has been signed off.
* Well written commits: The commit is atomic and I believe the commit message accurately describes the change that was made.

---

Signed-off-by: Nick Jones <nick@nicksays.co.uk>