### PR TITLE
Don't copy host volumes on recreate

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -911,6 +911,10 @@ def get_container_data_volumes(container, volumes_option):
         if not mount:
             continue
 
+        # Volume was previously a host volume, now it's a container volume
+        if not mount.get('Name'):
+            continue
+
         # Copy existing volume from old container
         volume = volume._replace(external=mount['Source'])
         volumes.append(volume)


### PR DESCRIPTION
I was doing some more testing of copy during recreate, and I noticed that if I removed a host volume, and there was a volume defined in the image for the same path or if you made it a container volume, you would continue to get the host volume instead.

This change makes it so that if you remove the host volume from the config, you won't keep getting the host volume. 