### PR TITLE
Fix treatment of global arguments in bash completion

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -18,7 +18,7 @@
 
 
 __docker_compose_q() {
-	docker-compose 2>/dev/null $daemon_options "$@"
+	docker-compose 2>/dev/null "${daemon_options[@]}" "$@"
 }
 
 # Transforms a multiline list of strings into a single line string


### PR DESCRIPTION
Bash completion did not treat global options like `-f` properly.
These options should get propagated to secondary calls to `docker-compose`.

To reproduce the problem:

This completes the available services:
```bash
docker-compose up <tab>
```
This should also complete services but does not:
```bash
docker-compose -f docker-compose.yml up <tab>
```