### PR TITLE
Make validation errors less robotic

### DIFF
--- a/compose/config/errors.py
+++ b/compose/config/errors.py
@@ -3,10 +3,11 @@ from __future__ import unicode_literals
 
 
 VERSION_EXPLANATION = (
-    'Either specify a version of "2" (or "2.0") and place your service '
-    'definitions under the `services` key, or omit the `version` key and place '
-    'your service definitions at the root of the file to use version 1.\n'
-    'For more on the Compose file format versions, see '
+    'You might be seeing this error because you\'re using the wrong Compose '
+    'file version. Either specify a version of "2" (or "2.0") and place your '
+    'service definitions under the `services` key, or omit the `version` key '
+    'and place your service definitions at the root of the file to use '
+    'version 1.\nFor more on the Compose file format versions, see '
     'https://docs.docker.com/compose/compose-file/')
 
 

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -416,6 +416,6 @@ def handle_errors(errors, format_error_func, filename):
 
     error_msg = '\n'.join(format_error_func(error) for error in errors)
     raise ConfigurationError(
-        "Validation failed{file_msg}, reason(s):\n{error_msg}".format(
-            file_msg=" in file '{}'".format(filename) if filename else "",
+        "The Compose file{file_msg} is invalid because:\n{error_msg}".format(
+            file_msg=" '{}'".format(filename) if filename else "",
             error_msg=error_msg))

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -219,7 +219,7 @@ def handle_error_for_schema_with_id(error, path):
             return get_unsupported_config_msg(path, invalid_config_key)
 
         if not error.path:
-            return '{}\n{}'.format(error.message, VERSION_EXPLANATION)
+            return '{}\n\n{}'.format(error.message, VERSION_EXPLANATION)
 
 
 def handle_generic_error(error, path):


### PR DESCRIPTION
```
ERROR: Validation failed in file './docker-compose.yml', reason(s):
Additional properties are not allowed ('dfjklhfsd' was unexpected)
Either specify a version of "2" (or "2.0") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```

is now

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Additional properties are not allowed ('dfjklhfsd' was unexpected)

You might be seeing this error because you're using the wrong Compose file version. Either specify a version of "2" (or "2.0") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```

Hopefully this will help meatbag(s) parse this.