### PR TITLE
Add support for healthcheck options in configuration

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -86,6 +86,7 @@ DOCKER_CONFIG_KEYS = [
     'volumes',
     'volumes_from',
     'working_dir',
+    'healthcheck'
 ]
 
 ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -82,6 +82,16 @@
         "dns": {"$ref": "#/definitions/string_or_list"},
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "domainname": {"type": "string"},
+        "healthcheck": {
+          "type": "object",
+          "properties": {
+            "interval": {"type":"string"},
+            "timeout": {"type":"string"},
+            "retries": {"type": "number"},
+            "command": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
         "entrypoint": {
           "oneOf": [
             {"type": "string"},

--- a/compose/service.py
+++ b/compose/service.py
@@ -10,6 +10,8 @@ from operator import attrgetter
 import enum
 import six
 from docker.errors import APIError
+from docker.utils import create_healthcheck
+from docker.utils import create_healthcheck_test_from_command
 from docker.utils import LogConfig
 from docker.utils.ports import build_port_bindings
 from docker.utils.ports import split_port
@@ -33,6 +35,7 @@ from .parallel import parallel_start
 from .progress_stream import stream_output
 from .progress_stream import StreamOutputError
 from .utils import json_hash
+from compose.utils import duration_from_string
 
 
 log = logging.getLogger(__name__)
@@ -648,7 +651,21 @@ class Service(object):
             container_options['volumes'] = dict(
                 (v.internal, {}) for v in container_options['volumes'])
 
-        container_options['image'] = self.image_name
+        if 'healthcheck' in container_options:
+            healthcheck = container_options['healthcheck']
+
+            container_options['healthcheck'] = create_healthcheck(
+                test=create_healthcheck_test_from_command(healthcheck.get('command')),
+                interval=(
+                    duration_from_string(healthcheck.get('interval')) if 'interval' in healthcheck
+                    else None
+                ),
+                timeout=(
+                    duration_from_string(healthcheck.get('timeout')) if 'timeout' in healthcheck
+                    else None
+                ),
+                retries=healthcheck.get('retries')
+            )
 
         container_options['labels'] = build_container_labels(
             container_options.get('labels', {}),

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -8,6 +8,7 @@ import json.decoder
 import logging
 
 import six
+from pytimeparse.timeparse import timeparse
 
 from .errors import StreamParseError
 
@@ -108,3 +109,7 @@ def microseconds_from_time_nano(time_nano):
 
 def build_string_dict(source_dict):
     return dict((k, str(v if v is not None else '')) for k, v in source_dict.items())
+
+
+def duration_from_string(duration_string):
+    return timeparse(duration_string) * 1000000000

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ enum34==1.0.4; python_version < '3.4'
 functools32==3.2.3.post2; python_version < '3.2'
 ipaddress==1.0.16
 jsonschema==2.5.1
+pytimeparse==1.1.5
 requests==2.7.0
 six==1.7.3
 texttable==0.8.4

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -60,3 +60,12 @@ class TestJsonStream(object):
             {'three': 'four'},
             {'x': 2}
         ]
+
+
+class TestDurationFromString(object):
+
+    def test_with_seconds(self):
+        assert utils.duration_from_string('2s') == 2000000000
+
+    def test_with_minutes(self):
+        assert utils.duration_from_string('5m') == 300000000000


### PR DESCRIPTION
I'm looking into adding healthcheck support to the Docker Compile yaml file.
Please see https://github.com/docker/docker-py/pull/1152 for the corresponding pull request over at docker-py.

Both of these PRs are a WIP, there are no tests, but I'd just like to see if I am on the right tracks and want to here your thoughts.

This is working for me locally and I'm testing it with a docker compose file with 12 services in which all have healthcheck options.

An example service config is:

```
myservice:
  image: ....
  healthcheck:
    interval: 5s
    timeout: 10s
    retries: 30
    command: exit 0
```
