### PR TITLE
Add a migration script for v1 to v2 compose format

### DIFF
--- a/contrib/migration/migrate-compose-file-v1-to-v2.py
+++ b/contrib/migration/migrate-compose-file-v1-to-v2.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""
+Migrate a Compose file from the V1 format in Compose 1.5 to the V2 format
+supported by Compose 1.6+
+"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import argparse
+import logging
+import sys
+
+import ruamel.yaml
+
+
+log = logging.getLogger('migrate')
+
+
+def migrate(content):
+    data = ruamel.yaml.load(content, ruamel.yaml.RoundTripLoader)
+
+    service_names = data.keys()
+    for name, service in data.items():
+        # remove links and external links
+        service.pop('links', None)
+        external_links = service.pop('external_links', None)
+        if external_links:
+            log.warn(
+                "Service {name} has external_links: {ext}, which are no longer "
+                "supported. See https://docs.docker.com/compose/networking/ "
+                "for options on how to connect external containers to the "
+                "compose network.".format(name=name, ext=external_links))
+
+        # net is now networks
+        if 'net' in service:
+            service['networks'] = [service.pop('net')]
+
+        # create build section
+        if 'dockerfile' in service:
+            service['build'] = {
+                'context': service.pop('build'),
+                'dockerfile': service.pop('dockerfile'),
+            }
+
+        # create logging section
+        if 'log_driver' in service:
+            service['logging'] = {'driver': service.pop('log_driver')}
+            if 'log_opt' in service:
+                service['logging']['options'] = service.pop('log_opt')
+
+        # volumes_from prefix with 'container:'
+        for idx, volume_from in enumerate(service.get('volumes_from', [])):
+            if volume_from.split(':', 1)[0] not in service_names:
+                service['volumes_from'][idx] = 'container:%s' % volume_from
+
+    data['services'] = {name: data.pop(name) for name in data.keys()}
+    data['version'] = 2
+    return data
+
+
+def write(stream, new_format, indent, width):
+    ruamel.yaml.dump(
+        new_format,
+        stream,
+        Dumper=ruamel.yaml.RoundTripDumper,
+        indent=indent,
+        width=width)
+
+
+def parse_opts(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filename", help="Compose file filename.")
+    parser.add_argument("-i", "--in-place", action='store_true')
+    parser.add_argument(
+        "--indent", type=int, default=2,
+        help="Number of spaces used to indent the output yaml.")
+    parser.add_argument(
+        "--width", type=int, default=80,
+        help="Number of spaces used as the output width.")
+    return parser.parse_args()
+
+
+def main(args):
+    logging.basicConfig()
+
+    opts = parse_opts(args)
+
+    with open(opts.filename, 'r') as fh:
+        new_format = migrate(fh.read())
+
+    if opts.in_place:
+        output = open(opts.filename, 'w')
+    else:
+        output = sys.stdout
+    write(output, new_format, opts.indent, opts.width)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Fixes #2678

`ruamel.yaml` does an ok job of preserving header comments, formatting, aliases, and anchors.

But it is still pretty limited:
 * inline comments may still be lost
 * comments above lines seem to always be lost
 * in some cases (it seems to be when using indent=4) an end-of-line comment can be added with the wrong amount of space (none), confusing the pyyaml parser
* the order of services and service options changes
* quotes around most string scalars are lost

I don't know of any round trip yaml parser that is any better (in python or any other language). I doubt the quality of this script is ever really going to be good enough to suggest it as the primary way to migrate. Since the quality isn't great, I don't think we should be including it as a compose command.

I think we should provide this script as a docker image, and suggest it as an alternative option in the migration doc, for users with very large compose files.

I think for most compose files the user will be better off just using their editor to make the necessary changes.