### PR TITLE
Falling back to default project name on empty COMPOSE_PROJECT_NAME

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -92,7 +92,7 @@ def get_project_name(working_dir, project_name=None):
         return re.sub(r'[^a-z0-9]', '', name.lower())
 
     project_name = project_name or os.environ.get('COMPOSE_PROJECT_NAME')
-    if project_name is not None:
+    if project_name:
         return normalize_name(project_name)
 
     project = os.path.basename(os.path.abspath(working_dir))

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -49,6 +49,13 @@ class CLITestCase(unittest.TestCase):
             project_name = get_project_name(None)
         self.assertEquals(project_name, name)
 
+    def test_project_name_with_empty_environment_var(self):
+        base_dir = 'tests/fixtures/simple-composefile'
+        with mock.patch.dict(os.environ):
+            os.environ['COMPOSE_PROJECT_NAME'] = ''
+            project_name = get_project_name(base_dir)
+        self.assertEquals('simplecomposefile', project_name)
+
     def test_get_project(self):
         base_dir = 'tests/fixtures/longer-filename-composefile'
         project = get_project(base_dir)


### PR DESCRIPTION
Fixes #2772 

Signed-off-by: Dimitar Bonev <dimitar.bonev@gmail.com>