### PR TITLE
bash completion for `docker-compose push`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -304,6 +304,18 @@ _docker_compose_pull() {
 }
 
 
+_docker_compose_push() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --ignore-push-failures" -- "$cur" ) )
+			;;
+		*)
+			__docker_compose_services_all
+			;;
+	esac
+}
+
+
 _docker_compose_restart() {
 	case "$prev" in
 		--timeout|-t)
@@ -467,6 +479,7 @@ _docker_compose() {
 		port
 		ps
 		pull
+		push
 		restart
 		rm
 		run


### PR DESCRIPTION
Ref: #3595
Please include in 1.8.0 as the feature is present there.
ping @sdurrheimer for zsh completion

I am not sure about which services to complete. Is "all services" correct? `docker-compose pull` restricts the completion to services based on images. I don't think this applies to `push`.