### PR TITLE
Fixing duplicate identifiers for 1.10

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,6 +4,7 @@ title = "Frequently Asked Questions"
 description = "Docker Compose FAQ"
 keywords = "documentation, docs,  docker, compose, faq"
 [menu.main]
+identifier="faq.compose"
 parent="workw_compose"
 weight=90
 +++

--- a/docs/reference/down.md
+++ b/docs/reference/down.md
@@ -4,7 +4,7 @@ title = "down"
 description = "down"
 keywords = ["fig, composition, compose, docker, orchestration, cli,  down"]
 [menu.main]
-identifier="build.compose"
+identifier="down.compose"
 parent = "smn_compose_cli"
 +++
 <![end-metadata]-->


### PR DESCRIPTION
If you don't specify an identifier, the title is used. When we built the `faq.md` was colliding with another in another file.  Also, in the project `build.compose` was twice.

![image](https://cloud.githubusercontent.com/assets/1347209/12762774/baf67b0e-c9a5-11e5-819d-096eef623a6f.png)


Signed-off-by: Mary Anthony <mary@docker.com>