### PR TITLE
reset colors after warning

### DIFF
--- a/contrib/migration/migrate-compose-file-v1-to-v2.py
+++ b/contrib/migration/migrate-compose-file-v1-to-v2.py
@@ -155,7 +155,7 @@ def parse_opts(args):
 
 
 def main(args):
-    logging.basicConfig(format='\033[33m%(levelname)s:\033[37m %(message)s\n')
+    logging.basicConfig(format='\033[33m%(levelname)s:\033[37m %(message)s\033[0m\n')
 
     opts = parse_opts(args)
 


### PR DESCRIPTION
If a warning is shown, and you happen to have no color setting in your (bash) prompt, the \033[37m setting stays active. With the message being hardly readable (light grey on my default light yellow background), that means the prompt is barely visible and you need to do `tput reset`.

(Would probably be better if the background color was set as well in case you have dark on light theme by default in your terminal.)

Signed-off-by: Anthon van der Neut anthon@mnt.org