### PR TITLE
Healthcheck/Readiness of the container functionality POC

### DIFF
--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -82,9 +82,16 @@
         "dns": {"$ref": "#/definitions/string_or_list"},
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "domainname": {"type": "string"},
-        "healthcheck-cmd": {"type": "string"},
-        "healthcheck-retries": {"type": "string"},
-        "healthcheck-delay": {"type": "string"},
+        "healthcheck": {
+          "type": "object",
+          "properties": {
+            "cmd": {"type":"string"},
+            "delay": {"type": "number"},
+            "retries": {"type": "number"}
+          },
+          "additionalProperties": false
+
+        },
         "entrypoint": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -82,6 +82,9 @@
         "dns": {"$ref": "#/definitions/string_or_list"},
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "domainname": {"type": "string"},
+        "healthcheck-cmd": {"type": "string"},
+        "healthcheck-retries": {"type": "string"},
+        "healthcheck-delay": {"type": "string"},
         "entrypoint": {
           "oneOf": [
             {"type": "string"},

--- a/compose/project.py
+++ b/compose/project.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime
+import time
 import logging
 import operator
 from functools import reduce
@@ -32,6 +33,7 @@ from .service import ServiceNetworkMode
 from .utils import microseconds_from_time_nano
 from .volume import ProjectVolumes
 
+from .errors import OperationFailedError
 
 log = logging.getLogger(__name__)
 
@@ -218,6 +220,75 @@ class Project(object):
 
         return NetworkMode(network_mode)
 
+    @staticmethod
+    def execute_cmd_with_retry(container, cmd, retries, delay):
+        for i in range(retries):
+            exec_id = container.create_exec(cmd)
+            # find way how to perform executing of command with timeout
+            container.start_exec(exec_id)
+            result = container.client.exec_inspect(exec_id)
+            is_running = result.get('Running')
+            exit_code = result.get('ExitCode')
+            log.info('Return ExitStatus: %s, Retry: %i' % (exit_code, i))
+            if not is_running and exit_code == 0:
+                log.info('Health check was finished with 0 exit code. Running next container...')
+                break
+            time.sleep(delay)
+        else:
+            return False
+        return result
+
+    @staticmethod
+    def healthcheck_start(service, services, execute):
+        cmd = service.options.get('healthcheck-cmd')
+        result = None
+        if cmd:
+            log.info('Check health status for %s' % service.name)
+            retries = service.options.get('healthcheck-retries', 2)
+            delay = service.options.get('healthcheck-delay', 5)
+            tokens = cmd.split(':', 1)
+            executed_cmd_locally = False
+            if len(tokens) == 2:
+                service_name = tokens[0]
+                cmd = tokens[1]
+                log.info('Execute remote command %s on %s service' % (cmd, service_name))
+                for s in services:
+                    if s.name == service_name:
+                        remote_service = s
+                        break
+                else:
+                    raise OperationFailedError(("Health check checking was failed for service %s: %s. " +
+                                                "Remote service wasn't found") % (service_name, cmd))
+                container = remote_service.get_container()
+
+                if container.is_running:
+                    result = Project.execute_cmd_with_retry(container, cmd, retries, delay)
+                    if not result:
+                        raise OperationFailedError(("Health check was finished for service %s: %s. " +
+                                                    "Return non zero result") % (service_name, cmd))
+                else:
+                    raise OperationFailedError("Cannot execute health check of service %s: %s. Service is not run" % (service_name, cmd))
+
+            else:
+                cmd = tokens[0]
+                executed_cmd_locally = True
+
+            containers = []
+            if result or executed_cmd_locally:
+                log.info('Starting container for %s service' % service.name)
+
+                execute(service)
+            if executed_cmd_locally:
+                log.info('Execute command %s on the service' % cmd)
+                result = Project.execute_cmd_with_retry(service.get_container(), cmd, retries, delay)
+
+            if not result and cmd:
+                raise OperationFailedError("Health check of service %s doesn't pass : %s" % (service.name, cmd))
+
+            return containers
+        else:
+            return execute(service)
+
     def start(self, service_names=None, **options):
         containers = []
 
@@ -232,7 +303,7 @@ class Project(object):
 
         parallel.parallel_execute(
             services,
-            start_service,
+            lambda service: Project.healthcheck_start(service, services, start_service),
             operator.attrgetter('name'),
             'Starting',
             get_deps)
@@ -392,7 +463,7 @@ class Project(object):
 
         results, errors = parallel.parallel_execute(
             services,
-            do,
+            lambda service: Project.healthcheck_start(service, services, do),
             operator.attrgetter('name'),
             None,
             get_deps

--- a/compose/project.py
+++ b/compose/project.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime
-import time
 import logging
 import operator
+import time
 from functools import reduce
 
 import enum
@@ -21,6 +21,7 @@ from .const import LABEL_ONE_OFF
 from .const import LABEL_PROJECT
 from .const import LABEL_SERVICE
 from .container import Container
+from .errors import OperationFailedError
 from .network import build_networks
 from .network import get_networks
 from .network import ProjectNetworks
@@ -32,8 +33,6 @@ from .service import Service
 from .service import ServiceNetworkMode
 from .utils import microseconds_from_time_nano
 from .volume import ProjectVolumes
-
-from .errors import OperationFailedError
 
 log = logging.getLogger(__name__)
 
@@ -267,7 +266,8 @@ class Project(object):
                         raise OperationFailedError(("Health check was finished for service %s: %s. " +
                                                     "Return non zero result") % (service_name, cmd))
                 else:
-                    raise OperationFailedError("Cannot execute health check of service %s: %s. Service is not run" % (service_name, cmd))
+                    raise OperationFailedError(("Cannot execute health check of service %s: %s." +
+                                               "Service is not run") % (service_name, cmd))
 
             else:
                 cmd = tokens[0]
@@ -283,7 +283,8 @@ class Project(object):
                 result = Project.execute_cmd_with_retry(service.get_container(), cmd, retries, delay)
 
             if not result and cmd:
-                raise OperationFailedError("Health check of service %s doesn't pass : %s" % (service.name, cmd))
+                raise OperationFailedError(("Health check of service %s " +
+                                           "doesn't pass : %s") % (service.name, cmd))
 
             return containers
         else:

--- a/compose/project.py
+++ b/compose/project.py
@@ -239,12 +239,13 @@ class Project(object):
 
     @staticmethod
     def healthcheck_start(service, services, execute):
-        cmd = service.options.get('healthcheck-cmd')
+        healthcheck_config = service.options.get('healthcheck', {})
+        cmd = healthcheck_config.get('cmd')
         result = None
         if cmd:
             log.info('Check health status for %s' % service.name)
-            retries = service.options.get('healthcheck-retries', 2)
-            delay = service.options.get('healthcheck-delay', 5)
+            retries = healthcheck_config.get('retries', 3)
+            delay = healthcheck_config.get('delay', 5)
             tokens = cmd.split(':', 1)
             executed_cmd_locally = False
             if len(tokens) == 2:


### PR DESCRIPTION
I would like to propose one of case how Healthcheck/Readiness functionality can be implemented on compose side

I faced with case when I don't have access to some of images which I using, I mean that I cannot change the content of it... Thus "wait-for-it" and "docker-size" in not an appropriate solution for me.

This is only POC which I would like to show and if it will be convenient for community it will be great...
## **Description**

This commit add new keywords on service level:

**_healthcheck-cmd_** - the main keyword which define healthcheck command which will be executed to check health ("redianes") of the service. 
Possible formats:
- service:cmd - to execute remote command
- cmd - to execute on the current service

First case helps to execute command on remote service even on external (I think). "links" and "depends_on" helps here to make sure that host was already up. In any case such check performed by code

Second case helps to prepare and make sure that current service is up and running, or check that local command successfully execute

**_healthcheck-retries_** - define how times should retry to execute the healthcheck-cmd to make sure that the host is ready (default: 2)

**_healthcheck-delay_** - define the delay between retries (default: 5)

Current behavior if healthcheck will failed in the end of retries the up will filed.

**Out of scope**:
- stop and delete containers if command was failed (is it need?)
- tests
- documentation

In any case I want to see this functionality in compose, thus I'm ready to fix all the notices which you are find =)

Enjoy and I hope that this functionality will be in the compose very soon!

Best Regards,
Vladimir

P.S: Let me know everything which I should do to see this compose =)
