### PR TITLE
Update Mac Engine install URL in error message

### DIFF
--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -88,9 +88,9 @@ def exit_with_error(msg):
 
 
 docker_not_found_mac = """
-    Couldn't connect to Docker daemon. You might need to install docker-osx:
+    Couldn't connect to Docker daemon. You might need to install Docker:
 
-    https://github.com/noplay/docker-osx
+    https://docs.docker.com/engine/installation/mac/
 """
 
 


### PR DESCRIPTION
It's, uh, a little out-of-date.