### PR TITLE
bash completion for `docker-compose rm --all`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -301,7 +301,7 @@ _docker_compose_restart() {
 _docker_compose_rm() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--force -f --help -v" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all -a --force -f --help -v" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_stopped


### PR DESCRIPTION
Ref: [changelog draft](https://github.com/docker/compose/pull/3198/commits/1339fa5840b56e1913240ba895aff71c1835d6e1#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR29)

Please schedule for 1.7.0 as the corresponding feature is present in that release.

ping @sdurrheimer for zsh completion