### PR TITLE
Implement #745: Ability to set default project name in YML

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -55,8 +55,9 @@ def get_client(verbose=False, version=None, tls_config=None, host=None):
 def get_project(project_dir, config_path=None, project_name=None, verbose=False,
                 host=None, tls_config=None):
     config_details = config.find(project_dir, config_path)
-    project_name = get_project_name(config_details.working_dir, project_name)
     config_data = config.load(config_details)
+    default_project_name = config_data.project.get('default_name', None)
+    project_name = get_project_name(config_details.working_dir, project_name, default_project_name)
 
     api_version = os.environ.get(
         'COMPOSE_API_VERSION',
@@ -69,11 +70,11 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
     return Project.from_config(project_name, config_data, client)
 
 
-def get_project_name(working_dir, project_name=None):
+def get_project_name(working_dir, project_name=None, default_project_name=None):
     def normalize_name(name):
         return re.sub(r'[^a-z0-9]', '', name.lower())
 
-    project_name = project_name or os.environ.get('COMPOSE_PROJECT_NAME')
+    project_name = project_name or os.environ.get('COMPOSE_PROJECT_NAME') or default_project_name
     if project_name:
         return normalize_name(project_name)
 

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -8,6 +8,15 @@
       "type": "string"
     },
 
+    "project": {
+      "id": "#/properties/project",
+      "type": "object",
+      "properties": {
+        "default_name": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+
     "services": {
       "id": "#/properties/services",
       "type": "object",

--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -22,7 +22,9 @@ def serialize_config(config):
         'services': {service.pop('name'): service for service in config.services},
         'networks': config.networks,
         'volumes': config.volumes,
+        'project': config.project
     }
+
     return yaml.safe_dump(
         output,
         default_flow_style=False,

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -32,11 +32,10 @@ You can use environment variables in configuration values with a Bash-like
 `${VARIABLE}` syntax - see [variable substitution](#variable-substitution) for
 full details.
 
-
 ## Service configuration reference
 
 > **Note:** There are two versions of the Compose file format – version 1 (the
-> legacy format, which does not support volumes or networks) and version 2 (the
+> legacy format, which does not support project, volumes or networks) and version 2 (the
 > most up-to-date). For more information, see the [Versioning](#versioning)
 > section.
 
@@ -892,6 +891,20 @@ refer to it within the Compose file:
         external:
           name: actual-name-of-network
 
+## Project configuration reference
+
+> **Note:** There are two versions of the Compose file format – version 1 (the
+> legacy format, which does not support project, volumes or networks) and version 2 (the
+> most up-to-date). For more information, see the [Versioning](#versioning)
+> section.
+
+This section contains a list of all configuration options supported by a project
+definition.
+
+### default_name
+
+This options allows you define project default name. If it not defined,
+basename of the project directory will be used as project default name.
 
 ## Versioning
 
@@ -945,7 +958,6 @@ Example:
     redis:
       image: redis
 
-
 ### Version 2
 
 Compose files using the version 2 syntax must indicate the version number at
@@ -972,9 +984,11 @@ Simple example:
       redis:
         image: redis
 
-A more extended example, defining volumes and networks:
+A more extended example, defining project, volumes and networks:
 
     version: '2'
+    project:
+        default_name: "myapp"
     services:
       web:
         build: .
@@ -999,7 +1013,6 @@ A more extended example, defining volumes and networks:
         driver: bridge
       back-tier:
         driver: bridge
-
 
 ### Upgrading
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,6 +66,11 @@ set a custom project name using the [`-p` command line
 option](./reference/overview.md) or the [`COMPOSE_PROJECT_NAME`
 environment variable](./reference/envvars.md#compose-project-name).
 
+If no custom project name provided, docker-compose will use default project name.
+You can provide it in [your docker-compose.yml](./compose-file.md#default_name).
+If it doesn't specified, then the basename of the project directory will be used
+as default project name.
+
 ## What's the difference between `up`, `run`, and `start`?
 
 Typically, you want `docker-compose up`. Use `up` to start or restart all the

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -23,8 +23,9 @@ identical to the container name.
 > **Note:** Your app's network is given a name based on the "project name",
 > which is based on the name of the directory it lives in. You can override the
 > project name with either the [`--project-name`
-> flag](reference/overview.md) or the [`COMPOSE_PROJECT_NAME` environment
-> variable](reference/envvars.md#compose-project-name).
+> flag](reference/overview.md), the [`COMPOSE_PROJECT_NAME` environment
+> variable](reference/envvars.md#compose-project-name),
+> or specify it in [docker-compose.yml](./compose-file.md#project-name).
 
 For example, suppose your app is in a directory called `myapp`, and your `docker-compose.yml` looks like this:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -91,9 +91,10 @@ Compose uses a project name to isolate environments from each other. You can mak
 * on a shared host or dev host, to prevent different projects, which may use the
   same service names, from interfering with each other
 
-The default project name is the basename of the project directory. You can set
-a custom project name by using the
-[`-p` command line option](./reference/overview.md) or the
+You can provide the default project name in [your docker-compose.yml](./compose-file.md#default_name).
+If it doesn't specified, then the basename of the project directory will be used
+as default project name. You can set a custom project name by using the
+[`-p` command line option](./reference/overview.md) or
 [`COMPOSE_PROJECT_NAME` environment variable](./reference/envvars.md#compose-project-name).
 
 ### Preserve volume data when containers are created

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -179,6 +179,9 @@ class CLITestCase(DockerClientTestCase):
         output = yaml.load(result.stdout)
         expected = {
             'version': '2.0',
+            'project': {
+                'default_name': 'v2full'
+            },
             'volumes': {'data': {'driver': 'local'}},
             'networks': {'front': {}},
             'services': {

--- a/tests/fixtures/v2-full/docker-compose.yml
+++ b/tests/fixtures/v2-full/docker-compose.yml
@@ -1,6 +1,9 @@
 
 version: "2"
 
+project:
+    default_name: v2full
+
 volumes:
   data:
     driver: local

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -50,6 +50,18 @@ class CLITestCase(unittest.TestCase):
             project_name = get_project_name(None)
         self.assertEquals(project_name, name)
 
+    def test_project_name_from_environment_new_var_over_config(self):
+        name = 'namefromenv'
+        with mock.patch.dict(os.environ):
+            os.environ['COMPOSE_PROJECT_NAME'] = name
+            project_name = get_project_name(None, None, 'name-from-config')
+        self.assertEquals(project_name, name)
+
+    def test_project_name_from_config(self):
+        default_project_name = 'defaultname'
+        project_name = get_project_name(None, project_name=None, default_project_name='default name')
+        self.assertEquals(project_name, default_project_name)
+
     def test_project_name_with_empty_environment_var(self):
         base_dir = 'tests/fixtures/simple-composefile'
         with mock.patch.dict(os.environ):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -76,6 +76,9 @@ class ConfigTest(unittest.TestCase):
         config_data = config.load(
             build_config_details({
                 'version': '2',
+                'project': {
+                    'default_name': 'example'
+                },
                 'services': {
                     'foo': {'image': 'busybox'},
                     'bar': {'image': 'busybox', 'environment': ['FOO=1']},


### PR DESCRIPTION
Added `project` section in docker compose file, which allows users to define **default** project name in their yaml files:

```
version: "2"
project:
    default_name: "example"
```

This will help teams not to forgot about that. For example in my company i have only 5 project, which uses docker compose, and I already experience some problems since developers sometime forgot to add custom project name.

### Name resolution rules

 - Use custom name from `-p` cli option if provided
 - Use custom name from `COMPOSE_NAME` env variable if available
 - Use `default_name` option from `project` section of yml fileif provided
 - Use basename of project directory  as project default name

### Multiple compose files

If multiple compose yml files provided, `project` section will be used only from main one. 

docker-compose.yml:
```
version: "2"
project:
    default_name: foo
```

docker-compose.override.yml:
```
version: 2
project:
    default_name: bar
```

If we start docker-compose as usual (i.e. `docker-compose.override.yml` will override service definition in main file), then project name will be `foo`.

But if we change the order of files:

```
docker-compose -f docker-compose.override.yml -f docker-compose.yml config
```

then `bar` will be used as project name.