### PR TITLE
Update `volumes_from` docs to state default

### DIFF
--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -378,7 +378,8 @@ information.
 ### volumes_from
 
 Mount all of the volumes from another service or container, optionally
-specifying read-only access(``ro``) or read-write(``rw``).
+specifying read-only access (``ro``) or read-write (``rw``). If no access level is specified,
+then read-write will be used.
 
     volumes_from:
      - service_name


### PR DESCRIPTION
[Proof of read-write](https://github.com/docker/compose/blob/cfb1b37da22242dc67d5123772b3fa4518458504/compose/config/types.py#L26).

I found myself wondering what the default was a couple of times, and finally decided to change it :)