### PR TITLE
#3731 Allows volumes to specify an `actual_name` property

### DIFF
--- a/compose/volume.py
+++ b/compose/volume.py
@@ -14,11 +14,12 @@ log = logging.getLogger(__name__)
 
 
 class Volume(object):
-    def __init__(self, client, project, name, driver=None, driver_opts=None,
+    def __init__(self, client, project, name, actual_name=None, driver=None, driver_opts=None,
                  external_name=None, labels=None):
         self.client = client
         self.project = project
         self.name = name
+        self.actual_name = actual_name
         self.driver = driver
         self.driver_opts = driver_opts
         self.external_name = external_name
@@ -54,6 +55,8 @@ class Volume(object):
     def full_name(self):
         if self.external_name:
             return self.external_name
+        if self.actual_name:
+            return self.actual_name
         return '{0}_{1}'.format(self.project, self.name)
 
     @property
@@ -81,6 +84,7 @@ class ProjectVolumes(object):
                 client=client,
                 project=name,
                 name=vol_name,
+                actual_name=data.get('actual_name'),
                 driver=data.get('driver'),
                 driver_opts=data.get('driver_opts'),
                 external_name=data.get('external_name'),

--- a/tests/unit/volume_test.py
+++ b/tests/unit/volume_test.py
@@ -24,3 +24,15 @@ class TestVolume(object):
         vol = volume.Volume(mock_client, 'foo', 'project', external_name='data')
         vol.remove()
         assert not mock_client.remove_volume.called
+
+    def test_full_name_volume(self, mock_client):
+        vol = volume.Volume(mock_client, 'project', 'foo')
+        assert vol.full_name == 'project_foo'
+
+    def test_full_name_volume_with_actual_name(self, mock_client):
+        vol = volume.Volume(mock_client, 'project', 'foo', actual_name='my-foo')
+        assert vol.full_name == 'my-foo'
+
+    def test_full_name_volume_with_external_name(self, mock_client):
+        vol = volume.Volume(mock_client, 'project', 'foo', external_name='my-external-foo')
+        assert vol.full_name == 'my-external-foo'


### PR DESCRIPTION
Allows volumes to specify an `actual_name` property, allowing to by pass some volume driver/hosting limitations.