### PR TITLE
Reinstall setuptools via ez_setup.py in Dockerfile.run

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,8 +1,11 @@
 
 FROM    alpine:edge
 RUN     apk -U add \
+            curl \
             python \
             py-pip
+
+RUN     curl https://bootstrap.pypa.io/ez_setup.py | python -
 
 COPY    requirements.txt /code/requirements.txt
 RUN     pip install -r /code/requirements.txt


### PR DESCRIPTION
Without this, I get the following when running `./script/build/image`:

```
Sending build context to Docker daemon 1.798 MB
Step 1 : FROM alpine:edge
 ---> 3fc33d6d5e74
Step 2 : RUN apk -U add             python             py-pip
 ---> Using cache
 ---> 6bf059bcc651
Step 3 : COPY requirements.txt /code/requirements.txt
 ---> Using cache
 ---> 7839eee70c1a
Step 4 : RUN pip install -r /code/requirements.txt
 ---> Running in 699843e7a5e7
Collecting PyYAML==3.11 (from -r /code/requirements.txt (line 1))
  Downloading PyYAML-3.11.zip (371kB)
    Complete output from command python setup.py egg_info:
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: -c --help [cmd1 cmd2 ...]
       or: -c --help-commands
       or: -c cmd --help

    error: invalid command 'egg_info'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-O3iKqT/PyYAML/
The command '/bin/sh -c pip install -r /code/requirements.txt' returned a non-zero code: 1
```