### PR TITLE
Fixes #1135 - Use a new version of pyinstaller 3.2 to build a valid E…

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,1 +1,1 @@
-pyinstaller==3.1.1
+pyinstaller==3.2


### PR DESCRIPTION
…LF file to stop prelinking breaking compose