### PR TITLE
Add support for swappiness constraint

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -69,6 +69,7 @@ DOCKER_CONFIG_KEYS = [
     'mac_address',
     'mem_limit',
     'memswap_limit',
+    'mem_swappiness',
     'net',
     'oom_score_adj'
     'pid',

--- a/compose/config/config_schema_v1.json
+++ b/compose/config/config_schema_v1.json
@@ -85,6 +85,7 @@
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
+        "mem_swappiness": {"type": "integer"},
         "net": {"type": "string"},
         "pid": {"type": ["string", "null"]},
 

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -139,6 +139,7 @@
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
+        "mem_swappiness": {"type": "integer"},
         "network_mode": {"type": "string"},
 
         "networks": {

--- a/compose/service.py
+++ b/compose/service.py
@@ -55,6 +55,7 @@ DOCKER_START_KEYS = [
     'mem_limit',
     'memswap_limit',
     'oom_score_adj',
+    'mem_swappiness',
     'pid',
     'privileged',
     'restart',
@@ -704,7 +705,8 @@ class Service(object):
             cpu_quota=options.get('cpu_quota'),
             shm_size=options.get('shm_size'),
             tmpfs=options.get('tmpfs'),
-            oom_score_adj=options.get('oom_score_adj')
+            oom_score_adj=options.get('oom_score_adj'),
+            mem_swappiness=options.get('mem_swappiness')
         )
 
     def build(self, no_cache=False, pull=False, force_rm=False):

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -744,7 +744,7 @@ then read-write will be used.
 >     - container_name
 >     - container_name:rw
 
-### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, oom_score_adj, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
+### cpu\_shares, cpu\_quota, cpuset, domainname, hostname, ipc, mac\_address, mem\_limit, memswap\_limit, mem\_swappiness, oom\_score\_adj, privileged, read\_only, restart, shm\_size, stdin\_open, tty, user, working\_dir
 
 Each of these is a single value, analogous to its
 [docker run](https://docs.docker.com/engine/reference/run/) counterpart.
@@ -763,6 +763,7 @@ Each of these is a single value, analogous to its
 
     mem_limit: 1000000000
     memswap_limit: 2000000000
+    mem_swappiness: 10
     privileged: true
 
     restart: always

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -852,6 +852,11 @@ class ServiceTest(DockerClientTestCase):
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.Dns'), ['8.8.8.8', '9.9.9.9'])
 
+    def test_mem_swappiness(self):
+        service = self.create_service('web', mem_swappiness=11)
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.MemorySwappiness'), 11)
+
     def test_restart_always_value(self):
         service = self.create_service('web', restart={'Name': 'always'})
         container = create_and_start_container(service)

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1271,6 +1271,24 @@ class ConfigTest(unittest.TestCase):
             }
         ]
 
+    def test_swappiness_option(self):
+        actual = config.load(build_config_details({
+            'version': '2',
+            'services': {
+                'web': {
+                    'image': 'alpine',
+                    'mem_swappiness': 10,
+                }
+            }
+        }))
+        assert actual.services == [
+            {
+                'name': 'web',
+                'image': 'alpine',
+                'mem_swappiness': 10,
+            }
+        ]
+
     def test_merge_service_dicts_from_files_with_extends_in_base(self):
         base = {
             'volumes': ['.:/app'],


### PR DESCRIPTION
Run a service using `docker run --memory-swappiness=0` (see
https://docs.docker.com/engine/reference/run/)

refs #2383