### PR TITLE
Align status output for parallel_execute

### DIFF
--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -35,7 +35,8 @@ def parallel_execute(objects, func, get_name, msg, get_deps=None):
 
     writer = ParallelStreamWriter(stream, msg)
     for obj in objects:
-        writer.initialize(get_name(obj))
+        writer.add_object(get_name(obj))
+    writer.write_initial()
 
     events = parallel_execute_iter(objects, func, get_deps)
 
@@ -207,12 +208,18 @@ class ParallelStreamWriter(object):
         self.stream = stream
         self.msg = msg
         self.lines = []
+        self.width = 0
 
-    def initialize(self, obj_index):
+    def add_object(self, obj_index):
+        self.lines.append(obj_index)
+        self.width = max(self.width, len(obj_index))
+
+    def write_initial(self):
         if self.msg is None:
             return
-        self.lines.append(obj_index)
-        self.stream.write("{} {} ... \r\n".format(self.msg, obj_index))
+        for line in self.lines:
+            self.stream.write("{} {:<{width}} ... \r\n".format(self.msg, line,
+                              width=self.width))
         self.stream.flush()
 
     def write(self, obj_index, status):
@@ -224,7 +231,8 @@ class ParallelStreamWriter(object):
         self.stream.write("%c[%dA" % (27, diff))
         # erase
         self.stream.write("%c[2K\r" % 27)
-        self.stream.write("{} {} ... {}\r".format(self.msg, obj_index, status))
+        self.stream.write("{} {:<{width}} ... {}\r".format(self.msg, obj_index,
+                          status, width=self.width))
         # move back down
         self.stream.write("%c[%dB" % (27, diff))
         self.stream.flush()

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -89,3 +89,18 @@ def test_parallel_execute_with_upstream_errors():
     assert (data_volume, None, APIError) in events
     assert (db, None, UpstreamError) in events
     assert (web, None, UpstreamError) in events
+
+
+def test_parallel_execute_alignment(capsys):
+    results, errors = parallel_execute(
+        objects=["short", "a very long name"],
+        func=lambda x: x,
+        get_name=six.text_type,
+        msg="Aligning",
+    )
+
+    assert errors == {}
+
+    _, err = capsys.readouterr()
+    a, b = err.split('\n')[:2]
+    assert a.index('...') == b.index('...')


### PR DESCRIPTION
Previously docker-compose would output lines that looked like:

    Starting service ... done
    Starting short ...
    Starting service-with-a-long-name ... done

It's difficult to scan down this output and get an idea of what's happening.

Now the statuses are aligned, and output looks like this:

    Starting service                  ... done
    Starting short                    ...
    Starting service-with-a-long-name ... done

To me, this is quite a bit easier to read.

Signed-off-by: Evan Shaw <evan@vendhq.com>