### PR TITLE
Ignore extra coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.egg-info
 *.pyc
-/.coverage
+.coverage*
 /.tox
 /build
 /coverage-html

--- a/script/clean
+++ b/script/clean
@@ -2,5 +2,6 @@
 set -e
 
 find . -type f -name '*.pyc' -delete
+find . -name .coverage.* -delete
 find -name __pycache__ -delete
 rm -rf docs/_site build dist docker-compose.egg-info


### PR DESCRIPTION
Ignore extra coverage files that are created because we run acceptance tests in a subprocess.

These files have the process id in their name, so they wont be removed by the normal coverage cleanup on each run.

Now doing the cleanup as part of the normal `./script/clean`