### PR TITLE
Fix scale race condition

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -228,11 +228,9 @@ class Service(object):
             sorted_running_containers = sorted(
                 running_containers,
                 key=attrgetter('number'))
-            parallel_stop(
-                sorted_running_containers[-num_to_stop:],
-                dict(timeout=timeout))
-
-        parallel_remove(self.containers(stopped=True), {})
+            containers_to_stop = sorted_running_containers[-num_to_stop:]
+            parallel_stop(containers_to_stop, dict(timeout=timeout))
+            parallel_remove(containers_to_stop, {})
 
     def create_container(self,
                          one_off=False,

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -746,6 +746,11 @@ class ServiceTest(DockerClientTestCase):
         for container in containers:
             self.assertEqual(list(container.inspect()['HostConfig']['PortBindings'].keys()), ['8000/tcp'])
 
+    def test_scale_with_immediate_exit(self):
+        service = self.create_service('web', image='busybox', command='true')
+        service.scale(2)
+        assert len(service.containers(stopped=True)) == 2
+
     def test_network_mode_none(self):
         service = self.create_service('web', net=Net('none'))
         container = create_and_start_container(service)


### PR DESCRIPTION
Also, made stoppping + removing happen as a single parallelised operation, much like creating + starting. This should make scaling down a little faster.

Closes #2559.