### PR TITLE
Refactor command dispatch and fix api version mismatch error

### DIFF
--- a/compose/cli/docopt_command.py
+++ b/compose/cli/docopt_command.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import sys
 from inspect import getdoc
 
 from docopt import docopt
@@ -15,24 +14,21 @@ def docopt_full_help(docstring, *args, **kwargs):
         raise SystemExit(docstring)
 
 
-class DocoptCommand(object):
-    def docopt_options(self):
-        return {'options_first': True}
+class DocoptDispatcher(object):
 
-    def sys_dispatch(self):
-        self.dispatch(sys.argv[1:])
-
-    def dispatch(self, argv):
-        self.perform_command(*self.parse(argv))
+    def __init__(self, command_class, options):
+        self.command_class = command_class
+        self.options = options
 
     def parse(self, argv):
-        options = docopt_full_help(getdoc(self), argv, **self.docopt_options())
+        command_help = getdoc(self.command_class)
+        options = docopt_full_help(command_help, argv, **self.options)
         command = options['COMMAND']
 
         if command is None:
-            raise SystemExit(getdoc(self))
+            raise SystemExit(command_help)
 
-        handler = self.get_handler(command)
+        handler = get_handler(self.command_class, command)
         docstring = getdoc(handler)
 
         if docstring is None:
@@ -41,17 +37,18 @@ class DocoptCommand(object):
         command_options = docopt_full_help(docstring, options['ARGS'], options_first=True)
         return options, handler, command_options
 
-    def get_handler(self, command):
-        command = command.replace('-', '_')
-        # we certainly want to have "exec" command, since that's what docker client has
-        # but in python exec is a keyword
-        if command == "exec":
-            command = "exec_command"
 
-        if not hasattr(self, command):
-            raise NoSuchCommand(command, self)
+def get_handler(command_class, command):
+    command = command.replace('-', '_')
+    # we certainly want to have "exec" command, since that's what docker client has
+    # but in python exec is a keyword
+    if command == "exec":
+        command = "exec_command"
 
-        return getattr(self, command)
+    if not hasattr(command_class, command):
+        raise NoSuchCommand(command, command_class)
+
+    return getattr(command_class, command)
 
 
 class NoSuchCommand(Exception):

--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -1,10 +1,27 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import contextlib
+import logging
 from textwrap import dedent
+
+from docker.errors import APIError
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ReadTimeout
+from requests.exceptions import SSLError
+
+from ..const import API_VERSION_TO_ENGINE_VERSION
+from ..const import HTTP_TIMEOUT
+from .utils import call_silently
+from .utils import is_mac
+from .utils import is_ubuntu
+
+
+log = logging.getLogger(__name__)
 
 
 class UserError(Exception):
+
     def __init__(self, msg):
         self.msg = dedent(msg).strip()
 
@@ -14,44 +31,90 @@ class UserError(Exception):
     __str__ = __unicode__
 
 
