### PR TITLE
Add optional argument to pull dependencies on docker-compose pull.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -499,10 +499,12 @@ class TopLevelCommand(object):
 
         Options:
             --ignore-pull-failures  Pull what it can and ignores images with pull failures.
+            --include-deps          Pull dependencies.
         """
         self.project.pull(
             service_names=options['SERVICE'],
-            ignore_pull_failures=options.get('--ignore-pull-failures')
+            ignore_pull_failures=options.get('--ignore-pull-failures'),
+            include_deps=options.get('--include-deps'),
         )
 
     def rm(self, options):

--- a/compose/project.py
+++ b/compose/project.py
@@ -428,8 +428,8 @@ class Project(object):
 
         return plans
 
-    def pull(self, service_names=None, ignore_pull_failures=False):
-        for service in self.get_services(service_names, include_deps=False):
+    def pull(self, service_names=None, ignore_pull_failures=False, include_deps=False):
+        for service in self.get_services(service_names, include_deps):
             service.pull(ignore_pull_failures)
 
     def _labeled_containers(self, stopped=False, one_off=OneOffFilter.exclude):

--- a/docs/reference/pull.md
+++ b/docs/reference/pull.md
@@ -16,6 +16,7 @@ Usage: pull [options] [SERVICE...]
 
 Options:
 --ignore-pull-failures  Pull what it can and ignores images with pull failures.
+--include-deps          Pull dependencies.
 ```
 
 Pulls service images.

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -250,6 +250,21 @@ class CLITestCase(DockerClientTestCase):
         assert 'Error: image library/nonexisting-image' in result.stderr
         assert 'not found' in result.stderr
 
+    def test_pull_with_no_deps(self):
+        self.base_dir = 'tests/fixtures/links-composefile'
+        result = self.dispatch(['pull', 'web'])
+        assert sorted(result.stderr.split('\n'))[1:] == [
+            'Pulling web (busybox:latest)...',
+        ]
+
+    def test_pull_with_include_deps(self):
+        self.base_dir = 'tests/fixtures/links-composefile'
+        result = self.dispatch(['pull', '--include-deps', 'web'])
+        assert sorted(result.stderr.split('\n'))[1:] == [
+            'Pulling db (busybox:latest)...',
+            'Pulling web (busybox:latest)...',
+        ]
+
     def test_build_plain(self):
         self.base_dir = 'tests/fixtures/simple-dockerfile'
         self.dispatch(['build', 'simple'])


### PR DESCRIPTION
This adds the `--include-deps` argument to `docker-compose pull` to additionally pull all dependencies/links images for the specified SERVICE.
