### PR TITLE
Extra hosts ipv6

### DIFF
--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -58,7 +58,7 @@ def parse_extra_hosts(extra_hosts_config):
         extra_hosts_dict = {}
         for extra_hosts_line in extra_hosts_config:
             # TODO: validate string contains ':' ?
-            host, ip = extra_hosts_line.split(':')
+            host, ip = extra_hosts_line.split(':', 1)
             extra_hosts_dict[host.strip()] = ip.strip()
         return extra_hosts_dict
 

--- a/tests/unit/config/types_test.py
+++ b/tests/unit/config/types_test.py
@@ -16,11 +16,13 @@ def test_parse_extra_hosts_list():
     assert parse_extra_hosts([
         "www.example.com: 192.168.0.17",
         "static.example.com:192.168.0.19",
-        "api.example.com: 192.168.0.18"
+        "api.example.com: 192.168.0.18",
+        "v6.example.com: ::1"
     ]) == {
         'www.example.com': '192.168.0.17',
         'static.example.com': '192.168.0.19',
-        'api.example.com': '192.168.0.18'
+        'api.example.com': '192.168.0.18',
+        'v6.example.com': '::1'
     }
 
 


### PR DESCRIPTION
Add support for IPv6 addresses with colons for extra_hosts. Fixes #1422

Fixes:

```
  File "/Users/cg/Documents/workspace/compose/compose/config/types.py", line 60, in parse_extra_hosts
    host, ip = extra_hosts_line.split(':')
ValueError: too many values to unpack
```

Example yml:

```yml
extra_hosts:
  - test-host:::1
```