### PR TITLE
Document `tmpfs` being v2 only

### DIFF
--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -228,6 +228,8 @@ Custom DNS search domains. Can be a single value or a list.
 
 ### tmpfs
 
+> [Version 2 file format](#version-2) only.
+
 Mount a temporary file system inside the container. Can be a single value or a list.
 
     tmpfs: /run


### PR DESCRIPTION
This caught me out until I found #3179, so I want to avoid anyone else being confused.