### PR TITLE
remove command completion for `docker-compose rm --a`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -325,7 +325,7 @@ _docker_compose_restart() {
 _docker_compose_rm() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all -a --force -f --help -v" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--force -f --help -v" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_stopped

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -281,7 +281,6 @@ __docker-compose_subcommand() {
         (rm)
             _arguments \
                 $opts_help \
-                '(-a --all)'{-a,--all}"[Also remove one-off containers]" \
                 '(-f --force)'{-f,--force}"[Don't ask to confirm removal]" \
                 '-v[Remove volumes associated with containers]' \
                 '*:stopped services:__docker-compose_stoppedservices' && ret=0


### PR DESCRIPTION
As `--all|-a` is deprecated, there's no use to suggest it any more in command completion.

edit: ref #3466

ping @sdurrheimer please check whether I broke zsh completion.