### PR TITLE
Add option to list not-yet-started containers

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -564,6 +564,7 @@ class TopLevelCommand(object):
 
         Options:
             -q    Only display IDs
+            -a   Show not started containers (default shows running and stopped)
         """
         containers = sorted(
             self.project.containers(service_names=options['SERVICE'], stopped=True) +
@@ -591,6 +592,12 @@ class TopLevelCommand(object):
                     container.human_readable_state,
                     container.human_readable_ports,
                 ])
+            if options['-a']:
+                not_started = [s for s in self.project.get_services()
+                               if s.get_container_name(1) not in [c.name for c in containers]]
+                for service in not_started:
+                    rows.append([service.get_container_name(1), '', 'Not started', ''])
+
             print(Formatter().table(headers, rows))
 
     def pull(self, options):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -343,10 +343,15 @@ class CLITestCase(DockerClientTestCase):
             },
         }
 
+    def test_ps_not_started(self):
+        result = self.dispatch(['ps', '-a'])
+        assert 1 == result.stdout.count('simplecomposefile_simple_1')
+        self.assertIn('Not started', result.stdout)
+
     def test_ps(self):
         self.project.get_service('simple').create_container()
         result = self.dispatch(['ps'])
-        assert 'simplecomposefile_simple_1' in result.stdout
+        assert 1 == result.stdout.count('simplecomposefile_simple_1')
 
     def test_ps_default_composefile(self):
         self.base_dir = 'tests/fixtures/multiple-composefiles'


### PR DESCRIPTION
Add flag -a to the ps command.

Fixes: https://github.com/docker/compose/issues/1061