### PR TITLE
Parallel execution refactor/fixes

### DIFF
--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -91,7 +91,7 @@ def parallel_execute_stream(objects, func, get_deps):
             yield event
 
         try:
-            event = results.get(timeout=1)
+            event = results.get(timeout=0.1)
         except Empty:
             continue
         # See https://github.com/docker/compose/issues/189

--- a/compose/service.py
+++ b/compose/service.py
@@ -135,6 +135,9 @@ class Service(object):
         self.networks = networks or {}
         self.options = options
 
+    def __repr__(self):
+        return '<Service: {}>'.format(self.name)
+
     def containers(self, stopped=False, one_off=False, filters={}):
         filters.update({'label': self.labels(one_off=one_off)})
 

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -22,6 +22,10 @@ deps = {
 }
 
 
+def get_deps(obj):
+    return deps[obj]
+
+
 def test_parallel_execute():
     results = parallel_execute(
         objects=[1, 2, 3, 4, 5],
@@ -44,7 +48,7 @@ def test_parallel_execute_with_deps():
         func=process,
         get_name=lambda obj: obj,
         msg="Processing",
-        get_deps=lambda obj: deps[obj],
+        get_deps=get_deps,
     )
 
     assert sorted(log) == sorted(objects)
@@ -67,7 +71,7 @@ def test_parallel_execute_with_upstream_errors():
         func=process,
         get_name=lambda obj: obj,
         msg="Processing",
-        get_deps=lambda obj: deps[obj],
+        get_deps=get_deps,
     )
 
     assert log == [cache]

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -5,6 +5,8 @@ import six
 from docker.errors import APIError
 
 from compose.parallel import parallel_execute
+from compose.parallel import parallel_execute_stream
+from compose.parallel import UpstreamError
 
 
 web = 'web'
@@ -75,3 +77,14 @@ def test_parallel_execute_with_upstream_errors():
     )
 
     assert log == [cache]
+
+    events = [
+        (obj, result, type(exception))
+        for obj, result, exception
+        in parallel_execute_stream(objects, process, get_deps)
+    ]
+
+    assert (cache, None, type(None)) in events
+    assert (data_volume, None, APIError) in events
+    assert (db, None, UpstreamError) in events
+    assert (web, None, UpstreamError) in events

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import six
+from docker.errors import APIError
+
+from compose.parallel import parallel_execute
+
+
+web = 'web'
+db = 'db'
+data_volume = 'data_volume'
+cache = 'cache'
+
+objects = [web, db, data_volume, cache]
+
+deps = {
+    web: [db, cache],
+    db: [data_volume],
+    data_volume: [],
+    cache: [],
+}
+
+
+def test_parallel_execute():
+    results = parallel_execute(
+        objects=[1, 2, 3, 4, 5],
+        func=lambda x: x * 2,
+        get_name=six.text_type,
+        msg="Doubling",
+    )
+
+    assert sorted(results) == [2, 4, 6, 8, 10]
+
+
+def test_parallel_execute_with_deps():
+    log = []
+
+    def process(x):
+        log.append(x)
+
+    parallel_execute(
+        objects=objects,
+        func=process,
+        get_name=lambda obj: obj,
+        msg="Processing",
+        get_deps=lambda obj: deps[obj],
+    )
+
+    assert sorted(log) == sorted(objects)
+
+    assert log.index(data_volume) < log.index(db)
+    assert log.index(db) < log.index(web)
+    assert log.index(cache) < log.index(web)
+
+
+def test_parallel_execute_with_upstream_errors():
+    log = []
+
+    def process(x):
+        if x is data_volume:
+            raise APIError(None, None, "Something went wrong")
+        log.append(x)
+
+    parallel_execute(
+        objects=objects,
+        func=process,
+        get_name=lambda obj: obj,
+        msg="Processing",
+        get_deps=lambda obj: deps[obj],
+    )
+
+    assert log == [cache]


### PR DESCRIPTION
- Fixes #3271
- Fixes another bug where if A depends on B and B fails, A is still executed
- Obviates the need for #3278 and #3279 by doing all set mutation in a single thread, to avoid race conditions and locks
- Adds basic logging and unit tests for `parallel` module