### PR TITLE
Bump 1.11.0

### DIFF
--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.11.0-rc1'
+__version__ = '1.11.0'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.11.0-rc1"
+VERSION="1.11.0"
 IMAGE="docker/compose:$VERSION"
 
 


### PR DESCRIPTION
### New Features

#### Compose file version 3.1

- Introduced version 3.1 of the `docker-compose.yml` specification. This
  version requires Docker Engine 1.13.0 or above. It introduces support
  for secrets. See the documentation for more information

#### Compose file version 2.0 and up

- Introduced the `docker-compose top` command that displays processes running
  for the different services managed by Compose.

### Bugfixes

- Fixed a bug where extending a service defining a healthcheck dictionary
  would cause `docker-compose` to error out.

- Fixed an issue where the `pid` entry in a service definition was being
  ignored when using multiple Compose files.