### PR TITLE
Add -w or --workdir to compose run to override workdir from commandline

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -472,6 +472,7 @@ class TopLevelCommand(DocoptCommand):
                                   to the host.
             -T                    Disable pseudo-tty allocation. By default `docker-compose run`
                                   allocates a TTY.
+            -w, --workdir=""      Working directory inside the container
         """
         service = project.get_service(options['SERVICE'])
         detach = options['-d']
@@ -520,6 +521,9 @@ class TopLevelCommand(DocoptCommand):
 
         if options['--name']:
             container_options['name'] = options['--name']
+
+        if options['--workdir']:
+            container_options['working_dir'] = options['--workdir']
 
         run_one_off_container(container_options, project, service, options)
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -26,6 +26,7 @@ Options:
 -p, --publish=[]      Publish a container's port(s) to the host
 --service-ports       Run command with the service's ports enabled and mapped to the host.
 -T                    Disable pseudo-tty allocation. By default `docker-compose run` allocates a TTY.
+-w, --workdir=""      Working directory inside the container
 ```
 
 Runs a one-time command against a service. For example, the following command starts the `web` service and runs `bash` as its command.

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -969,6 +969,24 @@ class CLITestCase(DockerClientTestCase):
         container, = service.containers(stopped=True, one_off=True)
         self.assertEqual(container.name, name)
 
+    def test_run_service_with_workdir_overridden(self):
+        self.base_dir = 'tests/fixtures/run-workdir'
+        name = 'service'
+        workdir = '/var'
+        self.dispatch(['run', '--workdir={workdir}'.format(workdir=workdir), name])
+        service = self.project.get_service(name)
+        container = service.containers(stopped=True, one_off=True)[0]
+        self.assertEqual(workdir, container.get('Config.WorkingDir'))
+
+    def test_run_service_with_workdir_overridden_short_form(self):
+        self.base_dir = 'tests/fixtures/run-workdir'
+        name = 'service'
+        workdir = '/var'
+        self.dispatch(['run', '-w', workdir, name])
+        service = self.project.get_service(name)
+        container = service.containers(stopped=True, one_off=True)[0]
+        self.assertEqual(workdir, container.get('Config.WorkingDir'))
+
     @v2_only()
     def test_run_interactive_connects_to_network(self):
         self.base_dir = 'tests/fixtures/networks'

--- a/tests/fixtures/run-workdir/docker-compose.yml
+++ b/tests/fixtures/run-workdir/docker-compose.yml
@@ -1,0 +1,4 @@
+service:
+  image: busybox:latest
+  working_dir: /etc
+  command: /bin/true

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -105,6 +105,7 @@ class CLITestCase(unittest.TestCase):
                 '--publish': [],
                 '--rm': None,
                 '--name': None,
+                '--workdir': None,
             })
 
         _, _, call_kwargs = mock_run_operation.mock_calls[0]
@@ -135,6 +136,7 @@ class CLITestCase(unittest.TestCase):
             '--publish': [],
             '--rm': None,
             '--name': None,
+            '--workdir': None,
         })
 
         _, _, call_kwargs = mock_client.create_container.mock_calls[0]
@@ -164,6 +166,7 @@ class CLITestCase(unittest.TestCase):
             '--publish': [],
             '--rm': None,
             '--name': None,
+            '--workdir': None,
         })
 
         self.assertEquals(
@@ -192,6 +195,7 @@ class CLITestCase(unittest.TestCase):
             '--publish': [],
             '--rm': True,
             '--name': None,
+            '--workdir': None,
         })
 
         self.assertFalse(


### PR DESCRIPTION
This adds the possibility to override the workdir from the command line, using either `-w` or `--workdir` just like `docker run`.
In essence it does the same as #332, though that code couldn't really be rebased so I wrote my own. Do we want to attribute anything of this to @scottynomad?

Also not really sure about the acceptance tests, there seem to be multiple different ways of doing them within `tests/acceptance/cli_test.py`. I basically mirrored the `-u` / `--user` tests.

Relevant for #363 
Fixes #2811