### PR TITLE
Disallow running with -d and —rm

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -700,6 +700,11 @@ class TopLevelCommand(object):
                 'can not be used together'
             )
 
+        if options['-d'] and options['--rm']:
+            raise UserError(
+                'Conflicting options: --rm and -d '
+            )
+
         if options['COMMAND'] is not None:
             command = [options['COMMAND']] + options['ARGS']
         elif options['--entrypoint'] is not None:


### PR DESCRIPTION
Currently, only -d is honoured. Failing fast on this
option is consistent with docker run —d —-rm <image>

Fixes: https://github.com/docker/compose/issues/4306
Signed-off-by: Clint Morgan <clint.a.m@gmail.com>