### PR TITLE
Fix docs: startup-order example config

### DIFF
--- a/docs/startup-order.md
+++ b/docs/startup-order.md
@@ -50,7 +50,7 @@ script:
               - "80:8000"
             depends_on:
               - "db"
-            entrypoint: ./wait-for-it.sh db:5432
+            entrypoint: ./wait-for-it.sh db:5432 --  # -- is important
           db:
             image: postgres
 


### PR DESCRIPTION
Without "--" there is an error because `wait-for-it` tries to parse original command like their own arguments.
