### PR TITLE
Fix signal handling with pyinstaller.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -54,7 +54,7 @@ def main():
     try:
         command = TopLevelCommand()
         command.sys_dispatch()
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, signals.ShutdownException):
         log.error("Aborting.")
         sys.exit(1)
     except (UserError, NoSuchService, ConfigurationError) as e:

--- a/compose/cli/multiplexer.py
+++ b/compose/cli/multiplexer.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from queue import Queue, Empty  # Python 3.x
 
+from compose.cli.signals import ShutdownException
 
 STOP = object()
 
@@ -47,7 +48,7 @@ class Multiplexer(object):
                 pass
             # See https://github.com/docker/compose/issues/189
             except thread.error:
-                raise KeyboardInterrupt()
+                raise ShutdownException()
 
     def _init_readers(self):
         for iterator in self.iterators:


### PR DESCRIPTION
Fixes #2904

In #2055 I added this `KeyboardInterrupt` to handle the pyinstaller issue of raising `thread.error` for some unknown reasons (probably a bug in pyinstaller). At the time this seemed to work, but after changing the signal handler logic to use exceptions, raising `KeyboardInterrupt` was no longer correct.

By instead raising  `ShutdownException` we drop into the correct try/except block when this bug occurs.

I've also adding a similar `try/except` for `thread.error` in the `parallel` module, since we use threads there as well, and we started to see the same issue during force shutdown.

This issue is difficult to test because it open happens with the pyinstaller binary, and even then it's not consistent. I did some manual testing and I wasn't able to reproduce the issue after making this change.
