### PR TITLE
Fix 404 issue, change APIError to more accureate ImageNotFound

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -10,6 +10,7 @@ from operator import attrgetter
 import enum
 import six
 from docker.errors import APIError
+from docker.errors import ImageNotFound
 from docker.errors import NotFound
 from docker.types import LogConfig
 from docker.utils.ports import build_port_bindings
@@ -318,11 +319,8 @@ class Service(object):
     def image(self):
         try:
             return self.client.inspect_image(self.image_name)
-        except APIError as e:
-            if e.response.status_code == 404 and e.explanation and 'No such image' in str(e.explanation):
-                raise NoSuchImageError("Image '{}' not found".format(self.image_name))
-            else:
-                raise
+        except ImageNotFound:
+            raise NoSuchImageError("Image '{}' not found".format(self.image_name))
 
     @property
     def image_name(self):


### PR DESCRIPTION
Actually this issue was found in docker-compose v1.9.0, when running an ansible-playbook, but after checking the latest code, I think it still occurs.

The reason is the [code](https://github.com/docker/docker-py/blob/738cfdcdf96e7ff56f6bb3a4966e337187ba51c4/docker/errors.py#L23) to get images in `docker-py` has been changed for a long time. It doesn't just raise `APIError` for all exceptions, but check the response code and response content to raise two more exceptions `ImageNotFound` and `NotFound`.

So if we still check the `APIError`, we will never raise the `NoSuchImageError` and make other applications confused to use it.

