### PR TITLE
Fixes #4522: Adds cli option --ignore-override

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -33,7 +33,8 @@ def project_from_options(project_dir, options):
         verbose=options.get('--verbose'),
         host=host,
         tls_config=tls_config_from_options(options),
-        environment=environment
+        environment=environment,
+        ignore_override=options['--ignore-override']
     )
 
 
@@ -93,10 +94,10 @@ def get_client(environment, verbose=False, version=None, tls_config=None, host=N
 
 
 def get_project(project_dir, config_path=None, project_name=None, verbose=False,
-                host=None, tls_config=None, environment=None):
+                host=None, tls_config=None, environment=None, ignore_override=False):
     if not environment:
         environment = Environment.from_env_file(project_dir)
-    config_details = config.find(project_dir, config_path, environment)
+    config_details = config.find(project_dir, config_path, environment, ignore_override)
     project_name = get_project_name(
         config_details.working_dir, project_name, environment
     )

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -168,6 +168,7 @@ class TopLevelCommand(object):
       --skip-hostname-check       Don't check the daemon's hostname against the name specified
                                   in the client certificate (for example if your docker host
                                   is an IP address)
+      --ignore-override           Ignore docker-compose.override.yml file during this run
 
     Commands:
       build              Build or rebuild services

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -231,7 +231,7 @@ class ServiceConfig(namedtuple('_ServiceConfig', 'working_dir filename name conf
             config)
 
 
-def find(base_dir, filenames, environment):
+def find(base_dir, filenames, environment, ignore_override=False):
     if filenames == ['-']:
         return ConfigDetails(
             os.getcwd(),
@@ -242,7 +242,7 @@ def find(base_dir, filenames, environment):
     if filenames:
         filenames = [os.path.join(base_dir, f) for f in filenames]
     else:
-        filenames = get_default_config_files(base_dir)
+        filenames = get_default_config_files(base_dir, ignore_override)
 
     log.debug("Using configuration files: {}".format(",".join(filenames)))
     return ConfigDetails(
@@ -268,7 +268,7 @@ def validate_config_version(config_files):
                     next_file.version))
 
 
-def get_default_config_files(base_dir):
+def get_default_config_files(base_dir, ignore_override=False):
     (candidates, path) = find_candidates_in_parent_dirs(SUPPORTED_FILENAMES, base_dir)
 
     if not candidates:
@@ -280,7 +280,10 @@ def get_default_config_files(base_dir):
         log.warn("Found multiple config files with supported names: %s", ", ".join(candidates))
         log.warn("Using %s\n", winner)
 
-    return [os.path.join(path, winner)] + get_default_override_file(path)
+    if ignore_override:
+        return [os.path.join(path, winner)]
+    else:
+        return [os.path.join(path, winner)] + get_default_override_file(path)
 
 
 def get_default_override_file(path):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1879,6 +1879,72 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(db.human_readable_command, 'top')
         self.assertEqual(other.human_readable_command, 'top')
 
+    def test_up_with_default_files_ignore_override(self):
+        # Set base dir to one which contains an docker-compose.override.yml file
+        self.base_dir = 'tests/fixtures/override-files'
+
+        # Explicitly set the list of compose files, leaving out .override. so it is
+        # picked up automatically
+        config_paths = None
+        self._project = get_project(self.base_dir, config_paths)
+
+        # dispatch with extra top-level param --ignore-override so the
+        # file docker-compose.override.yml is not used
+        self.dispatch(
+            [
+                'up', '-d'
+            ],
+            ['--ignore-override'])
+
+        containers = self.project.containers()
+        self.assertEqual(len(containers), 2)
+
+        # assert that none of the settings in .override. were used
+        web, db = containers
+        self.assertEqual(web.human_readable_command, 'sleep 200')
+        self.assertTrue({'db'} <= set(get_links(web)))
+        self.assertEqual(db.human_readable_command, 'sleep 200')
+
+    def test_up_with_excplicit_use_of_override_file_and_ignore_override(self):
+        # Purpose: to show that the use of --ignore-override will not impact
+        # the explicit list of files if it includes an override. That is, if
+        # the user lists a file then then it will be used and --ignore-override
+        # will only impact the *automatic* use of docker-compose.override.yml
+
+        # Set base dir to one which contains an docker-compose.override.yml file
+        self.base_dir = 'tests/fixtures/override-files'
+
+        # Explicitly set the list of compose files, including .override.
+        config_paths = [
+            'docker-compose.yml',
+            'docker-compose.override.yml',
+            'extra.yml',
+
+        ]
+        self._project = get_project(self.base_dir, config_paths)
+
+        # dispatch with extra top-level param --ignore-override but we
+        # still expect it to be used because it was explicitly listed in
+        # the list of files
+        self.dispatch(
+            [
+                '-f', config_paths[0],
+                '-f', config_paths[1],
+                '-f', config_paths[2],
+                'up', '-d'
+            ],
+            ['--ignore-override'])
+
+        containers = self.project.containers()
+        self.assertEqual(len(containers), 3)
+
+        # assert that the settings in .override. were used
+        web, other, db = containers
+        self.assertEqual(web.human_readable_command, 'top')
+        self.assertTrue({'db', 'other'} <= set(get_links(web)))
+        self.assertEqual(db.human_readable_command, 'top')
+        self.assertEqual(other.human_readable_command, 'top')
+
     def test_up_with_extends(self):
         self.base_dir = 'tests/fixtures/extends'
         self.dispatch(['up', '-d'], None)


### PR DESCRIPTION
For issue #4522, adds cli option --ignore-override

When option `--ignore-override` is provided the docker-compose.override.yml, if it exists, will not be considered for any command.