### PR TITLE
Fix validation message when there are multiple nested oneOf validations.

### DIFF
--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -312,6 +312,10 @@ def _parse_oneof_validator(error):
     types = []
     for context in error.context:
 
+        if context.validator == 'oneOf':
+            _, error_msg = _parse_oneof_validator(context)
+            return path_string(context.path), error_msg
+
         if context.validator == 'required':
             return (None, context.message)
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -371,6 +371,27 @@ class ConfigTest(unittest.TestCase):
         error_msg = "service 'web' doesn't have any configuration options"
         assert error_msg in exc.exconly()
 
+    def test_load_with_empty_build_args(self):
+        config_details = build_config_details(
+            {
+                'version': '2',
+                'services': {
+                    'web': {
+                        'build': {
+                            'context': '.',
+                            'args': None,
+                        },
+                    },
+                },
+            }
+        )
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(config_details)
+        assert (
+            "services.web.build.args contains an invalid type, it should be an "
+            "array, or an object" in exc.exconly()
+        )
+
     def test_config_integer_service_name_raise_validation_error(self):
         with pytest.raises(ConfigurationError) as excinfo:
             config.load(


### PR DESCRIPTION
Fixes #2969

Nested oneOf validations were failing, this adds the recursive call to get the correct error message.