### PR TITLE
Don't re-parse healthcheck values coming from extended services

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -716,9 +716,15 @@ def process_healthcheck(service_dict, service_name):
         hc['test'] = raw['test']
 
     if 'interval' in raw:
-        hc['interval'] = parse_nanoseconds_int(raw['interval'])
+        if not isinstance(raw['interval'], six.integer_types):
+            hc['interval'] = parse_nanoseconds_int(raw['interval'])
+        else:  # Conversion has been done previously
+            hc['interval'] = raw['interval']
     if 'timeout' in raw:
-        hc['timeout'] = parse_nanoseconds_int(raw['timeout'])
+        if not isinstance(raw['timeout'], six.integer_types):
+            hc['timeout'] = parse_nanoseconds_int(raw['timeout'])
+        else:  # Conversion has been done previously
+            hc['timeout'] = raw['timeout']
     if 'retries' in raw:
         hc['retries'] = raw['retries']
 

--- a/tests/fixtures/extends/healthcheck-1.yml
+++ b/tests/fixtures/extends/healthcheck-1.yml
@@ -1,0 +1,9 @@
+version: '2.1'
+services:
+  demo:
+    image: foobar:latest
+    healthcheck:
+      test: ["CMD", "/health.sh"]
+      interval: 10s
+      timeout: 5s
+      retries: 36

--- a/tests/fixtures/extends/healthcheck-2.yml
+++ b/tests/fixtures/extends/healthcheck-2.yml
@@ -1,0 +1,6 @@
+version: '2.1'
+services:
+  demo:
+    extends:
+      file: healthcheck-1.yml
+      service: demo

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3098,6 +3098,19 @@ class ExtendsTest(unittest.TestCase):
             'other': {'condition': 'service_started'}
         }
 
+    def test_extends_with_healthcheck(self):
+        service_dicts = load_from_filename('tests/fixtures/extends/healthcheck-2.yml')
+        assert service_sort(service_dicts) == [{
+            'name': 'demo',
+            'image': 'foobar:latest',
+            'healthcheck': {
+                'test': ['CMD', '/health.sh'],
+                'interval': 10000000000,
+                'timeout': 5000000000,
+                'retries': 36,
+            }
+        }]
+
 
 @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')
 class ExpandPathTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #4418 