### PR TITLE
Constraint build argument types. Numbers are cast into strings.

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -293,8 +293,12 @@ def load(config_details):
     config_details = config_details._replace(config_files=processed_files)
 
     main_file = config_details.config_files[0]
-    volumes = load_volumes(config_details.config_files)
-    networks = load_mapping(config_details.config_files, 'get_networks', 'Network')
+    volumes = load_mapping(
+        config_details.config_files, 'get_volumes', 'Volume'
+    )
+    networks = load_mapping(
+        config_details.config_files, 'get_networks', 'Network'
+    )
     service_dicts = load_services(
         config_details.working_dir,
         main_file,
@@ -334,15 +338,12 @@ def load_mapping(config_files, get_func, entity_type):
 
             mapping[name] = config
 
+            if 'driver_opts' in config:
+                config['driver_opts'] = build_string_dict(
+                    config['driver_opts']
+                )
+
     return mapping
-
-
-def load_volumes(config_files):
-    volumes = load_mapping(config_files, 'get_volumes', 'Volume')
-    for volume_name, volume in volumes.items():
-        if 'driver_opts' in volume:
-            volume['driver_opts'] = build_string_dict(volume['driver_opts'])
-    return volumes
 
 
 def load_services(working_dir, config_file, service_configs):

--- a/compose/config/fields_schema_v2.0.json
+++ b/compose/config/fields_schema_v2.0.json
@@ -78,7 +78,7 @@
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {"type": "string"}
+            "^.+$": {"type": ["string", "number"]}
           }
         },
         "external": {

--- a/compose/config/service_schema_v2.0.json
+++ b/compose/config/service_schema_v2.0.json
@@ -23,7 +23,20 @@
               "properties": {
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
-                "args": {"$ref": "#/definitions/list_or_dict"}
+                "args": {
+                  "oneOf": [
+                    {"$ref": "#/definitions/list_of_strings"},
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        "^.+$": {
+                          "type": ["string", "number"]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                }
               },
               "additionalProperties": false
             }

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -95,4 +95,4 @@ def microseconds_from_time_nano(time_nano):
 
 
 def build_string_dict(source_dict):
-    return dict([(k, str(v)) for k, v in source_dict.items()])
+    return dict((k, str(v)) for k, v in source_dict.items())

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -92,3 +92,7 @@ def json_hash(obj):
 
 def microseconds_from_time_nano(time_nano):
     return int(time_nano % 1000000000 / 1000)
+
+
+def build_string_dict(source_dict):
+    return dict([(k, str(v)) for k, v in source_dict.items()])


### PR DESCRIPTION
Numerical `driver_opts` are also valid and typecast into strings.

FIxes #2927 