### PR TITLE
Fix typo in unpause reference doc

### DIFF
--- a/docs/reference/unpause.md
+++ b/docs/reference/unpause.md
@@ -9,7 +9,7 @@ parent = "smn_compose_cli"
 +++
 <![end-metadata]-->
 
-# pause
+# unpause
 
 ```
 Usage: unpause [SERVICE...]


### PR DESCRIPTION
Found a small type in `docs/reference/unpause.md` :stuck_out_tongue_closed_eyes:.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>