### PR TITLE
Rails Docs: Add nodejs to apt-get install command

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -22,7 +22,7 @@ container. This is done using a file called `Dockerfile`. To begin with, the
 Dockerfile consists of:
 
     FROM ruby:2.2.0
-    RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+    RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
     RUN mkdir /myapp
     WORKDIR /myapp
     ADD Gemfile /myapp/Gemfile


### PR DESCRIPTION
When using the latest version of Rails, the tutorial currently errors when running `docker-compose up` with the following error:

```
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:80:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'uglifier'. (Bundler::GemRequireError)
```

Installing nodejs in the build fixes the issue.