### PR TITLE
Add user agent to API calls

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -10,6 +10,7 @@ from docker.utils import kwargs_from_env
 
 from ..const import HTTP_TIMEOUT
 from .errors import UserError
+from .utils import generate_user_agent
 
 log = logging.getLogger(__name__)
 
@@ -66,5 +67,7 @@ def docker_client(environment, version=None, tls_config=None, host=None,
         kwargs['timeout'] = int(timeout)
     else:
         kwargs['timeout'] = HTTP_TIMEOUT
+
+    kwargs['user_agent'] = generate_user_agent()
 
     return Client(**kwargs)

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -107,3 +107,18 @@ def get_build_version():
 
 def is_docker_for_mac_installed():
     return is_mac() and os.path.isdir('/Applications/Docker.app')
+
+
+def generate_user_agent():
+    parts = [
+        "docker-compose/{}".format(compose.__version__),
+        "docker-py/{}".format(docker.__version__),
+    ]
+    try:
+        p_system = platform.system()
+        p_release = platform.release()
+    except IOError:
+        pass
+    else:
+        parts.append("{}/{}".format(p_system, p_release))
+    return " ".join(parts)

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
+import platform
 
 import docker
 import pytest
 
+import compose
 from compose.cli import errors
 from compose.cli.docker_client import docker_client
 from compose.cli.docker_client import tls_config_from_options
@@ -39,6 +41,16 @@ class DockerClientTestCase(unittest.TestCase):
 
         assert fake_log.error.call_count == 1
         assert '123' in fake_log.error.call_args[0][0]
+
+    def test_user_agent(self):
+        client = docker_client(os.environ)
+        expected = "docker-compose/{0} docker-py/{1} {2}/{3}".format(
+            compose.__version__,
+            docker.__version__,
+            platform.system(),
+            platform.release()
+        )
+        self.assertEqual(client.headers['User-Agent'], expected)
 
 
 class TLSConfigTestCase(unittest.TestCase):


### PR DESCRIPTION
Thanks to @mgoelzer's [excellent work in Engine](https://github.com/docker/docker/pull/21306), client user agents are now passed through to registries. This was partially so we could figure out how many people were using Compose and on what versions.

So now it's in, we should probably actually set a user agent in Compose. ;)

Pending a docker-py release so we can vendor it properly. @shin- - do you think it'd be possible to get [this change](https://github.com/docker/docker-py/pull/1125) in docker-py 1.9.0 so we can get this in Compose 1.8.0?