### PR TITLE
[Carry #3373] Unset env vars behavior in 'run' mirroring engine

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -19,6 +19,7 @@ from ..bundle import MissingDigests
 from ..bundle import serialize_bundle
 from ..config import ConfigurationError
 from ..config import parse_environment
+from ..config.environment import Environment
 from ..config.serialize import serialize_config
 from ..const import DEFAULT_TIMEOUT
 from ..const import IS_WINDOWS_PLATFORM

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -891,7 +891,9 @@ def build_container_options(options, detach, command):
     }
 
     if options['-e']:
-        container_options['environment'] = parse_environment(options['-e'])
+        container_options['environment'] = Environment.from_command_line(
+            parse_environment(options['-e'])
+        )
 
     if options['--entrypoint']:
         container_options['entrypoint'] = options.get('--entrypoint')

--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -60,6 +60,18 @@ class Environment(dict):
         instance.update(os.environ)
         return instance
 
+    @classmethod
+    def from_command_line(cls, parsed_env_opts):
+        result = cls()
+        for k, v in parsed_env_opts.items():
+            # Values from the command line take priority, unless they're unset
+            # in which case they take the value from the system's environment
+            if v is None and k in os.environ:
+                result[k] = os.environ[k]
+            else:
+                result[k] = v
+        return result
+
     def __getitem__(self, key):
         try:
             return super(Environment, self).__getitem__(key)

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1220,9 +1220,13 @@ class CLITestCase(DockerClientTestCase):
     def test_run_env_values_from_system(self):
         os.environ['FOO'] = 'bar'
         os.environ['BAR'] = 'baz'
-        result = self.dispatch(['run', '-e', 'FOO', 'simple', 'env'], None)
-        assert 'FOO=bar' in result.stdout
-        assert 'BAR=baz' not in result.stdout
+
+        self.dispatch(['run', '-e', 'FOO', 'simple', 'true'], None)
+
+        container = self.project.containers(one_off=OneOffFilter.only, stopped=True)[0]
+        environment = container.get('Config.Env')
+        assert 'FOO=bar' in environment
+        assert 'BAR=baz' not in environment
 
     def test_rm(self):
         service = self.project.get_service('simple')

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1216,6 +1216,14 @@ class CLITestCase(DockerClientTestCase):
             'simplecomposefile_simple_run_1',
             'exited'))
 
+    @mock.patch.dict(os.environ)
+    def test_run_env_values_from_system(self):
+        os.environ['FOO'] = 'bar'
+        os.environ['BAR'] = 'baz'
+        result = self.dispatch(['run', '-e', 'FOO', 'simple', 'env'], None)
+        assert 'FOO=bar' in result.stdout
+        assert 'BAR=baz' not in result.stdout
+
     def test_rm(self):
         service = self.project.get_service('simple')
         service.create_container()


### PR DESCRIPTION
We appear to have a bug on Python 3.4 where the output of `run` is sometimes blank. This warrants further investigation, but for now I've fixed the test in #3373 so it doesn't depend on `run`.

Fixes #3343 