### PR TITLE
Make env_file optional

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -598,7 +598,10 @@ def resolve_environment(service_dict, environment=None):
     """
     env = {}
     for env_file in service_dict.get('env_file', []):
-        env.update(env_vars_from_file(env_file))
+        try:
+            env.update(env_vars_from_file(env_file))
+        except ConfigurationError as exc:
+            log.warn('{} - ignoring'.format(exc.msg))
 
     env.update(parse_environment(service_dict.get('environment')))
     return dict(resolve_env_var(k, v, environment) for k, v in six.iteritems(env))

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2936,13 +2936,13 @@ class EnvTest(unittest.TestCase):
         )
 
     def test_resolve_environment_nonexistent_file(self):
-        with pytest.raises(ConfigurationError) as exc:
+        with mock.patch('compose.config.config.log') as mock_logging:
             config.load(build_config_details(
                 {'foo': {'image': 'example', 'env_file': 'nonexistent.env'}},
                 working_dir='tests/fixtures/env'))
 
-        assert 'Couldn\'t find env file' in exc.exconly()
-        assert 'nonexistent.env' in exc.exconly()
+        assert 'Couldn\'t find env file' in mock_logging.warn.call_args[0][0]
+        assert 'nonexistent.env' in mock_logging.warn.call_args[0][0]
 
     @mock.patch.dict(os.environ)
     def test_resolve_environment_from_env_file_with_empty_values(self):


### PR DESCRIPTION
This makes sure:
- the actual file is not necessary, meaning that you don't have to create it each time you clone (given that usually `.env` files are ignored)
- you still get a warning if the file doesn't exist, so you can be aware of times where a file should have been loaded but eventually didn't, for example due to a typo

Fix #3560 

Signed-off-by: Antonis Kalipetis akalipetis@gmail.com
