### PR TITLE
Adding optional selection of SSL Version

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import logging
 import os
 import re
+import ssl
 
 import six
 
@@ -37,8 +38,8 @@ def get_config_path_from_options(options):
     return None
 
 
-def get_client(verbose=False, version=None):
-    client = docker_client(version=version)
+def get_client(verbose=False, version=None, tls_version=None):
+    client = docker_client(version=version, tls_version=tls_version)
     if verbose:
         version_info = six.iteritems(client.version())
         log.info(get_version_info('full'))
@@ -57,7 +58,15 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False)
     api_version = os.environ.get(
         'COMPOSE_API_VERSION',
         API_VERSIONS[config_data.version])
-    client = get_client(verbose=verbose, version=api_version)
+    compose_tls_version = os.environ.get(
+        'COMPOSE_TLS_VERSION',
+        None)
+
+    tls_version = None
+    if compose_tls_version:
+        tls_version = ssl.getattr("PROTOCOL_{}".format(compose_tls_version))
+
+    client = get_client(verbose=verbose, version=api_version, tls_version=tls_version)
 
     return Project.from_config(project_name, config_data, client)
 

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -14,7 +14,7 @@ from .errors import UserError
 log = logging.getLogger(__name__)
 
 
-def docker_client(version=None):
+def docker_client(version=None, tls_version=None):
     """
     Returns a docker-py client configured using environment variables
     according to the same logic as the official Docker client.
@@ -24,7 +24,7 @@ def docker_client(version=None):
                  "Please use COMPOSE_HTTP_TIMEOUT instead.")
 
     try:
-        kwargs = kwargs_from_env(assert_hostname=False)
+        kwargs = kwargs_from_env(assert_hostname=False, ssl_version=tls_version)
     except TLSParameterError:
         raise UserError(
             "TLS configuration is invalid - make sure your DOCKER_TLS_VERIFY "

--- a/docs/reference/envvars.md
+++ b/docs/reference/envvars.md
@@ -75,6 +75,10 @@ Configures the path to the `ca.pem`, `cert.pem`, and `key.pem` files used for TL
 Configures the time (in seconds) a request to the Docker daemon is allowed to hang before Compose considers
 it failed. Defaults to 60 seconds.
 
+## COMPOSE\_TLS\_VERSION
+
+Configure which TLS version is used for TLS communication with the `docker` daemon, defaults to `TBD`
+Can be `TLSv1`, `TLSv1_1`, `TLSv1_2`.
 
 ## Related Information
 


### PR DESCRIPTION
To allow users to be able to select another ssl version

(Windows boot2docker apparantly loves PROTOCOL_TLSv1)

This way you can change the version via env DOCKER_SSL_VERSION

Please comment, haven't done much