### PR TITLE
Set the project name in the environment

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -68,7 +68,10 @@ def set_project_name_from_options(working_dir, options):
     project_name = get_project_name(
         working_dir,
         project_name=options.get('--project-name'))
-    os.environ[PROJECT_NAME_VAR] = project_name
+    if six.PY2:
+        os.environ[PROJECT_NAME_VAR] = six.binary_type(project_name)
+    else:
+        os.environ[PROJECT_NAME_VAR] = project_name
     return project_name
 
 

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -36,6 +36,10 @@ Setting this is optional. If you do not set this, the `COMPOSE_PROJECT_NAME`
 defaults to the `basename` of the project directory. See also the `-p`
 [command-line option](docker-compose.md).
 
+This environment variable is always available from a Compose file. If the `-p`
+option is used, or if no project name is set, Compose will inject the chosen
+project name into the environment.
+
 ### COMPOSE\_FILE
 
 Specify the file containing the compose configuration. If not provided,

--- a/tests/fixtures/inject-project-name/docker-compose.yml
+++ b/tests/fixtures/inject-project-name/docker-compose.yml
@@ -1,0 +1,6 @@
+
+web:
+    image: alpine:edge
+    command: echo ${COMPOSE_PROJECT_NAME}
+    environment:
+        COMPOSE_PROJECT_NAME:

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -18,6 +18,7 @@ from compose.cli.command import set_project_name_from_options
 from compose.cli.docopt_command import NoSuchCommand
 from compose.cli.errors import UserError
 from compose.cli.main import TopLevelCommand
+from compose.config import config
 from compose.const import IS_WINDOWS_PLATFORM
 from compose.service import Service
 
@@ -54,9 +55,10 @@ class CLITestCase(unittest.TestCase):
 
     def test_get_project(self):
         project_name, options = 'projectname', {}
-        compose_config = [
-            {'image': 'alpine:edge', 'name': 'web'},
-        ]
+        compose_config = config.Config(
+            services=[{'image': 'alpine:edge', 'name': 'web'}],
+            version=2,
+            volumes=[])
         project = get_project(project_name, compose_config, options)
         assert project.name == project_name
         assert project.client


### PR DESCRIPTION
Fixes #2294

This normalizes the behaviour of setting the project name, so no matter how it's set (or not set), a compose file can use the name, or  inject it into a container.