### PR TITLE
Don't strip ANSI color codes when output is not a TTY

### DIFF
--- a/compose/cli/colors.py
+++ b/compose/cli/colors.py
@@ -33,7 +33,7 @@ def make_color_fn(code):
     return lambda s: ansi_color(code, s)
 
 
-colorama.init()
+colorama.init(strip=False)
 for (name, code) in get_pairs():
     globals()[name] = make_color_fn(code)
 


### PR DESCRIPTION
Fixes #4408 