### PR TITLE
fix serialize restart spec with null string

### DIFF
--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -93,6 +93,8 @@ def parse_restart_spec(restart_config):
 
 
 def serialize_restart_spec(restart_spec):
+    if not restart_spec:
+        return ''
     parts = [restart_spec['Name']]
     if restart_spec['MaximumRetryCount']:
         parts.append(six.text_type(restart_spec['MaximumRetryCount']))

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -236,6 +236,10 @@ class CLITestCase(DockerClientTestCase):
                     'image': 'busybox',
                     'restart': 'on-failure:5',
                 },
+                'restart-null': {
+                    'image': 'busybox',
+                    'restart': ''
+                },
             },
             'networks': {},
             'volumes': {},

--- a/tests/fixtures/restart/docker-compose.yml
+++ b/tests/fixtures/restart/docker-compose.yml
@@ -12,3 +12,6 @@ services:
   on-failure-5:
     image: busybox
     restart: "on-failure:5"
+  restart-null:
+    image: busybox
+    restart: ""


### PR DESCRIPTION
Signed-off-by: realityone <realityone@me.com>

Compose will meet an unexpected error when restart field is a null string, but it is valid in docker. 

Here is the error info:

```
[realityone@rEimu ~/Downloads]$ cat docker-compose.yml 
restart-null:
  image: busybox
  restart: ''

[realityone@rEimu ~/Downloads]$ docker-compose -f docker-compose.yml config
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "compose/cli/main.py", line 58, in main
  File "compose/cli/main.py", line 103, in perform_command
  File "compose/cli/main.py", line 242, in config
  File "compose/config/serialize.py", line 24, in serialize_config
  File "compose/config/serialize.py", line 49, in denormalize_service_dict
  File "compose/config/types.py", line 95, in serialize_restart_spec
TypeError: 'NoneType' object has no attribute '__getitem__'
docker-compose returned -1
[realityone@rEimu ~/Downloads]$ 
```

I closed last pr by mistake.

https://github.com/docker/compose/pull/3548