### PR TITLE
Fixes #3674

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -95,7 +95,15 @@ class LogPrinter(object):
                 # active containers to tail, so continue
                 continue
 
-            self.output.write(line)
+            try:
+                self.output.write(line)
+            except UnicodeEncodeError:
+                bytes = line.encode(self.output.encoding, 'backslashreplace')
+                if hasattr(self.output, 'buffer'):
+                    self.output.buffer.write(bytes)
+                else:
+                    line = bytes.decode(self.output.encoding, 'strict')
+                    self.output.write(line)
             self.output.flush()
 
 


### PR DESCRIPTION
When docker compose is printing output from the container in real time if the output contains unicode characters it doesn't understand, docker compose throws an execution. This catches and prints out an escaped representation of the Unicode characters.