### PR TITLE
Don't flood logs on restarted or reattached container

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -175,9 +175,8 @@ def build_log_generator(container, log_args):
     # if the container doesn't have a log_stream we need to attach to container
     # before log printer starts running
     if container.log_stream is None:
-        stream = container.logs(stdout=True, stderr=True, stream=True, **log_args)
-    else:
-        stream = container.log_stream
+        container.attach_log_stream()
+    stream = container.log_stream
 
     return split_buffer(stream)
 

--- a/tests/unit/cli/log_printer_test.py
+++ b/tests/unit/cli/log_printer_test.py
@@ -90,17 +90,18 @@ class TestBuildLogGenerator(object):
 
     def test_no_log_stream(self, mock_container):
         mock_container.log_stream = None
-        mock_container.logs.return_value = iter([b"hello\nworld"])
+        mock_container.attach_log_stream.return_value = None
+
+        def set_iter():
+            mock_container.log_stream = iter([b"hello\nworld"])
+
+        mock_container.attach_log_stream.side_effect = set_iter
         log_args = {'follow': True}
 
         generator = build_log_generator(mock_container, log_args)
         assert next(generator) == "hello\n"
         assert next(generator) == "world"
-        mock_container.logs.assert_called_once_with(
-            stdout=True,
-            stderr=True,
-            stream=True,
-            **log_args)
+        mock_container.attach_log_stream.assert_called_once_with()
 
     def test_with_log_stream(self, mock_container):
         mock_container.log_stream = iter([b"hello\nworld"])


### PR DESCRIPTION
### Background

I often use `docker-compose restart foobar` to restart only single container run by `docker-compose up`.
(I want to restart rails container after rewriting files in config/ dir and not webpack container.)
But it floods log from beginning and eats 100% CPU.

Cause of issue is calling `container.logs()` which streams log from beginning, instead of calling `container.attach_log_stream()` which used in compose/service.py.

This PR fixes it..!

### Step to reproduce

1. `docker-compose up`
2. output log (e.g. f5 attack)
3. start another terminal session
4. `docker-compose restart container_with_large_log`

or

1. `docker-compose up`
2. output log (e.g. f5 attack)
3. Ctrl+\
4. `docker-compose up` (reattaches to existing services)

### Related issue

Feature: Ability to clear log history
https://github.com/docker/compose/issues/1083#issuecomment-91352820

> Each time I restart containers append many lines to the log.