### PR TITLE
Fix alias tests on 1.11

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1164,7 +1164,7 @@ class CLITestCase(DockerClientTestCase):
             for _, config in networks.items():
                 # TODO: once we drop support for API <1.24, this can be changed to:
                 # assert config['Aliases'] == [container.short_id]
-                aliases = set(config['Aliases']) - set([container.short_id])
+                aliases = set(config['Aliases'] or []) - set([container.short_id])
                 assert not aliases
 
     @v2_only()
@@ -1184,7 +1184,7 @@ class CLITestCase(DockerClientTestCase):
         for _, config in networks.items():
             # TODO: once we drop support for API <1.24, this can be changed to:
             # assert config['Aliases'] == [container.short_id]
-            aliases = set(config['Aliases']) - set([container.short_id])
+            aliases = set(config['Aliases'] or []) - set([container.short_id])
             assert not aliases
 
         assert self.lookup(container, 'app')


### PR DESCRIPTION
The fix in https://github.com/docker/compose/pull/3652 caused a regression when testing against 1.11.
