### PR TITLE
Check for short id alias, and don't disconnect if it already exists

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -535,7 +535,7 @@ class Service(object):
 
     def _get_aliases(self, network, container=None):
         if container and container.labels.get(LABEL_ONE_OFF) == "True":
-            return set()
+            return []
 
         return list(
             {self.name} |

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -663,6 +663,35 @@ class ServiceTest(unittest.TestCase):
             'for this service are created on a single host, the port will clash.'.format(name))
 
 
+class TestServiceNetwork(object):
+
+    def test_connect_container_to_networks_short_aliase_exists(self):
+        mock_client = mock.create_autospec(docker.Client)
+        service = Service(
+            'db',
+            mock_client,
+            'myproject',
+            image='foo',
+            networks={'project_default': {}})
+        container = Container(
+            None,
+            {
+                'Id': 'abcdef',
+                'NetworkSettings': {
+                    'Networks': {
+                        'project_default': {
+                            'Aliases': ['analias', 'abcdef'],
+                        },
+                    },
+                },
+            },
+            True)
+        service.connect_container_to_networks(container)
+
+        assert not mock_client.disconnect_container_from_network.call_count
+        assert not mock_client.connect_container_to_network.call_count
+
+
 def sort_by_name(dictionary_list):
     return sorted(dictionary_list, key=lambda k: k['name'])
 


### PR DESCRIPTION
Fixes #3252

Related to https://github.com/docker/libnetwork/issues/996 and https://github.com/docker/docker/pull/21901

Windows engine doesn't have network disconnect, so we can check if the short id alias already exists, and skip the disconnect if it does exist.

cc @friism, @mavenugo