### PR TITLE
Fix #3248: Accidental config_hash change

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -726,7 +726,7 @@ class MergeDict(dict):
 
         merged = parse_sequence_func(self.base.get(field, []))
         merged.update(parse_sequence_func(self.override.get(field, [])))
-        self[field] = [item.repr() for item in merged.values()]
+        self[field] = [item.repr() for item in sorted(merged.values())]
 
     def merge_scalar(self, field):
         if self.needs_merge(field):
@@ -928,7 +928,7 @@ def dict_from_path_mappings(path_mappings):
 
 
 def path_mappings_from_dict(d):
-    return [join_path_mapping(v) for v in d.items()]
+    return [join_path_mapping(v) for v in sorted(d.items())]
 
 
 def split_path_mapping(volume_path):


### PR DESCRIPTION
When merging volumes for different config files, [each volumes list is being converted to dict and then back to list](https://github.com/docker/compose/blob/e2cb7b0237085415ce48900309a61c73b5938520/compose/config/config.py#L917-L931).
In Python 3 order of elements in hash table (dict, set, etc) may be different in different processes. So it causes accidental changes of `config_dict` and that causes recreating of containers.

Sorry, I don't know how to write determined test that will not blink from run to run.

Signed-off-by: Vladimir Lagunov <lagunov.vladimir@gmail.com>