### PR TITLE
Unset env vars behavior in 'run' mirroring engine

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -821,7 +821,9 @@ def build_container_options(options, detach, command):
     }
 
     if options['-e']:
-        container_options['environment'] = parse_environment(options['-e'])
+        container_options['environment'] = Environment.from_command_line(
+            parse_environment(options['-e'])
+        )
 
     if options['--entrypoint']:
         container_options['entrypoint'] = options.get('--entrypoint')

--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -58,6 +58,18 @@ class Environment(dict):
         instance.update(os.environ)
         return instance
 
+    @classmethod
+    def from_command_line(cls, parsed_env_opts):
+        result = cls()
+        for k, v in parsed_env_opts.items():
+            # Values from the command line take priority, unless they're unset
+            # in which case they take the value from the system's environment
+            if v is None and k in os.environ:
+                result[k] = os.environ[k]
+            else:
+                result[k] = v
+        return result
+
     def __getitem__(self, key):
         try:
             return super(Environment, self).__getitem__(key)

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1120,6 +1120,14 @@ class CLITestCase(DockerClientTestCase):
             'simplecomposefile_simple_run_1',
             'exited'))
 
+    @mock.patch.dict(os.environ)
+    def test_run_env_values_from_system(self):
+        os.environ['FOO'] = 'bar'
+        os.environ['BAR'] = 'baz'
+        result = self.dispatch(['run', '-e', 'FOO', 'simple', 'env'], None)
+        assert 'FOO=bar' in result.stdout
+        assert 'BAR=baz' not in result.stdout
+
     def test_rm(self):
         service = self.project.get_service('simple')
         service.create_container()


### PR DESCRIPTION
Unset env vars passed to `run` via command line options take the value of the system's var with the same name.

Fixes #3343