### PR TITLE
Fix showing error service name when one of the services' name is invalid

### DIFF
--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -13,6 +13,7 @@ from jsonschema import Draft4Validator
 from jsonschema import FormatChecker
 from jsonschema import RefResolver
 from jsonschema import ValidationError
+from jsonschema import _utils
 
 from ..const import COMPOSEFILE_V1 as V1
 from .errors import ConfigurationError
@@ -200,10 +201,11 @@ def handle_error_for_schema_with_id(error, path):
     schema_id = error.schema['id']
 
     if is_service_dict_schema(schema_id) and error.validator == 'additionalProperties':
-        return "Invalid service name '{}' - only {} characters are allowed".format(
+        properties = _utils.find_additional_properties(error.instance, error.schema)
+	return "Invalid service name '{}' - only {} characters are allowed".format(
             # The service_name is the key to the json object
-            list(error.instance)[0],
-            VALID_NAME_CHARS)
+            properties.next(),
+	    VALID_NAME_CHARS)
 
     if error.validator == 'additionalProperties':
         if schema_id == '#/definitions/service':


### PR DESCRIPTION
The problem is easy to reproduce, using the yaml file below:

a-zA-Z0-9._:
  image: busybox:latest
  command: top
invalid@name:
  image: busybox:latest
  command: top

and the result will be:
ERROR: Validation failed in file './docker-compose.yml', reason(s):
Invalid service name 'a-zA-Z0-9._' - only [a-zA-Z0-9._-] characters are allowed

Signed-off-by: Lei Gong xue177125184@gmail.com
