### PR TITLE
tearDown the project override at the end of each test case

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -114,6 +114,8 @@ class CLITestCase(DockerClientTestCase):
             for n in networks:
                 if n['Name'].startswith('{}_'.format(self.project.name)):
                     self.client.remove_network(n['Name'])
+        if hasattr(self, '_project'):
+            del self._project
 
         super(CLITestCase, self).tearDown()
 

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -63,6 +63,10 @@ class DockerClientTestCase(unittest.TestCase):
 
         cls.client = docker_client(Environment(), version)
 
+    @classmethod
+    def tearDownClass(cls):
+        del cls.client
+
     def tearDown(self):
         for c in self.client.containers(
                 all=True,


### PR DESCRIPTION
self._project.client is a docker.client.Client, so creating a new self._project
leaks (via the embedded connection pool) a bunch of Unix socket file
descriptors for each test which overrides self.project using this mechanism.

In my tests I observed the test harness using 800-900 file descriptor, which is
OK on Linux with the default limit of 1024 but breaks on OSX (e.g. with
Docker4Mac) where the default limit is only 256. The failure can be provoked on
Linux too with `ulimit -n 256`.

With this fix I have observed the process ending with ~100 file descriptors
open, including 83 Unix sockets, so I think there is likely at least one more
leak lurking.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>