### PR TITLE
Fix signal handling with pyinstaller binary

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,1 +1,3 @@
-pyinstaller==3.1.1
+#pyinstaller==3.1.1
+# pyinstaller 3.1.1 with fix for signals
+git+https://github.com/dnephin/pyinstaller.git@9e8cad86e6f19f16ad9aec4e16bc5c57454cb072#egg=pyinstaller


### PR DESCRIPTION
Fixes #2904

If you have an OSX box, it would be good to test this out.  It seems to have completely fixed the issue on linux.

Upstream PR is https://github.com/pyinstaller/pyinstaller/pull/1822