### PR TITLE
allow custom container names in zsh completion

### DIFF
--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -115,7 +115,12 @@ __docker-compose_get_services() {
         if [[ ${services[@]} == *"${line[${begin[CONTAINER ID]},${end[CONTAINER ID]}]%% ##}"* ]]; then
             names=(${(ps:,:)${${line[${begin[NAMES]},-1]}%% *}})
             for name in $names; do
-                s="${${name%_*}#*_}:${(l:15:: :::)${${line[${begin[CREATED]},${end[CREATED]}]/ ago/}%% ##}}"
+                local last=${name##*_}
+                local dir=${PWD##*/}
+                if [ ! -z "${last##*[!0-9]*}" ] && [ "${name%%_*}" = "$dir" ] ; then
+                    name=${${name%_*}#*_}
+                fi
+                s="${name}:${(l:15:: :::)${${line[${begin[CREATED]},${end[CREATED]}]/ ago/}%% ##}}"
                 s="$s, ${line[${begin[CONTAINER ID]},${end[CONTAINER ID]}]%% ##}"
                 s="$s, ${${${line[${begin[IMAGE]},${end[IMAGE]}]}/:/\\:}%% ##}"
                 if [[ ${line[${begin[STATUS]},${end[STATUS]}]} = Exit* ]]; then


### PR DESCRIPTION
when you define a container_name in your docker-compose.yml the completion won't work correctly.

example:

docker-compose.yml
```
version:"2"
services:
  my_service:
    image: busybox
    container_name: my_service
```

the current behavior is:
```
$ docker-compose run <TAB> ... my
$ docker-compose run my
```

expected behavior would be:

```
$ docker-compose run <TAB> ... my_service
$ docker-compose run my_service
```

this pull request tries to find out, if a service was automatically named by compose, or if a custom name was given by comparing if the last part of a container name is a number and the first part is the current directory.