### PR TITLE
Fix signal handlers by moving shutdown logic out of handler

### DIFF
--- a/compose/cli/signals.py
+++ b/compose/cli/signals.py
@@ -1,0 +1,18 @@
+import signal
+
+
+class ShutdownException(Exception):
+    pass
+
+
+def shutdown(signal, frame):
+    raise ShutdownException()
+
+
+def set_signal_handler(handler):
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+
+def set_signal_handler_to_shutdown():
+    set_signal_handler(shutdown)

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -86,7 +86,8 @@ class ContainerStateCondition(object):
             return False
 
     def __str__(self):
-        return "waiting for container to have state %s" % self.expected
+        state = 'running' if self.running else 'stopped'
+        return "waiting for container to be %s" % state
 
 
 class CLITestCase(DockerClientTestCase):

--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -54,7 +54,7 @@ class CLIMainTestCase(unittest.TestCase):
         service_names = ['web', 'db']
         timeout = 12
 
-        with mock.patch('compose.cli.main.signal', autospec=True) as mock_signal:
+        with mock.patch('compose.cli.main.signals.signal', autospec=True) as mock_signal:
             attach_to_logs(project, log_printer, service_names, timeout)
 
         assert mock_signal.signal.mock_calls == [


### PR DESCRIPTION
Fixes #2543
Fixes #2580

As suggested by @cjerdonek in #2543, the issue with our shutdown signal handlers may be that we're doing too much in the handler itself. This change moves all the shutdown into a try/except in the main flow, and only raises an exception in the handler.

With this change #2543 seems to be resolved. If anyone is still able to reproduce the issue, please let me know.
