### PR TITLE
Add ServiceError to handle APIErrors for scaling

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -34,6 +34,7 @@ from ..service import ConvergenceStrategy
 from ..service import ImageType
 from ..service import NeedsBuildError
 from ..service import OperationFailedError
+from ..service import ServiceError
 from .command import get_config_from_options
 from .command import project_from_options
 from .docopt_command import DocoptDispatcher
@@ -65,6 +66,8 @@ def main():
         sys.exit(1)
     except (UserError, NoSuchService, ConfigurationError,
             ProjectError, OperationFailedError) as e:
+    except (UserError, NoSuchService, ConfigurationError, ProjectError, 
+            ServiceError, OperationFailedError) as e:
         log.error(e.msg)
         sys.exit(1)
     except BuildError as e:

--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -222,33 +222,40 @@ class ParallelStreamWriter(object):
 
 
 def parallel_operation(containers, operation, options, message):
-    parallel_execute(
+    results, errors = parallel_execute(
         containers,
         operator.methodcaller(operation, **options),
         operator.attrgetter('name'),
         message)
+    return results, errors
 
 
 def parallel_remove(containers, options):
     stopped_containers = [c for c in containers if not c.is_running]
-    parallel_operation(stopped_containers, 'remove', options, 'Removing')
+    results, errors = parallel_operation(stopped_containers, 'remove', options, 'Removing')
+    return results, errors
 
 
 def parallel_start(containers, options):
-    parallel_operation(containers, 'start', options, 'Starting')
+    results, errors = parallel_operation(containers, 'start', options, 'Starting')
+    return results, errors
 
 
 def parallel_pause(containers, options):
-    parallel_operation(containers, 'pause', options, 'Pausing')
+    results, errors = parallel_operation(containers, 'pause', options, 'Pausing')
+    return results, errors
 
 
 def parallel_unpause(containers, options):
-    parallel_operation(containers, 'unpause', options, 'Unpausing')
+    results, errors = parallel_operation(containers, 'unpause', options, 'Unpausing')
+    return results, errors
 
 
 def parallel_kill(containers, options):
-    parallel_operation(containers, 'kill', options, 'Killing')
+    results, errors = parallel_operation(containers, 'kill', options, 'Killing')
+    return results, errors
 
 
 def parallel_restart(containers, options):
-    parallel_operation(containers, 'restart', options, 'Restarting')
+    results, errors = parallel_operation(containers, 'restart', options, 'Restarting')
+    return results, errors

--- a/compose/service.py
+++ b/compose/service.py
@@ -80,6 +80,11 @@ class NoSuchImageError(Exception):
     pass
 
 
+class ServiceError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+
 ServiceName = namedtuple('ServiceName', 'project service number')
 
 
@@ -167,6 +172,10 @@ class Service(object):
             self.start_container_if_stopped(c, **options)
         return containers
 
+    def check_errors(self, errors):
+        if errors:
+            raise ServiceError('Encountered errors while scaling service')
+
     def scale(self, desired_num, timeout=DEFAULT_TIMEOUT):
         """
         Adjusts the number of containers to the specified number and ensures
@@ -223,7 +232,9 @@ class Service(object):
                 else:
                     containers_to_start = stopped_containers
 
-                parallel_start(containers_to_start, {})
+                results, errors = parallel_start(containers_to_start, {})
+
+                self.check_errors(errors)
 
                 num_running += len(containers_to_start)
 
@@ -235,12 +246,14 @@ class Service(object):
                 )
             ]
 
-            parallel_execute(
+            results, errors = parallel_execute(
                 container_numbers,
                 lambda n: create_and_start(service=self, number=n),
                 lambda n: self.get_container_name(n),
                 "Creating and starting"
             )
+
+            self.check_errors(errors)
 
         if desired_num < num_running:
             num_to_stop = num_running - desired_num
@@ -249,12 +262,14 @@ class Service(object):
                 running_containers,
                 key=attrgetter('number'))
 
-            parallel_execute(
+            results, errors = parallel_execute(
                 sorted_running_containers[-num_to_stop:],
                 stop_and_remove,
                 lambda c: c.name,
                 "Stopping and removing",
             )
+
+            self.check_errors(errors)
 
     def create_container(self,
                          one_off=False,

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -30,6 +30,7 @@ from compose.service import ConvergencePlan
 from compose.service import ConvergenceStrategy
 from compose.service import NetworkMode
 from compose.service import Service
+from compose.service import ServiceError
 from tests.integration.testcases import v2_only
 
 
@@ -734,7 +735,8 @@ class ServiceTest(DockerClientTestCase):
                 explanation="Boom")):
 
             with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
-                service.scale(3)
+                with self.assertRaises(ServiceError):
+                    service.scale(3)
 
         self.assertEqual(len(service.containers()), 1)
         self.assertTrue(service.containers()[0].is_running)
@@ -792,7 +794,8 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('app', container_name='custom-container')
         self.assertEqual(service.custom_container_name, 'custom-container')
 
-        service.scale(3)
+        with self.assertRaises(ServiceError):
+            service.scale(3)
 
         captured_output = mock_log.warn.call_args[0][0]
 


### PR DESCRIPTION
When using `docker-compose scale` any errors occurring during the starting, creating, or stopping of containers are printed to the console but the exit code of `docker-compose` is 0. This change handles the errors in a similar way to this pull request for `Project.up`: https://github.com/docker/compose/pull/3400
