### PR TITLE
3191 help cli feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@
 /venv
 README.rst
 compose/GITSHA
-.DS_Store
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /venv
 README.rst
 compose/GITSHA
+.DS_Store
+.idea/

--- a/compose/cli/docopt_command.py
+++ b/compose/cli/docopt_command.py
@@ -34,10 +34,6 @@ class DocoptDispatcher(object):
         if docstring is None:
             raise NoSuchCommand(command, self)
 
-        # checks to see if the command is help and if so outputs top level command options
-        if command == 'help' and options['ARGS'] == []:
-            raise SystemExit(docstring + '\n-------------------\n\n' + command_help)
-
         command_options = docopt_full_help(docstring, options['ARGS'], options_first=True)
         return options, handler, command_options
 

--- a/compose/cli/docopt_command.py
+++ b/compose/cli/docopt_command.py
@@ -34,6 +34,10 @@ class DocoptDispatcher(object):
         if docstring is None:
             raise NoSuchCommand(command, self)
 
+        # checks to see if the command is help and if so outputs top level command options
+        if command == 'help' and options['ARGS'] == []:
+            raise SystemExit(docstring + '\n-------------------\n\n' + command_help)
+
         command_options = docopt_full_help(docstring, options['ARGS'], options_first=True)
         return options, handler, command_options
 


### PR DESCRIPTION
Addressing issue #3191. Added code to output the top level command options if docker-compose help with no command options provided. Provides similar functionality to other docker cli tools.