### PR TITLE
Add zsh completion for 'docker-compose logs -f --follow --tail -t --t…

### DIFF
--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -235,7 +235,10 @@ __docker-compose_subcommand() {
         (logs)
             _arguments \
                 $opts_help \
+                '(-f --follow)'{-f,--follow}'[Follow log output]' \
                 '--no-color[Produce monochrome output.]' \
+                '--tail=[Number of lines to show from the end of the logs for each container.]:number of lines: ' \
+                '(-t --timestamps)'{-t,--timestamps}'[Show timestamps]' \
                 '*:services:__docker-compose_services_all' && ret=0
             ;;
         (pause)


### PR DESCRIPTION
…imestamps'

Ref. #2720

@albers thx for the ping

Signed-off-by: Steve Durrheimer <s.durrheimer@gmail.com>