### PR TITLE
Handle new pull failures behavior in Engine 1.13

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -10,6 +10,7 @@ from operator import attrgetter
 import enum
 import six
 from docker.errors import APIError
+from docker.errors import NotFound
 from docker.utils import LogConfig
 from docker.utils.ports import build_port_bindings
 from docker.utils.ports import split_port
@@ -829,12 +830,11 @@ class Service(object):
         repo, tag, separator = parse_repository_tag(self.options['image'])
         tag = tag or 'latest'
         log.info('Pulling %s (%s%s%s)...' % (self.name, repo, separator, tag))
-        output = self.client.pull(repo, tag=tag, stream=True)
-
         try:
+            output = self.client.pull(repo, tag=tag, stream=True)
             return progress_stream.get_digest_from_pull(
                 stream_output(output, sys.stdout))
-        except StreamOutputError as e:
+        except (StreamOutputError, NotFound) as e:
             if not ignore_pull_failures:
                 raise
             else:

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -330,12 +330,13 @@ class CLITestCase(DockerClientTestCase):
     def test_pull_with_ignore_pull_failures(self):
         result = self.dispatch([
             '-f', 'ignore-pull-failures.yml',
-            'pull', '--ignore-pull-failures'])
+            'pull', '--ignore-pull-failures']
+        )
 
         assert 'Pulling simple (busybox:latest)...' in result.stderr
         assert 'Pulling another (nonexisting-image:latest)...' in result.stderr
-        assert 'Error: image library/nonexisting-image' in result.stderr
-        assert 'not found' in result.stderr
+        assert ('repository nonexisting-image not found' in result.stderr or
+                'image library/nonexisting-image:latest not found' in result.stderr)
 
     def test_build_plain(self):
         self.base_dir = 'tests/fixtures/simple-dockerfile'


### PR DESCRIPTION
- Now returns a 404 status
- Error message has been updated (`repository nonexisting-image not found: does not exist or no read access`) (test updated to support both forms)

cc @aanand @dnephin 