### PR TITLE
Fix bugs with entrypoint/command in docker-compose run

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -668,8 +668,10 @@ class TopLevelCommand(object):
                 'can not be used together'
             )
 
-        if options['COMMAND']:
+        if options['COMMAND'] is not None:
             command = [options['COMMAND']] + options['ARGS']
+        elif options['--entrypoint'] is not None:
+            command = []
         else:
             command = service.options.get('command')
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import datetime
 import json
 import os
-import shlex
 import signal
 import subprocess
 import time
@@ -983,16 +982,54 @@ class CLITestCase(DockerClientTestCase):
             [u'/bin/true'],
         )
 
-    def test_run_service_with_entrypoint_overridden(self):
-        self.base_dir = 'tests/fixtures/dockerfile_with_entrypoint'
-        name = 'service'
-        self.dispatch(['run', '--entrypoint', '/bin/echo', name, 'helloworld'])
-        service = self.project.get_service(name)
-        container = service.containers(stopped=True, one_off=OneOffFilter.only)[0]
-        self.assertEqual(
-            shlex.split(container.human_readable_command),
-            [u'/bin/echo', u'helloworld'],
-        )
+    def test_run_service_with_dockerfile_entrypoint(self):
+        self.base_dir = 'tests/fixtures/entrypoint-dockerfile'
+        self.dispatch(['run', 'test'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') == ['printf']
+        assert container.get('Config.Cmd') == ['default', 'args']
+
+    def test_run_service_with_dockerfile_entrypoint_overridden(self):
+        self.base_dir = 'tests/fixtures/entrypoint-dockerfile'
+        self.dispatch(['run', '--entrypoint', 'echo', 'test'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') == ['echo']
+        assert not container.get('Config.Cmd')
+
+    def test_run_service_with_dockerfile_entrypoint_and_command_overridden(self):
+        self.base_dir = 'tests/fixtures/entrypoint-dockerfile'
+        self.dispatch(['run', '--entrypoint', 'echo', 'test', 'foo'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') == ['echo']
+        assert container.get('Config.Cmd') == ['foo']
+
+    def test_run_service_with_compose_file_entrypoint(self):
+        self.base_dir = 'tests/fixtures/entrypoint-composefile'
+        self.dispatch(['run', 'test'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') == ['printf']
+        assert container.get('Config.Cmd') == ['default', 'args']
+
+    def test_run_service_with_compose_file_entrypoint_overridden(self):
+        self.base_dir = 'tests/fixtures/entrypoint-composefile'
+        self.dispatch(['run', '--entrypoint', 'echo', 'test'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') == ['echo']
+        assert not container.get('Config.Cmd')
+
+    def test_run_service_with_compose_file_entrypoint_and_command_overridden(self):
+        self.base_dir = 'tests/fixtures/entrypoint-composefile'
+        self.dispatch(['run', '--entrypoint', 'echo', 'test', 'foo'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') == ['echo']
+        assert container.get('Config.Cmd') == ['foo']
+
+    def test_run_service_with_compose_file_entrypoint_and_empty_string_command(self):
+        self.base_dir = 'tests/fixtures/entrypoint-composefile'
+        self.dispatch(['run', '--entrypoint', 'echo', 'test', ''])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') == ['echo']
+        assert container.get('Config.Cmd') == ['']
 
     def test_run_service_with_user_overridden(self):
         self.base_dir = 'tests/fixtures/user-composefile'

--- a/tests/fixtures/dockerfile_with_entrypoint/docker-compose.yml
+++ b/tests/fixtures/dockerfile_with_entrypoint/docker-compose.yml
@@ -1,2 +1,0 @@
-service:
-  build: .

--- a/tests/fixtures/entrypoint-composefile/docker-compose.yml
+++ b/tests/fixtures/entrypoint-composefile/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "2"
+services:
+  test:
+    image: busybox
+    entrypoint: printf
+    command: default args

--- a/tests/fixtures/entrypoint-dockerfile/Dockerfile
+++ b/tests/fixtures/entrypoint-dockerfile/Dockerfile
@@ -1,3 +1,4 @@
 FROM busybox:latest
 LABEL com.docker.compose.test_image=true
-ENTRYPOINT echo "From prebuilt entrypoint"
+ENTRYPOINT ["printf"]
+CMD ["default", "args"]

--- a/tests/fixtures/entrypoint-dockerfile/docker-compose.yml
+++ b/tests/fixtures/entrypoint-dockerfile/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "2"
+services:
+  test:
+    build: .


### PR DESCRIPTION
- When no command is passed but `--entrypoint` is, set Cmd to `[]`
- When command is a single empty string, set Cmd to `[""]`

Closes #3531 