### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ that should get you started.
 This step is optional, but recommended. Pre-commit hooks will run style checks
 and in some cases fix style issues for you, when you commit code.
 
-Install the git pre-commit hooks using [tox](https://tox.readthedocs.org) by
+Install the git pre-commit hooks using [tox](https://tox.readthedocs.io) by
 running `tox -e pre-commit` or by following the
 [pre-commit install guide](http://pre-commit.com/#install).
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.