### PR TITLE
Fix `run` when using a non-default log driver

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -667,7 +667,7 @@ def run_one_off_container(container_options, project, service, options):
         sys.exit(1)
 
     set_signal_handler(shutdown)
-    dockerpty.start(project.client, container.id, interactive=not options['-T'])
+    dockerpty.start(project.client, container.id, interactive=not options['-T'], logs=False)
     exit_code = container.wait()
     remove_container()
     sys.exit(exit_code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==3.11
 docker-py==1.5.0
-dockerpty==0.3.4
+dockerpty==0.3.5
 docopt==0.6.1
 enum34==1.0.4
 jsonschema==2.5.1


### PR DESCRIPTION
Fixes #2448

As soon as @aanand releases a new version of dockerpty, this change should be enough to fix #2448. I'm opening the PR early to give time for feedback etc. Maybe there are tests that need to be written or something for the PR to be acceptable?