### PR TITLE
Replace PyYAML with ruamel.yaml

### DIFF
--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -8,6 +8,7 @@ import ssl
 import subprocess
 
 import docker
+import ruamel.yaml
 from six.moves import input
 
 import compose
@@ -68,13 +69,15 @@ def get_version_info(scope):
             "{}\n"
             "docker-py version: {}\n"
             "{} version: {}\n"
-            "OpenSSL version: {}"
+            "OpenSSL version: {}\n"
+            "ruamel.yaml version: {}"
         ).format(
             versioninfo,
             docker.version,
             platform.python_implementation(),
             platform.python_version(),
-            ssl.OPENSSL_VERSION)
+            ssl.OPENSSL_VERSION,
+            ruamel.yaml.__version__)
 
     raise ValueError("{} is not a valid version scope".format(scope))
 

--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import ruamel.yaml
 import six
-import yaml
 
 from compose.config import types
 
@@ -12,8 +12,8 @@ def serialize_config_type(dumper, data):
     return representer(data.repr())
 
 
-yaml.SafeDumper.add_representer(types.VolumeFromSpec, serialize_config_type)
-yaml.SafeDumper.add_representer(types.VolumeSpec, serialize_config_type)
+ruamel.yaml.SafeDumper.add_representer(types.VolumeFromSpec, serialize_config_type)
+ruamel.yaml.SafeDumper.add_representer(types.VolumeSpec, serialize_config_type)
 
 
 def serialize_config(config):
@@ -23,7 +23,7 @@ def serialize_config(config):
         'networks': config.networks,
         'volumes': config.volumes,
     }
-    return yaml.safe_dump(
+    return ruamel.yaml.safe_dump(
         output,
         default_flow_style=False,
         indent=2,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def find_version(*file_paths):
 install_requires = [
     'cached-property >= 1.2.0, < 2',
     'docopt >= 0.6.1, < 0.7',
-    'PyYAML >= 3.10, < 4',
+    'ruamel.yaml >= 0.11, < 1',
     'requests >= 2.6.1, < 2.8',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -11,7 +11,7 @@ import time
 from collections import namedtuple
 from operator import attrgetter
 
-import yaml
+import ruamel.yaml
 from docker import errors
 
 from .. import mock
@@ -175,7 +175,7 @@ class CLITestCase(DockerClientTestCase):
         # assert there are no python objects encoded in the output
         assert '!!' not in result.stdout
 
-        output = yaml.load(result.stdout)
+        output = ruamel.yaml.load(result.stdout)
         expected = {
             'version': '2.0',
             'volumes': {'data': {'driver': 'local'}},
@@ -473,10 +473,12 @@ class CLITestCase(DockerClientTestCase):
             assert '{}:database'.format(db_container.name) in links
 
         # db and app joined the back network
-        assert sorted(back_network['Containers']) == sorted([db_container.id, app_container.id])
+        assert sorted(back_network['Containers']) == sorted([db_container.id,
+                                                             app_container.id])
 
         # web and app joined the front network
-        assert sorted(front_network['Containers']) == sorted([web_container.id, app_container.id])
+        assert sorted(front_network['Containers']) == sorted([web_container.id,
+                                                              app_container.id])
 
         # web can see app but not db
         assert self.lookup(web_container, "app")
@@ -500,7 +502,8 @@ class CLITestCase(DockerClientTestCase):
 
     @v2_only()
     def test_up_with_network_mode(self):
-        c = self.client.create_container('busybox', 'top', name='composetest_network_mode_container')
+        c = self.client.create_container('busybox', 'top',
+                                         name='composetest_network_mode_container')
         self.addCleanup(self.client.remove_container, c, force=True)
         self.client.start(c)
         container_mode_source = 'container:{}'.format(c['Id'])
@@ -896,7 +899,8 @@ class CLITestCase(DockerClientTestCase):
     def test_run_service_with_explicitly_maped_ip_ports(self):
         # create one off container
         self.base_dir = 'tests/fixtures/ports-composefile'
-        self.dispatch(['run', '-d', '-p', '127.0.0.1:30000:3000', '--publish', '127.0.0.1:30001:3001', 'simple'], None)
+        self.dispatch(['run', '-d', '-p', '127.0.0.1:30000:3000', '--publish',
+                       '127.0.0.1:30001:3001', 'simple'], None)
         container = self.project.get_service('simple').containers(one_off=True)[0]
 
         # get port information
@@ -1211,7 +1215,8 @@ class CLITestCase(DockerClientTestCase):
             if index is None:
                 result = self.dispatch(['port', 'simple', str(number)])
             else:
-                result = self.dispatch(['port', '--index=' + str(index), 'simple', str(number)])
+                result = self.dispatch(['port', '--index=' + str(index),
+                                        'simple', str(number)])
             return result.stdout.rstrip()
 
         self.assertEqual(get_port(3000), containers[0].get_local_port(3000))


### PR DESCRIPTION
PyYAML supports YAML 1.1 which has features that require users
to quote some input. Main problem are sexagesimals, so that
"- 25:25" is interpreted as "- 1525". In ruamel.yaml this is
intpreted as if it was written "- '25:25'".
In addition the above, Yes/No/On/Off are no longer interpreted
as booleans, and scalars starting with a 0 and consisting of
numbers no longer as octals, but normal integers (use 0o12 if you
need octals).

The YAML 1.2 is implemented in ruamel.yaml for the RoundTripLoader.
In order to preserver safe loader, the VersionedResolver is combined
with the SafeConstructor in SafeLoader_1_2, which is used explicitly
to load YAML files.
A simple test is provided to confirm that sexagesimals no longer
break user input.

(Several lines that I never touched needed to be wrapped to let the
pre-commit hooks pass the flake8 test).

Signed-off-by: Anthon van der Neut a.van.der.neut@ruamel.eu
