### PR TITLE
Fix TypeError in Exception handling

### DIFF
--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -66,7 +66,7 @@ def handle_connection_errors(client):
 
 
 def log_api_error(e, client_version):
-    if 'client is newer than server' not in e.explanation:
+    if b'client is newer than server' not in e.explanation:
         log.error(e.explanation)
         return
 

--- a/tests/unit/cli/errors_test.py
+++ b/tests/unit/cli/errors_test.py
@@ -37,13 +37,13 @@ class TestHandleConnectionErrors(object):
     def test_api_error_version_mismatch(self, mock_logging):
         with pytest.raises(errors.ConnectionError):
             with handle_connection_errors(mock.Mock(api_version='1.22')):
-                raise APIError(None, None, "client is newer than server")
+                raise APIError(None, None, b"client is newer than server")
 
         _, args, _ = mock_logging.error.mock_calls[0]
         assert "Docker Engine of version 1.10.0 or greater" in args[0]
 
     def test_api_error_version_other(self, mock_logging):
-        msg = "Something broke!"
+        msg = b"Something broke!"
         with pytest.raises(errors.ConnectionError):
             with handle_connection_errors(mock.Mock(api_version='1.22')):
                 raise APIError(None, None, msg)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/tmp/tmp.02tgGaAGtW/docker-compose/bin/docker-compose", line 11, in <module>
    sys.exit(main())
  File "/tmp/tmp.02tgGaAGtW/docker-compose/lib/python3.4/site-packages/compose/cli/main.py", line 68, in main
    log_api_error(e)
  File "/tmp/tmp.02tgGaAGtW/docker-compose/lib/python3.4/site-packages/compose/cli/main.py", line 89, in log_api_error
    if 'client is newer than server' in e.explanation:
TypeError: 'str' does not support the buffer interface