### PR TITLE
Declare networks in Compose file

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -704,7 +704,7 @@ def run_one_off_container(container_options, project, service, options):
         **container_options)
 
     if options['-d']:
-        container.start()
+        service.start_container(container)
         print(container.name)
         return
 
@@ -716,6 +716,7 @@ def run_one_off_container(container_options, project, service, options):
     try:
         try:
             dockerpty.start(project.client, container.id, interactive=not options['-T'])
+            service.connect_container_to_networks(container)
             exit_code = container.wait()
         except signals.ShutdownException:
             project.client.stop(container.id)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -696,8 +696,7 @@ def run_one_off_container(container_options, project, service, options):
                 start_deps=True,
                 strategy=ConvergenceStrategy.never)
 
-    if project.use_networking:
-        project.ensure_network_exists()
+    project.initialize_networks()
 
     container = service.create_container(
         quiet=True,

--- a/compose/config/fields_schema_v2.json
+++ b/compose/config/fields_schema_v2.json
@@ -17,6 +17,15 @@
       },
       "additionalProperties": false
     },
+    "networks": {
+      "id": "#/properties/networks",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/network"
+        }
+      }
+    },
     "volumes": {
       "id": "#/properties/volumes",
       "type": "object",
@@ -30,6 +39,10 @@
   },
 
   "definitions": {
+    "network": {
+      "id": "#/definitions/network",
+      "type": "object"
+    },
     "volume": {
       "id": "#/definitions/volume",
       "type": ["object", "null"],

--- a/compose/config/service_schema_v2.json
+++ b/compose/config/service_schema_v2.json
@@ -89,6 +89,13 @@
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
+
+        "networks": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+
         "pid": {"type": ["string", "null"]},
 
         "ports": {

--- a/compose/config/service_schema_v2.json
+++ b/compose/config/service_schema_v2.json
@@ -89,7 +89,6 @@
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
-        "net": {"type": "string"},
         "pid": {"type": ["string", "null"]},
 
         "ports": {

--- a/compose/network.py
+++ b/compose/network.py
@@ -11,6 +11,7 @@ from .config import ConfigurationError
 log = logging.getLogger(__name__)
 
 
+# TODO: support external networks
 class Network(object):
     def __init__(self, client, project, name, driver=None, driver_opts=None):
         self.client = client

--- a/compose/network.py
+++ b/compose/network.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import logging
+
+from docker.errors import NotFound
+
+from .config import ConfigurationError
+
+
+log = logging.getLogger(__name__)
+
+
+class Network(object):
+    def __init__(self, client, project, name, driver=None, driver_opts=None):
+        self.client = client
+        self.project = project
+        self.name = name
+        self.driver = driver
+        self.driver_opts = driver_opts
+
+    def ensure(self):
+        try:
+            data = self.inspect()
+            if self.driver and data['Driver'] != self.driver:
+                raise ConfigurationError(
+                    'Network {} needs to be recreated - driver has changed'
+                    .format(self.full_name))
+            if data['Options'] != (self.driver_opts or {}):
+                raise ConfigurationError(
+                    'Network {} needs to be recreated - options have changed'
+                    .format(self.full_name))
+        except NotFound:
+            driver_name = 'the default driver'
+            if self.driver:
+                driver_name = 'driver "{}"'.format(self.driver)
+
+            log.info(
+                'Creating network "{}" with {}'
+                .format(self.full_name, driver_name)
+            )
+
+            self.client.create_network(
+                self.full_name, self.driver, self.driver_opts
+            )
+
+    def remove(self):
+        # TODO: don't remove external networks
+        log.info("Removing network {}".format(self.full_name))
+        self.client.remove_network(self.full_name)
+
+    def inspect(self):
+        return self.client.inspect_network(self.full_name)
+
+    @property
+    def full_name(self):
+        return '{0}_{1}'.format(self.project, self.name)

--- a/compose/project.py
+++ b/compose/project.py
@@ -64,7 +64,9 @@ class Project(object):
                 custom_networks.append(
                     Network(
                         client=client, project=name, name=network_name,
-                        driver=data.get('driver'), driver_opts=data.get('driver_opts')
+                        driver=data.get('driver'),
+                        driver_opts=data.get('driver_opts'),
+                        external_name=data.get('external_name'),
                     )
                 )
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -72,7 +72,7 @@ class Project(object):
 
         for service_dict in config_data.services:
             if use_networking:
-                networks = project.get_networks(
+                networks = get_networks(
                     service_dict,
                     custom_networks + [project.default_network])
                 net = Net(networks[0]) if networks else Net("none")
@@ -170,21 +170,6 @@ class Project(object):
         for service in services:
             service.remove_duplicate_containers()
         return services
-
-    def get_networks(self, service_dict, network_definitions):
-        networks = []
-        for name in service_dict.pop('networks', ['default']):
-            if name in ['bridge', 'host']:
-                networks.append(name)
-            else:
-                matches = [n for n in network_definitions if n.name == name]
-                if matches:
-                    networks.append(matches[0].full_name)
-                else:
-                    raise ConfigurationError(
-                        'Service "{}" uses an undefined network "{}"'
-                        .format(service_dict['name'], name))
-        return networks
 
     def get_links(self, service_dict):
         links = []
@@ -472,6 +457,22 @@ class Project(object):
 
         dep_services.append(service)
         return acc + dep_services
+
+
+def get_networks(service_dict, network_definitions):
+    networks = []
+    for name in service_dict.pop('networks', ['default']):
+        if name in ['bridge', 'host']:
+            networks.append(name)
+        else:
+            matches = [n for n in network_definitions if n.name == name]
+            if matches:
+                networks.append(matches[0].full_name)
+            else:
+                raise ConfigurationError(
+                    'Service "{}" uses an undefined network "{}"'
+                    .format(service_dict['name'], name))
+    return networks
 
 
 def get_volumes_from(project, service_dict):

--- a/compose/project.py
+++ b/compose/project.py
@@ -69,13 +69,18 @@ class Project(object):
                 )
 
         for service_dict in config_data.services:
-            networks = project.get_networks(
-                service_dict,
-                custom_networks + [project.default_network])
+            if use_networking:
+                networks = project.get_networks(
+                    service_dict,
+                    custom_networks + [project.default_network])
+                net = Net(networks[0]) if networks else Net("none")
+                links = []
+            else:
+                networks = []
+                net = project.get_net(service_dict)
+                links = project.get_links(service_dict)
 
-            links = project.get_links(service_dict)
             volumes_from = get_volumes_from(project, service_dict)
-            net = project.get_net(service_dict)
 
             project.services.append(
                 Service(
@@ -194,9 +199,6 @@ class Project(object):
         return links
 
     def get_net(self, service_dict):
-        if self.use_networking:
-            return Net(None)
-
         net = service_dict.pop('net', None)
         if not net:
             return Net(None)

--- a/compose/project.py
+++ b/compose/project.py
@@ -172,13 +172,16 @@ class Project(object):
     def get_networks(self, service_dict, network_definitions):
         networks = []
         for name in service_dict.pop('networks', ['default']):
-            matches = [n for n in network_definitions if n.name == name]
-            if matches:
-                networks.append(matches[0].full_name)
+            if name in ['bridge', 'host']:
+                networks.append(name)
             else:
-                raise ConfigurationError(
-                    'Service "{}" uses an undefined network "{}"'
-                    .format(service_dict['name'], name))
+                matches = [n for n in network_definitions if n.name == name]
+                if matches:
+                    networks.append(matches[0].full_name)
+                else:
+                    raise ConfigurationError(
+                        'Service "{}" uses an undefined network "{}"'
+                        .format(service_dict['name'], name))
         return networks
 
     def get_links(self, service_dict):

--- a/compose/project.py
+++ b/compose/project.py
@@ -300,11 +300,7 @@ class Project(object):
         if not self.use_networking:
             return
 
-        networks = self.networks
-        if self.uses_default_network():
-            networks.append(self.default_network)
-
-        for network in networks:
+        for network in self.networks:
             network.ensure()
 
     def uses_default_network(self):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -390,7 +390,7 @@ class CLITestCase(DockerClientTestCase):
             container = containers[0]
             self.assertIn(container.id, network['Containers'])
 
-            networks = container.get('NetworkSettings.Networks').keys()
+            networks = list(container.get('NetworkSettings.Networks'))
             self.assertEqual(networks, [network['Name']])
 
     def test_up_with_networks(self):
@@ -453,7 +453,7 @@ class CLITestCase(DockerClientTestCase):
 
         for name in ['bridge', 'host', 'none']:
             container = self.project.get_service(name).containers()[0]
-            assert container.get('NetworkSettings.Networks').keys() == [name]
+            assert list(container.get('NetworkSettings.Networks')) == [name]
             assert container.get('HostConfig.NetworkMode') == name
 
     def test_up_external_networks(self):
@@ -477,7 +477,7 @@ class CLITestCase(DockerClientTestCase):
 
         self.dispatch(['-f', filename, 'up', '-d'])
         container = self.project.containers()[0]
-        assert sorted(container.get('NetworkSettings.Networks').keys()) == sorted(network_names)
+        assert sorted(list(container.get('NetworkSettings.Networks'))) == sorted(network_names)
 
     def test_up_no_services(self):
         self.base_dir = 'tests/fixtures/no-services'

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -382,13 +382,16 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(networks[0]['Driver'], 'bridge')
 
         network = self.client.inspect_network(networks[0]['Id'])
-        # print self.project.services[0].containers()[0].get('NetworkSettings')
-        self.assertEqual(len(network['Containers']), len(services))
 
         for service in services:
             containers = service.containers()
             self.assertEqual(len(containers), 1)
-            self.assertIn(containers[0].id, network['Containers'])
+
+            container = containers[0]
+            self.assertIn(container.id, network['Containers'])
+
+            networks = container.get('NetworkSettings.Networks').keys()
+            self.assertEqual(networks, [network['Name']])
 
     def test_up_with_networks(self):
         self.base_dir = 'tests/fixtures/networks'

--- a/tests/fixtures/net-container/docker-compose.yml
+++ b/tests/fixtures/net-container/docker-compose.yml
@@ -1,0 +1,7 @@
+foo:
+  image: busybox
+  command: top
+  net: "container:bar"
+bar:
+  image: busybox
+  command: top

--- a/tests/fixtures/net-container/v2-invalid.yml
+++ b/tests/fixtures/net-container/v2-invalid.yml
@@ -1,0 +1,10 @@
+version: 2
+
+services:
+  foo:
+    image: busybox
+    command: top
+  bar:
+    image: busybox
+    command: top
+    net: "container:foo"

--- a/tests/fixtures/networks/docker-compose.yml
+++ b/tests/fixtures/networks/docker-compose.yml
@@ -1,0 +1,7 @@
+version: 2
+
+networks:
+  foo:
+    driver:
+
+  bar: {}

--- a/tests/fixtures/networks/docker-compose.yml
+++ b/tests/fixtures/networks/docker-compose.yml
@@ -1,7 +1,19 @@
 version: 2
 
-networks:
-  foo:
-    driver:
+services:
+  web:
+    image: busybox
+    command: top
+    networks: ["front"]
+  app:
+    image: busybox
+    command: top
+    networks: ["front", "back"]
+  db:
+    image: busybox
+    command: top
+    networks: ["back"]
 
-  bar: {}
+networks:
+  front: {}
+  back: {}

--- a/tests/fixtures/networks/external-networks.yml
+++ b/tests/fixtures/networks/external-networks.yml
@@ -1,0 +1,16 @@
+version: 2
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks:
+      - networks_foo
+      - bar
+
+networks:
+  networks_foo:
+    external: true
+  bar:
+    external:
+      name: networks_bar

--- a/tests/fixtures/networks/missing-network.yml
+++ b/tests/fixtures/networks/missing-network.yml
@@ -1,0 +1,10 @@
+version: 2
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks: ["foo"]
+
+networks:
+  bar: {}

--- a/tests/fixtures/networks/predefined-networks.yml
+++ b/tests/fixtures/networks/predefined-networks.yml
@@ -1,0 +1,17 @@
+version: 2
+
+services:
+  bridge:
+    image: busybox
+    command: top
+    networks: ["bridge"]
+
+  host:
+    image: busybox
+    command: top
+    networks: ["host"]
+
+  none:
+    image: busybox
+    command: top
+    networks: []

--- a/tests/fixtures/no-links-composefile/docker-compose.yml
+++ b/tests/fixtures/no-links-composefile/docker-compose.yml
@@ -1,0 +1,9 @@
+db:
+  image: busybox:latest
+  command: top
+web:
+  image: busybox:latest
+  command: top
+console:
+  image: busybox:latest
+  command: top

--- a/tests/fixtures/no-services/docker-compose.yml
+++ b/tests/fixtures/no-services/docker-compose.yml
@@ -1,0 +1,5 @@
+version: 2
+
+networks:
+  foo: {}
+  bar: {}

--- a/tests/integration/resilience_test.py
+++ b/tests/integration/resilience_test.py
@@ -17,7 +17,7 @@ class ResilienceTest(DockerClientTestCase):
         self.project = Project('composetest', [self.db], self.client)
 
         container = self.db.create_container()
-        container.start()
+        self.db.start_container(container)
         self.host_path = container.get_mount('/var/db')['Source']
 
     def test_successful_recreate(self):
@@ -35,7 +35,7 @@ class ResilienceTest(DockerClientTestCase):
         self.assertEqual(container.get_mount('/var/db')['Source'], self.host_path)
 
     def test_start_failure(self):
-        with mock.patch('compose.container.Container.start', crash):
+        with mock.patch('compose.service.Service.start_container', crash):
             with self.assertRaises(Crash):
                 self.project.up(strategy=ConvergenceStrategy.always)
 

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -21,35 +21,27 @@ class ProjectTest(unittest.TestCase):
     def setUp(self):
         self.mock_client = mock.create_autospec(docker.Client)
 
-    def test_from_dict(self):
-        project = Project.from_config('composetest', Config(None, [
-            {
-                'name': 'web',
-                'image': 'busybox:latest'
-            },
-            {
-                'name': 'db',
-                'image': 'busybox:latest'
-            },
-        ], None), None)
-        self.assertEqual(len(project.services), 2)
-        self.assertEqual(project.get_service('web').name, 'web')
-        self.assertEqual(project.get_service('web').options['image'], 'busybox:latest')
-        self.assertEqual(project.get_service('db').name, 'db')
-        self.assertEqual(project.get_service('db').options['image'], 'busybox:latest')
-
     def test_from_config(self):
-        config = Config(None, [
-            {
-                'name': 'web',
-                'image': 'busybox:latest',
-            },
-            {
-                'name': 'db',
-                'image': 'busybox:latest',
-            },
-        ], None)
-        project = Project.from_config('composetest', config, None)
+        config = Config(
+            version=None,
+            services=[
+                {
+                    'name': 'web',
+                    'image': 'busybox:latest',
+                },
+                {
+                    'name': 'db',
+                    'image': 'busybox:latest',
+                },
+            ],
+            networks=None,
+            volumes=None,
+        )
+        project = Project.from_config(
+            name='composetest',
+            config_data=config,
+            client=None,
+        )
         self.assertEqual(len(project.services), 2)
         self.assertEqual(project.get_service('web').name, 'web')
         self.assertEqual(project.get_service('web').options['image'], 'busybox:latest')
@@ -58,16 +50,21 @@ class ProjectTest(unittest.TestCase):
         self.assertFalse(project.use_networking)
 
     def test_from_config_v2(self):
-        config = Config(2, [
-            {
-                'name': 'web',
-                'image': 'busybox:latest',
-            },
-            {
-                'name': 'db',
-                'image': 'busybox:latest',
-            },
-        ], None)
+        config = Config(
+            version=2,
+            services=[
+                {
+                    'name': 'web',
+                    'image': 'busybox:latest',
+                },
+                {
+                    'name': 'db',
+                    'image': 'busybox:latest',
+                },
+            ],
+            networks=None,
+            volumes=None,
+        )
         project = Project.from_config('composetest', config, None)
         self.assertEqual(len(project.services), 2)
         self.assertTrue(project.use_networking)
@@ -161,13 +158,20 @@ class ProjectTest(unittest.TestCase):
         container_id = 'aabbccddee'
         container_dict = dict(Name='aaa', Id=container_id)
         self.mock_client.inspect_container.return_value = container_dict
-        project = Project.from_config('test', Config(None, [
-            {
-                'name': 'test',
-                'image': 'busybox:latest',
-                'volumes_from': [VolumeFromSpec('aaa', 'rw', 'container')]
-            }
-        ], None), self.mock_client)
+        project = Project.from_config(
+            name='test',
+            client=self.mock_client,
+            config_data=Config(
+                version=None,
+                services=[{
+                    'name': 'test',
+                    'image': 'busybox:latest',
+                    'volumes_from': [VolumeFromSpec('aaa', 'rw', 'container')]
+                }],
+                networks=None,
+                volumes=None,
+            ),
+        )
         assert project.get_service('test')._get_volumes_from() == [container_id + ":rw"]
 
     def test_use_volumes_from_service_no_container(self):
@@ -180,33 +184,51 @@ class ProjectTest(unittest.TestCase):
                 "Image": 'busybox:latest'
             }
         ]
-        project = Project.from_config('test', Config(None, [
-            {
-                'name': 'vol',
-                'image': 'busybox:latest'
-            },
-            {
-                'name': 'test',
-                'image': 'busybox:latest',
-                'volumes_from': [VolumeFromSpec('vol', 'rw', 'service')]
-            }
-        ], None), self.mock_client)
+        project = Project.from_config(
+            name='test',
+            client=self.mock_client,
+            config_data=Config(
+                version=None,
+                services=[
+                    {
+                        'name': 'vol',
+                        'image': 'busybox:latest'
+                    },
+                    {
+                        'name': 'test',
+                        'image': 'busybox:latest',
+                        'volumes_from': [VolumeFromSpec('vol', 'rw', 'service')]
+                    }
+                ],
+                networks=None,
+                volumes=None,
+            ),
+        )
         assert project.get_service('test')._get_volumes_from() == [container_name + ":rw"]
 
     def test_use_volumes_from_service_container(self):
         container_ids = ['aabbccddee', '12345']
 
-        project = Project.from_config('test', Config(None, [
-            {
-                'name': 'vol',
-                'image': 'busybox:latest'
-            },
-            {
-                'name': 'test',
-                'image': 'busybox:latest',
-                'volumes_from': [VolumeFromSpec('vol', 'rw', 'service')]
-            }
-        ], None), None)
+        project = Project.from_config(
+            name='test',
+            client=None,
+            config_data=Config(
+                version=None,
+                services=[
+                    {
+                        'name': 'vol',
+                        'image': 'busybox:latest'
+                    },
+                    {
+                        'name': 'test',
+                        'image': 'busybox:latest',
+                        'volumes_from': [VolumeFromSpec('vol', 'rw', 'service')]
+                    }
+                ],
+                networks=None,
+                volumes=None,
+            ),
+        )
         with mock.patch.object(Service, 'containers') as mock_return:
             mock_return.return_value = [
                 mock.Mock(id=container_id, spec=Container)
@@ -313,12 +335,21 @@ class ProjectTest(unittest.TestCase):
         ]
 
     def test_net_unset(self):
-        project = Project.from_config('test', Config(None, [
-            {
-                'name': 'test',
-                'image': 'busybox:latest',
-            }
-        ], None), self.mock_client)
+        project = Project.from_config(
+            name='test',
+            client=self.mock_client,
+            config_data=Config(
+                version=None,
+                services=[
+                    {
+                        'name': 'test',
+                        'image': 'busybox:latest',
+                    }
+                ],
+                networks=None,
+                volumes=None,
+            ),
+        )
         service = project.get_service('test')
         self.assertEqual(service.net.id, None)
         self.assertNotIn('NetworkMode', service._get_container_host_config({}))
@@ -327,13 +358,22 @@ class ProjectTest(unittest.TestCase):
         container_id = 'aabbccddee'
         container_dict = dict(Name='aaa', Id=container_id)
         self.mock_client.inspect_container.return_value = container_dict
-        project = Project.from_config('test', Config(None, [
-            {
-                'name': 'test',
-                'image': 'busybox:latest',
-                'net': 'container:aaa'
-            }
-        ], None), self.mock_client)
+        project = Project.from_config(
+            name='test',
+            client=self.mock_client,
+            config_data=Config(
+                version=None,
+                services=[
+                    {
+                        'name': 'test',
+                        'image': 'busybox:latest',
+                        'net': 'container:aaa'
+                    },
+                ],
+                networks=None,
+                volumes=None,
+            ),
+        )
         service = project.get_service('test')
         self.assertEqual(service.net.mode, 'container:' + container_id)
 
@@ -347,17 +387,26 @@ class ProjectTest(unittest.TestCase):
                 "Image": 'busybox:latest'
             }
         ]
-        project = Project.from_config('test', Config(None, [
-            {
-                'name': 'aaa',
-                'image': 'busybox:latest'
-            },
-            {
-                'name': 'test',
-                'image': 'busybox:latest',
-                'net': 'container:aaa'
-            }
-        ], None), self.mock_client)
+        project = Project.from_config(
+            name='test',
+            client=self.mock_client,
+            config_data=Config(
+                version=None,
+                services=[
+                    {
+                        'name': 'aaa',
+                        'image': 'busybox:latest'
+                    },
+                    {
+                        'name': 'test',
+                        'image': 'busybox:latest',
+                        'net': 'container:aaa'
+                    },
+                ],
+                networks=None,
+                volumes=None,
+            ),
+        )
 
         service = project.get_service('test')
         self.assertEqual(service.net.mode, 'container:' + container_name)
@@ -403,11 +452,16 @@ class ProjectTest(unittest.TestCase):
             },
         }
         project = Project.from_config(
-            'test',
-            Config(None, [{
-                'name': 'web',
-                'image': 'busybox:latest',
-            }], None),
-            self.mock_client,
+            name='test',
+            client=self.mock_client,
+            config_data=Config(
+                version=None,
+                services=[{
+                    'name': 'web',
+                    'image': 'busybox:latest',
+                }],
+                networks=None,
+                volumes=None,
+            ),
         )
         self.assertEqual([c.id for c in project.containers()], ['1'])


### PR DESCRIPTION
Closes #2478.

TODO:
- [x] Preserve existing behaviour for legacy files
- [x] Decide on API version switching logic
- [x] Remove the `net` option in v2
- [x] Add the `networks` option, enabling services to connect to multiple networks
- [x] Don't connect containers to the `bridge` network by default
- [x] Special-case the external networks `host` and `bridge`
- [x] Support the `external` option for all other externally-defined networks

TODO in separate PRs:
- Aliasing (automatic, not user-specified)
- Validation