### PR TITLE
Added `top` to `docker-compose` to display running processes

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -434,6 +434,18 @@ _docker_compose_stop() {
 }
 
 
+_docker_compose_top() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_compose_services_running
+			;;
+	esac
+}
+
+
 _docker_compose_unpause() {
 	case "$cur" in
 		-*)
@@ -499,6 +511,7 @@ _docker_compose() {
 		scale
 		start
 		stop
+		top
 		unpause
 		up
 		version

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -341,6 +341,11 @@ __docker-compose_subcommand() {
                 $opts_timeout \
                 '*:running services:__docker-compose_runningservices' && ret=0
             ;;
+        (top)
+            _arguments \
+                $opts_help \
+                '*:running services:__docker-compose_runningservices' && ret=0
+            ;;
         (unpause)
             _arguments \
                 $opts_help \

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1907,3 +1907,23 @@ class CLITestCase(DockerClientTestCase):
             "BAZ=2",
         ])
         self.assertTrue(expected_env <= set(web.get('Config.Env')))
+
+    def test_top_services_not_running(self):
+        self.base_dir = 'tests/fixtures/top'
+        result = self.dispatch(['top'])
+        assert len(result.stdout) == 0
+
+    def test_top_services_running(self):
+        self.base_dir = 'tests/fixtures/top'
+        self.dispatch(['up', '-d'])
+        result = self.dispatch(['top'])
+
+        self.assertIn('top_service_a', result.stdout)
+        self.assertIn('top_service_b', result.stdout)
+        self.assertNotIn('top_not_a_service', result.stdout)
+
+    def test_top_processes_running(self):
+        self.base_dir = 'tests/fixtures/top'
+        self.dispatch(['up', '-d'])
+        result = self.dispatch(['top'])
+        assert result.stdout.count("top") == 4

--- a/tests/fixtures/top/docker-compose.yml
+++ b/tests/fixtures/top/docker-compose.yml
@@ -1,0 +1,6 @@
+service_a:
+  image: busybox:latest
+  command: top
+service_b:
+  image: busybox:latest
+  command: top


### PR DESCRIPTION
This commit allows `docker-compose` to access `top` for containers much like running `docker top` directly on a given container.

This commit includes:
- `docker-compose` CLI changes to expose `top`
- Completions for `bash` and `zsh`
- Required testing for the new `top` command
- `Signed-off-by` within the commit

---

For example, consider the following `yml`:

``` yml
service_a:
  image: busybox:latest
  command: top
service_b:
  image: busybox:latest
  command: top
```

We can inspect the running processes now by running `docker-compose top`:

``` bash
$ docker-compose top
compose_service_a_1
PID    USER   TIME   COMMAND
----------------------------
4060   root   0:00   top

compose_service_b_1
PID    USER   TIME   COMMAND
----------------------------
4115   root   0:00   top
```

As well as drill down to a specific one:

``` bash
$ docker-compose top service_a
compose_service_a_1
PID    USER   TIME   COMMAND
----------------------------
4060   root   0:00   top
```

---

🎉 First time contributing to `docker-compose`, which is a piece of software I use almost daily! 🎉 
