### PR TITLE
Corrected broken swarm documentation link

### DIFF
--- a/SWARM.md
+++ b/SWARM.md
@@ -1,1 +1,1 @@
-This file has moved to: https://docs.docker.com/compose/swarm/
+This file has moved to: https://github.com/docker/compose/blob/master/docs/swarm.md


### PR DESCRIPTION
Fixes #3004 - This is important because this page is the 3rd Google result for "docker compose swarm"