### PR TITLE
bash completion for `docker-compose up --build`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -407,7 +407,7 @@ _docker_compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--abort-on-container-exit -d --force-recreate --help --no-build --no-color --no-deps --no-recreate --timeout -t --remove-orphans" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--abort-on-container-exit --build -d --force-recreate --help --no-build --no-color --no-deps --no-recreate --timeout -t --remove-orphans" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all


### PR DESCRIPTION
Ref: [changelog draft](https://github.com/docker/compose/pull/3198/commits/1339fa5840b56e1913240ba895aff71c1835d6e1#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR59)

Please schedule for 1.7.0 as the corresponding feature is present in that release.

ping @sdurrheimer for zsh completion