### PR TITLE
Prevent installing Compose in an environment where `docker-py` is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import codecs
@@ -9,9 +10,18 @@ import os
 import re
 import sys
 
+import pip
 import pkg_resources
 from setuptools import find_packages
 from setuptools import setup
+
+
+if 'docker-py' in [x.project_name for x in pip.get_installed_distributions()]:
+    print(
+        'ERROR: "docker-py" needs to be uninstalled before installing this'
+        ' package:\npip uninstall docker-py', file=sys.stderr
+    )
+    sys.exit(1)
 
 
 def read(*parts):


### PR DESCRIPTION
Fixes #4344 