### PR TITLE
Empty env var #2359

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -464,18 +464,12 @@ def resolve_environment(service_dict):
         env.update(env_vars_from_file(env_file))
 
     env.update(parse_environment(service_dict.get('environment')))
-    d = dict(resolve_env_var(k, v) for k, v in six.iteritems(env))
-    if '_' in d.keys():
-        del d['_']
-    return d
+    return dict(filter(None, (resolve_env_var(k, v) for k, v in six.iteritems(env))))
 
 
 def resolve_build_args(build):
     args = parse_build_arguments(build.get('args'))
-    d = dict(resolve_env_var(k, v) for k, v in six.iteritems(args))
-    if '_' in d.keys():
-        del d['_']
-    return d
+    return dict(filter(None, (resolve_env_var(k, v) for k, v in six.iteritems(args))))
 
 
 def validate_extended_service_dict(service_dict, filename, service):
@@ -736,7 +730,7 @@ def resolve_env_var(key, val):
     elif key in os.environ:
         return key, os.environ[key]
     else:
-        return "_", None
+        return ()
 
 
 def env_vars_from_file(filename):

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -464,12 +464,18 @@ def resolve_environment(service_dict):
         env.update(env_vars_from_file(env_file))
 
     env.update(parse_environment(service_dict.get('environment')))
-    return dict(resolve_env_var(k, v) for k, v in six.iteritems(env))
+    d = dict(resolve_env_var(k, v) for k, v in six.iteritems(env))
+    if '_' in d.keys():
+        del d['_']
+    return d
 
 
 def resolve_build_args(build):
     args = parse_build_arguments(build.get('args'))
-    return dict(resolve_env_var(k, v) for k, v in six.iteritems(args))
+    d = dict(resolve_env_var(k, v) for k, v in six.iteritems(args))
+    if '_' in d.keys():
+        del d['_']
+    return d
 
 
 def validate_extended_service_dict(service_dict, filename, service):
@@ -730,7 +736,7 @@ def resolve_env_var(key, val):
     elif key in os.environ:
         return key, os.environ[key]
     else:
-        return key, ''
+        return "_", None
 
 
 def env_vars_from_file(filename):

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -860,7 +860,6 @@ class ServiceTest(DockerClientTestCase):
             'FILE_DEF': 'F1',
             'FILE_DEF_EMPTY': '',
             'ENV_DEF': 'E3',
-            'NO_DEF': ''
         }.items():
             self.assertEqual(env[k], v)
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1443,7 +1443,7 @@ class EnvTest(unittest.TestCase):
         }
         self.assertEqual(
             resolve_environment(service_dict),
-            {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3', 'NO_DEF': ''},
+            {'FILE_DEF': 'F1', 'FILE_DEF_EMPTY': '', 'ENV_DEF': 'E3'},
         )
 
     def test_resolve_environment_from_env_file(self):
@@ -1484,7 +1484,6 @@ class EnvTest(unittest.TestCase):
                 'FILE_DEF': u'bär',
                 'FILE_DEF_EMPTY': '',
                 'ENV_DEF': 'E3',
-                'NO_DEF': ''
             },
         )
 
@@ -1503,7 +1502,7 @@ class EnvTest(unittest.TestCase):
         }
         self.assertEqual(
             resolve_build_args(build),
-            {'arg1': 'value1', 'empty_arg': '', 'env_arg': 'value2', 'no_env': ''},
+            {'arg1': 'value1', 'empty_arg': '', 'env_arg': 'value2'},
         )
 
     @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')


### PR DESCRIPTION
closes #2359. I tried to keep the changes minimal. I also changed the behavior of env_file pass-throughs. This makes compose's behavior similar to docker run's.