### PR TITLE
fixed documentation about traversing yml files

### DIFF
--- a/docs/reference/docker-compose.md
+++ b/docs/reference/docker-compose.md
@@ -85,12 +85,12 @@ stdin. When stdin is used all paths in the configuration are
 relative to the current working directory.
 
 The `-f` flag is optional. If you don't provide this flag on the command line,
-Compose traverses the working directory and its subdirectories looking for a
+Compose traverses the working directory and its parent directories looking for a
 `docker-compose.yml` and a `docker-compose.override.yml` file. You must
-supply at least the `docker-compose.yml` file. If both files are present,
-Compose combines the two files into a single configuration. The configuration
-in the `docker-compose.override.yml` file is applied over and in addition to
-the values in the `docker-compose.yml` file.
+supply at least the `docker-compose.yml` file. If both files are present on the 
+same directory level, Compose combines the two files into a single configuration. 
+The configuration in the `docker-compose.override.yml` file is applied over and 
+in addition to the values in the `docker-compose.yml` file.
 
 See also the `COMPOSE_FILE` [environment variable](overview.md#compose-file).
 


### PR DESCRIPTION
Actually compose is traversing "upwards" in the directory tree, looking in parent folders for a yml file. Using subdirectories wouldn't make sense, since you may end up finding multiple files.

Or I understood something completely wrong here :)