### PR TITLE
Add support for creating volume and network with label definition

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -361,6 +361,9 @@ def load_mapping(config_files, get_func, entity_type):
                     config['driver_opts']
                 )
 
+            if 'labels' in config:
+                config['labels'] = parse_labels(config['labels'])
+
     return mapping
 
 

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -246,7 +246,8 @@
             "name": {"type": "string"}
           },
           "additionalProperties": false
-        }
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -268,6 +269,7 @@
             "name": {"type": "string"}
           }
         },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "additionalProperties": false
       },
       "additionalProperties": false

--- a/compose/network.py
+++ b/compose/network.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 class Network(object):
     def __init__(self, client, project, name, driver=None, driver_opts=None,
-                 ipam=None, external_name=None, internal=False):
+                 ipam=None, external_name=None, internal=False, labels=None):
         self.client = client
         self.project = project
         self.name = name
@@ -24,6 +24,7 @@ class Network(object):
         self.ipam = create_ipam_config_from_dict(ipam)
         self.external_name = external_name
         self.internal = internal
+        self.labels = labels
 
     def ensure(self):
         if self.external_name:
@@ -70,6 +71,7 @@ class Network(object):
                 options=self.driver_opts,
                 ipam=self.ipam,
                 internal=self.internal,
+                labels=self.labels,
             )
 
     def remove(self):
@@ -118,6 +120,7 @@ def build_networks(name, config_data, client):
             ipam=data.get('ipam'),
             external_name=data.get('external_name'),
             internal=data.get('internal'),
+            labels=data.get('labels'),
         )
         for network_name, data in network_config.items()
     }

--- a/compose/volume.py
+++ b/compose/volume.py
@@ -12,17 +12,18 @@ log = logging.getLogger(__name__)
 
 class Volume(object):
     def __init__(self, client, project, name, driver=None, driver_opts=None,
-                 external_name=None):
+                 external_name=None, labels=None):
         self.client = client
         self.project = project
         self.name = name
         self.driver = driver
         self.driver_opts = driver_opts
         self.external_name = external_name
+        self.labels = labels
 
     def create(self):
         return self.client.create_volume(
-            self.full_name, self.driver, self.driver_opts
+            self.full_name, self.driver, self.driver_opts, labels=self.labels
         )
 
     def remove(self):
@@ -68,7 +69,8 @@ class ProjectVolumes(object):
                 name=vol_name,
                 driver=data.get('driver'),
                 driver_opts=data.get('driver_opts'),
-                external_name=data.get('external_name')
+                external_name=data.get('external_name'),
+                labels=data.get('labels')
             )
             for vol_name, data in config_volumes.items()
         }

--- a/tests/fixtures/networks/network-label.yml
+++ b/tests/fixtures/networks/network-label.yml
@@ -1,0 +1,13 @@
+version: "2.1"
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks:
+      - network_with_label
+
+networks:
+  network_with_label:
+    labels:
+      - "label_key=label_val"

--- a/tests/fixtures/volumes/volume-label.yml
+++ b/tests/fixtures/volumes/volume-label.yml
@@ -1,0 +1,13 @@
+version: "2.1"
+
+services:
+  web:
+    image: busybox
+    command: top
+    volumes:
+      - volume_with_label:/data
+
+volumes:
+  volume_with_label:
+    labels:
+      - "label_key=label_val"

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -376,6 +376,59 @@ class ConfigTest(unittest.TestCase):
             }
         }
 
+    def test_load_config_volume_and_network_labels(self):
+        base_file = config.ConfigFile(
+            'base.yaml',
+            {
+                'version': '2.1',
+                'services': {
+                    'web': {
+                        'image': 'example/web',
+                    },
+                },
+                'networks': {
+                    'with_label': {
+                        'labels': {
+                            'label_key': 'label_val'
+                        }
+                    }
+                },
+                'volumes': {
+                    'with_label': {
+                        'labels': {
+                            'label_key': 'label_val'
+                        }
+                    }
+                }
+            }
+        )
+
+        details = config.ConfigDetails('.', [base_file])
+        network_dict = config.load(details).networks
+        volume_dict = config.load(details).volumes
+
+        self.assertEqual(
+            network_dict,
+            {
+                'with_label': {
+                    'labels': {
+                        'label_key': 'label_val'
+                    }
+                }
+            }
+        )
+
+        self.assertEqual(
+            volume_dict,
+            {
+                'with_label': {
+                    'labels': {
+                        'label_key': 'label_val'
+                    }
+                }
+            }
+        )
+
     def test_load_config_invalid_service_names(self):
         for invalid_name in ['?not?allowed', ' ', '', '!', '/', '\xe2']:
             with pytest.raises(ConfigurationError) as exc:


### PR DESCRIPTION
Fixes #3892 

**- What I did**
Add volume and network label support for compose file v2

**- How I did it**
1. Add **labels** to volume and network section in **config_schema_v2.0.json** 
2. Add implementation
3. Add doc of volume and network label to **docs/compose-file.md**

**-How to verify it**
Add test in **tests/unit/config/config_test.py**, **tests/integration/project_test.py** and **tests/acceptance/cli_test.py**

@shin- PTAL

Signed-off-by: dbdd <wangtong2712@gmail.com>