### PR TITLE
Handle connection errors on project initialization

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -8,6 +8,7 @@ import ssl
 
 import six
 
+from . import errors
 from . import verbose_proxy
 from .. import config
 from ..config.environment import Environment
@@ -110,7 +111,8 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
         host=host, environment=environment
     )
 
-    return Project.from_config(project_name, config_data, client)
+    with errors.handle_connection_errors(client):
+        return Project.from_config(project_name, config_data, client)
 
 
 def get_project_name(working_dir, project_name=None, environment=None):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -154,6 +154,19 @@ class CLITestCase(DockerClientTestCase):
             returncode=0
         )
 
+    def test_host_not_reachable(self):
+        result = self.dispatch(['-H=tcp://doesnotexist:8000', 'ps'], returncode=1)
+        assert "Couldn't connect to Docker daemon" in result.stderr
+
+    def test_host_not_reachable_volumes_from_container(self):
+        self.base_dir = 'tests/fixtures/volumes-from-container'
+
+        container = self.client.create_container('busybox', 'true', name='composetest_data_container')
+        self.addCleanup(self.client.remove_container, container)
+
+        result = self.dispatch(['-H=tcp://doesnotexist:8000', 'ps'], returncode=1)
+        assert "Couldn't connect to Docker daemon" in result.stderr
+
     def test_config_list_services(self):
         self.base_dir = 'tests/fixtures/v2-full'
         result = self.dispatch(['config', '--services'])

--- a/tests/fixtures/volumes-from-container/docker-compose.yml
+++ b/tests/fixtures/volumes-from-container/docker-compose.yml
@@ -1,0 +1,5 @@
+version: "2"
+services:
+  test:
+    image: busybox
+    volumes_from: ["container:composetest_data_container"]


### PR DESCRIPTION
Closes #3779.

The test is a bit awkward - we only create the container so that the teardown step doesn't fail when initialising the project. Is there a cleaner way we can test it?