### PR TITLE
Pass the --disable-pip-version-check option to pip freeze

### DIFF
--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -13,7 +13,9 @@ try:
     # https://github.com/docker/compose/issues/4481
     # https://github.com/pypa/pip/blob/master/pip/_vendor/__init__.py
     s_cmd = subprocess.Popen(
-        ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE
+        ['pip', '--disable-pip-version-check', 'freeze'],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE
     )
     packages = s_cmd.communicate()[0].splitlines()
     dockerpy_installed = len(


### PR DESCRIPTION
I noticed this in an environment with no direct internet access. A new version of docker-compose appeared to be hanging for a few seconds on every invocation and it turned out that this was due to pip attempting to check whether it was up to date.

The `--disable-pip-version-check` option prevents this and has been part of pip's interface since version 6.