### PR TITLE
Use colorama to enable colored output on Windows

### DIFF
--- a/compose/cli/colors.py
+++ b/compose/cli/colors.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import colorama
+
 NAMES = [
     'grey',
     'red',
@@ -30,6 +33,7 @@ def make_color_fn(code):
     return lambda s: ansi_color(code, s)
 
 
+colorama.init()
 for (name, code) in get_pairs():
     globals()[name] = make_color_fn(code)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 PyYAML==3.11
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.2.0
+colorama==0.3.7
 docker==2.0.0
 dockerpty==0.4.1
 docopt==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ def find_version(*file_paths):
 
 install_requires = [
     'cached-property >= 1.2.0, < 2',
+    'colorama >= 0.3.7, < 0.4',
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
     'requests >= 2.6.1, != 2.11.0, < 2.12',


### PR DESCRIPTION
I've seen it mentioned multiple times in issues but I can't find it again for some reason - Anyway, [colorama](https://pypi.python.org/pypi/colorama) takes care of colored output on Windows.
