### PR TITLE
Fix linux master build

### DIFF
--- a/script/travis/build-binary
+++ b/script/travis/build-binary
@@ -4,8 +4,8 @@ set -ex
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     script/build-linux
-    script/build-image master
-    # TODO: requires auth
+    # TODO: requires auth to push, so disable for now
+    # script/build-image master
     # docker push docker/compose:master
 else
     script/prepare-osx


### PR DESCRIPTION
We don't include `git` in the `Dockerfile.run`, and it's needed to install dependencies. Since we're not actually pushing this image to the registry there's no reason to build it here.

This should be fixed by the time we release 1.6 because we'll have removed the git url from requirements.txt.

https://travis-ci.org/dnephin/compose/builds/102679653