-class DockerNotFoundMac(UserError):
-    def __init__(self):
-        super(DockerNotFoundMac, self).__init__("""
-        Couldn't connect to Docker daemon. You might need to install docker-osx:
-
-        https://github.com/noplay/docker-osx
-        """)
+class ConnectionError(Exception):
+    pass
 
 
-class DockerNotFoundUbuntu(UserError):
-    def __init__(self):
-        super(DockerNotFoundUbuntu, self).__init__("""
-        Couldn't connect to Docker daemon. You might need to install Docker:
+@contextlib.contextmanager
+def handle_connection_errors(client):
+    try:
+        yield
+    except SSLError as e:
+        log.error('SSL error: %s' % e)
+        raise ConnectionError()
+    except RequestsConnectionError:
+        if call_silently(['which', 'docker']) != 0:
+            if is_mac():
+                exit_with_error(docker_not_found_mac)
+            if is_ubuntu():
+                exit_with_error(docker_not_found_ubuntu)
+            exit_with_error(docker_not_found_generic)
+        if call_silently(['which', 'docker-machine']) == 0:
+            exit_with_error(conn_error_docker_machine)
+        exit_with_error(conn_error_generic.format(url=client.base_url))
+    except APIError as e:
+        log_api_error(e, client.api_version)
+        raise ConnectionError()
+    except ReadTimeout as e:
+        log.error(
+            "An HTTP request took too long to complete. Retry with --verbose to "
+            "obtain debug information.\n"
+            "If you encounter this issue regularly because of slow network "
+            "conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher "
+            "value (current value: %s)." % HTTP_TIMEOUT)
+        raise ConnectionError()
 
-        https://docs.docker.com/engine/installation/ubuntulinux/
-        """)
+
+def log_api_error(e, client_version):
+    if 'client is newer than server' not in e.explanation:
+        log.error(e.explanation)
+        return
+
+    version = API_VERSION_TO_ENGINE_VERSION.get(client_version)
+    if not version:
+        # They've set a custom API version
+        log.error(e.explanation)
+        return
+
+    log.error(
+        "The Docker Engine version is less than the minimum required by "
+        "Compose. Your current project requires a Docker Engine of "
+        "version {version} or greater.".format(version=version))
 
 
-class DockerNotFoundGeneric(UserError):
-    def __init__(self):
-        super(DockerNotFoundGeneric, self).__init__("""
-        Couldn't connect to Docker daemon. You might need to install Docker:
-
-        https://docs.docker.com/engine/installation/
-        """)
+def exit_with_error(msg):
+    log.error(dedent(msg).strip())
+    raise ConnectionError()
 
 
-class ConnectionErrorDockerMachine(UserError):
-    def __init__(self):
-        super(ConnectionErrorDockerMachine, self).__init__("""
-        Couldn't connect to Docker daemon - you might need to run `docker-machine start default`.
-        """)
+docker_not_found_mac = """
+    Couldn't connect to Docker daemon. You might need to install docker-osx:
+
+    https://github.com/noplay/docker-osx
+"""
 
 
-class ConnectionErrorGeneric(UserError):
-    def __init__(self, url):
-        super(ConnectionErrorGeneric, self).__init__("""
-        Couldn't connect to Docker daemon at %s - is it running?
+docker_not_found_ubuntu = """
+    Couldn't connect to Docker daemon. You might need to install Docker:
 
-        If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.
-        """ % url)
+    https://docs.docker.com/engine/installation/ubuntulinux/
+"""
+
+
+docker_not_found_generic = """
+    Couldn't connect to Docker daemon. You might need to install Docker:
+
+    https://docs.docker.com/engine/installation/
+"""
+
+
+conn_error_docker_machine = """
+    Couldn't connect to Docker daemon - you might need to run `docker-machine start default`.
+"""
+
+
+conn_error_generic = """
+    Couldn't connect to Docker daemon at {url} - is it running?
+
+    If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.
+"""

--- a/tests/unit/cli/command_test.py
+++ b/tests/unit/cli/command_test.py
@@ -4,26 +4,10 @@ from __future__ import unicode_literals
 import os
 
 import pytest
-from requests.exceptions import ConnectionError
 
-from compose.cli import errors
-from compose.cli.command import friendly_error_message
 from compose.cli.command import get_config_path_from_options
 from compose.const import IS_WINDOWS_PLATFORM
 from tests import mock
-
-
-class TestFriendlyErrorMessage(object):
-
-    def test_dispatch_generic_connection_error(self):
-        with pytest.raises(errors.ConnectionErrorGeneric):
-            with mock.patch(
-                'compose.cli.command.call_silently',
-                autospec=True,
-                side_effect=[0, 1]
-            ):
-                with friendly_error_message():
-                    raise ConnectionError()
 
 
 class TestGetConfigPathFromOptions(object):

--- a/tests/unit/cli/errors_test.py
+++ b/tests/unit/cli/errors_test.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import pytest
+from docker.errors import APIError
+from requests.exceptions import ConnectionError
+
+from compose.cli import errors
+from compose.cli.errors import handle_connection_errors
+from tests import mock
+
+
+@pytest.yield_fixture
+def mock_logging():
+    with mock.patch('compose.cli.errors.log', autospec=True) as mock_log:
+        yield mock_log
+
+
+def patch_call_silently(side_effect):
+    return mock.patch(
+        'compose.cli.errors.call_silently',
+        autospec=True,
+        side_effect=side_effect)
+
+
+class TestHandleConnectionErrors(object):
+
+    def test_generic_connection_error(self, mock_logging):
+        with pytest.raises(errors.ConnectionError):
+            with patch_call_silently([0, 1]):
+                with handle_connection_errors(mock.Mock()):
+                    raise ConnectionError()
+
+        _, args, _ = mock_logging.error.mock_calls[0]
+        assert "Couldn't connect to Docker daemon at" in args[0]
+
+    def test_api_error_version_mismatch(self, mock_logging):
+        with pytest.raises(errors.ConnectionError):
+            with handle_connection_errors(mock.Mock(api_version='1.22')):
+                raise APIError(None, None, "client is newer than server")
+
+        _, args, _ = mock_logging.error.mock_calls[0]
+        assert "Docker Engine of version 1.10.0 or greater" in args[0]
+
+    def test_api_error_version_other(self, mock_logging):
+        msg = "Something broke!"
+        with pytest.raises(errors.ConnectionError):
+            with handle_connection_errors(mock.Mock(api_version='1.22')):
+                raise APIError(None, None, msg)
+
+        mock_logging.error.assert_called_once_with(msg)

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -64,26 +64,20 @@ class CLITestCase(unittest.TestCase):
         self.assertTrue(project.client)
         self.assertTrue(project.services)
 
-    def test_help(self):
-        command = TopLevelCommand()
-        with self.assertRaises(SystemExit):
-            command.dispatch(['-h'])
-
     def test_command_help(self):
-        with self.assertRaises(SystemExit) as ctx:
-            TopLevelCommand().dispatch(['help', 'up'])
+        with pytest.raises(SystemExit) as exc:
+            TopLevelCommand.help({'COMMAND': 'up'})
 
-        self.assertIn('Usage: up', str(ctx.exception))
+        assert 'Usage: up' in exc.exconly()
 
     def test_command_help_nonexistent(self):
-        with self.assertRaises(NoSuchCommand):
-            TopLevelCommand().dispatch(['help', 'nonexistent'])
+        with pytest.raises(NoSuchCommand):
+            TopLevelCommand.help({'COMMAND': 'nonexistent'})
 
     @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason="requires dockerpty")
     @mock.patch('compose.cli.main.RunOperation', autospec=True)
     @mock.patch('compose.cli.main.PseudoTerminal', autospec=True)
     def test_run_interactive_passes_logs_false(self, mock_pseudo_terminal, mock_run_operation):
