### PR TITLE
Start, restart, pause and unpause exit with non-zero if nothing to do

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -265,7 +265,8 @@ class TopLevelCommand(DocoptCommand):
 
         Usage: pause [SERVICE...]
         """
-        project.pause(service_names=options['SERVICE'])
+        containers = project.pause(service_names=options['SERVICE'])
+        exit_if(not containers, 'No containers to pause', 1)
 
     def port(self, project, options):
         """
@@ -476,7 +477,8 @@ class TopLevelCommand(DocoptCommand):
 
         Usage: start [SERVICE...]
         """
-        project.start(service_names=options['SERVICE'])
+        containers = project.start(service_names=options['SERVICE'])
+        exit_if(not containers, 'No containers to start', 1)
 
     def stop(self, project, options):
         """
@@ -504,7 +506,8 @@ class TopLevelCommand(DocoptCommand):
                                      (default: 10)
         """
         timeout = int(options.get('--timeout') or DEFAULT_TIMEOUT)
-        project.restart(service_names=options['SERVICE'], timeout=timeout)
+        containers = project.restart(service_names=options['SERVICE'], timeout=timeout)
+        exit_if(not containers, 'No containers to restart', 1)
 
     def unpause(self, project, options):
         """
@@ -512,7 +515,8 @@ class TopLevelCommand(DocoptCommand):
 
         Usage: unpause [SERVICE...]
         """
-        project.unpause(service_names=options['SERVICE'])
+        containers = project.unpause(service_names=options['SERVICE'])
+        exit_if(not containers, 'No containers to unpause', 1)
 
     def up(self, project, options):
         """
@@ -674,3 +678,9 @@ def set_signal_handler(handler):
 
 def list_containers(containers):
     return ", ".join(c.name for c in containers)
+
+
+def exit_if(condition, message, exit_code):
+    if condition:
+        log.error(message)
+        raise SystemExit(exit_code)

--- a/compose/project.py
+++ b/compose/project.py
@@ -187,17 +187,24 @@ class Project(object):
                     net_name))
 
     def start(self, service_names=None, **options):
+        containers = []
         for service in self.get_services(service_names):
-            service.start(**options)
+            service_containers = service.start(**options)
+            containers.extend(service_containers)
+        return containers
 
     def stop(self, service_names=None, **options):
         parallel.parallel_stop(self.containers(service_names), options)
 
     def pause(self, service_names=None, **options):
-        parallel.parallel_pause(reversed(self.containers(service_names)), options)
+        containers = self.containers(service_names)
+        parallel.parallel_pause(reversed(containers), options)
+        return containers
 
     def unpause(self, service_names=None, **options):
-        parallel.parallel_unpause(self.containers(service_names), options)
+        containers = self.containers(service_names)
+        parallel.parallel_unpause(containers, options)
+        return containers
 
     def kill(self, service_names=None, **options):
         parallel.parallel_kill(self.containers(service_names), options)
@@ -206,7 +213,9 @@ class Project(object):
         parallel.parallel_remove(self.containers(service_names, stopped=True), options)
 
     def restart(self, service_names=None, **options):
-        parallel.parallel_restart(self.containers(service_names, stopped=True), options)
+        containers = self.containers(service_names, stopped=True)
+        parallel.parallel_restart(containers, options)
+        return containers
 
     def build(self, service_names=None, no_cache=False, pull=False, force_rm=False):
         for service in self.get_services(service_names):

--- a/compose/service.py
+++ b/compose/service.py
@@ -138,8 +138,10 @@ class Service(object):
         raise ValueError("No container found for %s_%s" % (self.name, number))
 
     def start(self, **options):
-        for c in self.containers(stopped=True):
+        containers = self.containers(stopped=True)
+        for c in containers:
             self.start_container_if_stopped(c, **options)
+        return containers
 
     def scale(self, desired_num, timeout=DEFAULT_TIMEOUT):
         """

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -664,6 +664,10 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(len(service.containers(stopped=True)), 1)
         self.assertFalse(service.containers(stopped=True)[0].is_running)
 
+    def test_start_no_containers(self):
+        result = self.dispatch(['start'], returncode=1)
+        assert 'No containers to start' in result.stderr
+
     def test_pause_unpause(self):
         self.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')
@@ -674,6 +678,14 @@ class CLITestCase(DockerClientTestCase):
 
         self.dispatch(['unpause'], None)
         self.assertFalse(service.containers()[0].is_paused)
+
+    def test_pause_no_containers(self):
+        result = self.dispatch(['pause'], returncode=1)
+        assert 'No containers to pause' in result.stderr
+
+    def test_unpause_no_containers(self):
+        result = self.dispatch(['unpause'], returncode=1)
+        assert 'No containers to unpause' in result.stderr
 
     def test_logs_invalid_service_name(self):
         self.dispatch(['logs', 'madeupname'], returncode=1)
@@ -736,6 +748,10 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(len(service.containers(stopped=True)), 1)
         self.dispatch(['restart', '-t', '1'], None)
         self.assertEqual(len(service.containers(stopped=False)), 1)
+
+    def test_restart_no_containers(self):
+        result = self.dispatch(['restart'], returncode=1)
+        assert 'No containers to restart' in result.stderr
 
     def test_scale(self):
         project = self.project


### PR DESCRIPTION
When there are no containers to restart (pause, unpause or start respectively), compose will now exit with non-zero status, printing an error message. This allows for usage like
```
docker-compose restart || docker-compose up
```
Fixes #1236 

Signed-off-by: Dimitar Bonev <dimitar.bonev@gmail.com>