### PR TITLE
Update rm.md

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -615,8 +615,7 @@ class TopLevelCommand(object):
         Options:
             -f, --force   Don't ask to confirm removal
             -v            Remove any anonymous volumes attached to containers
-            -a, --all     Obsolete. Also remove one-off containers created by
-                          docker-compose run
+            -a, --all     Deprecated - no effect.
         """
         if options.get('--all'):
             log.warn(

--- a/docs/reference/rm.md
+++ b/docs/reference/rm.md
@@ -17,8 +17,7 @@ Usage: rm [options] [SERVICE...]
 Options:
     -f, --force   Don't ask to confirm removal
     -v            Remove any anonymous volumes attached to containers
-    -a, --all     Also remove one-off containers created by
-                  docker-compose run
+    -a, --all     Deprecated - no effect.
 ```
 
 Removes stopped service containers.


### PR DESCRIPTION
Receiving this message when using the -a flag : `--all flag is obsolete. This is now the default behavior of `docker-compose rm`, I proposed to mark it in the docs but I don't know which way is the best