### PR TITLE
Bump 1.9.0 rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Bug Fixes
 - Fixed a bug where unicode values in environment variables would sometimes
   raise a unicode exception when retrieved.
 
+- Fixed an issue where Compose would incorrectly detect a configuration
+  mismatch for overlay networks.
+
 
 1.8.1 (2016-09-22)
 -----------------

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,80 @@
-// Only run on Linux atm
-wrappedNode(label: 'docker') {
-  deleteDir()
-  stage "checkout"
-  checkout scm
+#!groovy
 
-  documentationChecker("docs")
+def image
+
+def checkDocs = { ->
+  wrappedNode(label: 'linux') {
+    deleteDir(); checkout(scm)
+    documentationChecker("docs")
+  }
 }
+
+def buildImage = { ->
+  wrappedNode(label: "linux && !zfs") {
+    stage("build image") {
+      deleteDir(); checkout(scm)
+      def imageName = "dockerbuildbot/compose:${gitCommit()}"
+      image = docker.image(imageName)
+      try {
+        image.pull()
+      } catch (Exception exc) {
+        image = docker.build(imageName, ".")
+        image.push()
+      }
+    }
+  }
+}
+
+def runTests = { Map settings ->
+  def dockerVersions = settings.get("dockerVersions", null)
+  def pythonVersions = settings.get("pythonVersions", null)
+
+  if (!pythonVersions) {
+    throw new Exception("Need Python versions to test. e.g.: `runTests(pythonVersions: 'py27,py34')`")
+  }
+  if (!dockerVersions) {
+    throw new Exception("Need Docker versions to test. e.g.: `runTests(dockerVersions: 'all')`")
+  }
+
+  { ->
+    wrappedNode(label: "linux && !zfs") {
+      stage("test python=${pythonVersions} / docker=${dockerVersions}") {
+        deleteDir(); checkout(scm)
+        def storageDriver = sh(script: 'docker info | awk -F \': \' \'$1 == "Storage Driver" { print $2; exit }\'', returnStdout: true).trim()
+        echo "Using local system's storage driver: ${storageDriver}"
+        sh """docker run \\
+          -t \\
+          --rm \\
+          --privileged \\
+          --volume="\$(pwd)/.git:/code/.git" \\
+          --volume="/var/run/docker.sock:/var/run/docker.sock" \\
+          -e "TAG=${image.id}" \\
+          -e "STORAGE_DRIVER=${storageDriver}" \\
+          -e "DOCKER_VERSIONS=${dockerVersions}" \\
+          -e "BUILD_NUMBER=\$BUILD_TAG" \\
+          -e "PY_TEST_VERSIONS=${pythonVersions}" \\
+          --entrypoint="script/ci" \\
+          ${image.id} \\
+          --verbose
+        """
+      }
+    }
+  }
+}
+
+def buildAndTest = { ->
+  buildImage()
+  // TODO: break this out into meaningful "DOCKER_VERSIONS" values instead of all
+  parallel(
+    failFast: true,
+    all_py27: runTests(pythonVersions: "py27", dockerVersions: "all"),
+    all_py34: runTests(pythonVersions: "py34", dockerVersions: "all"),
+  )
+}
+
+
+parallel(
+  failFast: false,
+  docs: checkDocs,
+  test: buildAndTest
+)

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.9.0-rc2'
+__version__ = '1.9.0-rc3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML==3.11
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.2.0
-docker-py==1.10.5
+docker-py==1.10.6
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4; python_version < '3.4'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.9.0-rc2"
+VERSION="1.9.0-rc3"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/script/test/all
+++ b/script/test/all
@@ -24,6 +24,7 @@ fi
 
 
 BUILD_NUMBER=${BUILD_NUMBER-$USER}
+PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py27,py34}
 
 for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"
@@ -58,6 +59,6 @@ for version in $DOCKER_VERSIONS; do
     --env="DOCKER_VERSION=$version" \
     --entrypoint="tox" \
     "$TAG" \
-    -e py27,py34 -- "$@"
+    -e "$PY_TEST_VERSIONS" -- "$@"
 
 done

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, < 2.12',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker-py >= 1.10.5, < 2.0',
+    'docker-py >= 1.10.6, < 2.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import pytest
+
+from .. import unittest
+from compose.config import ConfigurationError
+from compose.network import check_remote_network_config
+from compose.network import Network
+
+
+class NetworkTest(unittest.TestCase):
+    def test_check_remote_network_config_success(self):
+        options = {'com.docker.network.driver.foo': 'bar'}
+        net = Network(
+            None, 'compose_test', 'net1', 'bridge',
+            options
+        )
+        check_remote_network_config(
+            {'Driver': 'bridge', 'Options': options}, net
+        )
+
+    def test_check_remote_network_config_whitelist(self):
+        options = {'com.docker.network.driver.foo': 'bar'}
+        remote_options = {
+            'com.docker.network.driver.overlay.vxlanid_list': '257',
+            'com.docker.network.driver.foo': 'bar'
+        }
+        net = Network(
+            None, 'compose_test', 'net1', 'overlay',
+            options
+        )
+        check_remote_network_config(
+            {'Driver': 'overlay', 'Options': remote_options}, net
+        )
+
+    def test_check_remote_network_config_driver_mismatch(self):
+        net = Network(None, 'compose_test', 'net1', 'overlay')
+        with pytest.raises(ConfigurationError):
+            check_remote_network_config({'Driver': 'bridge', 'Options': {}}, net)
+
+    def test_check_remote_network_config_options_mismatch(self):
+        net = Network(None, 'compose_test', 'net1', 'overlay')
+        with pytest.raises(ConfigurationError):
+            check_remote_network_config({'Driver': 'overlay', 'Options': {
+                'com.docker.network.driver.foo': 'baz'
+            }}, net)


### PR DESCRIPTION
Bug Fixes
- Fixed several bugs related to `npipe` protocol support on Windows.
- Fixed an issue where Compose would incorrectly detect a configuration
  mismatch for overlay networks.