### PR TITLE
Use docker-py's default behavior when no explicit host on Windows

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -9,7 +9,6 @@ from docker.tls import TLSConfig
 from docker.utils import kwargs_from_env
 
 from ..const import HTTP_TIMEOUT
-from ..const import IS_WINDOWS_PLATFORM
 from .errors import UserError
 from .utils import generate_user_agent
 from .utils import unquote_path
@@ -71,10 +70,5 @@ def docker_client(environment, version=None, tls_config=None, host=None,
         kwargs['timeout'] = HTTP_TIMEOUT
 
     kwargs['user_agent'] = generate_user_agent()
-
-    if 'base_url' not in kwargs and IS_WINDOWS_PLATFORM:
-        # docker-py 1.10 defaults to using npipes, but we don't want that
-        # change in compose yet - use the default TCP connection instead.
-        kwargs['base_url'] = 'tcp://127.0.0.1:2375'
 
     return Client(**kwargs)

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -60,14 +60,6 @@ class DockerClientTestCase(unittest.TestCase):
         )
         self.assertEqual(client.headers['User-Agent'], expected)
 
-    @mock.patch.dict(os.environ)
-    def test_docker_client_default_windows_host(self):
-        with mock.patch('compose.cli.docker_client.IS_WINDOWS_PLATFORM', True):
-            if 'DOCKER_HOST' in os.environ:
-                del os.environ['DOCKER_HOST']
-            client = docker_client(os.environ)
-            assert client.base_url == 'http://127.0.0.1:2375'
-
 
 class TLSConfigTestCase(unittest.TestCase):
     ca_cert = 'tests/fixtures/tls/ca.pem'


### PR DESCRIPTION
This is essentially a revert of #3954.

Fixes #3701 