### PR TITLE
Add --resolve-image-digests option to docker-compose config command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -263,43 +263,7 @@ class TopLevelCommand(object):
         if not output:
             output = "{}.dab".format(self.project.name)
 
-        with errors.handle_connection_errors(self.project.client):
-            try:
-                image_digests = get_image_digests(
-                    self.project,
-                    allow_push=options['--push-images'],
-                )
-            except MissingDigests as e:
-                def list_images(images):
-                    return "\n".join("    {}".format(name) for name in sorted(images))
-
-                paras = ["Some images are missing digests."]
-
-                if e.needs_push:
-                    command_hint = (
-                        "Use `docker-compose push {}` to push them. "
-                        "You can do this automatically with `docker-compose bundle --push-images`."
-                        .format(" ".join(sorted(e.needs_push)))
-                    )
-                    paras += [
-                        "The following images can be pushed:",
-                        list_images(e.needs_push),
-                        command_hint,
-                    ]
-
-                if e.needs_pull:
-                    command_hint = (
-                        "Use `docker-compose pull {}` to pull them. "
-                        .format(" ".join(sorted(e.needs_pull)))
-                    )
-
-                    paras += [
-                        "The following images need to be pulled:",
-                        list_images(e.needs_pull),
-                        command_hint,
-                    ]
-
-                raise UserError("\n\n".join(paras))
+        image_digests = image_digests_for_project(self.project, options['--push-images'])
 
         with open(output, 'w') as f:
             f.write(serialize_bundle(compose_config, image_digests))
@@ -326,43 +290,7 @@ class TopLevelCommand(object):
 
         if options['--resolve-image-digests']:
             self.project = project_from_options('.', config_options)
-
-            with errors.handle_connection_errors(self.project.client):
-                try:
-                    image_digests = get_image_digests(
-                        self.project,
-                        allow_push=False
-                    )
-                except MissingDigests as e:
-                    def list_images(images):
-                        return "\n".join("    {}".format(name) for name in sorted(images))
-
-                    paras = ["Some images are missing digests."]
-
-                    if e.needs_push:
-                        command_hint = (
-                            "Use `docker-compose push {}` to push them. "
-                            .format(" ".join(sorted(e.needs_push)))
-                        )
-                        paras += [
-                            "The following images can be pushed:",
-                            list_images(e.needs_push),
-                            command_hint,
-                        ]
-
-                    if e.needs_pull:
-                        command_hint = (
-                            "Use `docker-compose pull {}` to pull them. "
-                            .format(" ".join(sorted(e.needs_pull)))
-                        )
-
-                        paras += [
-                            "The following images need to be pulled:",
-                            list_images(e.needs_pull),
-                            command_hint,
-                        ]
-
-                    raise UserError("\n\n".join(paras))
+            image_digests = image_digests_for_project(self.project)
 
         if options['--quiet']:
             return
@@ -1075,6 +1003,45 @@ def convergence_strategy_from_opts(options):
 def timeout_from_opts(options):
     timeout = options.get('--timeout')
     return None if timeout is None else int(timeout)
+
+
+def image_digests_for_project(project, allow_push=False):
+    with errors.handle_connection_errors(project.client):
+        try:
+            return get_image_digests(
+                project,
+                allow_push=allow_push
+            )
+        except MissingDigests as e:
+            def list_images(images):
+                return "\n".join("    {}".format(name) for name in sorted(images))
+
+            paras = ["Some images are missing digests."]
+
+            if e.needs_push:
+                command_hint = (
+                    "Use `docker-compose push {}` to push them. "
+                    .format(" ".join(sorted(e.needs_push)))
+                )
+                paras += [
+                    "The following images can be pushed:",
+                    list_images(e.needs_push),
+                    command_hint,
+                ]
+
+            if e.needs_pull:
+                command_hint = (
+                    "Use `docker-compose pull {}` to pull them. "
+                    .format(" ".join(sorted(e.needs_pull)))
+                )
+
+                paras += [
+                    "The following images need to be pulled:",
+                    list_images(e.needs_pull),
+                    command_hint,
+                ]
+
+            raise UserError("\n\n".join(paras))
 
 
 def exitval_from_opts(options, project):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3654,6 +3654,25 @@ class SerializeTest(unittest.TestCase):
         assert denormalized_service['healthcheck']['interval'] == '100s'
         assert denormalized_service['healthcheck']['timeout'] == '30s'
 
+    def test_denormalize_image_has_digest(self):
+        service_dict = {
+            'image': 'busybox'
+        }
+        image_digest = 'busybox@sha256:abcde'
+
+        assert denormalize_service_dict(service_dict, V3_0, image_digest) == {
+            'image': 'busybox@sha256:abcde'
+        }
+
+    def test_denormalize_image_no_digest(self):
+        service_dict = {
+            'image': 'busybox'
+        }
+
+        assert denormalize_service_dict(service_dict, V3_0) == {
+            'image': 'busybox'
+        }
+
     def test_serialize_secrets(self):
         service_dict = {
             'image': 'example/web',


### PR DESCRIPTION
Add an option named `--digest` to the `docker-compose config` command. It pins images to specific image digests for compose files, just like the `docker-compose bundle` command for DAB files.

Resolves #4332.