### PR TITLE
Clarify behaviour of 'rm'

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -343,6 +343,11 @@ class TopLevelCommand(DocoptCommand):
         """
         Remove stopped service containers.
 
+        By default, volumes attached to containers will not be removed. You can see all
+        volumes with `docker volume ls`.
+
+        Any data which is not in a volume will be lost.
+
         Usage: rm [options] [SERVICE...]
 
         Options:

--- a/docs/reference/rm.md
+++ b/docs/reference/rm.md
@@ -20,3 +20,8 @@ Options:
 ```
 
 Removes stopped service containers.
+
+By default, volumes attached to containers will not be removed. You can see all
+volumes with `docker volume ls`.
+
+Any data which is not in a volume will be lost.


### PR DESCRIPTION
Replaces #1169, making a clear distinction between data inside/outside volumes, and letting the user know how to get at volumes for containers which have been removed (now that we have a `docker volume` command ✨).