### PR TITLE
Add missing log event filter when using docker-compose logs.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -426,7 +426,8 @@ class TopLevelCommand(object):
             self.project,
             containers,
             options['--no-color'],
-            log_args).run()
+            log_args,
+            event_stream=self.project.events(service_names=options['SERVICE'])).run()
 
     def pause(self, options):
         """


### PR DESCRIPTION
Proposed fix for #3361