### PR TITLE
Only allow tmpfs with the v2 format

### DIFF
--- a/compose/config/config_schema_v1.json
+++ b/compose/config/config_schema_v1.json
@@ -104,7 +104,6 @@
         "shm_size": {"type": ["number", "string"]},
         "stdin_open": {"type": "boolean"},
         "stop_signal": {"type": "string"},
-        "tmpfs": {"$ref": "#/definitions/string_or_list"},
         "tty": {"type": "boolean"},
         "ulimits": {
           "type": "object",

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -28,6 +28,7 @@ from compose.service import ConvergencePlan
 from compose.service import ConvergenceStrategy
 from compose.service import NetworkMode
 from compose.service import Service
+from tests.integration.testcases import v2_only
 
 
 def create_and_start_container(service, **override_options):
@@ -875,6 +876,7 @@ class ServiceTest(DockerClientTestCase):
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.DnsSearch'), ['dc1.example.com', 'dc2.example.com'])
 
+    @v2_only()
     def test_tmpfs(self):
         service = self.create_service('web', tmpfs=['/run'])
         container = create_and_start_container(service)

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1196,9 +1196,12 @@ class ConfigTest(unittest.TestCase):
 
     def test_tmpfs_option(self):
         actual = config.load(build_config_details({
-            'web': {
-                'image': 'alpine',
-                'tmpfs': '/run',
+            'version': '2',
+            'services': {
+                'web': {
+                    'image': 'alpine',
+                    'tmpfs': '/run',
+                }
             }
         }))
         assert actual.services == [


### PR DESCRIPTION
I missed this in #3137

I believe tmpfs is only 1.10+ so we should only add it to v2.