### PR TITLE
Add overwrite strategy options to config

### DIFF
--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -211,7 +211,16 @@
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "overwrite": {
+          "type": "array",
+          "items": {
+            "type": ["string"],
+            "format": "overwrites"
+          },
+          "uniqueItems": true
+        },
+        "override_strategy": {"type": "string"}
       },
 
       "dependencies": {

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -42,6 +42,8 @@ DOCKER_CONFIG_HINTS = {
 
 VALID_NAME_CHARS = '[a-zA-Z0-9\._\-]'
 VALID_EXPOSE_FORMAT = r'^\d+(\-\d+)?(\/[a-zA-Z]+)?$'
+VALID_OVERWRITE_FORMAT = r'^(ports)$'
+VALID_OVERRIDE_STRATEGY_FORMAT = r'^(default|overwrite)$'
 
 
 @FormatChecker.cls_checks(format="ports", raises=ValidationError)
@@ -59,6 +61,26 @@ def format_expose(instance):
         if not re.match(VALID_EXPOSE_FORMAT, instance):
             raise ValidationError(
                 "should be of the format 'PORT[/PROTOCOL]'")
+
+    return True
+
+
+@FormatChecker.cls_checks(format="overwrite", raises=ValidationError)
+def format_overwrite(instance):
+    if isinstance(instance, six.string_types):
+            if not re.match(VALID_OVERWRITE_FORMAT, instance):
+                raise ValidationError(
+                    "should be of the format 'ports'")
+
+    return True
+
+
+@FormatChecker.cls_checks(format="override_strategy", raises=ValidationError)
+def format_override_strategy(instance):
+    if isinstance(instance, six.string_types):
+        if not re.match(VALID_OVERRIDE_STRATEGY_FORMAT, instance):
+            raise ValidationError(
+                "should be either 'default' or 'overwrite'")
 
     return True
 
@@ -361,7 +383,7 @@ def process_config_schema_errors(error):
 
 def validate_against_config_schema(config_file):
     schema = load_jsonschema(config_file.version)
-    format_checker = FormatChecker(["ports", "expose"])
+    format_checker = FormatChecker(["overwrite", "override_strategy", "ports", "expose"])
     validator = Draft4Validator(
         schema,
         resolver=RefResolver(get_resolver_path(), schema),


### PR DESCRIPTION
This PR introduces two new configuration options; override_strategy and overwrite.

**override_strategy**: Can be either 'default' or 'overwrite'. Default does nothing except being explicit. 'Overwrite' overwrites the base config with the override config.

**overwrite**: If override_strategy is set, this does not apply. Otherwise it will look at all the fields in the overwrite array and again overwrite the base config with the override config.
- Relates to #2260
  https://github.com/docker/compose/issues/2260#issuecomment-246574209

Note there is currently no tests, I wanted to just see if there was any interest in this PR first.
