### PR TITLE
WIP: Fix output of 'config' for v1 files

### DIFF
--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -5,6 +5,8 @@ import six
 import yaml
 
 from compose.config import types
+from compose.config.config import V1
+from compose.config.config import V2_0
 
 
 def serialize_config_type(dumper, data):
@@ -17,12 +19,20 @@ yaml.SafeDumper.add_representer(types.VolumeSpec, serialize_config_type)
 
 
 def serialize_config(config):
+    services = {service.pop('name'): service for service in config.services}
+
+    if config.version == V1:
+        for service_dict in services.values():
+            if 'network_mode' not in service_dict:
+                service_dict['network_mode'] = 'bridge'
+
     output = {
-        'version': config.version,
-        'services': {service.pop('name'): service for service in config.services},
+        'version': V2_0,
+        'services': services,
         'networks': config.networks,
         'volumes': config.volumes,
     }
+
     return yaml.safe_dump(
         output,
         default_flow_style=False,

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 import os
 from collections import namedtuple
 
+import six
+
 from compose.config.config import V1
 from compose.config.errors import ConfigurationError
 from compose.const import IS_WINDOWS_PLATFORM
@@ -87,6 +89,13 @@ def parse_restart_spec(restart_config):
         max_retry_count = 0
 
     return {'Name': name, 'MaximumRetryCount': int(max_retry_count)}
+
+
+def serialize_restart_spec(restart_spec):
+    parts = [restart_spec['Name']]
+    if restart_spec['MaximumRetryCount']:
+        parts.append(six.text_type(restart_spec['MaximumRetryCount']))
+    return ':'.join(parts)
 
 
 def parse_extra_hosts(extra_hosts_config):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -145,15 +145,11 @@ class CLITestCase(DockerClientTestCase):
         # Prevent tearDown from trying to create a project
         self.base_dir = None
 
-    # TODO: this shouldn't be v2-dependent
-    @v2_only()
     def test_config_list_services(self):
         self.base_dir = 'tests/fixtures/v2-full'
         result = self.dispatch(['config', '--services'])
         assert set(result.stdout.rstrip().split('\n')) == {'web', 'other'}
 
-    # TODO: this shouldn't be v2-dependent
-    @v2_only()
     def test_config_quiet_with_error(self):
         self.base_dir = None
         result = self.dispatch([
@@ -162,14 +158,10 @@ class CLITestCase(DockerClientTestCase):
         ], returncode=1)
         assert "'notaservice' must be a mapping" in result.stderr
 
-    # TODO: this shouldn't be v2-dependent
-    @v2_only()
     def test_config_quiet(self):
         self.base_dir = 'tests/fixtures/v2-full'
         assert self.dispatch(['config', '-q']).stdout == ''
 
-    # TODO: this shouldn't be v2-dependent
-    @v2_only()
     def test_config_default(self):
         self.base_dir = 'tests/fixtures/v2-full'
         result = self.dispatch(['config'])

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -190,6 +190,31 @@ class CLITestCase(DockerClientTestCase):
         }
         assert output == expected
 
+    def test_config_v1(self):
+        self.base_dir = 'tests/fixtures/v1-config'
+        result = self.dispatch(['config'])
+        assert yaml.load(result.stdout) == {
+            'version': '2.0',
+            'services': {
+                'net': {
+                    'image': 'busybox',
+                    'network_mode': 'bridge',
+                },
+                'volume': {
+                    'image': 'busybox',
+                    'volumes': ['/data:rw'],
+                    'network_mode': 'bridge',
+                },
+                'app': {
+                    'image': 'busybox',
+                    'volumes_from': ['service:volume:rw'],
+                    'network_mode': 'service:net',
+                },
+            },
+            'networks': {},
+            'volumes': {},
+        }
+
     def test_ps(self):
         self.project.get_service('simple').create_container()
         result = self.dispatch(['ps'])

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -675,9 +675,7 @@ class CLITestCase(DockerClientTestCase):
             ['-f', 'v2-invalid.yml', 'up', '-d'],
             returncode=1)
 
-        # TODO: fix validation error messages for v2 files
-        # assert "Unsupported config option for service 'web': 'net'" in exc.exconly()
-        assert "Unsupported config option" in result.stderr
+        assert "Unsupported config option for services.bar: 'net'" in result.stderr
 
     def test_up_with_net_v1(self):
         self.base_dir = 'tests/fixtures/net-container'

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -190,6 +190,33 @@ class CLITestCase(DockerClientTestCase):
         }
         assert output == expected
 
+    def test_config_restart(self):
+        self.base_dir = 'tests/fixtures/restart'
+        result = self.dispatch(['config'])
+        assert yaml.load(result.stdout) == {
+            'version': '2.0',
+            'services': {
+                'never': {
+                    'image': 'busybox',
+                    'restart': 'no',
+                },
+                'always': {
+                    'image': 'busybox',
+                    'restart': 'always',
+                },
+                'on-failure': {
+                    'image': 'busybox',
+                    'restart': 'on-failure',
+                },
+                'on-failure-5': {
+                    'image': 'busybox',
+                    'restart': 'on-failure:5',
+                },
+            },
+            'networks': {},
+            'volumes': {},
+        }
+
     def test_config_v1(self):
         self.base_dir = 'tests/fixtures/v1-config'
         result = self.dispatch(['config'])

--- a/tests/fixtures/restart/docker-compose.yml
+++ b/tests/fixtures/restart/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2"
+services:
+  never:
+    image: busybox
+    restart: "no"
+  always:
+    image: busybox
+    restart: always
+  on-failure:
+    image: busybox
+    restart: on-failure
+  on-failure-5:
+    image: busybox
+    restart: "on-failure:5"

--- a/tests/fixtures/v1-config/docker-compose.yml
+++ b/tests/fixtures/v1-config/docker-compose.yml
@@ -1,0 +1,10 @@
+net:
+  image: busybox
+volume:
+  image: busybox
+  volumes:
+    - /data
+app:
+  image: busybox
+  net: "container:net"
+  volumes_from: ["volume"]


### PR DESCRIPTION
When run on a v1 file, `docker-compose config` returns invalid YAML:

```yaml
version: '1'
networks: {}
volumes: {}
services:
  foo:
    network_mode: "service:bar"
```

TODO:

- [x] Output a version 2 file
- [x] Set `network_mode: bridge`
- [x] Denormalise `restart`
- [x] Check for anything else that needs denormalising