### PR TITLE
Install python from deb packages instead of source in the CI Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,28 @@
-FROM debian:wheezy
+FROM debian:jessie
 
-RUN set -ex; \
-    apt-get update -qq; \
+RUN apt-get update -qq && \
     apt-get install -y \
+        libpython2.7 \
+        libpython3.4 \
         locales \
-        gcc \
-        make \
-        zlib1g \
-        zlib1g-dev \
-        libssl-dev \
+        python2.7 \
+        python2.7-dev \
+        python-setuptools \
+        python3.4 \
+        python3.4-dev \
+        python3-setuptools \
         git \
         ca-certificates \
         curl \
-        libsqlite3-dev \
-    ; \
+    && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.8.3 \
         -o /usr/local/bin/docker && \
     chmod +x /usr/local/bin/docker
 
-# Build Python 2.7.9 from source
-RUN set -ex; \
-    curl -L https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz | tar -xz; \
-    cd Python-2.7.9; \
-    ./configure --enable-shared; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf /Python-2.7.9
-
-# Build python 3.4 from source
-RUN set -ex; \
-    curl -L https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tgz | tar -xz; \
-    cd Python-3.4.3; \
-    ./configure --enable-shared; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf /Python-3.4.3
-
-# Make libpython findable
-ENV LD_LIBRARY_PATH /usr/local/lib
-
-# Install setuptools
-RUN set -ex; \
-    curl -L https://bootstrap.pypa.io/ez_setup.py | python
-
 # Install pip
-RUN set -ex; \
-    curl -L https://pypi.python.org/packages/source/p/pip/pip-7.0.1.tar.gz | tar -xz; \
-    cd pip-7.0.1; \
-    python setup.py install; \
-    cd ..; \
-    rm -rf pip-7.0.1
+RUN curl -L https://bootstrap.pypa.io/get-pip.py | python
 
 # Python3 requires a valid locale
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cached-property==1.2.0
 docker-py==1.7.0
 dockerpty==0.4.1
 docopt==0.6.1
-enum34==1.0.4
+enum34==1.1.2
 jsonschema==2.5.1
 requests==2.7.0
 six==1.7.3


### PR DESCRIPTION
I think this should reduce the time of our test runs.

I had to upgrade enum34 to get it to install with the slightly newer version of python 3.4