### PR TITLE
Add support for templatable hostname

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -622,16 +622,20 @@ class Service(object):
 
         container_options.setdefault('detach', True)
 
-        # If a qualified hostname was given, split it into an
-        # unqualified hostname and a domainname unless domainname
-        # was also given explicitly. This matches the behavior of
-        # the official Docker CLI in that scenario.
-        if ('hostname' in container_options and
-                'domainname' not in container_options and
-                '.' in container_options['hostname']):
-            parts = container_options['hostname'].partition('.')
-            container_options['hostname'] = parts[0]
-            container_options['domainname'] = parts[2]
+        if ('hostname' in container_options):
+
+            # If a qualified hostname was given, split it into an
+            # unqualified hostname and a domainname unless domainname
+            # was also given explicitly. This matches the behavior of
+            # the official Docker CLI in that scenario.
+            if ('domainname' not in container_options and '.' in container_options['hostname']):
+                parts = container_options['hostname'].partition('.')
+                container_options['hostname'] = parts[0]
+                container_options['domainname'] = parts[2]
+
+            if ('{num}' in container_options['hostname']):
+                container_options['hostname'] = \
+                    container_options['hostname'].replace('{num}', str(number))
 
         if 'ports' in container_options or 'expose' in self.options:
             container_options['ports'] = build_container_ports(

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -146,6 +146,25 @@ class ServiceTest(unittest.TestCase):
         self.assertEqual(opts['hostname'], 'name', 'hostname')
         self.assertFalse('domainname' in opts, 'domainname')
 
+    def test_templatable_hostname(self):
+        service = Service('foo', image='foo', hostname='name{num}', client=self.mock_client)
+        opts = service._get_container_create_options({'image': 'foo'}, 1)
+        self.assertEqual(opts['hostname'], 'name1', 'hostname')
+        self.assertFalse('domainname' in opts, 'domainname')
+
+    def test_templatable_hostname_with_domainname(self):
+        service = Service('foo', image='foo', hostname='name{num}.domain', client=self.mock_client)
+        opts = service._get_container_create_options({'image': 'foo'}, 1)
+        self.assertEqual(opts['hostname'], 'name1', 'hostname')
+        self.assertEqual(opts['domainname'], 'domain', 'domainname')
+
+    def test_templatable_hostname_number_is_taken_into_account(self):
+        service = Service('foo', image='foo', hostname='name{num}', client=self.mock_client)
+        for i in range(1, 3):
+            opts = service._get_container_create_options({'image': 'foo'}, i)
+            self.assertEqual(opts['hostname'], 'name' + str(i), 'hostname')
+            self.assertFalse('domainname' in opts, 'domainname')
+
     def test_memory_swap_limit(self):
         self.mock_client.create_host_config.return_value = {}
 


### PR DESCRIPTION
Hi, first of all, thanks for this amazing piece of software!

I'm trying to set up dev/test environment for our ops team, which develops salt stack formulas. I want them to be able to easily scale number of salt minion instances, which will have instance number included in hostname.

It is really neccessary to have proper hostnames here, because distributed services deployed on these minions need to be able to talk to each other (no I don't want any form of service discovery here, because we have fixed hostnames for this services in production).

I think doing this for all containers by default would be really invasive breaking change, for people already using docker-compose, so I propose making `hostname` parameter templatable. Everyone can choose, whether he wants to use instance number in hostname or not and can even choose in which format hostname will be.

Example `docker-compose.yml`, would look something like this.

```
version: '2'
services:
  master:
    build: ./images/master
    hostname: master
    volumes:
      - ./env:/www/salt/env
  minion:
    build: ./images/minion
    hostname: minion{num}
    links:
      - master
```

What you guys think? Is this solution acceptable for you?

Thanks!!

Signed-off-by: David Moravek david.moravek@firma.seznam.cz
