### PR TITLE
unnamed volumes do not accept a mode suffix

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -192,7 +192,7 @@ class CLITestCase(DockerClientTestCase):
                 'other': {
                     'image': 'busybox:latest',
                     'command': 'top',
-                    'volumes': ['/data:rw'],
+                    'volumes': ['/data'],
                 },
             },
         }


### PR DESCRIPTION
as long as unnamed volumes do not accept mode (':rw') suffixes, `docker-compose config` should not add such a suffix.

This references issue #3664.

However I'm not sure if the missing support is the problem or just the wrong `docker-compose config`-output. But anyway `docker-compose config` should not output anything that is not a valid configuration file anymore.
