### PR TITLE
Parallel execution: check readiness of each object individually

### DIFF
--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -94,7 +94,9 @@ def setup_queue(objects, func, get_deps, get_name):
         )
 
     def feed():
-        for obj in filter(ready, objects):
+        for obj in objects:
+            if not ready(obj):
+                continue
             started.add(obj)
             t = Thread(target=do_op, args=(obj,))
             t.daemon = True


### PR DESCRIPTION
Prevents edge-cases where some objects would be processed multiple times

Fixes #3271 