### PR TITLE
Remove unused functions in service

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -141,34 +141,6 @@ class Service(object):
         for c in self.containers(stopped=True):
             self.start_container_if_stopped(c, **options)
 
-    # TODO: remove these functions, project takes care of starting/stopping,
-    def stop(self, **options):
-        for c in self.containers():
-            log.info("Stopping %s" % c.name)
-            c.stop(**options)
-
-    def pause(self, **options):
-        for c in self.containers(filters={'status': 'running'}):
-            log.info("Pausing %s" % c.name)
-            c.pause(**options)
-
-    def unpause(self, **options):
-        for c in self.containers(filters={'status': 'paused'}):
-            log.info("Unpausing %s" % c.name)
-            c.unpause()
-
-    def kill(self, **options):
-        for c in self.containers():
-            log.info("Killing %s" % c.name)
-            c.kill(**options)
-
-    def restart(self, **options):
-        for c in self.containers(stopped=True):
-            log.info("Restarting %s" % c.name)
-            c.restart(**options)
-
-    # end TODO
-
     def scale(self, desired_num, timeout=DEFAULT_TIMEOUT):
         """
         Adjusts the number of containers to the specified number and ensures

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -52,6 +52,11 @@ def wait_on_condition(condition, delay=0.1, timeout=20):
         time.sleep(delay)
 
 
+def kill_service(service):
+    for container in service.containers():
+        container.kill()
+
+
 class ContainerCountCondition(object):
 
     def __init__(self, project, expected):
@@ -637,13 +642,13 @@ class CLITestCase(DockerClientTestCase):
     def test_rm(self):
         service = self.project.get_service('simple')
         service.create_container()
-        service.kill()
+        kill_service(service)
         self.assertEqual(len(service.containers(stopped=True)), 1)
         self.dispatch(['rm', '--force'], None)
         self.assertEqual(len(service.containers(stopped=True)), 0)
         service = self.project.get_service('simple')
         service.create_container()
-        service.kill()
+        kill_service(service)
         self.assertEqual(len(service.containers(stopped=True)), 1)
         self.dispatch(['rm', '-f'], None)
         self.assertEqual(len(service.containers(stopped=True)), 0)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -73,42 +73,6 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(service)
         self.assertEqual(service.containers()[0].name, 'composetest_web_1')
 
-    def test_start_stop(self):
-        service = self.create_service('scalingtest')
-        self.assertEqual(len(service.containers(stopped=True)), 0)
-
-        service.create_container()
-        self.assertEqual(len(service.containers()), 0)
-        self.assertEqual(len(service.containers(stopped=True)), 1)
-
-        service.start()
-        self.assertEqual(len(service.containers()), 1)
-        self.assertEqual(len(service.containers(stopped=True)), 1)
-
-        service.stop(timeout=1)
-        self.assertEqual(len(service.containers()), 0)
-        self.assertEqual(len(service.containers(stopped=True)), 1)
-
-        service.stop(timeout=1)
-        self.assertEqual(len(service.containers()), 0)
-        self.assertEqual(len(service.containers(stopped=True)), 1)
-
-    def test_kill_remove(self):
-        service = self.create_service('scalingtest')
-
-        create_and_start_container(service)
-        self.assertEqual(len(service.containers()), 1)
-
-        remove_stopped(service)
-        self.assertEqual(len(service.containers()), 1)
-
-        service.kill()
-        self.assertEqual(len(service.containers()), 0)
-        self.assertEqual(len(service.containers(stopped=True)), 1)
-
-        remove_stopped(service)
-        self.assertEqual(len(service.containers(stopped=True)), 0)
-
     def test_create_container_with_one_off(self):
         db = self.create_service('db')
         container = db.create_container(one_off=True)


### PR DESCRIPTION
This commit removes the dead code in service.py.
It prevents confusion for the contributors.