### PR TITLE
Only show port clash warning if multiple containers are about to be started

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -179,7 +179,7 @@ class Service(object):
                      'Remove the custom name to scale the service.'
                      % (self.name, self.custom_container_name))
 
-        if self.specifies_host_port():
+        if self.specifies_host_port() and desired_num > 1:
             log.warn('The "%s" service specifies a port on the host. If multiple containers '
                      'for this service are created on a single host, the port will clash.'
                      % self.name)


### PR DESCRIPTION
Fixes #2096: Only print out the log trace when you're scaling to more than one container.

Signed-off-by: Danyal Prout <me@dany.al>