-        command = TopLevelCommand()
         mock_client = mock.create_autospec(docker.Client)
         project = Project.from_config(
             name='composetest',
@@ -92,6 +86,7 @@ class CLITestCase(unittest.TestCase):
                 'service': {'image': 'busybox'}
             }),
         )
+        command = TopLevelCommand(project)
 
         with pytest.raises(SystemExit):
             command.run(project, {
@@ -126,7 +121,7 @@ class CLITestCase(unittest.TestCase):
             }),
         )
 
-        command = TopLevelCommand()
+        command = TopLevelCommand(project)
         command.run(project, {
             'SERVICE': 'service',
             'COMMAND': None,
@@ -147,7 +142,7 @@ class CLITestCase(unittest.TestCase):
             'always'
         )
 
-        command = TopLevelCommand()
+        command = TopLevelCommand(project)
         command.run(project, {
             'SERVICE': 'service',
             'COMMAND': None,
@@ -168,7 +163,6 @@ class CLITestCase(unittest.TestCase):
         )
 
     def test_command_manula_and_service_ports_together(self):
-        command = TopLevelCommand()
         project = Project.from_config(
             name='composetest',
             client=None,
@@ -176,6 +170,7 @@ class CLITestCase(unittest.TestCase):
                 'service': {'image': 'busybox'},
             }),
         )
+        command = TopLevelCommand(project)
 
         with self.assertRaises(UserError):
             command.run(project, {

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -89,7 +89,7 @@ class CLITestCase(unittest.TestCase):
         command = TopLevelCommand(project)
 
         with pytest.raises(SystemExit):
-            command.run(project, {
+            command.run({
                 'SERVICE': 'service',
                 'COMMAND': None,
                 '-e': [],
@@ -122,7 +122,7 @@ class CLITestCase(unittest.TestCase):
         )
 
         command = TopLevelCommand(project)
-        command.run(project, {
+        command.run({
             'SERVICE': 'service',
             'COMMAND': None,
             '-e': [],
@@ -143,7 +143,7 @@ class CLITestCase(unittest.TestCase):
         )
 
         command = TopLevelCommand(project)
-        command.run(project, {
+        command.run({
             'SERVICE': 'service',
             'COMMAND': None,
             '-e': [],
@@ -173,7 +173,7 @@ class CLITestCase(unittest.TestCase):
         command = TopLevelCommand(project)
 
         with self.assertRaises(UserError):
-            command.run(project, {
+            command.run({
                 'SERVICE': 'service',
                 'COMMAND': None,
                 '-e': [],


### PR DESCRIPTION
Fixes #3015

The first few commits are refactoring of the command dispatch. Instead of a subclass/superclass there are now two separate classes. The first is concerned with:

* parsing docstrings
* displaying the top level help
* finding the appropriate handler function

The second is the `TopLevelCommand` which has all the handler functions for each subcommand. It now accepts a `Project` object to the constructor, instead of to each handler function. This would allow us to unit test the commands by passing in a mock of the project.

Finally I consolidated the connection error handling into one place. It was split between `main()`, and `friendly_error_message()`. It's now all in the `errors.py` module, and only more general errors are left in `main()`. 
