### PR TITLE
Do not normalize volume paths on Windows by default

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -651,7 +651,10 @@ def finalize_service(service_config, service_names, version, environment):
 
     if 'volumes' in service_dict:
         service_dict['volumes'] = [
-            VolumeSpec.parse(v) for v in service_dict['volumes']]
+            VolumeSpec.parse(
+                v, environment.get('COMPOSE_CONVERT_WINDOWS_PATHS')
+            ) for v in service_dict['volumes']
+        ]
 
     if 'net' in service_dict:
         network_mode = service_dict.pop('net')

--- a/compose/network.py
+++ b/compose/network.py
@@ -26,6 +26,7 @@ class Network(object):
         self.external_name = external_name
         self.internal = internal
         self.enable_ipv6 = enable_ipv6
+        self.labels = labels
 
     def ensure(self):
         if self.external_name:

--- a/tests/unit/config/types_test.py
+++ b/tests/unit/config/types_test.py
@@ -63,35 +63,67 @@ class TestVolumeSpec(object):
             VolumeSpec.parse('one:two:three:four')
         assert 'has incorrect format' in exc.exconly()
 
-    def test_parse_volume_windows_absolute_path(self):
-        windows_path = "c:\\Users\\me\\Documents\\shiny\\config:\\opt\\shiny\\config:ro"
-        assert VolumeSpec._parse_win32(windows_path) == (
+    def test_parse_volume_windows_absolute_path_normalized(self):
+        windows_path = "c:\\Users\\me\\Documents\\shiny\\config:/opt/shiny/config:ro"
+        assert VolumeSpec._parse_win32(windows_path, True) == (
             "/c/Users/me/Documents/shiny/config",
             "/opt/shiny/config",
             "ro"
         )
 
-    def test_parse_volume_windows_internal_path(self):
+    def test_parse_volume_windows_absolute_path_native(self):
+        windows_path = "c:\\Users\\me\\Documents\\shiny\\config:/opt/shiny/config:ro"
+        assert VolumeSpec._parse_win32(windows_path, False) == (
+            "c:\\Users\\me\\Documents\\shiny\\config",
+            "/opt/shiny/config",
+            "ro"
+        )
+
+    def test_parse_volume_windows_internal_path_normalized(self):
         windows_path = 'C:\\Users\\reimu\\scarlet:C:\\scarlet\\app:ro'
-        assert VolumeSpec._parse_win32(windows_path) == (
+        assert VolumeSpec._parse_win32(windows_path, True) == (
             '/c/Users/reimu/scarlet',
-            '/c/scarlet/app',
+            'C:\\scarlet\\app',
             'ro'
         )
 
-    def test_parse_volume_windows_just_drives(self):
+    def test_parse_volume_windows_internal_path_native(self):
+        windows_path = 'C:\\Users\\reimu\\scarlet:C:\\scarlet\\app:ro'
+        assert VolumeSpec._parse_win32(windows_path, False) == (
+            'C:\\Users\\reimu\\scarlet',
+            'C:\\scarlet\\app',
+            'ro'
+        )
+
+    def test_parse_volume_windows_just_drives_normalized(self):
         windows_path = 'E:\\:C:\\:ro'
-        assert VolumeSpec._parse_win32(windows_path) == (
+        assert VolumeSpec._parse_win32(windows_path, True) == (
             '/e/',
-            '/c/',
+            'C:\\',
             'ro'
         )
 
-    def test_parse_volume_windows_mixed_notations(self):
-        windows_path = '/c/Foo:C:\\bar'
-        assert VolumeSpec._parse_win32(windows_path) == (
+    def test_parse_volume_windows_just_drives_native(self):
+        windows_path = 'E:\\:C:\\:ro'
+        assert VolumeSpec._parse_win32(windows_path, False) == (
+            'E:\\',
+            'C:\\',
+            'ro'
+        )
+
+    def test_parse_volume_windows_mixed_notations_normalized(self):
+        windows_path = 'C:\\Foo:/root/foo'
+        assert VolumeSpec._parse_win32(windows_path, True) == (
             '/c/Foo',
-            '/c/bar',
+            '/root/foo',
+            'rw'
+        )
+
+    def test_parse_volume_windows_mixed_notations_native(self):
+        windows_path = 'C:\\Foo:/root/foo'
+        assert VolumeSpec._parse_win32(windows_path, False) == (
+            'C:\\Foo',
+            '/root/foo',
             'rw'
         )
 

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -786,7 +786,7 @@ class ServiceVolumesTest(unittest.TestCase):
         self.mock_client = mock.create_autospec(docker.Client)
 
     def test_build_volume_binding(self):
-        binding = build_volume_binding(VolumeSpec.parse('/outside:/inside'))
+        binding = build_volume_binding(VolumeSpec.parse('/outside:/inside', True))
         assert binding == ('/inside', '/outside:/inside:rw')
 
     def test_get_container_data_volumes(self):
@@ -845,10 +845,10 @@ class ServiceVolumesTest(unittest.TestCase):
 
     def test_merge_volume_bindings(self):
         options = [
-            VolumeSpec.parse('/host/volume:/host/volume:ro'),
-            VolumeSpec.parse('/host/rw/volume:/host/rw/volume'),
-            VolumeSpec.parse('/new/volume'),
-            VolumeSpec.parse('/existing/volume'),
+            VolumeSpec.parse('/host/volume:/host/volume:ro', True),
+            VolumeSpec.parse('/host/rw/volume:/host/rw/volume', True),
+            VolumeSpec.parse('/new/volume', True),
+            VolumeSpec.parse('/existing/volume', True),
         ]
 
         self.mock_client.inspect_image.return_value = {
@@ -882,8 +882,8 @@ class ServiceVolumesTest(unittest.TestCase):
             'web',
             image='busybox',
             volumes=[
-                VolumeSpec.parse('/host/path:/data1'),
-                VolumeSpec.parse('/host/path:/data2'),
+                VolumeSpec.parse('/host/path:/data1', True),
+                VolumeSpec.parse('/host/path:/data2', True),
             ],
             client=self.mock_client,
         )
@@ -1007,7 +1007,7 @@ class ServiceVolumesTest(unittest.TestCase):
             'web',
             client=self.mock_client,
             image='busybox',
-            volumes=[VolumeSpec.parse(volume)],
+            volumes=[VolumeSpec.parse(volume, True)],
         ).create_container()
 
         assert self.mock_client.create_container.call_count == 1


### PR DESCRIPTION
Add environment variable `COMPOSE_CONVERT_WINDOWS_PATHS` to enable normalization if needed (Toolbox / Machine users)

This is a proposed fix for #3923.

- It might break some user projects for people using Toolbox / Machine, but the old behavior can be enabled using the newly introduced environment variable.
- It would not break projects for "Docker for Windows" users, as the proxy for D4W does that path conversion already.
- It would fix the issue for Docker on Windows Server users, which can not be worked around currently.

