### PR TITLE
log_driver and log_opt moved to logging key.

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -51,8 +51,6 @@ DOCKER_CONFIG_KEYS = [
     'ipc',
     'labels',
     'links',
-    'log_driver',
-    'log_opt',
     'mac_address',
     'mem_limit',
     'memswap_limit',
@@ -78,6 +76,7 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'dockerfile',
     'expose',
     'external_links',
+    'logging',
 ]
 
 DOCKER_VALID_URL_PREFIXES = (

--- a/compose/config/fields_schema_v1.json
+++ b/compose/config/fields_schema_v1.json
@@ -75,8 +75,15 @@
         "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
-        "log_driver": {"type": "string"},
-        "log_opt": {"type": "object"},
+        "logging": {
+            "type": "object",
+
+            "properties": {
+                "driver": {"type": "string"},
+                "options": {"type": "object"}
+            },
+            "additionalProperties": false
+        },
 
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -324,29 +324,37 @@ for this service, e.g:
 Environment variables will also be created - see the [environment variable
 reference](env.md) for details.
 
-### log_driver
+### logging
 
-Specify a logging driver for the service's containers, as with the ``--log-driver``
-option for docker run ([documented here](https://docs.docker.com/engine/reference/logging/overview/)).
+Logging configuration for the service. This configuration replaces the previous
+`log_driver` and `log_opt` keys.
+
+    logging:
+        driver: log_driver
+        options:
+            syslog-address: "tcp://192.168.0.42:123"
+
+The `driver`  name specifies a logging driver for the service's
+containers, as with the ``--log-driver`` option for docker run
+([documented here](https://docs.docker.com/engine/reference/logging/overview/)).
 
 The default value is json-file.
 
-    log_driver: "json-file"
-    log_driver: "syslog"
-    log_driver: "none"
+    driver: "json-file"
+    driver: "syslog"
+    driver: "none"
 
 > **Note:** Only the `json-file` driver makes the logs available directly from
 > `docker-compose up` and `docker-compose logs`. Using any other driver will not
 > print any logs.
 
-### log_opt
+Specify logging options for the logging driver with the ``options`` key, as with the ``--log-opt`` option for `docker run`.
 
-Specify logging options with `log_opt` for the logging driver, as with the ``--log-opt`` option for `docker run`.
 
 Logging options are key value pairs. An example of `syslog` options:
 
-    log_driver: "syslog"
-    log_opt:
+    driver: "syslog"
+    options:
       syslog-address: "tcp://192.168.0.42:123"
 
 ### net

--- a/tests/fixtures/logging-composefile/compose2.yml
+++ b/tests/fixtures/logging-composefile/compose2.yml
@@ -1,0 +1,3 @@
+another:
+  logging:
+    driver: "none"

--- a/tests/fixtures/logging-composefile/docker-compose.yml
+++ b/tests/fixtures/logging-composefile/docker-compose.yml
@@ -1,0 +1,12 @@
+simple:
+  image: busybox:latest
+  command: top
+  logging:
+    driver: "none"
+another:
+  image: busybox:latest
+  command: top
+  logging:
+    driver: "json-file"
+    options:
+        max-size: "10m"

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -888,7 +888,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertNotEqual(one_off_container.name, 'my-web-container')
 
     def test_log_drive_invalid(self):
-        service = self.create_service('web', log_driver='xxx')
+        service = self.create_service('web', logging={'driver': 'xxx'})
         expected_error_msg = "logger: no log driver named 'xxx' is registered"
 
         with self.assertRaisesRegexp(APIError, expected_error_msg):
@@ -902,7 +902,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertFalse(log_config['Config'])
 
     def test_log_drive_none(self):
-        service = self.create_service('web', log_driver='none')
+        service = self.create_service('web', logging={'driver': 'none'})
         log_config = create_and_start_container(service).log_config
 
         self.assertEqual('none', log_config['Type'])

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -156,7 +156,8 @@ class ServiceTest(unittest.TestCase):
         self.mock_client.create_host_config.return_value = {}
 
         log_opt = {'syslog-address': 'tcp://192.168.0.42:123'}
-        service = Service(name='foo', image='foo', hostname='name', client=self.mock_client, log_driver='syslog', log_opt=log_opt)
+        logging = {'driver': 'syslog', 'options': log_opt}
+        service = Service(name='foo', image='foo', hostname='name', client=self.mock_client, logging=logging)
         service._get_container_create_options({'some': 'overrides'}, 1)
 
         self.assertTrue(self.mock_client.create_host_config.called)


### PR DESCRIPTION
Moving ```log_driver``` and ```log_opt``` to a new ```logging``` key:
```
logging:
    driver:
    options:
```
Implements #2503

Signed-off-by: Dimitar Bonev <dimitar.bonev@gmail.com>