### PR TITLE
Pull services in parallel

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -607,7 +607,7 @@ class TopLevelCommand(object):
         self.project.pull(
             service_names=options['SERVICE'],
             ignore_pull_failures=options.get('--ignore-pull-failures'),
-            in_parallel=options.get('--parallel')
+            parallel_pull=options.get('--parallel')
         )
 
     def push(self, options):

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -602,10 +602,12 @@ class TopLevelCommand(object):
 
         Options:
             --ignore-pull-failures  Pull what it can and ignores images with pull failures.
+            --parallel              Pull multiple images in parallel.
         """
         self.project.pull(
             service_names=options['SERVICE'],
-            ignore_pull_failures=options.get('--ignore-pull-failures')
+            ignore_pull_failures=options.get('--ignore-pull-failures'),
+            in_parallel=options.get('--parallel')
         )
 
     def push(self, options):

--- a/compose/project.py
+++ b/compose/project.py
@@ -456,7 +456,7 @@ class Project(object):
 
     def pull(self, service_names=None, ignore_pull_failures=False):
         def pull_service(service):
-            service.pull(ignore_pull_failures)
+            service.pull(ignore_pull_failures, True)
 
         services = self.get_services(service_names, include_deps=False)
         parallel.parallel_execute(

--- a/compose/project.py
+++ b/compose/project.py
@@ -463,7 +463,8 @@ class Project(object):
             services,
             pull_service,
             operator.attrgetter('name'),
-            'Pulling')
+            'Pulling',
+            limit=5)
 
     def push(self, service_names=None, ignore_push_failures=False):
         for service in self.get_services(service_names, include_deps=False):

--- a/compose/project.py
+++ b/compose/project.py
@@ -454,17 +454,22 @@ class Project(object):
 
         return plans
 
-    def pull(self, service_names=None, ignore_pull_failures=False):
-        def pull_service(service):
-            service.pull(ignore_pull_failures, True)
-
+    def pull(self, service_names=None, ignore_pull_failures=False, in_parallel=False):
         services = self.get_services(service_names, include_deps=False)
-        parallel.parallel_execute(
-            services,
-            pull_service,
-            operator.attrgetter('name'),
-            'Pulling',
-            limit=5)
+
+        if in_parallel:
+            def pull_service(service):
+                service.pull(ignore_pull_failures, True)
+
+            parallel.parallel_execute(
+                services,
+                pull_service,
+                operator.attrgetter('name'),
+                'Pulling',
+                limit=5)
+        else:
+            for service in services:
+                service.pull(ignore_pull_failures)
 
     def push(self, service_names=None, ignore_push_failures=False):
         for service in self.get_services(service_names, include_deps=False):

--- a/compose/project.py
+++ b/compose/project.py
@@ -454,10 +454,10 @@ class Project(object):
 
         return plans
 
-    def pull(self, service_names=None, ignore_pull_failures=False, in_parallel=False):
+    def pull(self, service_names=None, ignore_pull_failures=False, parallel_pull=False):
         services = self.get_services(service_names, include_deps=False)
 
-        if in_parallel:
+        if parallel_pull:
             def pull_service(service):
                 service.pull(ignore_pull_failures, True)
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -455,8 +455,15 @@ class Project(object):
         return plans
 
     def pull(self, service_names=None, ignore_pull_failures=False):
-        for service in self.get_services(service_names, include_deps=False):
+        def pull_service(service):
             service.pull(ignore_pull_failures)
+
+        services = self.get_services(service_names, include_deps=False)
+        parallel.parallel_execute(
+            services,
+            pull_service,
+            operator.attrgetter('name'),
+            'Pulling')
 
     def push(self, service_names=None, ignore_push_failures=False):
         for service in self.get_services(service_names, include_deps=False):

--- a/compose/service.py
+++ b/compose/service.py
@@ -886,17 +886,19 @@ class Service(object):
 
         return any(has_host_port(binding) for binding in self.options.get('ports', []))
 
-    def pull(self, ignore_pull_failures=False):
+    def pull(self, ignore_pull_failures=False, silent=False):
         if 'image' not in self.options:
             return
 
         repo, tag, separator = parse_repository_tag(self.options['image'])
         tag = tag or 'latest'
-        log.info('Pulling %s (%s%s%s)...' % (self.name, repo, separator, tag))
+        if not silent:
+            log.info('Pulling %s (%s%s%s)...' % (self.name, repo, separator, tag))
         try:
             output = self.client.pull(repo, tag=tag, stream=True)
-            return progress_stream.get_digest_from_pull(
-                stream_output(output, sys.stdout))
+            if not silent:
+                return progress_stream.get_digest_from_pull(
+                    stream_output(output, sys.stdout))
         except (StreamOutputError, NotFound) as e:
             if not ignore_pull_failures:
                 raise

--- a/compose/service.py
+++ b/compose/service.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
+import os
 import re
 import sys
 from collections import namedtuple
@@ -896,7 +897,11 @@ class Service(object):
             log.info('Pulling %s (%s%s%s)...' % (self.name, repo, separator, tag))
         try:
             output = self.client.pull(repo, tag=tag, stream=True)
-            if not silent:
+            if silent:
+                with open(os.devnull, 'w') as devnull:
+                    return progress_stream.get_digest_from_pull(
+                        stream_output(output, devnull))
+            else:
                 return progress_stream.get_digest_from_pull(
                     stream_output(output, sys.stdout))
         except (StreamOutputError, NotFound) as e:

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -82,7 +82,7 @@ def test_parallel_execute_with_upstream_errors():
     events = [
         (obj, result, type(exception))
         for obj, result, exception
-        in parallel_execute_iter(objects, process, get_deps)
+        in parallel_execute_iter(objects, process, get_deps, None)
     ]
 
     assert (cache, None, type(None)) in events


### PR DESCRIPTION
Updates #1652

This PR adds a new `--parallel` flag on `docker-compose pull` that pulls images in parallel, which should hopefully speed up pulls for projects with lots of services. By default, with no flag, you get the old, non-parallel behavior.

`parallel_execute` now accepts an optional `limit` parameter that specifies the number of threads that actually run at one time. There are arguably more elegant approaches than mine, but I opted to keep the diff relatively small. I'm happy to get some feedback about this. I've somewhat arbitrarily chosen 5 as the limit for the number of parallel pulls. I'm also happy to break this part out into a separate PR since it's mostly independent from the rest of this PR and could be useful in other contexts.

The normal `docker-compose pull` output is silenced when pulling in parallel. This means we no longer get progress bars with `--parallel`, but the output is easier to understand.

I've tested this manually and it seems to work. I'm not sure how I'd go about
writing an automated test for it, but open to suggestions.