### PR TITLE
Warn on missing digests, don't push/pull by default

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -15,6 +15,7 @@ from . import errors
 from . import signals
 from .. import __version__
 from ..bundle import get_image_digests
+from ..bundle import MissingDigests
 from ..bundle import serialize_bundle
 from ..config import ConfigurationError
 from ..config import parse_environment
@@ -218,12 +219,17 @@ class TopLevelCommand(object):
         """
         Generate a Docker bundle from the Compose file.
 
-        Local images will be pushed to a Docker registry, and remote images
-        will be pulled to fetch an image digest.
+        Images must have digests stored, which requires interaction with a
+        Docker registry. If digests aren't stored for all images, you can pass
+        `--fetch-digests` to automatically fetch them. Images for services
+        with a `build` key will be pushed. Images for services without a
+        `build` key will be pulled.
 
         Usage: bundle [options]
 
         Options:
+            --fetch-digests            Automatically fetch image digests if missing
+
             -o, --output PATH          Path to write the bundle file to.
                                        Defaults to "<project name>.dsb".
         """
@@ -235,7 +241,26 @@ class TopLevelCommand(object):
             output = "{}.dsb".format(self.project.name)
 
         with errors.handle_connection_errors(self.project.client):
-            image_digests = get_image_digests(self.project)
+            try:
+                image_digests = get_image_digests(
+                    self.project,
+                    allow_fetch=options['--fetch-digests'],
+                )
+            except MissingDigests as e:
+                def list_images(images):
+                    return "\n".join("    {}".format(name) for name in sorted(images))
+
+                paras = ["Some images are missing digests."]
+
+                if e.needs_push:
+                    paras += ["The following images need to be pushed:", list_images(e.needs_push)]
+
+                if e.needs_pull:
+                    paras += ["The following images need to be pulled:", list_images(e.needs_pull)]
+
+                paras.append("If this is OK, run `docker-compose bundle --fetch-digests`.")
+
+                raise UserError("\n\n".join(paras))
 
         with open(output, 'w') as f:
             f.write(serialize_bundle(compose_config, image_digests))


### PR DESCRIPTION
Safer default behaviour. Added a `--fetch-digests` flag to `bundle` to automatically push/pull.

```console
$ docker-compose bundle
ERROR: Some images are missing digests.

The following images need to be pushed:

    aanand/counter

The following images need to be pulled:

    redis

If this is OK, run `docker-compose bundle --fetch-digests`.

```