### PR TITLE
Allow an 'extra' top-level element in config files.

### DIFF
--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -38,6 +38,12 @@
         }
       },
       "additionalProperties": false
+    },
+
+    "extra": {
+      "id": "#/properties/extra",
+      "type": "object",
+      "additionalProperties": true
     }
   },
 

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -38,6 +38,12 @@
         }
       },
       "additionalProperties": false
+    },
+
+    "extra": {
+      "id": "#/properties/extra",
+      "type": "object",
+      "additionalProperties": true
     }
   },
 

--- a/compose/config/config_schema_v3.0.json
+++ b/compose/config/config_schema_v3.0.json
@@ -39,6 +39,12 @@
         }
       },
       "additionalProperties": false
+    },
+
+    "extra": {
+      "id": "#/properties/extra",
+      "type": "object",
+      "additionalProperties": true
     }
   },
 

--- a/compose/config/config_schema_v3.1.json
+++ b/compose/config/config_schema_v3.1.json
@@ -41,6 +41,12 @@
       "additionalProperties": false
     },
 
+    "extra": {
+      "id": "#/properties/extra",
+      "type": "object",
+      "additionalProperties": true
+    },
+
     "secrets": {
       "id": "#/properties/secrets",
       "type": "object",


### PR DESCRIPTION
This allows writers of docker-compose.yml files to factor out repeated
bits of configuration to be under an 'extra' top-level key, allowing the
use of yml anchors.

Signed-off-by: Tommy Beadle <tbeadle@gmail.com>