### PR TITLE
Stop `extends` from clobbering `depends_on` in the dependant service

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -82,6 +82,7 @@ DOCKER_CONFIG_KEYS = [
 ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'build',
     'container_name',
+    'depends_on',
     'dockerfile',
     'expose',
     'external_links',


### PR DESCRIPTION
Presently (using 1.6.0-rc2), this config:
```yaml
version: 2
services:
  foo:
    image: busybox
    command: echo foo

  bar:
    extends: foo
    command: echo bar
    depends_on:
      - biz

  biz:
    image: busybox
    command: echo biz
```
Results in the following resolved config after loading:
```yaml
networks: {}
services:
  bar:
    command: echo bar
    image: busybox
  biz:
    command: echo biz
    image: busybox
  foo:
    command: echo foo
    image: busybox
version: 2
volumes: {}
```
(It silently drops the `depends_on` set on `bar`.)

The fix I found is simple enough. I do think a test should be added to guard against this, but I'm very unfamiliar with both Python and the testing style used in this project, so I'd appreciate some guidance as to how to proceed to add a test.