### PR TITLE
Alias containers by short id

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -420,8 +420,12 @@ class CLITestCase(DockerClientTestCase):
             container = containers[0]
             self.assertIn(container.id, network['Containers'])
 
-            networks = list(container.get('NetworkSettings.Networks'))
-            self.assertEqual(networks, [network['Name']])
+            networks = container.get('NetworkSettings.Networks')
+            self.assertEqual(list(networks), [network['Name']])
+
+            self.assertEqual(
+                sorted(networks[network['Name']]['Aliases']),
+                sorted([service.name, container.short_id]))
 
             for service in services:
                 assert self.lookup(container, service.name)


### PR DESCRIPTION
This necessitates a small change in how we connect to networks: rather than setting links and aliases for the one arbitrarily-picked network the container joins on creation, we disconnect and reconnect it immediately after creating it, so that we can set the short-id alias.

Closes #2702.