### PR TITLE
introduce a config option to not auto-up services

### DIFF
--- a/compose/config/config_schema_v1.json
+++ b/compose/config/config_schema_v1.json
@@ -18,6 +18,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "build": {"type": "string"},
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -50,6 +50,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "build": {
           "oneOf": [
             {"type": "string"},

--- a/compose/project.py
+++ b/compose/project.py
@@ -145,7 +145,7 @@ class Project(object):
             if name not in valid_names:
                 raise NoSuchService(name)
 
-    def get_services(self, service_names=None, include_deps=False):
+    def get_services(self, service_names=None, include_deps=False, auto_up_only=False):
         """
         Returns a list of this project's services filtered
         by the provided list of names, or all services if service_names is None
@@ -161,9 +161,15 @@ class Project(object):
         """
         if service_names is None or len(service_names) == 0:
             service_names = self.service_names
+        else:
+            auto_up_only = False
 
         unsorted = [self.get_service(name) for name in service_names]
-        services = [s for s in self.services if s in unsorted]
+        services = [
+            s
+            for s in self.services
+            if s in unsorted and (not auto_up_only or s.options.get('auto_up', True))
+        ]
 
         if include_deps:
             services = reduce(self._inject_deps, services, [])
@@ -173,8 +179,8 @@ class Project(object):
 
         return uniques
 
-    def get_services_without_duplicate(self, service_names=None, include_deps=False):
-        services = self.get_services(service_names, include_deps)
+    def get_services_without_duplicate(self, service_names=None, include_deps=False, auto_up_only=False):
+        services = self.get_services(service_names, include_deps, auto_up_only)
         for service in services:
             service.remove_duplicate_containers()
         return services
@@ -307,7 +313,11 @@ class Project(object):
         strategy=ConvergenceStrategy.changed,
         do_build=BuildAction.none,
     ):
-        services = self.get_services_without_duplicate(service_names, include_deps=True)
+        services = self.get_services_without_duplicate(
+            service_names,
+            include_deps=True,
+            auto_up_only=True
+        )
 
         for svc in services:
             svc.ensure_image_exists(do_build=do_build)
@@ -376,7 +386,8 @@ class Project(object):
 
         services = self.get_services_without_duplicate(
             service_names,
-            include_deps=start_deps)
+            include_deps=start_deps,
+            auto_up_only=True)
 
         for svc in services:
             svc.ensure_image_exists(do_build=do_build)

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -43,6 +43,15 @@ full details.
 This section contains a list of all configuration options supported by a service
 definition.
 
+### auto_up
+
+Specify whether a service should be started by `docker-compose up` by default.
+
+When set to `false` the service is only started when pulled in as a dependency by
+another service or explicitly given on the command line. Otherwise the service is
+also started when simply executing `docker-compose up`.
+When not given this option defaults to `true`.
+
 ### build
 
 Configuration options that are applied at build time.


### PR DESCRIPTION
This is a PoC implementation of solution 2) from #1896:
It adds the config option `auto_up` as boolean to mark a service to not start by default when calling `docker-compose up` but instead only when given explicitly or pulled in as a dependency of another service.

The option is `True` by default so behavior when omitting it is the same as before. When `auto_up: false` is given it should only affect `docker-compose up` and `docker-compose create` (though I'm not 100% sure about any other side effects of this change).

Further discussion should take place at #1896.

Still TODO: update docs, tests and comments for the changed functions!
