### PR TITLE
Fix bug where confirmation prompt doesn't show due to line buffering

### DIFF
--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -6,9 +6,9 @@ import os
 import platform
 import ssl
 import subprocess
+import sys
 
 import docker
-from six.moves import input
 
 import compose
 
@@ -40,6 +40,16 @@ def yesno(prompt, default=None):
         return default
     else:
         return None
+
+
+def input(prompt):
+    """
+    Version of input (raw_input in Python 2) which forces a flush of sys.stdout
+    to avoid problems where the prompt fails to appear due to line buffering
+    """
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    return sys.stdin.readline().rstrip(b'\n')
 
 
 def call_silently(*args, **kwargs):


### PR DESCRIPTION
Alternate solutions, according to [this Stack Overflow answer](http://stackoverflow.com/questions/107705/disable-output-buffering):

- Ensure that `PYTHONUNBUFFERED=1`. I can't see a way to do that from within the Python code.
- Wrap stdout in an object which flushes on every write. It would work, and would cover other cases too, but I don't want to think about how/whether it would mess with dockerpty.

Closes #2897.