### PR TITLE
Bump 1.9.0 rc2

### DIFF
--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.9.0-rc1'
+__version__ = '1.9.0-rc2'

--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import contextlib
 import logging
 import socket
+from distutils.spawn import find_executable
 from textwrap import dedent
 
 from docker.errors import APIError
@@ -13,7 +14,6 @@ from requests.exceptions import SSLError
 from requests.packages.urllib3.exceptions import ReadTimeoutError
 
 from ..const import API_VERSION_TO_ENGINE_VERSION
-from .utils import call_silently
 from .utils import is_docker_for_mac_installed
 from .utils import is_mac
 from .utils import is_ubuntu
@@ -90,11 +90,11 @@ def exit_with_error(msg):
 
 
 def get_conn_error_message(url):
-    if call_silently(['which', 'docker']) != 0:
+    if find_executable('docker') is None:
         return docker_not_found_msg("Couldn't connect to Docker daemon.")
     if is_docker_for_mac_installed():
         return conn_error_docker_for_mac
-    if call_silently(['which', 'docker-machine']) == 0:
+    if find_executable('docker-machine') is not None:
         return conn_error_docker_machine
     return conn_error_generic.format(url=url)
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -10,6 +10,7 @@ import pipes
 import re
 import subprocess
 import sys
+from distutils.spawn import find_executable
 from inspect import getdoc
 from operator import attrgetter
 
@@ -1063,9 +1064,8 @@ def exit_if(condition, message, exit_code):
 
 
 def call_docker(args):
-    try:
-        executable_path = subprocess.check_output(["which", "docker"]).strip()
-    except subprocess.CalledProcessError:
+    executable_path = find_executable('docker')
+    if not executable_path:
         raise UserError(errors.docker_not_found_msg("Couldn't find `docker` binary."))
 
     args = [executable_path] + args

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -140,6 +140,7 @@
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
+        "mem_swappiness": {"type": "integer"},
         "network_mode": {"type": "string"},
 
         "networks": {
@@ -167,6 +168,14 @@
               "additionalProperties": false
             }
           ]
+        },
+        "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
+        "group_add": {
+            "type": "array",
+            "items": {
+                "type": ["string", "number"]
+            },
+            "uniqueItems": true
         },
         "pid": {"type": ["string", "null"]},
 
@@ -248,6 +257,7 @@
           },
           "additionalProperties": false
         },
+        "internal": {"type": "boolean"},
         "enable_ipv6": {"type": "boolean"},
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },

--- a/compose/project.py
+++ b/compose/project.py
@@ -538,6 +538,10 @@ def get_volumes_from(project, service_dict):
 def warn_for_swarm_mode(client):
     info = client.info()
     if info.get('Swarm', {}).get('LocalNodeState') == 'active':
+        if info.get('ServerVersion', '').startswith('ucp'):
+            # UCP does multi-node scheduling with traditional Compose files.
+            return
+
         log.warn(
             "The Docker Engine you're using is running in swarm mode.\n\n"
             "Compose does not use swarm mode to deploy services to multiple nodes in a swarm. "

--- a/docker-compose.spec
+++ b/docker-compose.spec
@@ -28,6 +28,11 @@ exe = EXE(pyz,
                 'DATA'
             ),
             (
+                'compose/config/config_schema_v2.1.json',
+                'compose/config/config_schema_v2.1.json',
+                'DATA'
+            ),
+            (
                 'compose/GITSHA',
                 'compose/GITSHA',
                 'DATA'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML==3.11
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.2.0
-docker-py==1.10.4
+docker-py==1.10.5
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4; python_version < '3.4'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.9.0-rc1"
+VERSION="1.9.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, < 2.12',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker-py >= 1.10.4, < 2.0',
+    'docker-py >= 1.10.5, < 2.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -826,9 +826,9 @@ class ProjectTest(DockerClientTestCase):
             name='composetest',
             config_data=config_data
         )
-        project.up()
+        project.up(detached=True)
 
-        service_container = project.get_service('web').containers()[0]
+        service_container = project.get_service('web').containers(stopped=True)[0]
         ipam_config = service_container.inspect().get(
             'NetworkSettings', {}
         ).get(
@@ -857,8 +857,8 @@ class ProjectTest(DockerClientTestCase):
             name='composetest',
             config_data=config_data
         )
-        project.up()
-        service_container = project.get_service('web').containers()[0]
+        project.up(detached=True)
+        service_container = project.get_service('web').containers(stopped=True)[0]
         assert service_container.inspect()['HostConfig']['Isolation'] == 'default'
 
     @v2_1_only()

--- a/tests/unit/cli/errors_test.py
+++ b/tests/unit/cli/errors_test.py
@@ -16,9 +16,9 @@ def mock_logging():
         yield mock_log
 
 
-def patch_call_silently(side_effect):
+def patch_find_executable(side_effect):
     return mock.patch(
-        'compose.cli.errors.call_silently',
+        'compose.cli.errors.find_executable',
         autospec=True,
         side_effect=side_effect)
 
@@ -27,7 +27,7 @@ class TestHandleConnectionErrors(object):
 
     def test_generic_connection_error(self, mock_logging):
         with pytest.raises(errors.ConnectionError):
-            with patch_call_silently([0, 1]):
+            with patch_find_executable(['/bin/docker', None]):
                 with handle_connection_errors(mock.Mock()):
                     raise ConnectionError()
 


### PR DESCRIPTION
**Breaking changes**

- For users of Docker Toolbox / Machine on Windows, the path conversion
  for volumes is no longer done by default. To enable it, please set the
  `COMPOSE_CONVERT_WINDOWS_PATHS` variable.

New Features

- Interactive mode for `docker-compose run` and `docker-compose exec` is
  now supported on Windows platforms.

- Introduced version 2.1 of the `docker-compose.yml` specification. Using
  this version requires to be used with Docker Engine 1.12 or above.
    - Added support for setting volume labels and network labels in
  `docker-compose.yml`.
    - Added support for the `isolation` parameter in service definitions.
    - Added support for link-local IPs in the service networks definitions.

- Added support for inline defaults in variable interpolation.

- Added support for the `group_add` and `oom_score_adj` parameters in
  service definitions.

- Added support for the `internal` and `enable_ipv6` parameters in network
  definitions.

- Compose now defaults to using the `npipe` protocol on Windows.

- Overriding a `logging` configuration will now properly merge the `options`
  mappings if the `driver` values do not conflict.

Bug Fixes

- Fixed several bugs related to `npipe` protocol support on Windows.

- Fixed an issue with Windows paths being incorrectly converted when
  using Docker on Windows Server.

- Fixed a bug where an empty `restart` value would sometimes result in an
  exception being raised.

- Fixed an issue where service logs containing unicode characters would
  sometimes cause an error to occur.

- Fixed a bug where unicode values in environment variables would sometimes
  raise a unicode exception when retrieved.