### PR TITLE
3501 - Add a new command option (images)

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -170,6 +170,7 @@ class TopLevelCommand(object):
       events             Receive real time events from containers
       exec               Execute a command in a running container
       help               Get help on a command
+      images             List images
       kill               Kill containers
       logs               View output from containers
       pause              Pause services
@@ -388,6 +389,43 @@ class TopLevelCommand(object):
             subject = cls
 
         print(getdoc(subject))
+
+    def images(self, options):
+        """
+        List images.
+        Usage: images [options] [SERVICE...]
+
+        Options:
+        -q     Only display IDs
+        """
+        containers = sorted(
+            self.project.containers(service_names=options['SERVICE'], stopped=True) +
+            self.project.containers(service_names=options['SERVICE'], one_off=OneOffFilter.only),
+            key=attrgetter('name'))
+
+        if options['-q']:
+            for container in containers:
+                print(str.split(str(container.image), ':')[1])
+        else:
+            headers = [
+                'Repository',
+                'Tag',
+                'Image Id',
+                'Size'
+            ]
+            rows = []
+            for container in containers:
+                image_config = container.image_config
+                repo_tags = str.split(str(image_config['RepoTags'][0]), ':')
+                image_id = str.split(str(container.image), ':')[1][0:12]
+                size = round(int(image_config['Size'])/float(1 << 20), 1)
+                rows.append([
+                    repo_tags[0],
+                    repo_tags[1],
+                    image_id,
+                    size
+                ])
+            print(Formatter().table(headers, rows))
 
     def kill(self, options):
         """

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -208,6 +208,16 @@ _docker_compose_help() {
 	COMPREPLY=( $( compgen -W "${commands[*]}" -- "$cur" ) )
 }
 
+_docker_compose_images() {
+    case "$cur" in
+	-*)
+	    COMPREPLY=( $( compgen -W "--help -q" -- "$cur" ) )
+	    ;;
+	*)
+	    __docker_compose_services_all
+	    ;;
+    esac
+}
 
 _docker_compose_kill() {
 	case "$prev" in

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -1,0 +1,21 @@
+<!--[metadata]>
++++
+title = "images"
+description = "Lists images."
+keywords = ["fig, composition, compose, docker, orchestration, cli,  images"]
+[menu.main]
+identifier="images.compose"
+parent = "smn_compose_cli"
++++
+<![end-metadata]-->
+
+# images
+
+```
+Usage: images [options] [SERVICE...]
+
+Options:
+-q    Only display IDs
+```
+
+Lists images.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,7 @@ The following pages describe the usage information for the [docker-compose](over
 * [down](down.md)
 * [events](events.md)
 * [help](help.md)
+* [images](images.md)
 * [kill](kill.md)
 * [logs](logs.md)
 * [pause](pause.md)

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -47,6 +47,7 @@ Commands:
   down               Stop and remove containers, networks, images, and volumes
   events             Receive real time events from containers
   help               Get help on a command
+  images             List images
   kill               Kill containers
   logs               View output from containers
   pause              Pause services

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1609,26 +1609,11 @@ class CLITestCase(DockerClientTestCase):
     def test_images(self):
         self.project.get_service('simple').create_container()
         result = self.dispatch(['images'])
-        assert 'simplecomposefile_simple' in result.stdout
+        assert 'busybox' in result.stdout
 
     def test_images_default_composefile(self):
         self.base_dir = 'tests/fixtures/multiple-composefiles'
         self.dispatch(['up', '-d'])
         result = self.dispatch(['images'])
 
-        self.assertIn('multiplecomposefiles_simple', result.stdout)
-        self.assertIn('multiplecomposefiles_another', result.stdout)
-        self.assertNotIn('multiplecomposefiles_yetanother', result.stdout)
-
-    def test_images_alternate_composefile(self):
-        config_path = os.path.abspath(
-            'tests/fixtures/multiple-composefiles/compose2.yml')
-        self._project = get_project(self.base_dir, [config_path])
-
-        self.base_dir = 'tests/fixtures/multiple-composefiles'
-        self.dispatch(['-f', 'compose2.yml', 'up', '-d'])
-        result = self.dispatch(['-f', 'compose2.yml', 'images'])
-
-        self.assertNotIn('multiplecomposefiles_simple', result.stdout)
-        self.assertNotIn('multiplecomposefiles_another', result.stdout)
-        self.assertIn('multiplecomposefiles_yetanother', result.stdout)
+        self.assertIn('busybox', result.stdout)

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1605,3 +1605,30 @@ class CLITestCase(DockerClientTestCase):
             "BAZ=2",
         ])
         self.assertTrue(expected_env <= set(web.get('Config.Env')))
+
+    def test_images(self):
+        self.project.get_service('simple').create_container()
+        result = self.dispatch(['images'])
+        assert 'simplecomposefile_simple' in result.stdout
+
+    def test_images_default_composefile(self):
+        self.base_dir = 'tests/fixtures/multiple-composefiles'
+        self.dispatch(['up', '-d'])
+        result = self.dispatch(['images'])
+
+        self.assertIn('multiplecomposefiles_simple', result.stdout)
+        self.assertIn('multiplecomposefiles_another', result.stdout)
+        self.assertNotIn('multiplecomposefiles_yetanother', result.stdout)
+
+    def test_images_alternate_composefile(self):
+        config_path = os.path.abspath(
+            'tests/fixtures/multiple-composefiles/compose2.yml')
+        self._project = get_project(self.base_dir, [config_path])
+
+        self.base_dir = 'tests/fixtures/multiple-composefiles'
+        self.dispatch(['-f', 'compose2.yml', 'up', '-d'])
+        result = self.dispatch(['-f', 'compose2.yml', 'images'])
+
+        self.assertNotIn('multiplecomposefiles_simple', result.stdout)
+        self.assertNotIn('multiplecomposefiles_another', result.stdout)
+        self.assertIn('multiplecomposefiles_yetanother', result.stdout)


### PR DESCRIPTION
Added `images` as a new docker-compose command option, that allow list the docker images. Similar to `docker images` command.
Issue: https://github.com/docker/compose/issues/3501

Signed-off-by: Jesus Rodriguez Tinoco jesus.rodriguez.tinoco@gmail.com
