### PR TITLE
bash completion for new `docker logs` options

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -211,9 +211,15 @@ _docker_compose_kill() {
 
 
 _docker_compose_logs() {
+	case "$prev" in
+		--tail)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --no-color" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--follow -f --help --no-color --tail --timestamps -t" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all


### PR DESCRIPTION
Ref: [changelog draft](https://github.com/docker/compose/pull/3198/commits/1339fa5840b56e1913240ba895aff71c1835d6e1#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR50)

Please schedule for 1.7.0 as the corresponding feature is present in that release.

ping @sdurrheimer for zsh completion