### PR TITLE
(docs) Typo in default volume path

### DIFF
--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -789,7 +789,7 @@ called `data` and mount it into the `db` service's containers.
       db:
         image: postgres
         volumes:
-          - data:/var/lib/postgres/data
+          - data:/var/lib/postgresql/data
 
     volumes:
       data:


### PR DESCRIPTION
The postgres image expects a specific volume path. The docs had a typo in that path. This can cause a lot of agony. This is not hypothetical agony, but very real agony that was very recently experienced :)