### PR TITLE
Attach interactively on Windows by shelling out

### DIFF
--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -17,6 +17,7 @@ from .utils import call_silently
 from .utils import is_docker_for_mac_installed
 from .utils import is_mac
 from .utils import is_ubuntu
+from .utils import is_windows
 
 
 log = logging.getLogger(__name__)
@@ -90,11 +91,7 @@ def exit_with_error(msg):
 
 def get_conn_error_message(url):
     if call_silently(['which', 'docker']) != 0:
-        if is_mac():
-            return docker_not_found_mac
-        if is_ubuntu():
-            return docker_not_found_ubuntu
-        return docker_not_found_generic
+        return docker_not_found_msg("Couldn't connect to Docker daemon.")
     if is_docker_for_mac_installed():
         return conn_error_docker_for_mac
     if call_silently(['which', 'docker-machine']) == 0:
@@ -102,25 +99,26 @@ def get_conn_error_message(url):
     return conn_error_generic.format(url=url)
 
 
-docker_not_found_mac = """
-    Couldn't connect to Docker daemon. You might need to install Docker:
-
-    https://docs.docker.com/engine/installation/mac/
-"""
+def docker_not_found_msg(problem):
+    return "{} You might need to install Docker:\n\n{}".format(
+        problem, docker_install_url())
 
 
-docker_not_found_ubuntu = """
-    Couldn't connect to Docker daemon. You might need to install Docker:
+def docker_install_url():
+    if is_mac():
+        return docker_install_url_mac
+    elif is_ubuntu():
+        return docker_install_url_ubuntu
+    elif is_windows():
+        return docker_install_url_windows
+    else:
+        return docker_install_url_generic
 
-    https://docs.docker.com/engine/installation/ubuntulinux/
-"""
 
-
-docker_not_found_generic = """
-    Couldn't connect to Docker daemon. You might need to install Docker:
-
-    https://docs.docker.com/engine/installation/
-"""
+docker_install_url_mac = "https://docs.docker.com/engine/installation/mac/"
+docker_install_url_ubuntu = "https://docs.docker.com/engine/installation/ubuntulinux/"
+docker_install_url_windows = "https://docs.docker.com/engine/installation/windows/"
+docker_install_url_generic = "https://docs.docker.com/engine/installation/"
 
 
 conn_error_docker_machine = """

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -11,6 +11,7 @@ import sys
 import docker
 
 import compose
+from ..const import IS_WINDOWS_PLATFORM
 
 # WindowsError is not defined on non-win32 platforms. Avoid runtime errors by
 # defining it as OSError (its parent class) if missing.
@@ -71,6 +72,10 @@ def is_mac():
 
 def is_ubuntu():
     return platform.system() == 'Linux' and platform.linux_distribution()[0] == 'Ubuntu'
+
+
+def is_windows():
+    return IS_WINDOWS_PLATFORM
 
 
 def get_version_info(scope):


### PR DESCRIPTION
As discussed in https://github.com/docker/docker/issues/26705, we can shell out to `docker start --attach` instead of using dockerpty.

The change is conservatively scoped to interactive mode on Windows so that no existing use cases are broken. Once we're more confident, we can expand outwards.

TODO:

- [x] User testing ([here's the binary!](https://ci.appveyor.com/api/buildjobs/raq027fhnl0c1xjn/artifacts/dist%2Fdocker-compose-Windows-x86_64.exe))
- [x] Sensible error message when no `docker` binary is found
- [x] <s>Find out if we need to do version checking on the `docker` binary (when was `docker start --attach` introduced?)</s> We don't - it's been there since 1.0.

Closes #3194.