### PR TITLE
Make created networks attachable for file format >=2.1

### DIFF
--- a/compose/network.py
+++ b/compose/network.py
@@ -6,6 +6,7 @@ import logging
 from docker.errors import NotFound
 from docker.types import IPAMConfig
 from docker.types import IPAMPool
+from docker.utils import version_gte
 
 from .config import ConfigurationError
 
@@ -72,6 +73,7 @@ class Network(object):
                 internal=self.internal,
                 enable_ipv6=self.enable_ipv6,
                 labels=self.labels,
+                attachable=version_gte(self.client._version, '1.24') or None
             )
 
     def remove(self):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -316,8 +316,8 @@ class CLITestCase(DockerClientTestCase):
                                 'memory': '50M',
                             },
                             'reservations': {
-                                    'cpus': '0.0001',
-                                    'memory': '20M',
+                                'cpus': '0.0001',
+                                'memory': '20M',
                             },
                         },
                         'restart_policy': {
@@ -928,6 +928,7 @@ class CLITestCase(DockerClientTestCase):
         assert foo_container.get('HostConfig.NetworkMode') == \
             'container:{}'.format(bar_container.id)
 
+    @v3_only()
     def test_up_with_healthcheck(self):
         def wait_on_health_status(container, status):
             def condition():
@@ -945,7 +946,7 @@ class CLITestCase(DockerClientTestCase):
         assert passes_container.get('Config.Healthcheck') == {
             "Test": ["CMD-SHELL", "/bin/true"],
             "Interval": nanoseconds_from_time_seconds(1),
-            "Timeout": nanoseconds_from_time_seconds(30*60),
+            "Timeout": nanoseconds_from_time_seconds(30 * 60),
             "Retries": 1,
         }
 


### PR DESCRIPTION
Depends on #4219 

This is necessary for applications in Swarm environments.