### PR TITLE
Remove anonymous volumes when using run --rm.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -947,7 +947,7 @@ def run_one_off_container(container_options, project, service, options):
 
     def remove_container(force=False):
         if options['--rm']:
-            project.client.remove_container(container.id, force=True)
+            project.client.remove_container(container.id, force=True, v=True)
 
     signals.set_signal_handler_to_shutdown()
     try:

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -984,6 +984,36 @@ class CLITestCase(DockerClientTestCase):
             [u'/bin/true'],
         )
 
+    def test_run_rm(self):
+        self.base_dir = 'tests/fixtures/volume'
+        proc = start_process(self.base_dir, ['run', '--rm', 'test'])
+        wait_on_condition(ContainerStateCondition(
+            self.project.client,
+            'volume_test_run_1',
+            'running'))
+        service = self.project.get_service('test')
+        containers = service.containers(one_off=OneOffFilter.only)
+        self.assertEqual(len(containers), 1)
+        mounts = containers[0].get('Mounts')
+        for mount in mounts:
+            if mount['Destination'] == '/container-path':
+                anonymousName = mount['Name']
+                break
+        os.kill(proc.pid, signal.SIGINT)
+        wait_on_process(proc, 1)
+
+        self.assertEqual(len(service.containers(stopped=True, one_off=OneOffFilter.only)), 0)
+
+        volumes = self.client.volumes()['Volumes']
+        assert volumes is not None
+        for volume in service.options.get('volumes'):
+            if volume.internal == '/container-named-path':
+                name = volume.external
+                break
+        volumeNames = [v['Name'] for v in volumes]
+        assert name in volumeNames
+        assert anonymousName not in volumeNames
+
     def test_run_service_with_dockerfile_entrypoint(self):
         self.base_dir = 'tests/fixtures/entrypoint-dockerfile'
         self.dispatch(['run', 'test'])

--- a/tests/fixtures/volume/docker-compose.yml
+++ b/tests/fixtures/volume/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  test:
+    image: busybox
+    command: top
+    volumes:
+      - /container-path
+      - testvolume:/container-named-path
+
+volumes:
+  testvolume: {}


### PR DESCRIPTION
Named volumes will not be removed.
This is consistent with the behavior of docker run --rm.

Fixes #2419, #3611
