### PR TITLE
Bump 1.12.0 rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ Change log
 - Fixed a bug where `docker-compose` would crash when trying to write into
   a closed pipe
 
+- Fixed an issue where Compose would not pick up on the value of
+  COMPOSE_TLS_VERSION when used in combination with command-line TLS flags
+
 1.11.2 (2017-02-17)
 -------------------
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.12.0-rc1'
+__version__ = '1.12.0-rc2'

--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -34,3 +34,9 @@ except OSError:
     # pip command is not available, which indicates it's probably the binary
     # distribution of Compose which is not affected
     pass
+except UnicodeDecodeError:
+    # ref: https://github.com/docker/compose/issues/4663
+    # This could be caused by a number of things, but it seems to be a
+    # python 2 + MacOS interaction. It's not ideal to ignore this, but at least
+    # it doesn't make the program unusable.
+    pass

--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -20,16 +20,15 @@ try:
         list(filter(lambda p: p.startswith(b'docker-py=='), packages))
     ) > 0
     if dockerpy_installed:
-        from .colors import red
+        from .colors import yellow
         print(
-            red('ERROR:'),
+            yellow('WARNING:'),
             "Dependency conflict: an older version of the 'docker-py' package "
-            "is polluting the namespace. "
-            "Run the following command to remedy the issue:\n"
-            "pip uninstall docker docker-py; pip install docker",
+            "may be polluting the namespace. "
+            "If you're experiencing crashes, run the following command to remedy the issue:\n"
+            "pip uninstall docker-py; pip uninstall docker; pip install docker",
             file=sys.stderr
         )
-        sys.exit(1)
 
 except OSError:
     # pip command is not available, which indicates it's probably the binary

--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import logging
 import os
 import re
-import ssl
 
 import six
 
@@ -15,6 +14,7 @@ from ..config.environment import Environment
 from ..const import API_VERSIONS
 from ..project import Project
 from .docker_client import docker_client
+from .docker_client import get_tls_version
 from .docker_client import tls_config_from_options
 from .utils import get_version_info
 
@@ -58,23 +58,6 @@ def get_config_path_from_options(base_dir, options, environment):
         pathsep = environment.get('COMPOSE_PATH_SEPARATOR', os.pathsep)
         return config_files.split(pathsep)
     return None
