### PR TITLE
Ignore error output of `stty size` when standard input is not a termi…

### DIFF
--- a/compose/cli/formatter.py
+++ b/compose/cli/formatter.py
@@ -10,7 +10,7 @@ from compose.cli import colors
 
 
 def get_tty_width():
-    tty_size = os.popen('stty size', 'r').read().split()
+    tty_size = os.popen('stty size 2> /dev/null', 'r').read().split()
     if len(tty_size) != 2:
         return 0
     _, width = tty_size


### PR DESCRIPTION
Simply redirected standard error to /dev/null, since we cannot actually handle that.

Fixes #1876
