### PR TITLE
Use posix shell instead of bash for run.sh

### DIFF
--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Run docker-compose in a container
 #


### PR DESCRIPTION
There are no bash specific uses in the script so we can use posix shell.

Signed-off-by: Natanael Copa natanael.copa@docker.com
