### PR TITLE
Fixed indentation level in example.

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -46,10 +46,10 @@ A `docker-compose.yml` looks like this:
         - logvolume01:/var/log
         links:
         - redis
-        redis:
-          image: redis
-        volumes:
-          logvolume01: {}
+      redis:
+        image: redis
+    volumes:
+      logvolume01: {}
 
 For more information about the Compose file, see the
 [Compose file reference](compose-file.md)


### PR DESCRIPTION
In the example, the indentation for the `redis` service and the top-level `volumes` seem be incorrect and all listed under the `web` service. This is potentially a source of confusion.