### PR TITLE
Add support for shm_size.  Fixes #2823.

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -72,6 +72,7 @@ DOCKER_CONFIG_KEYS = [
     'read_only',
     'restart',
     'security_opt',
+    'shm_size',
     'stdin_open',
     'stop_signal',
     'tty',

--- a/compose/config/service_schema_v1.json
+++ b/compose/config/service_schema_v1.json
@@ -98,6 +98,7 @@
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},
         "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
         "stdin_open": {"type": "boolean"},
         "stop_signal": {"type": "string"},
         "tty": {"type": "boolean"},

--- a/compose/config/service_schema_v2.0.json
+++ b/compose/config/service_schema_v2.0.json
@@ -127,6 +127,7 @@
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},
         "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
         "stdin_open": {"type": "boolean"},
         "stop_signal": {"type": "string"},
         "tty": {"type": "boolean"},

--- a/compose/service.py
+++ b/compose/service.py
@@ -57,6 +57,7 @@ DOCKER_START_KEYS = [
     'volumes_from',
     'security_opt',
     'cpu_quota',
+    'shm_size',
 ]
 
 
@@ -654,6 +655,7 @@ class Service(object):
             ipc_mode=options.get('ipc'),
             cgroup_parent=options.get('cgroup_parent'),
             cpu_quota=options.get('cpu_quota'),
+            shm_size=options.get('shm_size'),
         )
 
     def build(self, no_cache=False, pull=False, force_rm=False):

--- a/compose/service.py
+++ b/compose/service.py
@@ -40,6 +40,7 @@ DOCKER_START_KEYS = [
     'cap_add',
     'cap_drop',
     'cgroup_parent',
+    'cpu_quota',
     'devices',
     'dns',
     'dns_search',
@@ -54,10 +55,9 @@ DOCKER_START_KEYS = [
     'pid',
     'privileged',
     'restart',
-    'volumes_from',
     'security_opt',
-    'cpu_quota',
     'shm_size',
+    'volumes_from',
 ]
 
 

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -591,7 +591,7 @@ specifying read-only access(``ro``) or read-write(``rw``).
 >     - container_name
 >     - container_name:rw
 
-### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, privileged, read\_only, restart, stdin\_open, tty, user, working\_dir
+### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
 
 Each of these is a single value, analogous to its
 [docker run](https://docs.docker.com/engine/reference/run/) counterpart.
@@ -615,6 +615,7 @@ Each of these is a single value, analogous to its
     restart: always
 
     read_only: true
+    shm_size: 64M
     stdin_open: true
     tty: true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 PyYAML==3.11
 cached-property==1.2.0
-docker-py==1.7.0
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4
+git+https://github.com/docker/docker-py.git@bba8e28f822c4cd3ebe2a2ca588f41f9d7d66e26#egg=docker-py
 jsonschema==2.5.1
 requests==2.7.0
 six==1.7.3

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -102,6 +102,12 @@ class ServiceTest(DockerClientTestCase):
         container.start()
         self.assertEqual(container.get('HostConfig.CpuQuota'), 40000)
 
+    def test_create_container_with_shm_size(self):
+        service = self.create_service('db', shm_size=67108864)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.ShmSize'), 67108864)
+
     def test_create_container_with_extra_hosts_list(self):
         extra_hosts = ['somehost:162.242.195.82', 'otherhost:50.31.209.229']
         service = self.create_service('db', extra_hosts=extra_hosts)


### PR DESCRIPTION
shm_size controls the size of /dev/shm in the container and requires Docker 1.10 or newer (API version 1.22).  This requires docker-py 1.8.0 (docker/docker-py#923).

Similar to fields like `mem_limit`, `shm_size` may be specified as either an integer or a string (e.g., `64M`).

Updating docker-py to the master branch in order to get the unreleased dependency on `shm_size` there in place.

Signed-off-by: Spencer Rinehart <anubis@overthemonkey.com>