### PR TITLE
Return exit code when exiting with --abort-on-container-exit

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -830,7 +830,14 @@ class TopLevelCommand(object):
 
             if cascade_stop:
                 print("Aborting on container exit...")
+
+                exit_code = 0
+                for e in self.project.containers(service_names=options['SERVICE'], stopped=True):
+                    if not e.is_running:
+                        exit_code = e.exit_code
+
                 self.project.stop(service_names=service_names, timeout=timeout)
+                sys.exit(exit_code)
 
     @classmethod
     def version(cls, options):


### PR DESCRIPTION
When you execute `docker-compose up --abort-on-container-exit` you may want to have access to return code from the container that exited.
