### PR TITLE
Add pytest.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    py.test -v -rxs \
+    py.test -v \
         --cov=compose \
         --cov-report html \
         --cov-report term \
@@ -47,3 +47,6 @@ max-line-length = 140
 # Set this high for now
 max-complexity = 12
 exclude = compose/packages
+
+[pytest]
+addopts = --tb=short -rxs


### PR DESCRIPTION
Copied over from docker-py. This makes running `py.test` at the command line a bit less annoying.