### PR TITLE
Add helper function invokation

### DIFF
--- a/compose/config/func_map.py
+++ b/compose/config/func_map.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import re
+import sys
+
+import docker
+
+import compose
+from compose.const import IS_WINDOWS_PLATFORM
+
+
+def __get_compose_version():
+    return compose.__version__
+
+
+def __get_docker_version():
+    return ".".join([str(i) for i in docker.version_info])
+
+
+def __get_platform():
+    return sys.platform
+
+
+def _get_uid():
+    if IS_WINDOWS_PLATFORM:
+        raise PosixOnlyHelperException(
+                'get_user_id helper is only available'
+                'on Posix operating systems')
+    return os.getuid()
+
+
+def _get_gid():
+    if IS_WINDOWS_PLATFORM:
+        raise PosixOnlyHelperException(
+                'get_group_id helper is only available'
+                'on Posix operating systems')
+    return os.getgid()
+
+func_map = {
+    "get_user_id": _get_uid,
+    "get_group_id": _get_gid,
+    "get_compose_version": __get_compose_version,
+    "get_docker_version": __get_docker_version,
+    "get_host_platform": __get_platform
+}
+
+func_regexp = re.compile(r'@\{(.*?)\}')
+inhibate_double_arobase = re.compile(r'@{2}{(.*?)}')
+
+
+class InvalidHelperFunction(Exception):
+    def __init__(self, string):
+        self.string = string
+
+
+class PosixOnlyHelperException(Exception):
+    def __init__(self, string):
+        self.string = string

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -32,6 +32,11 @@ You can use environment variables in configuration values with a Bash-like
 `${VARIABLE}` syntax - see [variable substitution](#variable-substitution) for
 full details.
 
+Futhermore, Compose exposes some helper functions that may be useful to get
+some values as launcher user id or host plateform name -
+see [helper function](#helper-functions) for full details.
+
+
 
 ## Service configuration reference
 
@@ -1128,6 +1133,24 @@ Compose.
 If you forget and use a single dollar sign (`$`), Compose interprets the value as an environment variable and will warn you:
 
   The VAR_NOT_INTERPOLATED_BY_COMPOSE is not set. Substituting an empty string.
+
+## Helper functions
+
+In configuration options, you may invoke "helper functions" to get specific host values.
+The form is `@{help_function}` where "helper\_function" is one of the following:
+
+- `get_user_id`: returns the current user id
+- `get_group_id`: returns the current user group id
+- `get_host_platform`: returns the name of the current platform - see [python sys.platform](https://docs.python.org/2/library/sys.html#sys.platform)
+- `get_docker_version`: returns the docker version (eg. 1.11.0)
+_ `get_compose_version`: returns the compose version (eg. 1.8.0)
+
+The whole helper functions returns `string` type value.
+
+To avoid helper function invokation, and get `@{string}`, you need to double arobase char
+as for environment variable that doubles dolar sign. Eg. `@@{foo}` yields `@{foo}` and will not be
+interpreted as helper function call.
+
 
 ## Compose documentation
 

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -6,8 +6,12 @@ import os
 import mock
 import pytest
 
+import compose
 from compose.config.environment import Environment
+from compose.config.func_map import InvalidHelperFunction
+from compose.config.func_map import PosixOnlyHelperException
 from compose.config.interpolation import interpolate_environment_variables
+from compose.const import IS_WINDOWS_PLATFORM
 
 
 @pytest.yield_fixture
@@ -15,6 +19,34 @@ def mock_env():
     with mock.patch.dict(os.environ):
         os.environ['USER'] = 'jenny'
         os.environ['FOO'] = 'bar'
+        yield
+
+
+@pytest.yield_fixture
+def mock_func_map():
+    def _uid():
+        return 5555
+
+    def _gid():
+        return 5556
+
+    def _docker_version():
+        return "1.2.3"
+
+    def _compose_version():
+        return compose.__version__
+
+    def _platform():
+        return 'mocked_platform'
+
+    with mock.patch.dict(compose.config.interpolation.func_map):
+        compose.config.interpolation.func_map = {
+            'get_user_id': _uid,
+            'get_group_id': _gid,
+            'get_compose_version': _compose_version,
+            'get_docker_version': _docker_version,
+            'get_host_platform': _platform
+        }
         yield
 
 
@@ -72,3 +104,73 @@ def test_interpolate_environment_variables_in_volumes(mock_env):
     assert interpolate_environment_variables(
         volumes, 'volume', Environment.from_env_file(None)
     ) == expected
+
+
+def test_invoke_funcmap_in_services(mock_env, mock_func_map):
+
+    services = {
+        'servicea': {
+            'image': '@{get_host_platform}:latest',
+            'user': '@{get_user_id}:@{get_group_id}',
+            'environment': {
+                'COMPOSE_VERSION': '@{get_compose_version}',
+                'DOCKER_VERSION': '@{get_docker_version}',
+            }
+        }
+    }
+    expected = {
+        'servicea': {
+            'image': 'mocked_platform:latest',
+            'user': '5555:5556',
+            'environment': {
+                'COMPOSE_VERSION': compose.__version__,
+                'DOCKER_VERSION': '1.2.3',
+            }
+        }
+    }
+
+    if not IS_WINDOWS_PLATFORM:
+        assert interpolate_environment_variables(
+            services, 'servicea', Environment.from_env_file(None)
+        ) == expected
+    else:
+        try:
+            interpolate_environment_variables(
+                services, 'servicea', Environment.from_env_file(None)
+            )
+        except PosixOnlyHelperException:
+            pass
+
+
+def test_inihbate_invoke_funcmap_in_services(mock_env, mock_func_map):
+
+    services = {
+        'servicea': {
+            'image': '@@{get_host_platform}:doubled'
+        }
+    }
+    expected = {
+        'servicea': {
+            'image': '@{get_host_platform}:doubled'
+        }
+    }
+    assert interpolate_environment_variables(
+        services, 'servicea', Environment.from_env_file(None)
+    ) == expected
+
+
+def test_calling_unknown_helper_function(mock_env, mock_func_map):
+
+    services = {
+        'servicea': {
+            'image': '@{unknown_function_test}:latest',
+        }
+    }
+
+    try:
+        assert interpolate_environment_variables(
+            services, 'servicea', Environment.from_env_file(None)
+        )
+        raise Exception("Should failed")
+    except InvalidHelperFunction:
+        pass


### PR DESCRIPTION
Helper function are useful to get some host specific values as docker
version or compose version.

List is:
- get_user_id
- get_group_id
- get_host_platform
- get_compose_version
- get_docker_version

Invokation is made by using `@{helper_function_name}` and always returns
string.

To inibate `@{}` and return arobase char, as for environment
interpolation, you may use `@@{...}` that returns `@{...}`.

This PR follows #3348 refusal and aims to propose a more secured way to get useful values that cannot be served by environment variable (without to set them)

Signed-off-by: Patrice Ferlet metal3d@gmail.com
