### PR TITLE
Fix flaky partial_change state test

### DIFF
--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -38,8 +38,8 @@ class BasicProjectTest(ProjectTestCase):
         super(BasicProjectTest, self).setUp()
 
         self.cfg = {
-            'db': {'image': 'busybox:latest'},
-            'web': {'image': 'busybox:latest'},
+            'db': {'image': 'busybox:latest', 'command': 'top'},
+            'web': {'image': 'busybox:latest', 'command': 'top'},
         }
 
     def test_no_change(self):


### PR DESCRIPTION
I believe the changes to run `up` in parallel are what caused this flake.

```
tests/integration/state_test.py:62: in test_partial_change
    self.assertEqual(len(new_containers), 2)
E   AssertionError: 1 != 2
```

There are two significant changes here:

1. the change to use `filter(ready, objects)` seems to fix the primary issue.
2. the change to use `command: 'top`` fixed another flake with this test, with a "can not stop this container", which I believe is caused by a race when the stop happens at the exact time the container exits itself naturally.