### PR TITLE
bash completion for `docker-compose create`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -107,6 +107,18 @@ _docker_compose_config() {
 }
 
 
+_docker_compose_create() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--force-recreate --help --no-build --no-recreate" -- "$cur" ) )
+			;;
+		*)
+			__docker_compose_services_all
+			;;
+	esac
+}
+
+
 _docker_compose_docker_compose() {
 	case "$prev" in
 		--file|-f)
@@ -409,6 +421,7 @@ _docker_compose() {
 	local commands=(
 		build
 		config
+		create
 		down
 		events
 		help


### PR DESCRIPTION
Ref #2547
Please cherry-pick into 1.6.0 as the command is part of that release.
ping @sdurrheimer for zsh completion: new command `docker-compose create`