### PR TITLE
Fix bash completion for `up --exit-code-from`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -498,6 +498,10 @@ _docker_compose_unpause() {
 
 _docker_compose_up() {
 	case "$prev" in
+		--exit-code-from)
+			__docker_compose_services_all
+			return
+			;;
 		--timeout|-t)
 			return
 			;;
@@ -505,7 +509,7 @@ _docker_compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--exit-code-from --abort-on-container-exit --build -d --force-recreate --help --no-build --no-color --no-deps --no-recreate --timeout -t --remove-orphans" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--abort-on-container-exit --build -d --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --timeout -t --remove-orphans" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all


### PR DESCRIPTION
Ref: #4397
`--exit-code-from` requires an argument.
Also corrected sort order.
Ping @sdurrheimer for zsh completion