### PR TITLE
Tidy up remaining lingering docker.client.Client objects in test suite

### DIFF
--- a/tests/integration/resilience_test.py
+++ b/tests/integration/resilience_test.py
@@ -20,6 +20,11 @@ class ResilienceTest(DockerClientTestCase):
         self.db.start_container(container)
         self.host_path = container.get_mount('/var/db')['Source']
 
+    def tearDown(self):
+        del self.project
+        del self.db
+        super(ResilienceTest, self).tearDown()
+
     def test_successful_recreate(self):
         self.project.up(strategy=ConvergenceStrategy.always)
         container = self.db.containers()[0]

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -17,6 +17,7 @@ class VolumeTest(DockerClientTestCase):
                 self.client.remove_volume(volume.full_name)
             except DockerException:
                 pass
+        del self.tmp_volumes
 
     def create_volume(self, name, driver=None, opts=None, external=None):
         if external and isinstance(external, bool):

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -18,6 +18,7 @@ class VolumeTest(DockerClientTestCase):
             except DockerException:
                 pass
         del self.tmp_volumes
+        super(VolumeTest, self).tearDown()
 
     def create_volume(self, name, driver=None, opts=None, external=None):
         if external and isinstance(external, bool):


### PR DESCRIPTION
Following on from #3748 these commits result in no unexplained open file descriptors at the end of the test run.

My testing methodology is to apply this skanky patch and compare the resulting `/tmp/*.fds` (e.g. with `wc -l /tmp/*.fds`) at the end:

```
diff --git a/tests/integration/testcases.py b/tests/integration/testcases.py
index 3e33a6c..bce892d 100644
--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -52,10 +52,14 @@ def v2_only():
 
     return decorator
 
+fdLogCount = 0
 
 class DockerClientTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        global fdLogCount
+        os.system('for i in /proc/self/fd/*; do printf "%%-20s\t%%s\n" $i $(readlink $i | sed -e "s/\(.*\):.*/\\1/g") ; done | sort -k 1.15n > /tmp/%02d-%s.%s.setUpClass.fds' % (fdLogCount, cls.__module__, cls.__name__))
+        fdLogCount = fdLogCount + 1
         if engine_version_too_low_for_v2():
             version = API_VERSIONS[V1]
         else:
@@ -66,6 +70,9 @@ class DockerClientTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         del cls.client
+        global fdLogCount
+        os.system('for i in /proc/self/fd/*; do printf "%%-20s\t%%s\n" $i $(readlink $i | sed -e "s/\(.*\):.*/\\1/g") ; done | sort -k 1.15n > /tmp/%02d-%s.%s.tearDownClass.fds' % (fdLogCount, cls.__module__, cls.__name__))
+        fdLogCount = fdLogCount + 1
 
     def tearDown(self):
         for c in self.client.containers(
```
