### PR TITLE
Docs don't mention docker-compose also requires read permission.

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -102,6 +102,11 @@ _docker_compose_build() {
 }
 
 
+_docker_compose_config() {
+	COMPREPLY=( $( compgen -W "--help --quiet -q --services" -- "$cur" ) )
+}
+
+
 _docker_compose_docker_compose() {
 	case "$prev" in
 		--file|-f)
@@ -373,6 +378,7 @@ _docker_compose() {
 
 	local commands=(
 		build
+		config
 		help
 		kill
 		logs

--- a/docs/install.md
+++ b/docs/install.md
@@ -46,7 +46,7 @@ which the release page specifies, in your terminal.
 
 5. Apply executable permissions to the binary:
 
-        $ chmod +x /usr/local/bin/docker-compose
+        $ chmod +rx /usr/local/bin/docker-compose
 
 6.  Optionally, install [command completion](completion.md) for the
 `bash` and `zsh` shell.


### PR DESCRIPTION
When installing docker-compose on Ubuntu I ran into the following problem:
````
Cannot open self /usr/local/bin/docker-compose or archive /usr/local/bin/docker-compose.pkg
````

Based on some Googling and information in https://github.com/docker/compose/issues/1135, adding the read permission solved the issue for me and other people.