### PR TITLE
Interpolate variables in the new sections of the Compose file

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -11,35 +11,32 @@ from .errors import ConfigurationError
 log = logging.getLogger(__name__)
 
 
-def interpolate_environment_variables(service_dicts):
+def interpolate_environment_variables(config, section):
     mapping = BlankDefaultDict(os.environ)
 
+    def process_item(name, config_dict):
+        return dict(
+            (key, interpolate_value(name, key, val, section, mapping))
+            for key, val in (config_dict or {}).items()
+        )
+
     return dict(
-        (service_name, process_service(service_name, service_dict, mapping))
-        for (service_name, service_dict) in service_dicts.items()
+        (name, process_item(name, config_dict))
+        for name, config_dict in config.items()
     )
 
 
-def process_service(service_name, service_dict, mapping):
-    return dict(
-        (key, interpolate_value(service_name, key, val, mapping))
-        for (key, val) in service_dict.items()
-    )
-
-
-def interpolate_value(service_name, config_key, value, mapping):
+def interpolate_value(name, config_key, value, section, mapping):
     try:
         return recursive_interpolate(value, mapping)
     except InvalidInterpolation as e:
         raise ConfigurationError(
             'Invalid interpolation format for "{config_key}" option '
-            'in service "{service_name}": "{string}"'
-            .format(
+            'in {section} "{name}": "{string}"'.format(
                 config_key=config_key,
-                service_name=service_name,
-                string=e.string,
-            )
-        )
+                name=name,
+                section=section,
+                string=e.string))
 
 
 def recursive_interpolate(obj, mapping):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -686,8 +686,8 @@ class ConfigTest(unittest.TestCase):
             )
         )
 
-        self.assertTrue(mock_logging.warn.called)
-        self.assertTrue(expected_warning_msg in mock_logging.warn.call_args[0][0])
+        assert mock_logging.warn.called
+        assert expected_warning_msg in mock_logging.warn.call_args[0][0]
 
     def test_config_valid_environment_dict_key_contains_dashes(self):
         services = config.load(
@@ -1664,15 +1664,13 @@ class ExtendsTest(unittest.TestCase):
             load_from_filename('tests/fixtures/extends/invalid-net.yml')
 
     @mock.patch.dict(os.environ)
-    def test_valid_interpolation_in_extended_service(self):
-        os.environ.update(
-            HOSTNAME_VALUE="penguin",
-        )
+    def test_load_config_runs_interpolation_in_extended_service(self):
+        os.environ.update(HOSTNAME_VALUE="penguin")
         expected_interpolated_value = "host-penguin"
-
-        service_dicts = load_from_filename('tests/fixtures/extends/valid-interpolation.yml')
+        service_dicts = load_from_filename(
+            'tests/fixtures/extends/valid-interpolation.yml')
         for service in service_dicts:
-            self.assertTrue(service['hostname'], expected_interpolated_value)
+            assert service['hostname'] == expected_interpolated_value
 
     @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
     def test_volume_path(self):

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+
+import mock
+import pytest
+
+from compose.config.interpolation import interpolate_environment_variables
+
+
+@pytest.yield_fixture
+def mock_env():
+    with mock.patch.dict(os.environ):
+        os.environ['USER'] = 'jenny'
+        os.environ['FOO'] = 'bar'
+        yield
+
+
+def test_interpolate_environment_variables_in_services(mock_env):
+    services = {
+        'servivea': {
+            'image': 'example:${USER}',
+            'volumes': ['$FOO:/target'],
+            'logging': {
+                'driver': '${FOO}',
+                'options': {
+                    'user': '$USER',
+                }
+            }
+        }
+    }
+    expected = {
+        'servivea': {
+            'image': 'example:jenny',
+            'volumes': ['bar:/target'],
+            'logging': {
+                'driver': 'bar',
+                'options': {
+                    'user': 'jenny',
+                }
+            }
+        }
+    }
+    assert interpolate_environment_variables(services, 'service') == expected
+
+
+def test_interpolate_environment_variables_in_volumes(mock_env):
+    volumes = {
+        'data': {
+            'driver': '$FOO',
+            'driver_opts': {
+                'max': 2,
+                'user': '${USER}'
+            }
+        },
+        'other': None,
+    }
+    expected = {
+        'data': {
+            'driver': 'bar',
+            'driver_opts': {
+                'max': 2,
+                'user': 'jenny'
+            }
+        },
+        'other': {},
+    }
+    assert interpolate_environment_variables(volumes, 'volume') == expected


### PR DESCRIPTION
Adds interpolation support for `volumes` and `networks` sections of the compose file.

Also adds `ConfigFile.get_networks()` and uses it as part of `load_mapping()` to avoid the rare bug where someone might use the name `volumes` or `networks` as a service name in a V1 config.