### PR TITLE
Added code to support no argument help command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -355,10 +355,14 @@ class TopLevelCommand(object):
         """
         Get help on a command.
 
-        Usage: help COMMAND
+        Usage: help [COMMAND]
         """
-        handler = get_handler(cls, options['COMMAND'])
-        raise SystemExit(getdoc(handler))
+        if options['COMMAND']:
+            subject = get_handler(cls, options['COMMAND'])
+        else:
+            subject = cls
+
+        print(getdoc(subject))
 
     def kill(self, options):
         """

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import os
 import shutil
 import tempfile
-from StringIO import StringIO
+from io import StringIO
 
 import docker
 import py

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import os
 import shutil
 import tempfile
+from StringIO import StringIO
 
 import docker
 import py
@@ -81,6 +82,12 @@ class CLITestCase(unittest.TestCase):
         self.assertEqual(project.name, 'longerfilenamecomposefile')
         self.assertTrue(project.client)
         self.assertTrue(project.services)
+
+    def test_command_help(self):
+        with mock.patch('sys.stdout', new=StringIO()) as fake_stdout:
+            TopLevelCommand.help({'COMMAND': 'up'})
+
+        assert "Usage: up" in fake_stdout.getvalue()
 
     def test_command_help_nonexistent(self):
         with pytest.raises(NoSuchCommand):

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -64,12 +64,6 @@ class CLITestCase(unittest.TestCase):
         self.assertTrue(project.client)
         self.assertTrue(project.services)
 
-    def test_command_help(self):
-        with pytest.raises(SystemExit) as exc:
-            TopLevelCommand.help({'COMMAND': 'up'})
-
-        assert 'Usage: up' in exc.exconly()
-
     def test_command_help_nonexistent(self):
         with pytest.raises(NoSuchCommand):
             TopLevelCommand.help({'COMMAND': 'nonexistent'})


### PR DESCRIPTION
Addressing issue #3191 . Added code to output the top level command options if docker-compose help with no command options provided. Provides similar functionality to other docker cli tools. Closing pull request #3234, because it is a fixed by this pull request to put the logic in main.py

Signed-off-by: Tony Witherspoon <tony.witherspoon@gmail.com>