### PR TITLE
Fix warning about boolean values

### DIFF
--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -64,16 +64,16 @@ def format_expose(instance):
 
 @FormatChecker.cls_checks(format="bool-value-in-mapping")
 def format_boolean_in_environment(instance):
-    """
-    Check if there is a boolean in the environment and display a warning.
+    """Check if there is a boolean in the mapping sections and display a warning.
     Always return True here so the validation won't raise an error.
     """
     if isinstance(instance, bool):
         log.warn(
-            "There is a boolean value in the 'environment' key.\n"
-            "Environment variables can only be strings.\n"
-            "Please add quotes to any boolean values to make them string "
-            "(eg, 'True', 'yes', 'N').\n"
+            "There is a boolean value in the 'environment', 'labels', or "
+            "'extra_hosts' field of a service.\n"
+            "These sections only support string values.\n"
+            "Please add quotes to any boolean values to make them strings "
+            "(eg, 'True', 'false', 'yes', 'N', 'on', 'Off').\n"
             "This warning will become an error in a future release. \r\n"
         )
     return True

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1100,7 +1100,7 @@ class ConfigTest(unittest.TestCase):
 
     @mock.patch('compose.config.validation.log')
     def test_logs_warning_for_boolean_in_environment(self, mock_logging):
-        expected_warning_msg = "There is a boolean value in the 'environment' key."
+        expected_warning_msg = "There is a boolean value in the 'environment'"
         config.load(
             build_config_details(
                 {'web': {


### PR DESCRIPTION
The warning was only covering the "environment" section, but we use the definition in other sections as well. See #2987

We can fix this better in #2993