### PR TITLE
Fix path of the parent dir of COMPOSE_FILE

### DIFF
--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -35,7 +35,7 @@ if [ "$(pwd)" != '/' ]; then
     VOLUMES="-v $(pwd):$(pwd)"
 fi
 if [ -n "$COMPOSE_FILE" ]; then
-    compose_dir=$(dirname $COMPOSE_FILE)
+    compose_dir=$(realpath $(dirname $COMPOSE_FILE))
 fi
 # TODO: also check --file argument
 if [ -n "$compose_dir" ]; then


### PR DESCRIPTION
Currently the `run.sh` tries to bind-mount the parent directory of the `COMPOSE_FILE`, but uses a relative path rather than an absolute path. It leads to the following error (with `export COMPOSE_FILE=docker/dev.yml`): 
> docker: Error response from daemon: Invalid bind mount spec "docker:docker": Invalid volume destination path: 'docker' mount path must be absolute..
See 'docker run --help'.
