### PR TITLE
Fix rebase-bump-commit script

### DIFF
--- a/script/release/rebase-bump-commit
+++ b/script/release/rebase-bump-commit
@@ -32,7 +32,7 @@ if [[ "$sha" == "$(git rev-parse HEAD)" ]]; then
     exit 0
 fi
 
-commits=$(git log --format="%H" "$sha..HEAD" | wc -l)
+commits=$(git log --format="%H" "$sha..HEAD" | wc -l | xargs echo)
 
 git rebase --onto $sha~1 HEAD~$commits $BRANCH
 git cherry-pick $sha


### PR DESCRIPTION
Trim whitespace from `wc`'s output before constructing arguments to `git rebase`