### PR TITLE
add support for multiple compose files to bash completion

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -18,7 +18,11 @@
 
 
 __docker_compose_q() {
-	docker-compose 2>/dev/null ${compose_file:+-f $compose_file} ${compose_project:+-p $compose_project} "$@"
+	local file_args
+	if [ ${#compose_files[@]} -ne 0 ] ; then
+		file_args="${compose_files[@]/#/-f }"
+	fi
+	docker-compose 2>/dev/null $file_args ${compose_project:+-p $compose_project} "$@"
 }
 
 # suppress trailing whitespace
@@ -456,14 +460,14 @@ _docker_compose() {
 	# special treatment of some top-level options
 	local command='docker_compose'
 	local counter=1
-	local compose_file compose_project
+	local compose_files=() compose_project
 	while [ $counter -lt $cword ]; do
 		case "${words[$counter]}" in
 			--file|-f)
 				(( counter++ ))
-				compose_file="${words[$counter]}"
+				compose_files+=(${words[$counter]})
 				;;
-			--project-name|p)
+			--project-name|-p)
 				(( counter++ ))
 				compose_project="${words[$counter]}"
 				;;


### PR DESCRIPTION
Since 1.6.0, Compose supports multiple compose files specified with `-f`.
These need to be passed to the docker invocations done by the completion.

/cc @sdurrheimer does this apply to zsh completion as well?