### PR TITLE
json_splitter: Don't break when buffer contains leading whitespace.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -23,6 +23,7 @@ from ..config.environment import Environment
 from ..config.serialize import serialize_config
 from ..const import DEFAULT_TIMEOUT
 from ..const import IS_WINDOWS_PLATFORM
+from ..errors import StreamParseError
 from ..progress_stream import StreamOutputError
 from ..project import NoSuchService
 from ..project import OneOffFilter
@@ -75,7 +76,7 @@ def main():
     except NeedsBuildError as e:
         log.error("Service '%s' needs to be built, but --no-build was passed." % e.service.name)
         sys.exit(1)
-    except errors.ConnectionError:
+    except (errors.ConnectionError, StreamParseError):
         sys.exit(1)
 
 

--- a/compose/errors.py
+++ b/compose/errors.py
@@ -5,3 +5,8 @@ from __future__ import unicode_literals
 class OperationFailedError(Exception):
     def __init__(self, reason):
         self.msg = reason
+
+
+class StreamParseError(RuntimeError):
+    def __init__(self, reason):
+        self.msg = reason

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -9,6 +9,8 @@ import logging
 
 import six
 
+from .errors import StreamParseError
+
 
 json_decoder = json.JSONDecoder()
 log = logging.getLogger(__name__)
@@ -64,12 +66,12 @@ def split_buffer(stream, splitter=None, decoder=lambda a: a):
     if buffered:
         try:
             yield decoder(buffered)
-        except ValueError:
+        except Exception as e:
             log.error(
-                'Compose tried parsing the following chunk as a JSON object, '
-                'but failed:\n%s' % repr(buffered)
+                'Compose tried decoding the following data chunk, but failed:'
+                '\n%s' % repr(buffered)
             )
-            raise
+            raise StreamParseError(e)
 
 
 def json_splitter(buffer):

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -15,6 +15,10 @@ class TestJsonSplitter(object):
         data = '{"foo": "bar"}\n  \n{"next": "obj"}'
         assert utils.json_splitter(data) == ({'foo': 'bar'}, '{"next": "obj"}')
 
+    def test_json_splitter_leading_whitespace(self):
+        data = '\n   \r{"foo": "bar"}\n\n   {"next": "obj"}'
+        assert utils.json_splitter(data) == ({'foo': 'bar'}, '{"next": "obj"}')
+
 
 class TestStreamAsText(object):
 
@@ -42,4 +46,17 @@ class TestJsonStream(object):
             {},
             [1, 2, 3],
             [],
+        ]
+
+    def test_with_leading_whitespace(self):
+        stream = [
+            '\n  \r\n  {"one": "two"}{"x": 1}',
+            '  {"three": "four"}\t\t{"x": 2}'
+        ]
+        output = list(utils.json_stream(stream))
+        assert output == [
+            {'one': 'two'},
+            {'x': 1},
+            {'three': 'four'},
+            {'x': 2}
         ]


### PR DESCRIPTION
Fixes #3788 

cc @dnephin 