### PR TITLE
Adopting background before stop and kill

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -10,6 +10,7 @@ import pipes
 import re
 import subprocess
 import sys
+import time
 from distutils.spawn import find_executable
 from inspect import getdoc
 from operator import attrgetter
@@ -51,7 +52,6 @@ from .log_printer import LogPrinter
 from .utils import get_version_info
 from .utils import human_readable_file_size
 from .utils import yesno
-
 
 if not IS_WINDOWS_PLATFORM:
     from dockerpty.pty import PseudoTerminal, RunOperation, ExecOperation
@@ -1200,14 +1200,17 @@ def up_shutdown_context(project, service_names, timeout, detached):
     signals.set_signal_handler_to_shutdown()
     try:
         try:
-            yield
+            try:
+                yield
+            except signals.ShutdownException:
+                print("Backgrounding in 2 seconds ... (press Ctrl+c again to stop)")
+                time.sleep(2)
         except signals.ShutdownException:
             print("Gracefully stopping... (press Ctrl+C again to force)")
             project.stop(service_names=service_names, timeout=timeout)
     except signals.ShutdownException:
         project.kill(service_names=service_names)
         sys.exit(2)
-
 
 def list_containers(containers):
     return ", ".join(c.name for c in containers)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1212,6 +1212,7 @@ def up_shutdown_context(project, service_names, timeout, detached):
         project.kill(service_names=service_names)
         sys.exit(2)
 
+
 def list_containers(containers):
     return ", ".join(c.name for c in containers)
 


### PR DESCRIPTION
Adopting 'background' first on Cntrl-C and allowing second and third taps to be stop and kill

Would fix #4560, though I am aware this changes current behaviour and perhaps should be tackled a different way.

Signed-off-by: David McKay <david@rawkode.com>