### PR TITLE
Enable interpolation of keys in compose file

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -14,27 +14,11 @@ log = logging.getLogger(__name__)
 def interpolate_environment_variables(config, section):
     mapping = BlankDefaultDict(os.environ)
 
-    def process_item(name, config_dict):
-        return dict(
-            (key, interpolate_value(name, key, val, section, mapping))
-            for key, val in (config_dict or {}).items()
-        )
-
-    return dict(
-        (name, process_item(name, config_dict))
-        for name, config_dict in config.items()
-    )
-
-
-def interpolate_value(name, config_key, value, section, mapping):
     try:
-        return recursive_interpolate(value, mapping)
+        return recursive_interpolate(config, mapping)
     except InvalidInterpolation as e:
         raise ConfigurationError(
-            'Invalid interpolation format for "{config_key}" option '
-            'in {section} "{name}": "{string}"'.format(
-                config_key=config_key,
-                name=name,
+            'Invalid interpolation format for "{string}" in {section}'.format(
                 section=section,
                 string=e.string))
 
@@ -44,7 +28,7 @@ def recursive_interpolate(obj, mapping):
         return interpolate(obj, mapping)
     elif isinstance(obj, dict):
         return dict(
-            (key, recursive_interpolate(val, mapping))
+            (interpolate(key, mapping), recursive_interpolate(val, mapping))
             for (key, val) in obj.items()
         )
     elif isinstance(obj, list):

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -18,7 +18,7 @@ def interpolate_environment_variables(config, section):
         return recursive_interpolate(config, mapping)
     except InvalidInterpolation as e:
         raise ConfigurationError(
-            'Invalid interpolation format for "{string}" in {section}'.format(
+            'Invalid interpolation format ("{string}") in "{section}"'.format(
                 section=section,
                 string=e.string))
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1465,10 +1465,8 @@ class InterpolationTest(unittest.TestCase):
                 )
             )
 
-        self.assertIn('Invalid', cm.exception.msg)
-        self.assertIn('for "image" option', cm.exception.msg)
-        self.assertIn('in service "web"', cm.exception.msg)
-        self.assertIn('"${"', cm.exception.msg)
+        self.assertIn('Invalid interpolation format ("${") in "service"',
+                      cm.exception.msg)
 
     def test_empty_environment_key_allowed(self):
         service_dict = config.load(

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -67,3 +67,25 @@ def test_interpolate_environment_variables_in_volumes(mock_env):
         'other': {},
     }
     assert interpolate_environment_variables(volumes, 'volume') == expected
+
+
+def test_interpolate_environment_variables_in_keys(mock_env):
+    volumes = {
+        'data': {
+            '$FOO': 'foo',
+            'driver_opts': {
+                'max': 2,
+                '${USER}_baz': 'bar'
+            }
+        }
+    }
+    expected = {
+        'data': {
+            'bar': 'foo',
+            'driver_opts': {
+                'max': 2,
+                'jenny_baz': 'bar'
+            }
+        }
+    }
+    assert interpolate_environment_variables(volumes, 'volume') == expected


### PR DESCRIPTION
This adds interpolation of all keys in the compose file except the
sections themselves. I have a need for doing that when, for example,
creating overlay networks based on some unique name:

```
networks:
  ${NAMESPACE}_overlay:
     driver: overlay

services:
  my_service:
    networks:
      - "${NAMESPACE}_overlay"
```

The reason for the slight code restructuring was to avoid code
duplication when implementing this. I do welcome feedback.