### PR TITLE
Fixed broken links on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Compose is a tool for defining and running multi-container Docker applications.
 With Compose, you use a Compose file to configure your application's services.
 Then, using a single command, you create and start all the services
 from your configuration. To learn more about all the features of Compose
-see [the list of features](docs/index.md#features).
+see [the list of features](https://github.com/docker/compose/blob/release/docs/overview.md#features).
 
 Compose is great for development, testing, and staging environments, as well as
 CI workflows. You can learn more about each case in
-[Common Use Cases](docs/overview.md#common-use-cases).
+[Common Use Cases](https://github.com/docker/compose/blob/release/docs/overview.md#common-use-cases).
 
 Using Compose is basically a three-step process.
 
@@ -34,7 +34,7 @@ A `docker-compose.yml` looks like this:
       image: redis
 
 For more information about the Compose file, see the
-[Compose file reference](docs/compose-file.md)
+[Compose file reference](https://github.com/docker/compose/blob/release/docs/compose-file.md)
 
 Compose has commands for managing the whole lifecycle of your application:
 


### PR DESCRIPTION
The downside of this is, that `master`'s readme links to files in `release`.