-
-
-def get_tls_version(environment):
-    compose_tls_version = environment.get('COMPOSE_TLS_VERSION', None)
-    if not compose_tls_version:
-        return None
-
-    tls_attr_name = "PROTOCOL_{}".format(compose_tls_version)
-    if not hasattr(ssl, tls_attr_name):
-        log.warn(
-            'The "{}" protocol is unavailable. You may need to update your '
-            'version of Python or OpenSSL. Falling back to TLSv1 (default).'
-            .format(compose_tls_version)
-        )
-        return None
-
-    return getattr(ssl, tls_attr_name)
 
 
 def get_client(environment, verbose=False, version=None, tls_config=None, host=None,

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1033,8 +1033,11 @@ def resolve_volume_path(working_dir, volume):
     if isinstance(volume, dict):
         host_path = volume.get('source')
         container_path = volume.get('target')
-        if host_path and volume.get('read_only'):
-            container_path += ':ro'
+        if host_path:
+            if volume.get('read_only'):
+                container_path += ':ro'
+            if volume.get('volume', {}).get('nocopy'):
+                container_path += ':nocopy'
     else:
         container_path, host_path = split_path_mapping(volume)
 

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -266,6 +266,10 @@ class ServicePort(namedtuple('_ServicePort', 'target published protocol mode ext
 
     @classmethod
     def parse(cls, spec):
+        if isinstance(spec, cls):
+            # WHen extending a service with ports, the port definitions have already been parsed
+            return [spec]
+
         if not isinstance(spec, dict):
             result = []
             for k, v in build_port_bindings([spec]).items():

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.12.0-rc1"
+VERSION="1.12.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -374,7 +374,8 @@ class CLITestCase(DockerClientTestCase):
                     'volumes': [
                         '/host/path:/container/path:ro',
                         'foobar:/container/volumepath:rw',
-                        '/anonymous'
+                        '/anonymous',
+                        'foobar:/container/volumepath2:nocopy'
                     ],
 
                     'stop_grace_period': '20s',

--- a/tests/fixtures/v3-full/docker-compose.yml
+++ b/tests/fixtures/v3-full/docker-compose.yml
@@ -44,6 +44,11 @@ services:
         target: /container/volumepath
       - type: volume
         target: /anonymous
+      - type: volume
+        source: foobar
+        target: /container/volumepath2
+        volume:
+          nocopy: true
 
     stop_grace_period: 20s
 volumes:

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1419,7 +1419,7 @@ class ProjectTest(DockerClientTestCase):
                         'test': 'exit 0',
                         'retries': 1,
                         'timeout': '10s',
-                        'interval': '0.1s'
+                        'interval': '1s'
                     },
                 },
                 'svc2': {
@@ -1456,7 +1456,7 @@ class ProjectTest(DockerClientTestCase):
                         'test': 'exit 1',
                         'retries': 1,
                         'timeout': '10s',
-                        'interval': '0.1s'
+                        'interval': '1s'
                     },
                 },
                 'svc2': {

--- a/tests/unit/cli/command_test.py
+++ b/tests/unit/cli/command_test.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
-import ssl
 
 import pytest
 
 from compose.cli.command import get_config_path_from_options
-from compose.cli.command import get_tls_version
 from compose.config.environment import Environment
 from compose.const import IS_WINDOWS_PLATFORM
 from tests import mock
@@ -57,21 +55,3 @@ class TestGetConfigPathFromOptions(object):
     def test_no_path(self):
         environment = Environment.from_env_file('.')
         assert not get_config_path_from_options('.', {}, environment)
-
-
-class TestGetTlsVersion(object):
-    def test_get_tls_version_default(self):
-        environment = {}
-        assert get_tls_version(environment) is None
-
-    @pytest.mark.skipif(not hasattr(ssl, 'PROTOCOL_TLSv1_2'), reason='TLS v1.2 unsupported')
-    def test_get_tls_version_upgrade(self):
-        environment = {'COMPOSE_TLS_VERSION': 'TLSv1_2'}
-        assert get_tls_version(environment) == ssl.PROTOCOL_TLSv1_2
-
-    def test_get_tls_version_unavailable(self):
-        environment = {'COMPOSE_TLS_VERSION': 'TLSv5_5'}
-        with mock.patch('compose.cli.command.log') as mock_log:
-            tls_version = get_tls_version(environment)
-        mock_log.warn.assert_called_once_with(mock.ANY)
-        assert tls_version is None

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3403,7 +3403,7 @@ class ExtendsTest(unittest.TestCase):
         self.assertEqual(service[0]['command'], "top")
 
     def test_extends_with_depends_on(self):
-        tmpdir = py.test.ensuretemp('test_extends_with_defined_version')
+        tmpdir = py.test.ensuretemp('test_extends_with_depends_on')
         self.addCleanup(tmpdir.remove)
         tmpdir.join('docker-compose.yml').write("""
             version: "2"
@@ -3434,6 +3434,28 @@ class ExtendsTest(unittest.TestCase):
                 'retries': 36,
             }
         }]
+
+    def test_extends_with_ports(self):
+        tmpdir = py.test.ensuretemp('test_extends_with_ports')
+        self.addCleanup(tmpdir.remove)
+        tmpdir.join('docker-compose.yml').write("""
+            version: '2'
+
+            services:
+              a:
+                image: nginx
+                ports:
+                  - 80
+
+              b:
+                extends:
+                  service: a
+        """)
+        services = load_from_filename(str(tmpdir.join('docker-compose.yml')))
+
+        assert len(services) == 2
+        for svc in services:
+            assert svc['ports'] == [types.ServicePort('80', None, None, None, None)]
 
 
 @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason='paths use slash')


### PR DESCRIPTION
 ### New features
 
 #### Compose file version 3.2
 
 - Introduced version 3.2 of the `docker-compose.yml` specification.
 
 - Added support for `cache_from` in the `build` section of services
 
 - Added support for the new expanded ports syntax in service definitions
 
 - Added support for the new expanded volumes syntax in service definitions
 
 #### Compose file version 2.1
 
 - Added support for `pids_limit` in service definitions
 
 #### Compose file version 2.0 and up
 
 - Added `--volumes` option to `docker-compose config` that lists named
   volumes declared for that project
 
 - Added support for `mem_reservation` in service definitions (2.x only)
 
 - Added support for `dns_opt` in service definitions (2.x only)
 
 #### All formats
 
 - Added a new `docker-compose images` command that lists images used by
   the current project's containers
 
 - Added a `--stop` (shorthand `-s`) option to `docker-compose rm` that stops
   the running containers before removing them
 
 - Added a `--resolve-image-digests` option to `docker-compose config` that
   pins the image version for each service to a permanent digest
 
 - Added a `--exit-code-from SERVICE` option to `docker-compose up`. When
   used, `docker-compose` will exit on any container's exit with the code
   corresponding to the specified service's exit code
 
 - Added a `--parallel` option to `docker-compose pull` that enables images
   for multiple services to be pulled simultaneously
 
 - Added a `--build-arg` option to `docker-compose build`
 
 - Added a `--volume <volume_mapping>` (shorthand `-v`) option to
   `docker-compose run` to declare runtime volumes to be mounted
 
 - Added a `--project-directory PATH` option to `docker-compose` that will
   affect path resolution for the project
 
 - When using `--abort-on-container-exit` in `docker-compose up`, the exit
   code for the container that caused the abort will be the exit code of
   the `docker-compose up` command
 
 - Users can now configure which path separator character they want to use
   to separate the `COMPOSE_FILE` environment value using the
   `COMPOSE_PATH_SEPARATOR` environment variable
 
 - Added support for port range to single port in port mappings
   (e.g. `8000-8010:80`)
 
 ### Bugfixes
 
 - `docker-compose run --rm` now removes anonymous volumes after execution,
   matching the behavior of `docker run --rm`.
 
 - Fixed a bug where override files containing port lists would cause a
   TypeError to be raised
 
 - Fixed a bug where scaling services up or down would sometimes re-use
   obsolete containers
 
 - Fixed a bug where the output of `docker-compose config` would be invalid
   if the project declared anonymous volumes
 
 - Variable interpolation now properly occurs in the `secrets` section of
   the Compose file
 
 - The `secrets` section now properly appears in the output of
   `docker-compose config`
 
 - Fixed a bug where changes to some networks properties would not be
   detected against previously created networks
 
 - Fixed a bug where `docker-compose` would crash when trying to write into
   a closed pipe
 
- Fixed an issue where Compose would not pick up on the value of
  `COMPOSE_TLS_VERSION` when used in combination with command-line TLS flags
