### PR TITLE
Fix docker image build script when using universal wheels

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,5 +1,6 @@
 
 FROM    alpine:3.4
+ARG     version
 RUN     apk -U add \
             python \
             py-pip
@@ -7,7 +8,7 @@ RUN     apk -U add \
 COPY    requirements.txt /code/requirements.txt
 RUN     pip install -r /code/requirements.txt
 
-ADD     dist/docker-compose-release-py2.py3-none-any.whl /code/docker-compose
-RUN     pip install --no-deps /code/docker-compose/docker-compose-*
+COPY     dist/docker_compose-${version}-py2.py3-none-any.whl /code/
+RUN     pip install --no-deps /code/docker_compose-${version}-py2.py3-none-any.whl
 
 ENTRYPOINT ["/usr/bin/docker-compose"]

--- a/script/build/image
+++ b/script/build/image
@@ -12,5 +12,4 @@ VERSION="$(python setup.py --version)"
 
 ./script/build/write-git-sha
 python setup.py sdist bdist_wheel
-cp dist/docker-compose-$VERSION-py2.py3-none-any.whl dist/docker-compose-release-py2.py3-none-any.whl
-docker build -t docker/compose:$TAG -f Dockerfile.run .
+docker build --build-arg version=$VERSION -t docker/compose:$TAG -f Dockerfile.run .


### PR DESCRIPTION
The `docker-compose-release-py2.py3-none-any.whl` file name is not a valid wheel filename. Use the original generated filename in combination with buildargs to be able to build the image again.