### PR TITLE
Updating build-args example in compose file

### DIFF
--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -74,6 +74,14 @@ This will result in an image named `webapp` and tagged `tag`, built from `./dir`
 > -   Using `build` together with `image` is not allowed. Attempting to do so
 >     results in an error.
 
+Specifying args requires using [args](#args) in the Dockerfile for consumption.
+
+     FROM $CONTAINER:$TAG
+     ARG NODE_ENV
+     ENV NODE_ENV ${NODE_ENV}
+
+In combination with passing environmental variables to Compose via an environment file or your local shell, you are now able to specify build-time values.
+
 #### context
 
 > [Version 2 file format](#version-2) only. In version 1, just use

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -119,6 +119,29 @@ Add build arguments. You can use either an array or a dictionary. Any
 boolean values; true, false, yes, no, need to be enclosed in quotes to ensure
 they are not converted to True or False by the YML parser.
 
+First, specify the arguments in your Dockerfile:
+
+    ARG buildno
+    ARG password
+
+    RUN echo "Build number: $buildno"
+    RUN script-requiring-password.sh "$password"
+
+Then specify the arguments under the `build` key. You can pass either a mapping
+or a list:
+
+    build:
+      context: .
+      args:
+        buildno: 1
+        password: secret
+
+    build:
+      context: .
+      args:
+        - buildno=1
+        - password=secret
+
 Build arguments with only a key are resolved to their environment value on the
 machine Compose is running on.
 

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -74,14 +74,6 @@ This will result in an image named `webapp` and tagged `tag`, built from `./dir`
 > -   Using `build` together with `image` is not allowed. Attempting to do so
 >     results in an error.
 
-Specifying args requires using [args](#args) in the Dockerfile for consumption.
-
-     FROM $CONTAINER:$TAG
-     ARG NODE_ENV
-     ENV NODE_ENV ${NODE_ENV}
-
-In combination with passing environmental variables to Compose via an environment file or your local shell, you are now able to specify build-time values.
-
 #### context
 
 > [Version 2 file format](#version-2) only. In version 1, just use


### PR DESCRIPTION
I think providing an example here helps make it clearer that you can't just pass the build-args without the Dockerfile expecting them. 