### PR TITLE
Adds additional validation to 'env_vars_from_file'.

### DIFF
--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -28,6 +28,8 @@ def env_vars_from_file(filename):
     """
     if not os.path.exists(filename):
         raise ConfigurationError("Couldn't find env file: %s" % filename)
+    elif not os.path.isfile(filename):
+        raise ConfigurationError("%s is not a file." % (filename))
     env = {}
     for line in codecs.open(filename, 'r', 'utf-8'):
         line = line.strip()


### PR DESCRIPTION
The 'env_file' directive and feature precludes the use of the name '.env' in the path shared with 'docker-config.yml', regardless of whether or not it is enabled (or desired).

This change adds an additional validation to allow the use of this path provided it is not a file.

A real-world example: by convention, a project I contribute to generates a virtualenv at project-level named '.env'. The presence of this path results in immediate failure of a docker-compose invocation.

To address this issue more generally (and to cover more use cases), I would suggest that this implicit path '.env', relative to the current working directory (see #3381), be configurable, e.g.:

```
    @classmethod
    def from_env_file(cls, base_dir):
        def _initialize():
            result = cls()
            if base_dir is None:
                return result
-             env_file_path = os.path.join(base_dir, '.env')
+             env_file_path = os.path.join(base_dir, ENV_FILE_PATH)
            try:
                return cls(env_vars_from_file(env_file_path))
            except ConfigurationError:
                pass
            return result
        instance = _initialize()
        instance.update(os.environ)
        return instance
```

and see no reason why it should be hard-coded.