### PR TITLE
Error when the project name is invalid for the default image name

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import operator
 import os
+import string
 import sys
 from collections import namedtuple
 
@@ -497,6 +498,13 @@ def validate_service(service_dict, service_name, version):
     if 'ulimits' in service_dict:
         validate_ulimits(service_dict['ulimits'])
 
+    if not service_dict.get('image') and has_uppercase(service_name):
+        raise ConfigurationError(
+            "Service '{name}' contains uppercase characters which are not valid "
+            "as part of an image name. Either use a lowercase service name or "
+            "use the `image` field to set a custom name for the service image."
+            .format(name=service_name))
+
 
 def process_service(service_config):
     working_dir = service_config.working_dir
@@ -859,6 +867,10 @@ def to_list(value):
         return [value]
     else:
         return value
+
+
+def has_uppercase(name):
+    return any(char in string.ascii_uppercase for char in name)
 
 
 def load_yaml(filename):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -544,6 +544,13 @@ class ConfigTest(unittest.TestCase):
                 )
             )
 
+    def test_load_errors_on_uppercase_with_no_image(self):
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(build_config_details({
+                'Foo': {'build': '.'},
+            }, 'tests/fixtures/build-ctx'))
+            assert "Service 'Foo' contains uppercase characters" in exc.exconly()
+
     def test_invalid_config_build_and_image_specified(self):
         expected_error_msg = "Service 'foo' has both an image and build path specified."
         with self.assertRaisesRegexp(ConfigurationError, expected_error_msg):


### PR DESCRIPTION
Users will get a more appropriate error message now, instead of one about invalid image name.