### PR TITLE
Return exit code when exiting with --abort-on-container-exit

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -890,11 +890,18 @@ class TopLevelCommand(object):
                 cascade_stop,
                 event_stream=self.project.events(service_names=service_names))
             print("Attaching to", list_containers(log_printer.containers))
-            log_printer.run()
+            cascade_starter = log_printer.run()
 
             if cascade_stop:
                 print("Aborting on container exit...")
+                exit_code = 0
+                for e in self.project.containers(service_names=options['SERVICE'], stopped=True):
+                    if (not e.is_running and cascade_starter == e.name):
+                        if not e.exit_code == 0:
+                            exit_code = e.exit_code
+                            break
                 self.project.stop(service_names=service_names, timeout=timeout)
+                sys.exit(exit_code)
 
     @classmethod
     def version(cls, options):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1085,10 +1085,18 @@ class CLITestCase(DockerClientTestCase):
         wait_on_condition(ContainerCountCondition(self.project, 0))
 
     def test_up_handles_abort_on_container_exit(self):
-        start_process(self.base_dir, ['up', '--abort-on-container-exit'])
-        wait_on_condition(ContainerCountCondition(self.project, 2))
-        self.project.stop(['simple'])
+        self.base_dir = 'tests/fixtures/abort-on-container-exit-0'
+        proc = start_process(self.base_dir, ['up', '--abort-on-container-exit'])
         wait_on_condition(ContainerCountCondition(self.project, 0))
+        proc.wait()
+        self.assertEqual(proc.returncode, 0)
+
+    def test_up_handles_abort_on_container_exit_code(self):
+        self.base_dir = 'tests/fixtures/abort-on-container-exit-1'
+        proc = start_process(self.base_dir, ['up', '--abort-on-container-exit'])
+        wait_on_condition(ContainerCountCondition(self.project, 0))
+        proc.wait()
+        self.assertEqual(proc.returncode, 1)
 
     def test_exec_without_tty(self):
         self.base_dir = 'tests/fixtures/links-composefile'

--- a/tests/fixtures/abort-on-container-exit-0/docker-compose.yml
+++ b/tests/fixtures/abort-on-container-exit-0/docker-compose.yml
@@ -1,0 +1,6 @@
+simple:
+  image: busybox:latest
+  command: top
+another:
+  image: busybox:latest
+  command: ls .

--- a/tests/fixtures/abort-on-container-exit-1/docker-compose.yml
+++ b/tests/fixtures/abort-on-container-exit-1/docker-compose.yml
@@ -1,0 +1,6 @@
+simple:
+  image: busybox:latest
+  command: top
+another:
+  image: busybox:latest
+  command: ls /thecakeisalie

--- a/tests/unit/cli/log_printer_test.py
+++ b/tests/unit/cli/log_printer_test.py
@@ -187,11 +187,13 @@ class TestConsumeQueue(object):
         assert next(generator) == 'b'
 
     def test_item_is_stop_with_cascade_stop(self):
+        """Return the name of the container that caused the cascade_stop"""
         queue = Queue()
-        for item in QueueItem.stop(), QueueItem.new('a'), QueueItem.new('b'):
+        for item in QueueItem.stop('foobar-1'), QueueItem.new('a'), QueueItem.new('b'):
             queue.put(item)
 
-        assert list(consume_queue(queue, True)) == []
+        generator = consume_queue(queue, True)
+        assert next(generator) is 'foobar-1'
 
     def test_item_is_none_when_timeout_is_hit(self):
         queue = Queue()


### PR DESCRIPTION
This replaces #4466 since I messed up when squashing commits.  

This is taking the code from #3725, which appears to have lost traction and implements the changes requested. 