### PR TITLE
allow multi-line env vars in env files

### DIFF
--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -21,23 +21,47 @@ def split_env(env):
     else:
         return env, None
 
+def strip_continuation(input):
+    return v[:-1].strip()
 
 def env_vars_from_file(filename):
     """
     Read in a line delimited file of environment variables.
+    Multi-line values can be continued with a trailing \ ala bash
     """
     if not os.path.exists(filename):
         raise ConfigurationError("Couldn't find env file: %s" % filename)
     elif not os.path.isfile(filename):
         raise ConfigurationError("%s is not a file." % (filename))
     env = {}
+
+    k = ""
+    v = ""
+    continued = false
+
     for line in codecs.open(filename, 'r', 'utf-8'):
         line = line.strip()
-        if line and not line.startswith('#'):
-            k, v = split_env(line)
-            env[k] = v
-    return env
 
+        if line and not line.startswith('#')
+          if not continued:
+            k, v = split_env(line)
+
+            if v.endswith("\"):
+              v = strip_continuation(v)
+              continued = true
+            else:
+              env[k] = v
+              continued = false
+          if continued:
+            if line.endswith("\"):
+              v = v + strip_continuation(line) + "\n"
+              continued = true
+            elif:
+              v = v + line + "\n"
+              env[k] = v
+              continued = false
+
+    return env
 
 class Environment(dict):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This PR is likely unusable as-is, but forms a basis to tackle #3527.

I'm not a Python developer, don't understand Python development, have no idea how to run the tests, and couldn't make heads-or-tails of the said tests, so I was unable to verify this code in any way. :-(

Hoping someone can whip it into shape and get it merged!
