### PR TITLE
Activate bash completion for Windows executable

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -571,4 +571,4 @@ _docker_compose() {
 	return 0
 }
 
-complete -F _docker_compose docker-compose
+complete -F _docker_compose docker-compose docker-compose.exe


### PR DESCRIPTION
On Unix shells running on Windows (cygwin, Docker Toolbox), command completion will expand the name of the Docker Compose binary to `docker-compose.exe`. If you manually installed bash completion, it will not trigger unless you remove the trailing `.exe`.
This PR makes bash completion work for binaries named `docker-compose` _and_ `docker-compose.exe`.