### PR TITLE
Bump 1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 Change log
 ==========
 
+1.11.2 (2017-02-17)
+-------------------
+
+### Bugfixes
+
+- Fixed a bug that was preventing secrets configuration from being
+  loaded properly
+
+- Fixed a bug where the `docker-compose config` command would fail
+  if the config file contained secrets definitions
+
+- Fixed an issue where Compose on some linux distributions would
+  pick up and load an outdated version of the requests library
+
+- Fixed an issue where socket-type files inside a build folder
+  would cause `docker-compose` to crash when trying to build that
+  service
+
+- Fixed an issue where recursive wildcard patterns `**` were not being
+  recognized in `.dockerignore` files.
+
 1.11.1 (2017-02-09)
 -------------------
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.11.1'
+__version__ = '1.11.2'

--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import subprocess
+import sys
+
+# Attempt to detect https://github.com/docker/compose/issues/4344
+try:
+    # We don't try importing pip because it messes with package imports
+    # on some Linux distros (Ubuntu, Fedora)
+    # https://github.com/docker/compose/issues/4425
+    # https://github.com/docker/compose/issues/4481
+    # https://github.com/pypa/pip/blob/master/pip/_vendor/__init__.py
+    s_cmd = subprocess.Popen(
+        ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE
+    )
+    packages = s_cmd.communicate()[0].splitlines()
+    dockerpy_installed = len(
+        list(filter(lambda p: p.startswith(b'docker-py=='), packages))
+    ) > 0
+    if dockerpy_installed:
+        from .colors import red
+        print(
+            red('ERROR:'),
+            "Dependency conflict: an older version of the 'docker-py' package "
+            "is polluting the namespace. "
+            "Run the following command to remedy the issue:\n"
+            "pip uninstall docker docker-py; pip install docker",
+            file=sys.stderr
+        )
+        sys.exit(1)
+
+except OSError:
+    # pip command is not available, which indicates it's probably the binary
+    # distribution of Compose which is not affected
+    pass

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -14,30 +14,6 @@ from distutils.spawn import find_executable
 from inspect import getdoc
 from operator import attrgetter
 
-
-# Attempt to detect https://github.com/docker/compose/issues/4344
-try:
-    # A regular import statement causes PyInstaller to freak out while
-    # trying to load pip. This way it is simply ignored.
-    pip = __import__('pip')
-    pip_packages = pip.get_installed_distributions()
-    if 'docker-py' in [pkg.project_name for pkg in pip_packages]:
-        from .colors import red
-        print(
-            red('ERROR:'),
-            "Dependency conflict: an older version of the 'docker-py' package "
-            "is polluting the namespace. "
-            "Run the following command to remedy the issue:\n"
-            "pip uninstall docker docker-py; pip install docker",
-            file=sys.stderr
-        )
-        sys.exit(1)
-except ImportError:
-    # pip is not available, which indicates it's probably the binary
-    # distribution of Compose which is not affected
-    pass
-
-
 from . import errors
 from . import signals
 from .. import __version__

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -763,6 +763,11 @@ def finalize_service(service_config, service_names, version, environment):
     if 'restart' in service_dict:
         service_dict['restart'] = parse_restart_spec(service_dict['restart'])
 
+    if 'secrets' in service_dict:
+        service_dict['secrets'] = [
+            types.ServiceSecret.parse(s) for s in service_dict['secrets']
+        ]
+
     normalize_build(service_dict, service_config.working_dir, environment)
 
     service_dict['name'] = service_config.name

--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -102,4 +102,7 @@ def denormalize_service_dict(service_dict, version):
                 service_dict['healthcheck']['timeout']
             )
 
+    if 'secrets' in service_dict:
+        service_dict['secrets'] = map(lambda s: s.repr(), service_dict['secrets'])
+
     return service_dict

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -256,8 +256,5 @@ class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
 
     def repr(self):
         return dict(
-            source=self.source,
-            target=self.target,
-            uid=self.uid,
-            gid=self.gid,
-            mode=self.mode)
+            [(k, v) for k, v in self._asdict().items() if v is not None]
+        )

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -253,3 +253,11 @@ class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
     @property
     def merge_field(self):
         return self.source
+
+    def repr(self):
+        return dict(
+            source=self.source,
+            target=self.target,
+            uid=self.uid,
+            gid=self.gid,
+            mode=self.mode)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyYAML==3.11
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.2.0
 colorama==0.3.7
-docker==2.0.2
+docker==2.1.0
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4; python_version < '3.4'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.11.1"
+VERSION="1.11.2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, < 2.12',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker >= 2.0.2, < 3.0',
+    'docker >= 2.1.0, < 3.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import codecs
-import logging
 import os
 import re
 import sys
@@ -64,11 +64,9 @@ try:
         for key, value in extras_require.items():
             if key.startswith(':') and pkg_resources.evaluate_marker(key[1:]):
                 install_requires.extend(value)
-except Exception:
-    logging.getLogger(__name__).exception(
-        'Failed to compute platform dependencies. All dependencies will be '
-        'installed as a result.'
-    )
+except Exception as e:
+    print("Failed to compute platform dependencies: {}. ".format(e) +
+          "All dependencies will be installed as a result.", file=sys.stderr)
     for key, value in extras_require.items():
         if key.startswith(':'):
             install_requires.extend(value)


### PR DESCRIPTION
### Bugfixes

- Fixed a bug that was preventing secrets configuration from being
  loaded properly

- Fixed a bug where the `docker-compose config` command would fail
  if the config file contained secrets definitions

- Fixed an issue where Compose on some linux distributions would
  pick up and load an outdated version of the requests library

- Fixed an issue where socket-type files inside a build folder
  would cause `docker-compose` to crash when trying to build that
  service

- Fixed an issue where recursive wildcard patterns `**` were not being
  recognized in `.dockerignore` files.