### PR TITLE
Remove extra ensure_image_exists() which causes duplicate builds.

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -309,12 +309,13 @@ class Project(object):
     ):
         services = self.get_services_without_duplicate(service_names, include_deps=True)
 
+        for svc in services:
+            svc.ensure_image_exists(do_build=do_build)
         plans = self._get_convergence_plans(services, strategy)
 
         for service in services:
             service.execute_convergence_plan(
                 plans[service.name],
-                do_build,
                 detached=True,
                 start=False)
 
@@ -366,21 +367,19 @@ class Project(object):
            remove_orphans=False):
 
         self.initialize()
+        self.find_orphan_containers(remove_orphans)
+
         services = self.get_services_without_duplicate(
             service_names,
             include_deps=start_deps)
 
-        plans = self._get_convergence_plans(services, strategy)
-
         for svc in services:
             svc.ensure_image_exists(do_build=do_build)
-
-        self.find_orphan_containers(remove_orphans)
+        plans = self._get_convergence_plans(services, strategy)
 
         def do(service):
             return service.execute_convergence_plan(
                 plans[service.name],
-                do_build=do_build,
                 timeout=timeout,
                 detached=detached
             )

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -1037,12 +1037,10 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(set(service.duplicate_containers()), set([duplicate]))
 
 
-def converge(service,
-             strategy=ConvergenceStrategy.changed,
-             do_build=True):
+def converge(service, strategy=ConvergenceStrategy.changed):
     """Create a converge plan from a strategy and execute the plan."""
     plan = service.convergence_plan(strategy)
-    return service.execute_convergence_plan(plan, do_build=do_build, timeout=1)
+    return service.execute_convergence_plan(plan, timeout=1)
 
 
 class ConfigHashTest(DockerClientTestCase):


### PR DESCRIPTION
Fixes #3286

`ensure_image_exists()` now happens before creating the convergence plan, so we generate the correct plan (instead of generating "start the old container").

In the case where something has change, we are now only passing `on_build=...` from the first call to `ensure_image_exists()`, so we don't end up building it twice.