### PR TITLE
Improve bash completion for `run -e`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -361,7 +361,7 @@ _docker_compose_rm() {
 _docker_compose_run() {
 	case "$prev" in
 		-e)
-			COMPREPLY=( $( compgen -e -- "$cur" ) )
+			COMPREPLY=( $( compgen -e -S = -- "$cur" ) )
 			__docker_compose_nospace
 			return
 			;;


### PR DESCRIPTION
A minor improvement: The names of environment variables will now automatically have a `=` appended, which saves typing one char and clearly indicates that you should specify a value now.

Doesn't have to go into 1.8.0. (but can, of course).