### PR TITLE
Pin base image to alpine:3.4 in Dockerfile.run

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,5 +1,5 @@
 
-FROM    alpine:edge
+FROM    alpine:3.4
 RUN     apk -U add \
             python \
             py-pip


### PR DESCRIPTION
Something regressed in `alpine:edge`, causing `pip install` to fail with `invalid command 'egg_info'`.