### PR TITLE
Fix assertion that was always true

### DIFF
--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -397,7 +397,7 @@ class ServiceTest(DockerClientTestCase):
 
         assert not mock_log.warn.called
         assert (
-            [mount['Destination'] for mount in new_container.get('Mounts')],
+            [mount['Destination'] for mount in new_container.get('Mounts')] ==
             ['/data']
         )
         assert new_container.get_mount('/data')['Source'] != host_path


### PR DESCRIPTION
An assertion was always evaluating to true in test_execute_convergence_plan_when_host_volume_is_removed.