### PR TITLE
Set storage options per container

### DIFF
--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -228,6 +228,7 @@
         "stdin_open": {"type": "boolean"},
         "stop_grace_period": {"type": "string", "format": "duration"},
         "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
         "tmpfs": {"$ref": "#/definitions/string_or_list"},
         "tty": {"type": "boolean"},
         "ulimits": {

--- a/compose/service.py
+++ b/compose/service.py
@@ -75,6 +75,7 @@ DOCKER_START_KEYS = [
     'restart',
     'security_opt',
     'shm_size',
+    'storage_opt',
     'sysctls',
     'userns_mode',
     'volumes_from',
@@ -786,7 +787,8 @@ class Service(object):
             oom_score_adj=options.get('oom_score_adj'),
             mem_swappiness=options.get('mem_swappiness'),
             group_add=options.get('group_add'),
-            userns_mode=options.get('userns_mode')
+            userns_mode=options.get('userns_mode'),
+            storage_opt=options.get('storage_opt')
         )
 
         # TODO: Add as an argument to create_host_config once it's supported

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -158,6 +158,13 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(set(container.get('HostConfig.SecurityOpt')), set(security_opt))
 
+    def test_create_container_with_storage_opt(self):
+        storage_opt = {'size': '1G'}
+        service = self.create_service('db', storage_opt=storage_opt)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.StorageOpt'), storage_opt)
+
     def test_create_container_with_mac_address(self):
         service = self.create_service('db', mac_address='02:42:ac:11:65:43')
         container = service.create_container()


### PR DESCRIPTION
Add the ability to set the storage option per container.


Fixes https://github.com/docker/compose/issues/4583

I've added this to compose version `3.2` only. Should I be adding it to all the `3.*` versions ?