### PR TITLE
Attempt to fix flaky logs test

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1257,13 +1257,14 @@ class CLITestCase(DockerClientTestCase):
             'logscomposefile_another_1',
             'exited'))
 
-        # sleep for a short period to allow the tailing thread to receive the
-        # event. This is not great, but there isn't an easy way to do this
-        # without being able to stream stdout from the process.
-        time.sleep(0.5)
-        os.kill(proc.pid, signal.SIGINT)
-        result = wait_on_process(proc, returncode=1)
+        self.dispatch(['kill', 'simple'])
+
+        result = wait_on_process(proc)
+
+        assert 'hello' in result.stdout
         assert 'test' in result.stdout
+        assert 'logscomposefile_another_1 exited with code 0' in result.stdout
+        assert 'logscomposefile_simple_1 exited with code 137' in result.stdout
 
     def test_logs_default(self):
         self.base_dir = 'tests/fixtures/logs-composefile'

--- a/tests/fixtures/logs-composefile/docker-compose.yml
+++ b/tests/fixtures/logs-composefile/docker-compose.yml
@@ -1,6 +1,6 @@
 simple:
   image: busybox:latest
-  command: sh -c "echo hello && sleep 200"
+  command: sh -c "echo hello && tail -f /dev/null"
 another:
   image: busybox:latest
   command: sh -c "echo test"


### PR DESCRIPTION
Rather than kill the `docker-compose` process, kill the one container it's tailing logs from.

In addition, make the `hello` container hang forever rather than for 2 seconds, just to rule out the possibility of creating a race condition if there's a significant delay in attaching.