### PR TITLE
Add config and create to docs/reference

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,0 +1,23 @@
+<!--[metadata]>
++++
+title = "config"
+description = "Config validates and view the compose file."
+keywords = ["fig, composition, compose, docker, orchestration, cli, config"]
+[menu.main]
+identifier="config.compose"
+parent = "smn_compose_cli"
++++
+<![end-metadata]-->
+
+# config
+
+```:
+Usage: config [options]
+
+Options:
+-q, --quiet     Only validate the configuration, don't print
+                anything.
+--services      Print the service names, one per line.
+```
+
+Validate and view the compose file.

--- a/docs/reference/create.md
+++ b/docs/reference/create.md
@@ -1,0 +1,25 @@
+<!--[metadata]>
++++
+title = "create"
+description = "Create creates containers for a service."
+keywords = ["fig, composition, compose, docker, orchestration, cli, create"]
+[menu.main]
+identifier="create.compose"
+parent = "smn_compose_cli"
++++
+<![end-metadata]-->
+
+# create
+
+```
+Usage: create [options] [SERVICE...]
+
+Options:
+--force-recreate       Recreate containers even if their configuration and
+                       image haven't changed. Incompatible with --no-recreate.
+--no-recreate          If containers already exist, don't recreate them.
+                       Incompatible with --force-recreate.
+--no-build             Don't build an image, even if it's missing
+```
+
+Creates containers for a service.


### PR DESCRIPTION
The reference doc for `create` and `config` commands seems to be absent on master. 🐰

Just adding those two documentation reference files with the bare minimum. Tell me if we should add more to it though. 🐗

ping @aanand @dnephin 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>