### PR TITLE
Use 12 characters for the short id

### DIFF
--- a/compose/container.py
+++ b/compose/container.py
@@ -60,7 +60,7 @@ class Container(object):
 
     @property
     def short_id(self):
-        return self.id[:10]
+        return self.id[:12]
 
     @property
     def name(self):

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -12,8 +12,9 @@ from compose.container import get_container_name
 class ContainerTest(unittest.TestCase):
 
     def setUp(self):
+        self.container_id = "abcabcabcbabc12345"
         self.container_dict = {
-            "Id": "abc",
+            "Id": self.container_id,
             "Image": "busybox:latest",
             "Command": "top",
             "Created": 1387384730,
@@ -41,19 +42,22 @@ class ContainerTest(unittest.TestCase):
         self.assertEqual(
             container.dictionary,
             {
-                "Id": "abc",
+                "Id": self.container_id,
                 "Image": "busybox:latest",
                 "Name": "/composetest_db_1",
             })
 
     def test_from_ps_prefixed(self):
-        self.container_dict['Names'] = ['/swarm-host-1' + n for n in self.container_dict['Names']]
+        self.container_dict['Names'] = [
+            '/swarm-host-1' + n for n in self.container_dict['Names']
+        ]
 
-        container = Container.from_ps(None,
-                                      self.container_dict,
-                                      has_been_inspected=True)
+        container = Container.from_ps(
+            None,
+            self.container_dict,
+            has_been_inspected=True)
         self.assertEqual(container.dictionary, {
-            "Id": "abc",
+            "Id": self.container_id,
             "Image": "busybox:latest",
             "Name": "/composetest_db_1",
         })
@@ -141,6 +145,10 @@ class ContainerTest(unittest.TestCase):
         self.assertEqual(container.get('Status'), "Up 8 seconds")
         self.assertEqual(container.get('HostConfig.VolumesFrom'), ["volume_id"])
         self.assertEqual(container.get('Foo.Bar.DoesNotExist'), None)
+
+    def test_short_id(self):
+        container = Container(None, self.container_dict, has_been_inspected=True)
+        assert container.short_id == self.container_id[:12]
 
 
 class GetContainerNameTestCase(unittest.TestCase):


### PR DESCRIPTION
Fixes #2845

Ref: https://github.com/docker/docker/blob/master/pkg/stringid/stringid.go

Looks like we've used 10 characters for short_id since the tool was named plum, but docker uses 12 characters.