### PR TITLE
Don't warn when the container volume is a compose option

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -880,6 +880,7 @@ def warn_on_masked_volume(volumes_option, container_volumes, service):
 
     for volume in volumes_option:
         if (
+            volume.external and
             volume.internal in container_volumes and
             container_volumes.get(volume.internal) != volume.external
         ):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -742,6 +742,18 @@ class ServiceVolumesTest(unittest.TestCase):
 
         assert not mock_log.warn.called
 
+    def test_warn_on_masked_no_warning_with_container_only_option(self):
+        volumes_option = [VolumeSpec(None, '/path', 'rw')]
+        container_volumes = [
+            VolumeSpec('/var/lib/docker/volume/path', '/path', 'rw')
+        ]
+        service = 'service_name'
+
+        with mock.patch('compose.service.log', autospec=True) as mock_log:
+            warn_on_masked_volume(volumes_option, container_volumes, service)
+
+        assert not mock_log.warn.called
+
     def test_create_with_special_volume_mode(self):
         self.mock_client.inspect_image.return_value = {'Id': 'imageid'}
 


### PR DESCRIPTION
Fixes: https://github.com/docker/compose/issues/2481#issuecomment-168874417

Another case where the volume masking warning is incorrect. 

If the volume comes from the Compose options the host paths will be different, but there is nothing being masked, so we shouldn't warn here either.