### PR TITLE
Remove ability to join bridge network + user-defined networks

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -470,16 +470,13 @@ def get_networks(service_dict, network_definitions):
 
     networks = []
     for name in service_dict.pop('networks', ['default']):
-        if name in ['bridge']:
-            networks.append(name)
+        matches = [n for n in network_definitions if n.name == name]
+        if matches:
+            networks.append(matches[0].full_name)
         else:
-            matches = [n for n in network_definitions if n.name == name]
-            if matches:
-                networks.append(matches[0].full_name)
-            else:
-                raise ConfigurationError(
-                    'Service "{}" uses an undefined network "{}"'
-                    .format(service_dict['name'], name))
+            raise ConfigurationError(
+                'Service "{}" uses an undefined network "{}"'
+                .format(service_dict['name'], name))
     return networks
 
 

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -472,11 +472,6 @@ Networks to join, referencing entries under the
       - some-network
       - other-network
 
-The value `bridge` can also be used to make containers join the pre-defined
-`bridge` network.
-
-There is no equivalent to `net: "container:[name or id]"`.
-
 ### pid
 
     pid: "host"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==3.11
 cached-property==1.2.0
-docker-py==1.7.0rc2
+docker-py==1.7.0rc3
 docopt==0.6.1
 enum34==1.0.4
 git+https://github.com/d11wtq/dockerpty.git@29b1394108b017ef3e3deaf00604a9eb99880d5e#egg=dockerpty

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -496,22 +496,6 @@ class CLITestCase(DockerClientTestCase):
         assert 'Service "web" uses an undefined network "foo"' in result.stderr
 
     @v2_only()
-    def test_up_with_bridge_network_plus_default(self):
-        filename = 'bridge.yml'
-
-        self.base_dir = 'tests/fixtures/networks'
-        self._project = get_project(self.base_dir, [filename])
-
-        self.dispatch(['-f', filename, 'up', '-d'], None)
-
-        container = self.project.containers()[0]
-
-        assert sorted(list(container.get('NetworkSettings.Networks'))) == sorted([
-            'bridge',
-            self.project.default_network.full_name,
-        ])
-
-    @v2_only()
     def test_up_with_network_mode(self):
         c = self.client.create_container('busybox', 'top', name='composetest_network_mode_container')
         self.addCleanup(self.client.remove_container, c, force=True)


### PR DESCRIPTION
Incorporates #2757.

Containers connected to the bridge network can't have aliases, so it's simpler to rule that they can *either* be connected to the bridge network (via `network_mode: bridge`) *or* be connected to user-defined networks (via `networks` or the default network).