### PR TITLE
Fix example formatting for depends_on.

### DIFF
--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -181,6 +181,8 @@ Express dependency between services, which has two effects:
   dependencies. In the following example, `docker-compose up web` will also
   create and start `db` and `redis`.
 
+Simple example:
+
     version: 2
     services:
       web:


### PR DESCRIPTION
Markdown was acting against expectations here by merging the example indented YAML into the previous list item instead of treating it as a code block.

I decided that a better way of handling this would be to add a "Simple example:" line that is also used elsewhere in this file.  It resets the markdown indentation in a way that works.

Signed-off-by: Spencer Rinehart <anubis@overthemonkey.com>