### PR TITLE
progress_stream: Avoid undefined ANSI escape codes

### DIFF
--- a/compose/progress_stream.py
+++ b/compose/progress_stream.py
@@ -32,12 +32,11 @@ def stream_output(output, stream):
         if not image_id:
             continue
 
-        if image_id in lines:
-            diff = len(lines) - lines[image_id]
-        else:
+        if image_id not in lines:
             lines[image_id] = len(lines)
             stream.write("\n")
-            diff = 0
+
+        diff = len(lines) - lines[image_id]
 
         # move cursor up `diff` rows
         stream.write("%c[%dA" % (27, diff))


### PR DESCRIPTION
The ANSI escape codes \e[0A (cursor up 0 lines) and \e[0B (cursor down 0 lines)
are not well defined and are treated differently by different terminals. In
particular xterm treats 0 as a missing parameter and therefore defaults to 1,
whereas rxvt-unicode treats these escapes as a request to move 0 lines.

However the use of these codes is unnecessary and were really just hiding the
fact that we were not correctly computing diff when adding a new line. Having
added the new line to the ids map and output the corresponding \n the correct
diff would be 1 and not 0 (which xterm interprets as 1) as currently.

Rather than changing the hardcoded 0 to a 1 pull the diff calculation out and
always do it since it produces the correct answer in both cases.

This fixes similar corruption when compose is pulling an image to that seen
with `docker pull` and rxvt-unicode (and likely other terminals in that family)
seen in docker/docker#28111.

This is the same as the fix made to Docker's pkg/jsonmessage in
https://github.com/docker/docker/pull/28238 (and I have shamelessly ripped off
most of this commit message from there).

Signed-off-by: Ian Campbell <ian.campbell@docker.com>