### PR TITLE
Prevent unnecessary inspection of containers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,4 +30,3 @@ The current state of integration is documented in [SWARM.md](SWARM.md).
 Compose works well for applications that are in a single repository and depend on services that are hosted on Docker Hub. If your application depends on another application within your organisation, Compose doesn't work as well.
 
 There are several ideas about how this could work, such as [including external files](https://github.com/docker/fig/issues/318).
-

--- a/compose/container.py
+++ b/compose/container.py
@@ -39,7 +39,7 @@ class Container(object):
 
     @classmethod
     def from_id(cls, client, id):
-        return cls(client, client.inspect_container(id))
+        return cls(client, client.inspect_container(id), has_been_inspected=True)
 
     @classmethod
     def create(cls, client, **options):

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -769,17 +769,17 @@ class ServiceTest(DockerClientTestCase):
         container = service.create_container(number=next_number, quiet=True)
         container.start()
 
-        self.assertTrue(container.is_running)
-        self.assertEqual(len(service.containers()), 1)
+        container.inspect()
+        assert container.is_running
+        assert len(service.containers()) == 1
 
         service.scale(1)
-
-        self.assertEqual(len(service.containers()), 1)
+        assert len(service.containers()) == 1
         container.inspect()
-        self.assertTrue(container.is_running)
+        assert container.is_running
 
         captured_output = mock_log.info.call_args[0]
-        self.assertIn('Desired container number already achieved', captured_output)
+        assert 'Desired container number already achieved' in captured_output
 
     @mock.patch('compose.service.log')
     def test_scale_with_custom_container_name_outputs_warning(self, mock_log):

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -270,12 +270,21 @@ class ProjectTest(unittest.TestCase):
                 'time': 1420092061,
                 'timeNano': 14200920610000004000,
             },
+            {
+                'status': 'destroy',
+                'from': 'example/db',
+                'id': 'eeeee',
+                'time': 1420092061,
+                'timeNano': 14200920610000004000,
+            },
         ])
 
         def dt_with_microseconds(dt, us):
             return datetime.datetime.fromtimestamp(dt).replace(microsecond=us)
 
         def get_container(cid):
+            if cid == 'eeeee':
+                raise NotFound(None, None, "oops")
             if cid == 'abcde':
                 name = 'web'
                 labels = {LABEL_SERVICE: name}


### PR DESCRIPTION
Fixes #3258

`Container.from_id()` is using a fresh `client.inspect_container()`, so it should be setting `has_been_inspected=True` to prevent another unnecessary inspect the next time a container property is accessed.

This was causing #3258 because `container.service` was being accessed outside of the `try/except` which handles missing containers.