### PR TITLE
Fix computation of service lists in bash completion

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -17,6 +17,10 @@
 #    . ~/.docker-compose-completion.sh
 
 
+__docker_compose_q() {
+	docker-compose 2>/dev/null ${compose_file:+-f $compose_file} ${compose_project:+-p $compose_project} "$@"
+}
+
 # suppress trailing whitespace
 __docker_compose_nospace() {
 	# compopt is not available in ancient bash versions
@@ -39,7 +43,7 @@ __docker_compose_compose_file() {
 
 # Extracts all service names from the compose file.
 ___docker_compose_all_services_in_compose_file() {
-	awk -F: '/^[a-zA-Z0-9]/{print $1}' "${compose_file:-$(__docker_compose_compose_file)}" 2>/dev/null
+	__docker_compose_q config --services
 }
 
 # All services, even those without an existing container
@@ -49,8 +53,12 @@ __docker_compose_services_all() {
 
 # All services that have an entry with the given key in their compose_file section
 ___docker_compose_services_with_key() {
-	# flatten sections to one line, then filter lines containing the key and return section name.
-	awk '/^[a-zA-Z0-9]/{printf "\n"};{printf $0;next;}' "${compose_file:-$(__docker_compose_compose_file)}" 2>/dev/null | awk -F: -v key=": +$1:" '$0 ~ key {print $1}'
+	# flatten sections under "services" to one line, then filter lines containing the key and return section name
+	__docker_compose_q config \
+		| sed -n -e '/^services:/,/^[^ ]/p' \
+		| sed -n 's/^  //p' \
+		| awk '/^[a-zA-Z0-9]/{printf "\n"};{printf $0;next;}' \
+		| awk -F: -v key=": +$1:" '$0 ~ key {print $1}'
 }
 
 # All services that are defined by a Dockerfile reference
@@ -67,11 +75,9 @@ __docker_compose_services_from_image() {
 # by a boolean expression passed in as argument.
 __docker_compose_services_with() {
 	local containers names
-	containers="$(docker-compose 2>/dev/null ${compose_file:+-f $compose_file} ${compose_project:+-p $compose_project} ps -q)"
-	names=( $(docker 2>/dev/null inspect --format "{{if ${1:-true}}} {{ .Name }} {{end}}" $containers) )
-	names=( ${names[@]%_*} )  # strip trailing numbers
-	names=( ${names[@]#*_} )  # strip project name
-	COMPREPLY=( $(compgen -W "${names[*]}" -- "$cur") )
+	containers="$(__docker_compose_q ps -q)"
+	names=$(docker 2>/dev/null inspect -f "{{if ${1:-true}}}{{range \$k, \$v := .Config.Labels}}{{if eq \$k \"com.docker.compose.service\"}}{{\$v}}{{end}}{{end}}{{end}}" $containers)
+	COMPREPLY=( $(compgen -W "$names" -- "$cur") )
 }
 
 # The services for which at least one paused container exists


### PR DESCRIPTION
Up to now, bash completion extracted services from "the" compose file (all services) or from container names (containers with special features, e.g. running ones).

This is no longer sufficient:
* compose files may be located in parent directories
* compose files may inherit from other files
* compose files may be enhanced or overridden by `docker-compose.override.yml`
* compose files may contain variables
* container names may be adjusted with the `container_name` directive

The completion of service names is therefore seriously broken. As some of these breaking changes are introduced in 1.6.0, I strongly suggest to include this patch in 1.6.0 as well.

This PR makes use of two new features in order to fix the shortcomings:
* `docker-compose config` gives access to the configuration as `compose` sees it
* the service name of a container is determined from its labels

There is still one feature missing: support for multiple `-f` options. I will add this in another PR.

/cc @sdurrheimer PTAL, maybe you can reuse the updated functions in zsh completion