### PR TITLE
Handle giving help a nonexistent command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 /venv
 README.rst
 compose/GITSHA
+*.swo
+*.swp
+.DS_Store

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -150,6 +150,12 @@ class CLITestCase(DockerClientTestCase):
         # Prevent tearDown from trying to create a project
         self.base_dir = None
 
+    def test_help_nonexistent(self):
+        self.base_dir = 'tests/fixtures/no-composefile'
+        result = self.dispatch(['help', 'foobar'], returncode=1)
+        assert 'No such command' in result.stderr
+        self.base_dir = None
+
     def test_shorthand_host_opt(self):
         self.dispatch(
             ['-H={0}'.format(os.environ.get('DOCKER_HOST', 'unix://')),


### PR DESCRIPTION
The CLI would show an unhandled exception when running: `$ docker-compose help foobar`

Now, it lists the commands.
