### PR TITLE
Build OSX binary on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ deploy:
   key: '$BINTRAY_API_KEY'
   file: ./bintray.json
   skip_cleanup: true
+  on:
+    all_branches: true

--- a/project/RELEASE-PROCESS.md
+++ b/project/RELEASE-PROCESS.md
@@ -55,10 +55,10 @@ Check out the bump branch and run the `build-binaries` script
 
 When prompted build the non-linux binaries and test them.
 
-1.  Build the Mac binary in a Mountain Lion VM:
+1.  Download the osx binary from Bintray. Make sure that the latest build has
+    finished, otherwise you'll be downloading an old binary.
 
-        script/setup/osx
-        script/build/osx
+    https://dl.bintray.com/docker-compose/$BRANCH_NAME/
 
 2.  Download the windows binary from AppVeyor
 

--- a/script/release/build-binaries
+++ b/script/release/build-binaries
@@ -23,11 +23,6 @@ REPO=docker/compose
 # Build the binaries
 script/clean
 script/build/linux
-# TODO: build osx binary
-# script/setup/osx
-# script/build/osx
-# TODO: build or fetch the windows binary
-echo "You need to build the osx/windows binaries, that step is not automated yet."
 
 echo "Building the container distribution"
 script/build/image $VERSION
@@ -35,3 +30,8 @@ script/build/image $VERSION
 echo "Create a github release"
 # TODO: script more of this https://developer.github.com/v3/repos/releases/
 browser https://github.com/$REPO/releases/new
+
+echo "Don't forget to download the osx and windows binaries from appveyor/bintray\!"
+echo "https://dl.bintray.com/docker-compose/$BRANCH/"
+echo "https://ci.appveyor.com/project/docker/compose"
+echo

--- a/script/release/make-branch
+++ b/script/release/make-branch
@@ -82,20 +82,6 @@ $SHELL || true
 git commit -a -m "Bump $VERSION" --signoff --no-verify
 
 
-echo "Push branch to user remote"
-GITHUB_USER=$USER
-USER_REMOTE="$(find_remote $GITHUB_USER/compose)"
-if [ -z "$USER_REMOTE" ]; then
-    echo "$GITHUB_USER/compose not found"
-    read -r -p "Enter the name of your GitHub fork (username/repo): " GITHUB_REPO
-    # assumes there is already a user remote somewhere
-    USER_REMOTE=$(find_remote $GITHUB_REPO)
-fi
-if [ -z "$USER_REMOTE" ]; then
-    >&2 echo "No user remote found. You need to 'git push' your branch."
-    exit 2
-fi
-
-
-git push $USER_REMOTE
-browser https://github.com/$REPO/compare/docker:release...$GITHUB_USER:$BRANCH?expand=1
+echo "Push branch to docker remote"
+git push $REMOTE
+browser https://github.com/$REPO/compare/docker:release...$BRANCH?expand=1

--- a/script/travis/bintray.json.tmpl
+++ b/script/travis/bintray.json.tmpl
@@ -1,7 +1,7 @@
 {
     "package": {
         "name": "${TRAVIS_OS_NAME}",
-        "repo": "master",
+        "repo": "${TRAVIS_BRANCH}",
         "subject": "docker-compose",
         "desc": "Automated build of master branch from travis ci.",
         "website_url": "https://github.com/docker/compose",
@@ -11,8 +11,8 @@
     },
 
     "version": {
-        "name": "master",
-        "desc": "Automated build of the master branch.",
+        "name": "${TRAVIS_BRANCH}",
+        "desc": "Automated build of the ${TRAVIS_BRANCH} branch.",
         "released": "${DATE}",
         "vcs_tag": "master"
     },


### PR DESCRIPTION
Fixes #271

This requires a change to the make-branch script, to have it push the bump branch
to the docker remote instead of the user remote. Pushing to the docker remote
triggers the travis build, which builds the binary.
