### PR TITLE
Fixing bash path problem.

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -1,4 +1,4 @@
-#!bash
+#!/bin/bash
 #
 # bash completion for docker-compose
 #


### PR DESCRIPTION
Fixing bash path problem, avoiding '**docker-compose-completion.sh: bash: bad interpreter: No such file or directory**' error