### PR TITLE
Fix list options when used with extends and multiple files

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -84,10 +84,7 @@ DOCKER_CONFIG_KEYS = [
 ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'build',
     'container_name',
-    'depends_on',
     'dockerfile',
-    'expose',
-    'external_links',
     'logging',
 ]
 
@@ -666,7 +663,14 @@ def merge_service_dicts(base, override, version):
     for field in ['volumes', 'devices']:
         merge_field(field, merge_path_mappings)
 
-    for field in ['ports', 'expose', 'external_links']:
+    for field in [
+        'depends_on',
+        'expose',
+        'external_links',
+        'links',
+        'ports',
+        'volumes_from',
+    ]:
         merge_field(field, operator.add, default=[])
 
     for field in ['dns', 'dns_search', 'env_file']:

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -84,6 +84,7 @@ DOCKER_CONFIG_KEYS = [
 ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'build',
     'container_name',
+    'depends_on',
     'dockerfile',
     'expose',
     'external_links',

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -168,3 +168,22 @@ class VolumeSpec(namedtuple('_VolumeSpec', 'external internal mode')):
     @property
     def is_named_volume(self):
         return self.external and not self.external.startswith(('.', '/', '~'))
+
+
+class ServiceLink(namedtuple('_ServiceLink', 'target alias')):
+
+    @classmethod
+    def parse(cls, link_spec):
+        target, _, alias = link_spec.partition(':')
+        if not alias:
+            alias = target
+        return cls(target, alias)
+
+    def repr(self):
+        if self.target == self.alias:
+            return self.target
+        return '{s.target}:{s.alias}'.format(s=self)
+
+    @property
+    def merge_field(self):
+        return self.alias

--- a/docs/extends.md
+++ b/docs/extends.md
@@ -32,12 +32,9 @@ contains your base configuration. The override file, as its name implies, can
 contain configuration overrides for existing services or entirely new
 services.
 
-If a service is defined in both files, Compose merges the configurations using
-the same rules as the `extends` field (see [Adding and overriding
-configuration](#adding-and-overriding-configuration)), with one exception.  If a
-service contains `links` or `volumes_from` those fields are copied over and
-replace any values in the original service, in the same way single-valued fields
-are copied.
+If a service is defined in both files Compose merges the configurations using
+the rules described in [Adding and overriding
+configuration](#adding-and-overriding-configuration).
 
 To use multiple override files, or an override file with a different name, you
 can use the `-f` option to specify the list of files. Compose merges files in
@@ -176,10 +173,12 @@ is useful if you have several services that reuse a common set of configuration
 options. Using `extends` you can define a common set of service options in one
 place and refer to it from anywhere.
 
-> **Note:** `links` and `volumes_from` are never shared between services using
-> `extends`. See
-> [Adding and overriding configuration](#adding-and-overriding-configuration)
- > for more information.
+> **Note:** `links`, `volumes_from`, and `depends_on` are never shared between
+> services using >`extends`. These exceptions exist to avoid
+> implicit dependencies&mdash;you always define `links` and `volumes_from`
+> locally. This ensures dependencies between services are clearly visible when
+> reading the current file. Defining these locally also ensures changes to the
+> referenced file don't result in breakage.
 
 ### Understand the extends configuration
 
@@ -275,13 +274,7 @@ common configuration:
 
 ## Adding and overriding configuration
 
-Compose copies configurations from the original service over to the local one,
-**except** for `links` and `volumes_from`. These exceptions exist to avoid
-implicit dependencies&mdash;you always define `links` and `volumes_from`
-locally. This ensures dependencies between services are clearly visible when
-reading the current file. Defining these locally also ensures changes to the
-referenced file don't result in breakage.
-
+Compose copies configurations from the original service over to the local one.
 If a configuration option is defined in both the original service the local
 service, the local value *replaces* or *extends* the original value.
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2313,7 +2313,7 @@ class ExtendsTest(unittest.TestCase):
         tmpdir = py.test.ensuretemp('test_extends_with_defined_version')
         self.addCleanup(tmpdir.remove)
         tmpdir.join('docker-compose.yml').write("""
-            version: 2
+            version: "2"
             services:
               base:
                 image: example


### PR DESCRIPTION
From #2771

`depends_on` was being dropped when used with `extends`.

I noticed we were actually treating these list options differently, so this fixes them so they all act the same way.  All list options should be joined together, not replace.

When `merge_service_dicts()` is called to merge `extends` many of these values wont exist (because we validate that they aren't in the base in `validate_extended_service_dict()`. 

When `merge_service_dicts()` is called to merge files these options will now be joined correctly.