### PR TITLE
Incorrect network name shown in the log when no driver is specified

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -297,9 +297,13 @@ class Project(object):
     def ensure_network_exists(self):
         # TODO: recreate network if driver has changed?
         if self.get_network() is None:
+            driver_name = 'the default driver'
+            if self.network_driver:
+                driver_name = 'driver "{}"'.format(self.network_driver)
+
             log.info(
-                'Creating network "{}" with driver "{}"'
-                .format(self.name, self.network_driver)
+                'Creating network "{}" with {}'
+                .format(self.name, driver_name)
             )
             self.client.create_network(self.name, driver=self.network_driver)
 


### PR DESCRIPTION
When using docker-compose with --x-networking, the log message incorrectly stated 'driver "None"' in the case when no driver was specified (no --x-network-driver used on the CLI).

This PR changes the code to output:
- When no driver is specified:
Creating network "XXX" with the default driver
- When --x-network-driver is used:
Creating network "XXX" with driver "YYY"

Fixes #2345 

Signed-off-by: Dimitar Bonev <dimitar.bonev@gmail.com>