### PR TITLE
Provide support for ARM 32bit

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,71 @@
+FROM armhf/debian:wheezy
+
+RUN set -ex; \
+    apt-get update -qq; \
+    apt-get install -y \
+        locales \
+        gcc \
+        make \
+        zlib1g \
+        zlib1g-dev \
+        libssl-dev \
+        git \
+        ca-certificates \
+        curl \
+        libsqlite3-dev \
+        libbz2-dev \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl https://get.docker.com/builds/Linux/armel/docker-1.8.3 \
+        -o /usr/local/bin/docker && \
+    chmod +x /usr/local/bin/docker
+
+# Build Python 2.7.13 from source
+RUN set -ex; \
+    curl -L https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz | tar -xz; \
+    cd Python-2.7.13; \
+    ./configure --enable-shared; \
+    make; \
+    make install; \
+    cd ..; \
+    rm -rf /Python-2.7.13
+
+# Build python 3.4 from source
+RUN set -ex; \
+    curl -L https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tgz | tar -xz; \
+    cd Python-3.4.6; \
+    ./configure --enable-shared; \
+    make; \
+    make install; \
+    cd ..; \
+    rm -rf /Python-3.4.6
+
+# Make libpython findable
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+# Install pip
+RUN set -ex; \
+    curl -L https://bootstrap.pypa.io/get-pip.py | python
+
+# Python3 requires a valid locale
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+
+RUN useradd -d /home/user -m -s /bin/bash user
+WORKDIR /code/
+
+RUN pip install tox==2.1.1
+
+ADD requirements.txt /code/
+ADD requirements-dev.txt /code/
+ADD .pre-commit-config.yaml /code/
+ADD setup.py /code/
+ADD tox.ini /code/
+ADD compose /code/compose/
+RUN tox --notest
+
+ADD . /code/
+RUN chown -R user /code/
+
+ENTRYPOINT ["/code/.tox/py27/bin/docker-compose"]

--- a/script/test/default
+++ b/script/test/default
@@ -5,11 +5,15 @@ set -ex
 
 TAG="docker-compose:$(git rev-parse --short HEAD)"
 
+# By default use the Dockerfile, but can be overriden to use an alternative file
+# e.g DOCKERFILE=Dockerfile.armhf script/test/default
+DOCKERFILE="${DOCKERFILE:-Dockerfile}"
+
 rm -rf coverage-html
 # Create the host directory so it's owned by $USER
 mkdir -p coverage-html
 
-docker build -t "$TAG" .
+docker build -f ${DOCKERFILE} -t "$TAG" .
 
 GIT_VOLUME="--volume=$(pwd)/.git:/code/.git"
 . script/test/all


### PR DESCRIPTION
I wanted to use `docker-compose` on my Raspberry Pi 2 (ARM 32bit). There is no built version for it, so I attempted to build one myself. The provided commit implement the necessary change to support this architecture. Fixes #3795 

Based on the `master` branch and due to recent commits (which upgraded pip and a few other dependencies), the change is now very simple. Basically it revolves around changing the base image (`debian` is x86_64 only, so I've been using `armhf/debian` instead) and downloading the docker binary for armel architecture.

I've tried to adapt the script/test/default in order to validate the generated docker-compose binary, but it is an unfinished job as I'm stuck with the fact that there are no images available of `dind` for ARM (`dockerswarm/dind` only provide x86_64 images).

Anyway, I have 2 small projects which uses docker-compose.yml and both works. But I'm only using a subset of all of docker-compose features, and I do not have a Swarm configured to test those aspects as well. So my commit is only partially validated. But at least it works perfectly for what I'm using of it.

_Note: Try to use the `bump-1.10.0` branch (in order to get a "stable" version of docker-compose) is a bit more tricky and requires several additional changes w.r.t. this PR. Those are visible on [this branch of my fork](https://github.com/jcberthon/compose/tree/compose-armv7), this is just for your information._