### PR TITLE
Detect stdin redirection on TTY

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -6,6 +6,7 @@ import contextlib
 import functools
 import json
 import logging
+import os
 import pipes
 import re
 import subprocess
@@ -436,6 +437,9 @@ class TopLevelCommand(object):
             args += command
 
             sys.exit(call_docker(args))
+
+        if tty and not os.isatty(sys.stdin.fileno()):
+            raise UserError("The input device is not a TTY, try using -T flag")
 
         create_exec_options = {
             "privileged": options["--privileged"],

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -417,26 +417,7 @@ class TopLevelCommand(object):
         tty = not options["-T"]
 
         if IS_WINDOWS_PLATFORM and not detach:
-            args = ["exec"]
-
-            if options["-d"]:
-                args += ["--detach"]
-            else:
-                args += ["--interactive"]
-
-            if not options["-T"]:
-                args += ["--tty"]
-
-            if options["--privileged"]:
-                args += ["--privileged"]
-
-            if options["--user"]:
-                args += ["--user", options["--user"]]
-
-            args += [container.id]
-            args += command
-
-            sys.exit(call_docker(args))
+            exec_command_docker(container, options, command)
 
         if tty and not os.isatty(sys.stdin.fileno()):
             raise UserError("The input device is not a TTY, try using -T flag")
@@ -1081,3 +1062,26 @@ def call_docker(args):
     log.debug(" ".join(map(pipes.quote, args)))
 
     return subprocess.call(args)
+
+
+def exec_command_docker(container, options, command):
+    args = ["exec"]
+
+    if options["-d"]:
+        args += ["--detach"]
+    else:
+        args += ["--interactive"]
+
+    if not options["-T"]:
+        args += ["--tty"]
+
+    if options["--privileged"]:
+        args += ["--privileged"]
+
+    if options["--user"]:
+        args += ["--user", options["--user"]]
+
+    args += [container.id]
+    args += command
+
+    sys.exit(call_docker(args))


### PR DESCRIPTION
When using `docker-compose exec` with TTY (without `-T` flag), stdin redirection provokes an exception:

```
$ docker-compose exec server cat < docker-compose.yaml
Traceback (most recent call last):
  File "/home/jaime/src/docker-compose/venv/bin/docker-compose", line 11, in <module>
    load_entry_point('docker-compose', 'console_scripts', 'docker-compose')()
  File "/home/jaime/src/docker-compose/compose/cli/main.py", line 64, in main
    command()
  File "/home/jaime/src/docker-compose/compose/cli/main.py", line 116, in perform_command
    handler(command, command_options)
  File "/home/jaime/src/docker-compose/compose/cli/main.py", line 461, in exec_command
    pty.start()
  File "build/bdist.linux-x86_64/egg/dockerpty/pty.py", line 338, in start

  File "build/bdist.linux-x86_64/egg/dockerpty/io.py", line 32, in set_blocking
    I/O classes. open() uses the file's blksize (as obtained by os.stat) if
ValueError: file descriptor cannot be a negative integer (-1)
```

It is also reported in #3352 

This code detects that stdin is not a TTY and gives a bit more meaningful error:

```
$ docker-compose exec server cat < docker-compose.yaml
ERROR: The input device is not a TTY
```

Apart of handling this error, I wonder if another different flag should be added to control if stdin should be kept open, as `docker exec -i` does.
