### PR TITLE
Added ability to change the working directory via a command-line flag

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -28,7 +28,8 @@ def project_from_options(project_dir, options):
         verbose=options.get('--verbose'),
         host=options.get('--host'),
         tls_config=tls_config_from_options(options),
-        environment=environment
+        environment=environment,
+        override_dir=options.get('--project-directory'),
     )
 
 
@@ -59,10 +60,10 @@ def get_client(environment, verbose=False, version=None, tls_config=None, host=N
 
 
 def get_project(project_dir, config_path=None, project_name=None, verbose=False,
-                host=None, tls_config=None, environment=None):
+                host=None, tls_config=None, environment=None, override_dir=None):
     if not environment:
         environment = Environment.from_env_file(project_dir)
-    config_details = config.find(project_dir, config_path, environment)
+    config_details = config.find(project_dir, config_path, environment, override_dir)
     project_name = get_project_name(
         config_details.working_dir, project_name, environment
     )

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -160,6 +160,8 @@ class TopLevelCommand(object):
       --skip-hostname-check       Don't check the daemon's hostname against the name specified
                                   in the client certificate (for example if your docker host
                                   is an IP address)
+      --project-directory PATH    Specify an alternate working directory
+                                  (default: the path of the compose file)
 
     Commands:
       build              Build or rebuild services

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -218,10 +218,10 @@ class ServiceConfig(namedtuple('_ServiceConfig', 'working_dir filename name conf
             config)
 
 
-def find(base_dir, filenames, environment):
+def find(base_dir, filenames, environment, override_dir='.'):
     if filenames == ['-']:
         return ConfigDetails(
-            os.getcwd(),
+            os.path.abspath(override_dir),
             [ConfigFile(None, yaml.safe_load(sys.stdin))],
             environment
         )
@@ -233,7 +233,7 @@ def find(base_dir, filenames, environment):
 
     log.debug("Using configuration files: {}".format(",".join(filenames)))
     return ConfigDetails(
-        os.path.dirname(filenames[0]),
+        override_dir or os.path.dirname(filenames[0]),
         [ConfigFile.from_filename(f) for f in filenames],
         environment
     )

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -39,6 +39,8 @@ Options:
   --skip-hostname-check       Don't check the daemon's hostname against the name specified
                               in the client certificate (for example if your docker host
                               is an IP address)
+  --project-directory PATH  Specify an alternate working directory
+                            (default: the path of the compose file)
 
 Commands:
   build              Build or rebuild services

--- a/tests/fixtures/build-path-override-dir/docker-compose.yml
+++ b/tests/fixtures/build-path-override-dir/docker-compose.yml
@@ -1,0 +1,2 @@
+foo:
+  build: ./build-ctx/

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2170,9 +2170,9 @@ class EnvTest(unittest.TestCase):
             set([VolumeSpec.parse('/opt/tmp:/opt/host/tmp')]))
 
 
-def load_from_filename(filename):
+def load_from_filename(filename, override_dir=None):
     return config.load(
-        config.find('.', [filename], Environment.from_env_file('.'))
+        config.find('.', [filename], Environment.from_env_file('.'), override_dir=override_dir)
     ).services
 
 
@@ -2705,6 +2705,12 @@ class BuildPathTest(unittest.TestCase):
 
     def test_from_file(self):
         service_dict = load_from_filename('tests/fixtures/build-path/docker-compose.yml')
+        self.assertEquals(service_dict, [{'name': 'foo', 'build': {'context': self.abs_context_path}}])
+
+    def test_from_file_override_dir(self):
+        override_dir = os.path.join(os.getcwd(), 'tests/fixtures/')
+        service_dict = load_from_filename(
+            'tests/fixtures/build-path-override-dir/docker-compose.yml', override_dir=override_dir)
         self.assertEquals(service_dict, [{'name': 'foo', 'build': {'context': self.abs_context_path}}])
 
     def test_valid_url_in_build_path(self):


### PR DESCRIPTION
Using the --cwd PATH option from the CLI, it is now possible to change the working directory to a path different from that of the compose file.

Implements #2586

Signed-off-by: Dimitar Bonev dimitar.bonev@gmail.com
