### PR TITLE
Only build as part of `up` if `--build` flag is set

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -21,6 +21,7 @@ from .container import Container
 from .network import build_networks
 from .network import get_networks
 from .network import ProjectNetworks
+from .service import BuildAction
 from .service import ContainerNetworkMode
 from .service import ConvergenceStrategy
 from .service import NetworkMode
@@ -249,7 +250,12 @@ class Project(object):
             else:
                 log.info('%s uses an image, skipping' % service.name)
 
-    def create(self, service_names=None, strategy=ConvergenceStrategy.changed, do_build=True):
+    def create(
+        self,
+        service_names=None,
+        strategy=ConvergenceStrategy.changed,
+        do_build=BuildAction.none,
+    ):
         services = self.get_services_without_duplicate(service_names, include_deps=True)
 
         plans = self._get_convergence_plans(services, strategy)
@@ -298,7 +304,7 @@ class Project(object):
            service_names=None,
            start_deps=True,
            strategy=ConvergenceStrategy.changed,
-           do_build=True,
+           do_build=BuildAction.none,
            timeout=DEFAULT_TIMEOUT,
            detached=False):
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -294,9 +294,9 @@ class Service(object):
 
         self.build()
         log.warn(
-            "Image for service {} was build because it was not found. To "
-            "rebuild this image you must use the `build` command or the "
-            "--build flag.".format(self.name))
+            "Image for service {} was built because it did not already exist. To "
+            "rebuild this image you must use `docker-compose build` or "
+            "`docker-compose up --build`.".format(self.name))
 
     def image(self):
         try:

--- a/docs/reference/create.md
+++ b/docs/reference/create.md
@@ -12,14 +12,15 @@ parent = "smn_compose_cli"
 # create
 
 ```
+Creates containers for a service.
+
 Usage: create [options] [SERVICE...]
 
 Options:
---force-recreate       Recreate containers even if their configuration and
-                       image haven't changed. Incompatible with --no-recreate.
---no-recreate          If containers already exist, don't recreate them.
-                       Incompatible with --force-recreate.
---no-build             Don't build an image, even if it's missing
+    --force-recreate       Recreate containers even if their configuration and
+                           image haven't changed. Incompatible with --no-recreate.
+    --no-recreate          If containers already exist, don't recreate them.
+                           Incompatible with --force-recreate.
+    --no-build             Don't build an image, even if it's missing.
+    --build                Build images before creating containers.
 ```
-
-Creates containers for a service.

--- a/docs/reference/up.md
+++ b/docs/reference/up.md
@@ -15,22 +15,24 @@ parent = "smn_compose_cli"
 Usage: up [options] [SERVICE...]
 
 Options:
--d                         Detached mode: Run containers in the background,
-                           print new container names.
-                           Incompatible with --abort-on-container-exit.
---no-color                 Produce monochrome output.
---no-deps                  Don't start linked services.
---force-recreate           Recreate containers even if their configuration
-                           and image haven't changed.
-                           Incompatible with --no-recreate.
---no-recreate              If containers already exist, don't recreate them.
-                           Incompatible with --force-recreate.
---no-build                 Don't build an image, even if it's missing
---abort-on-container-exit  Stops all containers if any container was stopped.
-                           Incompatible with -d.
--t, --timeout TIMEOUT      Use this timeout in seconds for container shutdown
-                           when attached or when containers are already
-                           running. (default: 10)
+    -d                         Detached mode: Run containers in the background,
+                               print new container names.
+                               Incompatible with --abort-on-container-exit.
+    --no-color                 Produce monochrome output.
+    --no-deps                  Don't start linked services.
+    --force-recreate           Recreate containers even if their configuration
+                               and image haven't changed.
+                               Incompatible with --no-recreate.
+    --no-recreate              If containers already exist, don't recreate them.
+                               Incompatible with --force-recreate.
+    --no-build                 Don't build an image, even if it's missing.
+    --build                    Build images before starting containers.
+    --abort-on-container-exit  Stops all containers if any container was stopped.
+                               Incompatible with -d.
+    -t, --timeout TIMEOUT      Use this timeout in seconds for container shutdown
+                               when attached or when containers are already
+                               running. (default: 10)
+
 ```
 
 Builds, (re)creates, starts, and attaches to containers for a service.

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -433,7 +433,7 @@ class ServiceTest(unittest.TestCase):
             service.create_container(do_build=BuildAction.none)
             assert mock_log.warn.called
             _, args, _ = mock_log.warn.mock_calls[0]
-            assert 'was build because it was not found' in args[0]
+            assert 'was built because it did not already exist' in args[0]
 
         self.mock_client.build.assert_called_once_with(
             tag='default_foo',


### PR DESCRIPTION
Fixes #693
Closes #12

Many users have been confused by the default build behaviour of `up`. 

This PR has been updated with the following behaviour:
* if the image doesn't exist build it, but warn that this is a one-time thing, and that you need to use `--build` in the future
* add `--build` to `up` and `create` to allow images to be built with a single command