### PR TITLE
for 1.6.0 the version value needs to be a string

### DIFF
--- a/contrib/migration/migrate-compose-file-v1-to-v2.py
+++ b/contrib/migration/migrate-compose-file-v1-to-v2.py
@@ -33,7 +33,7 @@ def migrate(content):
 
     services = {name: data.pop(name) for name in data.keys()}
 
-    data['version'] = 2
+    data['version'] = "2"
     data['services'] = services
     create_volumes_section(data)
 


### PR DESCRIPTION
After conversion a file would immediately not load in docker-compose 1.6.0 with the message:

  ERROR: Version in "./converted.yml" is invalid - it should be a string.

Signed-off-by: Anthon van der Neut anthon@mnt.org