### PR TITLE
Fix flaky multiplex test

### DIFF
--- a/tests/unit/multiplexer_test.py
+++ b/tests/unit/multiplexer_test.py
@@ -49,18 +49,13 @@ class MultiplexerTest(unittest.TestCase):
             list(mux.loop())
 
     def test_cascade_stop(self):
-        mux = Multiplexer([
-            ((lambda x: sleep(0.01) or x)(x) for x in ['after 0.01 sec T1',
-                                                       'after 0.02 sec T1',
-                                                       'after 0.03 sec T1']),
-            ((lambda x: sleep(0.02) or x)(x) for x in ['after 0.02 sec T2',
-                                                       'after 0.04 sec T2',
-                                                       'after 0.06 sec T2']),
-        ], cascade_stop=True)
+        def fast_stream():
+            for num in range(3):
+                yield "stream1 %s" % num
 
-        self.assertEqual(
-            ['after 0.01 sec T1',
-             'after 0.02 sec T1',
-             'after 0.02 sec T2',
-             'after 0.03 sec T1'],
-            sorted(list(mux.loop())))
+        def slow_stream():
+            sleep(5)
+            yield "stream2 FAIL"
+
+        mux = Multiplexer([fast_stream(), slow_stream()], cascade_stop=True)
+        assert "stream2 FAIL" not in set(mux.loop())


### PR DESCRIPTION
We just added this test in #2130, and it's already failed once:
https://ci.appveyor.com/project/dnephin/compose/build/make_volumes_from_more_explicit-366#L764

I forgot that I wanted to change it before we merged it, so doing it now. Instead of relying on precise timing and scheduling of threads, make one really fast (no sleep) stream, and one really slow (long sleep) stream.  

I believe this gives us the same test coverage without sleeping or working about it flaking.