### PR TITLE
Only set a container affinity if there are volumes to copy over

### DIFF
--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -267,13 +267,52 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(
             opts['labels'][LABEL_CONFIG_HASH],
             'f8bfa1058ad1f4231372a0b1639f0dfdb574dafff4e8d7938049ae993f7cf1fc')
-        self.assertEqual(
-            opts['environment'],
-            {
-                'affinity:container': '=ababab',
-                'also': 'real',
-            }
+        assert opts['environment'] == {'also': 'real'}
+
+    def test_get_container_create_options_sets_affinity_with_binds(self):
+        service = Service(
+            'foo',
+            image='foo',
+            client=self.mock_client,
         )
+        self.mock_client.inspect_image.return_value = {'Id': 'abcd'}
+        prev_container = mock.Mock(
+            id='ababab',
+            image_config={'ContainerConfig': {'Volumes': ['/data']}})
+
+        def container_get(key):
+            return {
+                'Mounts': [
+                    {
+                        'Destination': '/data',
+                        'Source': '/some/path',
+                        'Name': 'abab1234',
+                    },
+                ]
+            }.get(key, None)
+
+        prev_container.get.side_effect = container_get
+
+        opts = service._get_container_create_options(
+            {},
+            1,
+            previous_container=prev_container)
+
+        assert opts['environment'] == {'affinity:container': '=ababab'}
+
+    def test_get_container_create_options_no_affinity_without_binds(self):
+        service = Service('foo', image='foo', client=self.mock_client)
+        self.mock_client.inspect_image.return_value = {'Id': 'abcd'}
+        prev_container = mock.Mock(
+            id='ababab',
+            image_config={'ContainerConfig': {}})
+        prev_container.get.return_value = None
+
+        opts = service._get_container_create_options(
+            {},
+            1,
+            previous_container=prev_container)
+        assert opts['environment'] == {}
 
     def test_get_container_not_found(self):
         self.mock_client.containers.return_value = []
@@ -650,6 +689,7 @@ class ServiceVolumesTest(unittest.TestCase):
             '/host/volume:/host/volume:ro',
             '/new/volume',
             '/existing/volume',
+            'named:/named/vol',
         ]]
 
         self.mock_client.inspect_image.return_value = {
@@ -710,7 +750,8 @@ class ServiceVolumesTest(unittest.TestCase):
             'ContainerConfig': {'Volumes': {}}
         }
 
-        intermediate_container = Container(self.mock_client, {
+        previous_container = Container(self.mock_client, {
+            'Id': 'cdefab',
             'Image': 'ababab',
             'Mounts': [{
                 'Source': '/var/lib/docker/aaaaaaaa',
@@ -727,8 +768,9 @@ class ServiceVolumesTest(unittest.TestCase):
             'existingvolume:/existing/volume:rw',
         ]
 
-        binds = merge_volume_bindings(options, intermediate_container)
+        binds, affinity = merge_volume_bindings(options, previous_container)
         assert sorted(binds) == sorted(expected)
+        assert affinity == {'affinity:container': '=cdefab'}
 
     def test_mount_same_host_path_to_two_volumes(self):
         service = Service(


### PR DESCRIPTION
Partially fixes #2866

Instead of always setting a container affinity, only set one if there are volumes to copy over from a previous container.