### PR TITLE
Fix assert_hostname logic in tls_config_from_options

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -49,7 +49,7 @@ def docker_client(environment, version=None, tls_config=None, host=None):
                  "Please use COMPOSE_HTTP_TIMEOUT instead.")
 
     try:
-        kwargs = kwargs_from_env(assert_hostname=False, environment=environment)
+        kwargs = kwargs_from_env(environment=environment)
     except TLSParameterError:
         raise UserError(
             "TLS configuration is invalid - make sure your DOCKER_TLS_VERIFY "

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -7,7 +7,6 @@ from docker import Client
 from docker.errors import TLSParameterError
 from docker.tls import TLSConfig
 from docker.utils import kwargs_from_env
-from requests.utils import urlparse
 
 from ..const import HTTP_TIMEOUT
 from .errors import UserError
@@ -21,15 +20,7 @@ def tls_config_from_options(options):
     cert = options.get('--tlscert')
     key = options.get('--tlskey')
     verify = options.get('--tlsverify')
-    host = options.get('--host')
     skip_hostname_check = options.get('--skip-hostname-check', False)
-
-    if not skip_hostname_check:
-        hostname = urlparse(host).hostname if host else None
-        # If the protocol is omitted, urlparse fails to extract the hostname.
-        # Make another attempt by appending a protocol.
-        if not hostname and host:
-            hostname = urlparse('tcp://{0}'.format(host)).hostname
 
     advanced_opts = any([ca_cert, cert, key, verify])
 
@@ -40,15 +31,9 @@ def tls_config_from_options(options):
         if cert or key:
             client_cert = (cert, key)
 
-        assert_hostname = None
-        if skip_hostname_check:
-            assert_hostname = False
-        elif hostname:
-            assert_hostname = hostname
-
         return TLSConfig(
             client_cert=client_cert, verify=verify, ca_cert=ca_cert,
-            assert_hostname=assert_hostname
+            assert_hostname=False if skip_hostname_check else None
         )
 
     return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==3.11
 cached-property==1.2.0
-docker-py==1.8.0rc3
+docker-py==1.8.0rc5
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 PyYAML==3.11
 cached-property==1.2.0
+docker-py==1.8.0rc3
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4
-git+https://github.com/docker/docker-py.git@ac3d4aae2c525b052e661f42307223676ca1b313#egg=docker-py
 jsonschema==2.5.1
 requests==2.7.0
 six==1.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 PyYAML==3.11
 cached-property==1.2.0
-docker-py==1.8.0rc2
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4
+git+https://github.com/docker/docker-py.git@ac3d4aae2c525b052e661f42307223676ca1b313#egg=docker-py
 jsonschema==2.5.1
 requests==2.7.0
 six==1.7.3

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -103,3 +103,31 @@ class TLSConfigTestCase(unittest.TestCase):
         options = {'--tlskey': self.key}
         with pytest.raises(docker.errors.TLSParameterError):
             tls_config_from_options(options)
+
+    def test_assert_hostname_explicit_host(self):
+        options = {
+            '--tlscacert': self.ca_cert, '--host': 'tcp://foobar.co.uk:1254'
+        }
+        result = tls_config_from_options(options)
+        assert isinstance(result, docker.tls.TLSConfig)
+        assert result.assert_hostname == 'foobar.co.uk'
+
+    def test_assert_hostname_explicit_host_no_proto(self):
+        options = {
+            '--tlscacert': self.ca_cert, '--host': 'foobar.co.uk:1254'
+        }
+        result = tls_config_from_options(options)
+        assert isinstance(result, docker.tls.TLSConfig)
+        assert result.assert_hostname == 'foobar.co.uk'
+
+    def test_assert_hostname_implicit_host(self):
+        options = {'--tlscacert': self.ca_cert}
+        result = tls_config_from_options(options)
+        assert isinstance(result, docker.tls.TLSConfig)
+        assert result.assert_hostname is None
+
+    def test_assert_hostname_explicit_skip(self):
+        options = {'--tlscacert': self.ca_cert, '--skip-hostname-check': True}
+        result = tls_config_from_options(options)
+        assert isinstance(result, docker.tls.TLSConfig)
+        assert result.assert_hostname is False

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -104,28 +104,6 @@ class TLSConfigTestCase(unittest.TestCase):
         with pytest.raises(docker.errors.TLSParameterError):
             tls_config_from_options(options)
 
-    def test_assert_hostname_explicit_host(self):
-        options = {
-            '--tlscacert': self.ca_cert, '--host': 'tcp://foobar.co.uk:1254'
-        }
-        result = tls_config_from_options(options)
-        assert isinstance(result, docker.tls.TLSConfig)
-        assert result.assert_hostname == 'foobar.co.uk'
-
-    def test_assert_hostname_explicit_host_no_proto(self):
-        options = {
-            '--tlscacert': self.ca_cert, '--host': 'foobar.co.uk:1254'
-        }
-        result = tls_config_from_options(options)
-        assert isinstance(result, docker.tls.TLSConfig)
-        assert result.assert_hostname == 'foobar.co.uk'
-
-    def test_assert_hostname_implicit_host(self):
-        options = {'--tlscacert': self.ca_cert}
-        result = tls_config_from_options(options)
-        assert isinstance(result, docker.tls.TLSConfig)
-        assert result.assert_hostname is None
-
     def test_assert_hostname_explicit_skip(self):
         options = {'--tlscacert': self.ca_cert, '--skip-hostname-check': True}
         result = tls_config_from_options(options)


### PR DESCRIPTION
1. `assert_hostname=True` is an error (at least for recent versions of urllib3 / requests). The code has been updated so we don't set that value anymore.
2. Improved hostname detection (`urlparse` would fail if no protocol was specified)
3. Avoid unnecessary lookup / computation if `--skip-hostname-check` is set.

This should help a little with #3210 . The main issue that remains is when the CA declares a hostname different from the one we're connecting through, causing the `SSLError: hostname '127.0.0.1' doesn't match u'localhost'` error. While this seems correct to do, the docker CLI obviously behaves differently. 

We could elect to skip the hostname check by default, or try and retrieve the CA's fingerprint and use `assert_fingerprint` instead. From [urllib3 docs](http://urllib3.readthedocs.org/en/latest/pools.html):
> VerifiedHTTPSConnection uses one of `assert_fingerprint`, `assert_hostname` and host in this order to verify connections. If `assert_hostname` is False, no verification is done.
