### PR TITLE
issue #2794 - environment variable interpolation fails for $RANDOM

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -68,7 +68,7 @@ class BlankDefaultDict(dict):
     def __getitem__(self, key):
         if key == "RANDOM":
             from random import randint
-            rand = (randint(2,9999))
+            rand = (randint(2, 9999))
             return rand
         else:
             try:

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -66,17 +66,22 @@ class BlankDefaultDict(dict):
         self.missing_keys = []
 
     def __getitem__(self, key):
-        try:
-            return super(BlankDefaultDict, self).__getitem__(key)
-        except KeyError:
-            if key not in self.missing_keys:
-                log.warn(
-                    "The {} variable is not set. Defaulting to a blank string."
-                    .format(key)
-                )
-                self.missing_keys.append(key)
+        if key == "RANDOM":
+            from random import randint
+            rand = (randint(2,9999))
+            return rand
+        else:
+            try:
+                return super(BlankDefaultDict, self).__getitem__(key)
+            except KeyError:
+                if key not in self.missing_keys:
+                    log.warn(
+                        "The {} variable is not set. Defaulting to a blank string."
+                        .format(key)
+                    )
+                    self.missing_keys.append(key)
 
-            return ""
+                return ""
 
 
 class InvalidInterpolation(Exception):


### PR DESCRIPTION
Fixes #2794

When using core docker we can instantiate a container interpolating $RANDOM (bash pseudo function) to obtain a runtime random integer value. This does not translate in compose because of python. The interpolation checks the key:values from the os.environ where $RANDOM doesn't persist.

My specific use case is mysql containers where the `server-id` requires a unique integer. Passing this to `command` reduces the amount custom, post-up scripting that needs to be performed. This could also prove useful in other cases.

Docker example:
```
[moore@host test]$ docker run --rm busybox echo $RANDOM
6735
[moore@host test]$ docker run --rm busybox echo $RANDOM
25738
```

Compose example
docker-compose.yml:
```
randomTest:
   image: busybox
   container_name: rand
   command: echo $RANDOM
```
test: (unpatched)
```
$ docker-compose up
WARNING: The RANDOM variable is not set. Defaulting to a blank string.
Recreating rand
Attaching to rand
rand |
rand exited with code 0
```
test: (patched)
```
$ docker-compose up
Recreating rand
Attaching to rand
rand | 1664
rand exited with code 0

$ docker-compose up
Recreating rand
Attaching to rand
rand | 8547
rand exited with code 0
```
