### PR TITLE
Support `-f url` to specify config url

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -9,6 +9,7 @@ import string
 import sys
 from collections import namedtuple
 
+import requests
 import six
 import yaml
 from cached_property import cached_property
@@ -102,6 +103,11 @@ DOCKER_VALID_URL_PREFIXES = (
     'git://',
     'github.com/',
     'git@',
+)
+
+COMPOSE_VALID_URL_PREFIXES = (
+    'http://',
+    'https://',
 )
 
 SUPPORTED_FILENAMES = [
@@ -226,6 +232,13 @@ def find(base_dir, filenames, environment):
         )
 
     if filenames:
+        if is_compose_url(filenames[0]):
+            response = requests.get(filenames[0])
+            response.raise_for_status()
+            return ConfigDetails(
+                os.getcwd(),
+                [ConfigFile(None, yaml.safe_load(response.text))])
+
         filenames = [os.path.join(base_dir, f) for f in filenames]
     else:
         filenames = get_default_config_files(base_dir)
@@ -891,6 +904,10 @@ def resolve_build_path(working_dir, build_path):
 
 def is_url(build_path):
     return build_path.startswith(DOCKER_VALID_URL_PREFIXES)
+
+
+def is_compose_url(url):
+    return url.startswith(COMPOSE_VALID_URL_PREFIXES)
 
 
 def validate_paths(service_dict):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2696,6 +2696,15 @@ class BuildPathTest(unittest.TestCase):
         service_dict = load_from_filename('tests/fixtures/build-path/docker-compose.yml')
         self.assertEquals(service_dict, [{'name': 'foo', 'build': {'context': self.abs_context_path}}])
 
+# E compose.config.errors.ConfigurationError:
+#     build path /build-ctx
+#     build path /code/https:/github.com/docker/compose/raw/master/tests/fixtures/build-ctx
+#     either does not exist, is not accessible, or is not a valid URL
+# def test_from_url(self):
+#     url = 'https://github.com/docker/compose/raw/master/tests/fixtures/build-path/docker-compose.yml'
+#     service_dict = load_from_filename(url)
+#     self.assertEquals(service_dict, [{'name': 'foo', 'build': {'context': url}}])
+
     def test_valid_url_in_build_path(self):
         valid_urls = [
             'git://github.com/docker/docker',


### PR DESCRIPTION
For example:

``` sh
docker-compose -f https://github.com/yongjhih/docker-parse-server/raw/master/docker-compose.yml up
```
