### PR TITLE
Add ability to remove one-off containers

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -491,8 +491,12 @@ class TopLevelCommand(object):
         Options:
             -f, --force   Don't ask to confirm removal
             -v            Remove volumes associated with containers
+            -a, --all     Also remove one-off containers
         """
-        all_containers = self.project.containers(service_names=options['SERVICE'], stopped=True)
+        all_containers = self.project.containers(
+            service_names=options['SERVICE'], stopped=True,
+            one_off=(None if options.get('--all') else False)
+        )
         stopped_containers = [c for c in all_containers if not c.is_running]
 
         if len(stopped_containers) > 0:
@@ -501,7 +505,8 @@ class TopLevelCommand(object):
                     or yesno("Are you sure? [yN] ", default=False):
                 self.project.remove_stopped(
                     service_names=options['SERVICE'],
-                    v=options.get('-v', False)
+                    v=options.get('-v', False),
+                    one_off=options.get('--all')
                 )
         else:
             print("No stopped containers")

--- a/compose/project.py
+++ b/compose/project.py
@@ -47,10 +47,12 @@ class Project(object):
         self.networks = networks or ProjectNetworks({}, False)
 
     def labels(self, one_off=False):
-        return [
-            '{0}={1}'.format(LABEL_PROJECT, self.name),
-            '{0}={1}'.format(LABEL_ONE_OFF, "True" if one_off else "False"),
-        ]
+        labels = ['{0}={1}'.format(LABEL_PROJECT, self.name)]
+        if one_off is not None:
+            labels.append(
+                '{0}={1}'.format(LABEL_ONE_OFF, "True" if one_off else "False")
+            )
+        return labels
 
     @classmethod
     def from_config(cls, name, config_data, client):
@@ -249,8 +251,10 @@ class Project(object):
     def kill(self, service_names=None, **options):
         parallel.parallel_kill(self.containers(service_names), options)
 
-    def remove_stopped(self, service_names=None, **options):
-        parallel.parallel_remove(self.containers(service_names, stopped=True), options)
+    def remove_stopped(self, service_names=None, one_off=False, **options):
+        parallel.parallel_remove(self.containers(
+            service_names, stopped=True, one_off=(None if one_off else False)
+        ), options)
 
     def down(self, remove_image_type, include_volumes, remove_orphans=False):
         self.stop()

--- a/compose/project.py
+++ b/compose/project.py
@@ -6,6 +6,7 @@ import logging
 import operator
 from functools import reduce
 
+import enum
 from docker.errors import APIError
 
 from . import parallel
@@ -35,6 +36,20 @@ from .volume import ProjectVolumes
 log = logging.getLogger(__name__)
 
 
+@enum.unique
+class OneOffFilter(enum.Enum):
+    include = 0
+    exclude = 1
+    only = 2
+
+    @classmethod
+    def update_labels(cls, value, labels):
+        if value == cls.only:
+            labels.append('{0}={1}'.format(LABEL_ONE_OFF, "True"))
+        elif value == cls.exclude or value is False:
+            labels.append('{0}={1}'.format(LABEL_ONE_OFF, "False"))
+
+
 class Project(object):
     """
     A collection of services.
@@ -48,10 +63,8 @@ class Project(object):
 
     def labels(self, one_off=False):
         labels = ['{0}={1}'.format(LABEL_PROJECT, self.name)]
-        if one_off is not None:
-            labels.append(
-                '{0}={1}'.format(LABEL_ONE_OFF, "True" if one_off else "False")
-            )
+
+        OneOffFilter.update_labels(one_off, labels)
         return labels
 
     @classmethod
@@ -253,7 +266,7 @@ class Project(object):
 
     def remove_stopped(self, service_names=None, one_off=False, **options):
         parallel.parallel_remove(self.containers(
-            service_names, stopped=True, one_off=(None if one_off else False)
+            service_names, stopped=True, one_off=one_off
         ), options)
 
     def down(self, remove_image_type, include_volumes, remove_orphans=False):

--- a/docs/reference/rm.md
+++ b/docs/reference/rm.md
@@ -17,6 +17,7 @@ Usage: rm [options] [SERVICE...]
 Options:
 -f, --force   Don't ask to confirm removal
 -v            Remove volumes associated with containers
+-a, --all     Also remove one-off containers
 ```
 
 Removes stopped service containers.

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1125,6 +1125,28 @@ class CLITestCase(DockerClientTestCase):
         self.dispatch(['rm', '-f'], None)
         self.assertEqual(len(service.containers(stopped=True)), 0)
 
+    def test_rm_all(self):
+        service = self.project.get_service('simple')
+        service.create_container(one_off=False)
+        service.create_container(one_off=True)
+        kill_service(service)
+        self.assertEqual(len(service.containers(stopped=True)), 1)
+        self.assertEqual(len(service.containers(stopped=True, one_off=True)), 1)
+        self.dispatch(['rm', '-f'], None)
+        self.assertEqual(len(service.containers(stopped=True)), 0)
+        self.assertEqual(len(service.containers(stopped=True, one_off=True)), 1)
+        self.dispatch(['rm', '-f', '-a'], None)
+        self.assertEqual(len(service.containers(stopped=True, one_off=True)), 0)
+
+        service.create_container(one_off=False)
+        service.create_container(one_off=True)
+        kill_service(service)
+        self.assertEqual(len(service.containers(stopped=True)), 1)
+        self.assertEqual(len(service.containers(stopped=True, one_off=True)), 1)
+        self.dispatch(['rm', '-f', '--all'], None)
+        self.assertEqual(len(service.containers(stopped=True)), 0)
+        self.assertEqual(len(service.containers(stopped=True, one_off=True)), 0)
+
     def test_stop(self):
         self.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -24,6 +24,7 @@ from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
 from compose.const import LABEL_VERSION
 from compose.container import Container
+from compose.project import OneOffFilter
 from compose.service import ConvergencePlan
 from compose.service import ConvergenceStrategy
 from compose.service import NetworkMode
@@ -60,7 +61,7 @@ class ServiceTest(DockerClientTestCase):
         db = self.create_service('db')
         container = db.create_container(one_off=True)
         self.assertEqual(db.containers(stopped=True), [])
-        self.assertEqual(db.containers(one_off=True, stopped=True), [container])
+        self.assertEqual(db.containers(one_off=OneOffFilter.only, stopped=True), [container])
 
     def test_project_is_added_to_container_name(self):
         service = self.create_service('web')
@@ -494,7 +495,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(db)
         create_and_start_container(db)
 
-        c = create_and_start_container(db, one_off=True)
+        c = create_and_start_container(db, one_off=OneOffFilter.only)
 
         self.assertEqual(
             set(get_links(c)),

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -14,6 +14,7 @@ from compose.const import LABEL_ONE_OFF
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
 from compose.container import Container
+from compose.project import OneOffFilter
 from compose.service import build_ulimits
 from compose.service import build_volume_binding
 from compose.service import BuildAction
@@ -256,7 +257,7 @@ class ServiceTest(unittest.TestCase):
         opts = service._get_container_create_options(
             {'name': name},
             1,
-            one_off=True)
+            one_off=OneOffFilter.only)
         self.assertEqual(opts['name'], name)
 
     def test_get_container_create_options_does_not_mutate_options(self):


### PR DESCRIPTION
`rm` command now accepts a `--all` argument (shorthand `-a`) to remove one-off containers as well.

Going forward, the plan is to have this always be the case, hence a warning should be added for users when using `rm`