### PR TITLE
Always use the Windows version of splitdrive when parsing volume mappings

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import functools
 import logging
+import ntpath
 import operator
 import os
 import string
@@ -944,7 +945,7 @@ def split_path_mapping(volume_path):
     if volume_path.startswith('.') or volume_path.startswith('~'):
         drive, volume_config = '', volume_path
     else:
-        drive, volume_config = os.path.splitdrive(volume_path)
+        drive, volume_config = ntpath.splitdrive(volume_path)
 
     if ':' in volume_config:
         (host, container) = volume_config.split(':', 1)

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2658,8 +2658,6 @@ class ExpandPathTest(unittest.TestCase):
 
 
 class VolumePathTest(unittest.TestCase):
-
-    @pytest.mark.xfail((not IS_WINDOWS_PLATFORM), reason='does not have a drive')
     def test_split_path_mapping_with_windows_path(self):
         host_path = "c:\\Users\\msamblanet\\Documents\\anvil\\connect\\config"
         windows_volume_path = host_path + ":/opt/connect/config:ro"

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2664,7 +2664,15 @@ class VolumePathTest(unittest.TestCase):
         expected_mapping = ("/opt/connect/config:ro", host_path)
 
         mapping = config.split_path_mapping(windows_volume_path)
-        self.assertEqual(mapping, expected_mapping)
+        assert mapping == expected_mapping
+
+    def test_split_path_mapping_with_windows_path_in_container(self):
+        host_path = 'c:\\Users\\remilia\\data'
+        container_path = 'c:\\scarletdevil\\data'
+        expected_mapping = (container_path, host_path)
+
+        mapping = config.split_path_mapping('{0}:{1}'.format(host_path, container_path))
+        assert mapping == expected_mapping
 
 
 @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')


### PR DESCRIPTION
Fixes #2487 
