### PR TITLE
Use latest OpenSSL version (1.0.2j) when building Mac binary on Travis

### DIFF
--- a/script/setup/osx
+++ b/script/setup/osx
@@ -10,12 +10,12 @@ openssl_version() {
   python -c "import ssl; print ssl.OPENSSL_VERSION"
 }
 
-desired_python_version="2.7.9"
-desired_python_brew_version="2.7.9"
-python_formula="https://raw.githubusercontent.com/Homebrew/homebrew/1681e193e4d91c9620c4901efd4458d9b6fcda8e/Library/Formula/python.rb"
+desired_python_version="2.7.12"
+desired_python_brew_version="2.7.12"
+python_formula="https://raw.githubusercontent.com/Homebrew/homebrew-core/737a2e34a89b213c1f0a2a24fc1a3c06635eed04/Formula/python.rb"
 
-desired_openssl_version="1.0.2h"
-desired_openssl_brew_version="1.0.2h_1"
+desired_openssl_version="1.0.2j"
+desired_openssl_brew_version="1.0.2j"
 openssl_formula="https://raw.githubusercontent.com/Homebrew/homebrew-core/30d3766453347f6e22b3ed6c74bb926d6def2eb5/Formula/openssl.rb"
 
 PATH="/usr/local/bin:$PATH"


### PR DESCRIPTION
Signed-off-by: Joffrey F <joffrey@docker.com>