### PR TITLE
Implement `userns_mode` HostConfig for services

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -86,6 +86,7 @@ DOCKER_CONFIG_KEYS = [
     'stop_signal',
     'tty',
     'user',
+    'userns_mode',
     'volume_driver',
     'volumes',
     'volumes_from',

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -217,6 +217,7 @@
           }
         },
         "user": {"type": "string"},
+        "userns_mode": {"type": "string"},
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},

--- a/compose/config/config_schema_v3.0.json
+++ b/compose/config/config_schema_v3.0.json
@@ -192,6 +192,7 @@
           }
         },
         "user": {"type": "string"},
+        "userns_mode": {"type": "string"},
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "working_dir": {"type": "string"}
       },

--- a/compose/service.py
+++ b/compose/service.py
@@ -64,6 +64,7 @@ DOCKER_START_KEYS = [
     'restart',
     'security_opt',
     'shm_size',
+    'userns_mode',
     'volumes_from',
 ]
 
@@ -720,7 +721,8 @@ class Service(object):
             tmpfs=options.get('tmpfs'),
             oom_score_adj=options.get('oom_score_adj'),
             mem_swappiness=options.get('mem_swappiness'),
-            group_add=options.get('group_add')
+            group_add=options.get('group_add'),
+            userns_mode=options.get('userns_mode')
         )
 
         # TODO: Add as an argument to create_host_config once it's supported

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -30,6 +30,7 @@ from compose.service import ConvergencePlan
 from compose.service import ConvergenceStrategy
 from compose.service import NetworkMode
 from compose.service import Service
+from tests.integration.testcases import v2_1_only
 from tests.integration.testcases import v2_only
 
 
@@ -841,6 +842,18 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('web', pid='host')
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.PidMode'), 'host')
+
+    @v2_1_only()
+    def test_userns_mode_none_defined(self):
+        service = self.create_service('web', userns_mode=None)
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.UsernsMode'), '')
+
+    @v2_1_only()
+    def test_userns_mode_host(self):
+        service = self.create_service('web', userns_mode='host')
+        container = create_and_start_container(service)
+        self.assertEqual(container.get('HostConfig.UsernsMode'), 'host')
 
     def test_dns_no_value(self):
         service = self.create_service('web')


### PR DESCRIPTION
Fixes #3349

This allows the key `userns_mode` to be used in service definitions.
Since `userns_mode` requires API version > 1.23, this is only available
in 2.1 and 3.0 versions of compose file

