### PR TITLE
Fix timeout value in error message

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -45,10 +45,6 @@ def docker_client(environment, version=None, tls_config=None, host=None,
     Returns a docker-py client configured using environment variables
     according to the same logic as the official Docker client.
     """
-    if 'DOCKER_CLIENT_TIMEOUT' in environment:
-        log.warn("The DOCKER_CLIENT_TIMEOUT environment variable is deprecated.  "
-                 "Please use COMPOSE_HTTP_TIMEOUT instead.")
-
     try:
         kwargs = kwargs_from_env(environment=environment, ssl_version=tls_version)
     except TLSParameterError:

--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -13,7 +13,6 @@ from requests.exceptions import SSLError
 from requests.packages.urllib3.exceptions import ReadTimeoutError
 
 from ..const import API_VERSION_TO_ENGINE_VERSION
-from ..const import HTTP_TIMEOUT
 from .utils import call_silently
 from .utils import is_docker_for_mac_installed
 from .utils import is_mac
@@ -47,7 +46,7 @@ def handle_connection_errors(client):
         raise ConnectionError()
     except RequestsConnectionError as e:
         if e.args and isinstance(e.args[0], ReadTimeoutError):
-            log_timeout_error()
+            log_timeout_error(client.timeout)
             raise ConnectionError()
         exit_with_error(get_conn_error_message(client.base_url))
     except APIError as e:
@@ -58,13 +57,13 @@ def handle_connection_errors(client):
         raise ConnectionError()
 
 
-def log_timeout_error():
+def log_timeout_error(timeout):
     log.error(
         "An HTTP request took too long to complete. Retry with --verbose to "
         "obtain debug information.\n"
         "If you encounter this issue regularly because of slow network "
         "conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher "
-        "value (current value: %s)." % HTTP_TIMEOUT)
+        "value (current value: %s)." % timeout)
 
 
 def log_api_error(e, client_version):

--- a/compose/const.py
+++ b/compose/const.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import os
 import sys
 
 DEFAULT_TIMEOUT = 10
-HTTP_TIMEOUT = int(os.environ.get('DOCKER_CLIENT_TIMEOUT', 60))
+HTTP_TIMEOUT = 60
 IMAGE_EVENTS = ['delete', 'import', 'pull', 'push', 'tag', 'untag']
 IS_WINDOWS_PLATFORM = (sys.platform == "win32")
 LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'


### PR DESCRIPTION
Also, stop checking `DOCKER_CLIENT_TIMEOUT` - it's been deprecated since 1.5.0.

Closes #3596.