### PR TITLE
Added bundler gem path as a volume to documentation 

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -22,6 +22,7 @@ container. This is done using a file called `Dockerfile`. To begin with, the
 Dockerfile consists of:
 
     FROM ruby:2.3
+    ENV BUNDLE_PATH /bundler
     RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
     RUN mkdir /myapp
     WORKDIR /myapp
@@ -58,10 +59,13 @@ to link them together and expose the web app's port.
         command: bundle exec rails s -p 3000 -b '0.0.0.0'
         volumes:
           - .:/myapp
+          - bundler:/bundler
         ports:
           - "3000:3000"
         depends_on:
           - db
+    volumes:
+      bundler: {}
 
 ### Build the project
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -21,7 +21,7 @@ dependencies, you'll need to define exactly what needs to be included in the
 container. This is done using a file called `Dockerfile`. To begin with, the
 Dockerfile consists of:
 
-    FROM ruby:2.2.0
+    FROM ruby:2.3
     RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
     RUN mkdir /myapp
     WORKDIR /myapp


### PR DESCRIPTION
By adding the volume, the developer doesn’t need to install every single gem every time they want to add an extra dependency. It just makes the development process smoother.
