### PR TITLE
Update Jenkinsfile to run "janky" tasks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,80 @@
-// Only run on Linux atm
-wrappedNode(label: 'docker') {
-  deleteDir()
-  stage "checkout"
-  checkout scm
+#!groovy
 
-  documentationChecker("docs")
+def image
+
+def checkDocs = { ->
+  wrappedNode(label: 'linux') {
+    deleteDir(); checkout(scm)
+    documentationChecker("docs")
+  }
 }
+
+def buildImage = { ->
+  wrappedNode(label: "linux && !zfs") {
+    stage("build image") {
+      deleteDir(); checkout(scm)
+      def imageName = "dockerbuildbot/compose:${gitCommit()}"
+      image = docker.image(imageName)
+      try {
+        image.pull()
+      } catch (Exception exc) {
+        image = docker.build(imageName, ".")
+        image.push()
+      }
+    }
+  }
+}
+
+def runTests = { Map settings ->
+  def dockerVersions = settings.get("dockerVersions", null)
+  def pythonVersions = settings.get("pythonVersions", null)
+
+  if (!pythonVersions) {
+    throw new Exception("Need Python versions to test. e.g.: `runTests(pythonVersions: 'py27,py34')`")
+  }
+  if (!dockerVersions) {
+    throw new Exception("Need Docker versions to test. e.g.: `runTests(dockerVersions: 'all')`")
+  }
+
+  { ->
+    wrappedNode(label: "linux && !zfs") {
+      stage("test python=${pythonVersions} / docker=${dockerVersions}") {
+        deleteDir(); checkout(scm)
+        def storageDriver = sh(script: 'docker info | awk -F \': \' \'$1 == "Storage Driver" { print $2; exit }\'', returnStdout: true).trim()
+        echo "Using local system's storage driver: ${storageDriver}"
+        sh """docker run \\
+          -t \\
+          --rm \\
+          --privileged \\
+          --volume="\$(pwd)/.git:/code/.git" \\
+          --volume="/var/run/docker.sock:/var/run/docker.sock" \\
+          -e "TAG=${image.id}" \\
+          -e "STORAGE_DRIVER=${storageDriver}" \\
+          -e "DOCKER_VERSIONS=${dockerVersions}" \\
+          -e "BUILD_NUMBER=\$BUILD_TAG" \\
+          -e "PY_TEST_VERSIONS=${pythonVersions}" \\
+          --entrypoint="script/ci" \\
+          ${image.id} \\
+          --verbose
+        """
+      }
+    }
+  }
+}
+
+def buildAndTest = { ->
+  buildImage()
+  // TODO: break this out into meaningful "DOCKER_VERSIONS" values instead of all
+  parallel(
+    failFast: true,
+    all_py27: runTests(pythonVersions: "py27", dockerVersions: "all"),
+    all_py34: runTests(pythonVersions: "py34", dockerVersions: "all"),
+  )
+}
+
+
+parallel(
+  failFast: false,
+  docs: checkDocs,
+  test: buildAndTest
+)

--- a/script/test/all
+++ b/script/test/all
@@ -24,6 +24,7 @@ fi
 
 
 BUILD_NUMBER=${BUILD_NUMBER-$USER}
+PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py27,py34}
 
 for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"
@@ -58,6 +59,6 @@ for version in $DOCKER_VERSIONS; do
     --env="DOCKER_VERSION=$version" \
     --entrypoint="tox" \
     "$TAG" \
-    -e py27,py34 -- "$@"
+    -e "$PY_TEST_VERSIONS" -- "$@"
 
 done


### PR DESCRIPTION
With this we can eventually disable the two jobs "Compose-PRs" and "Compose Master", and update the leeroy-config to use the pipeline job. The pipeline job and results are separated by branch/PR and are shown here: https://jenkins.dockerproject.org/job/docker/job/compose/

The `continuous-integration/jenkins/pr-head` commit status entry on PRs becomes more meaningful, now representing the tests that were previously covered by the `janky` status as well as the documentation checks which it already signifies.

This build is also faster, due to (a) parallelization and (b) short-circuiting of the image build if it already exists on hub.docker.com.

CI changes will be easier to make and more visible / auditable as they will now go through the usual code review process.

@shin- 
