### PR TITLE
added failing test for "service:"-prefix to volumes_from

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -187,7 +187,7 @@ class CLITestCase(DockerClientTestCase):
                         'context': os.path.abspath(self.base_dir),
                     },
                     'networks': {'front': None, 'default': None},
-                    'volumes_from': ['service:other:rw'],
+                    'volumes_from': ['other:rw'],
                 },
                 'other': {
                     'image': 'busybox:latest',


### PR DESCRIPTION
the "service:" prefix is not supported for volumes_from, so `docker-compose config` should not add it.

This references issue #3666.

However I'm not sure if the missing support is the problem or just the wrong docker-compose config-output. But anyway docker-compose config should not output anything that is not a valid configuration file anymore.
