### PR TITLE
A few fixes to the container-based install, which is broken on:

### DIFF
--- a/script/run.sh
+++ b/script/run.sh
@@ -53,4 +53,4 @@ if [ -t 0 ]; then
     DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
 fi
 
-exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE $@
+exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE "$@"

--- a/script/run.sh
+++ b/script/run.sh
@@ -31,7 +31,9 @@ fi
 
 
 # Setup volume mounts for compose config and context
-VOLUMES="-v $(pwd):$(pwd)"
+if [ "$(pwd)" != '/' ]; then
+    VOLUMES="-v $(pwd):$(pwd)"
+fi
 if [ -n "$COMPOSE_FILE" ]; then
     compose_dir=$(dirname $COMPOSE_FILE)
 fi
@@ -50,4 +52,4 @@ else
     DOCKER_RUN_OPTIONS="-i"
 fi
 
-exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w $(pwd) $IMAGE $@
+exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE $@

--- a/script/run.sh
+++ b/script/run.sh
@@ -47,9 +47,10 @@ fi
 
 # Only allocate tty if we detect one
 if [ -t 1 ]; then
-    DOCKER_RUN_OPTIONS="-ti"
-else
-    DOCKER_RUN_OPTIONS="-i"
+    DOCKER_RUN_OPTIONS="-t"
+fi
+if [ -t 0 ]; then
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
 fi
 
 exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE $@


### PR DESCRIPTION
* when pwd is /
* when stdin is not tty
* when invoking `run sh -c 'echo foo'`