### PR TITLE
Add missing --name flag to run reference doc

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -17,6 +17,7 @@ Usage: run [options] [-e KEY=VAL...] SERVICE [COMMAND] [ARGS...]
 Options:
 -d                    Detached mode: Run container in the background, print
                           new container name.
+--name NAME           Assign a name to the container
 --entrypoint CMD      Override the entrypoint of the image.
 -e KEY=VAL            Set an environment variable (can be used multiple times)
 -u, --user=""         Run as specified username or uid


### PR DESCRIPTION
Found a small missing flag (`--name`) in `docs/reference/run.md` :stuck_out_tongue_closed_eyes:.
Wondering if we need to add something on the text below to illustrate it (but it feels so obvious though).

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>