### PR TITLE
Supported group_add

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -61,6 +61,7 @@ DOCKER_CONFIG_KEYS = [
     'env_file',
     'environment',
     'extra_hosts',
+    'group_add',
     'hostname',
     'image',
     'ipc',

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -168,6 +168,13 @@
           ]
         },
         "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
+        "group_add": {
+            "type": "array",
+            "items": {
+                "type": ["string", "number"]
+            },
+            "uniqueItems": true
+        },
         "pid": {"type": ["string", "null"]},
 
         "ports": {

--- a/compose/service.py
+++ b/compose/service.py
@@ -48,6 +48,7 @@ DOCKER_START_KEYS = [
     'dns_search',
     'env_file',
     'extra_hosts',
+    'group_add',
     'ipc',
     'read_only',
     'log_driver',
@@ -706,7 +707,8 @@ class Service(object):
             shm_size=options.get('shm_size'),
             tmpfs=options.get('tmpfs'),
             oom_score_adj=options.get('oom_score_adj'),
-            mem_swappiness=options.get('mem_swappiness')
+            mem_swappiness=options.get('mem_swappiness'),
+            group_add=options.get('group_add')
         )
 
     def build(self, no_cache=False, pull=False, force_rm=False):

--- a/docs/compose-file.md
+++ b/docs/compose-file.md
@@ -889,6 +889,20 @@ A full example:
             host2: 172.28.1.6
             host3: 172.28.1.7
 
+### group_add
+
+Specify additional groups (by name or number) which the user inside the container will be a member of. Groups must exist in both the container and the host system to be added. An example of where this is useful is when multiple containers (running as different users) need to all read or write the same file on the host system. That file can be owned by a group shared by all the containers, and specified in `group_add`. See the [Docker documentation](https://docs.docker.com/engine/reference/run/#/additional-groups) for more details.
+
+A full example:
+
+    version: '2'
+    services:
+        image: alpine
+        group_add:
+          - mail
+
+Running `id` inside the created container will show that the user belongs to the `mail` group, which would not have been the case if `group_add` were not used.
+
 ### internal
 
 By default, Docker also connects a bridge network to it to provide external connectivity. If you want to create an externally isolated overlay network, you can set this option to `true`.

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -867,6 +867,14 @@ class ServiceTest(DockerClientTestCase):
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.OomScoreAdj'), 500)
 
+    def test_group_add_value(self):
+        service = self.create_service('web', group_add=["root", "1"])
+        container = create_and_start_container(service)
+
+        host_container_groupadd = container.get('HostConfig.GroupAdd')
+        self.assertTrue("root" in host_container_groupadd)
+        self.assertTrue("1" in host_container_groupadd)
+
     def test_restart_on_failure_value(self):
         service = self.create_service('web', restart={
             'Name': 'on-failure',

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1289,6 +1289,26 @@ class ConfigTest(unittest.TestCase):
             }
         ]
 
+    def test_group_add_option(self):
+
+        actual = config.load(build_config_details({
+            'version': '2',
+            'services': {
+                'web': {
+                    'image': 'alpine',
+                    'group_add': ["docker", 777]
+                }
+             }
+        }))
+
+        assert actual.services == [
+            {
+                'name': 'web',
+                'image': 'alpine',
+                'group_add': ["docker", 777]
+            }
+        ]
+
     def test_merge_service_dicts_from_files_with_extends_in_base(self):
         base = {
             'volumes': ['.:/app'],


### PR DESCRIPTION
Implements #3328. Adds the `group_add` feature into Compose. `group_add` was added to docker in [PR10717](https://github.com/docker/docker/pull/10717) and allows users to specify additional groups to run the container user under.