### PR TITLE
Fix integration test on Docker for Mac

### DIFF
--- a/tests/unit/cli/errors_test.py
+++ b/tests/unit/cli/errors_test.py
@@ -32,7 +32,7 @@ class TestHandleConnectionErrors(object):
                     raise ConnectionError()
 
         _, args, _ = mock_logging.error.mock_calls[0]
-        assert "Couldn't connect to Docker daemon at" in args[0]
+        assert "Couldn't connect to Docker daemon" in args[0]
 
     def test_api_error_version_mismatch(self, mock_logging):
         with pytest.raises(errors.ConnectionError):


### PR DESCRIPTION
There's probably a better way to test this (i.e. without substring matching), but this is the most minimal fix.

Closes #3831.
