### PR TITLE
Fix schema divergence - add missing fields to compose 2.1 schema

### DIFF
--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -140,6 +140,7 @@
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
+        "mem_swappiness": {"type": "integer"},
         "network_mode": {"type": "string"},
 
         "networks": {
@@ -167,6 +168,14 @@
               "additionalProperties": false
             }
           ]
+        },
+        "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
+        "group_add": {
+            "type": "array",
+            "items": {
+                "type": ["string", "number"]
+            },
+            "uniqueItems": true
         },
         "pid": {"type": ["string", "null"]},
 
@@ -248,6 +257,7 @@
           },
           "additionalProperties": false
         },
+        "internal": {"type": "boolean"},
         "enable_ipv6": {"type": "boolean"},
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },


### PR DESCRIPTION
PRs that were made to add fields before 2.1 was a thing and weren't ported afterwards.