### PR TITLE
Merge deploy options in service dicts

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -879,6 +879,7 @@ def merge_service_dicts(base, override, version):
     md.merge_mapping('depends_on', parse_depends_on)
     md.merge_sequence('links', ServiceLink.parse)
     md.merge_sequence('secrets', types.ServiceSecret.parse)
+    md.merge_mapping('deploy', parse_deploy)
 
     for field in ['volumes', 'devices']:
         md.merge_field(field, merge_path_mappings)
@@ -1003,6 +1004,7 @@ parse_sysctls = functools.partial(parse_dict_or_list, split_kv, 'sysctls')
 parse_depends_on = functools.partial(
     parse_dict_or_list, lambda k: (k, {'condition': 'service_started'}), 'depends_on'
 )
+parse_deploy = functools.partial(parse_dict_or_list, split_kv, 'deploy')
 
 
 def parse_ulimits(ulimits):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1950,6 +1950,57 @@ class ConfigTest(unittest.TestCase):
         actual = config.merge_service_dicts(base, override, V3_1)
         assert actual['secrets'] == override['secrets']
 
+    def test_merge_deploy(self):
+        base = {
+            'image': 'busybox',
+        }
+        override = {
+            'deploy': {
+                'mode': 'global',
+                'restart_policy': {
+                    'condition': 'on-failure'
+                }
+            }
+        }
+        actual = config.merge_service_dicts(base, override, V3_0)
+        assert actual['deploy'] == override['deploy']
+
+    def test_merge_deploy_override(self):
+        base = {
+            'image': 'busybox',
+            'deploy': {
+                'mode': 'global',
+                'restart_policy': {
+                    'condition': 'on-failure'
+                },
+                'placement': {
+                    'constraints': [
+                        'node.role == manager'
+                    ]
+                }
+            }
+        }
+        override = {
+            'deploy': {
+                'mode': 'replicated',
+                'restart_policy': {
+                    'condition': 'any'
+                }
+            }
+        }
+        actual = config.merge_service_dicts(base, override, V3_0)
+        assert actual['deploy'] == {
+            'mode': 'replicated',
+            'restart_policy': {
+                'condition': 'any'
+            },
+            'placement': {
+                'constraints': [
+                    'node.role == manager'
+                ]
+            }
+        }
+
     def test_external_volume_config(self):
         config_details = build_config_details({
             'version': '2',


### PR DESCRIPTION
Update `merge_service_dicts()` to merge deploy mappings. Compose file version 3 added the `deploy` key to service dicts to specify configs related to Docker services. But, the merge function did not handle `deploy` keys, causing them to be dropped when services were merged.

Resolves #4517