### PR TITLE
Prevent pip version checks when calling `pip freeze`

### DIFF
--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
 import subprocess
 import sys
 
@@ -12,8 +13,12 @@ try:
     # https://github.com/docker/compose/issues/4425
     # https://github.com/docker/compose/issues/4481
     # https://github.com/pypa/pip/blob/master/pip/_vendor/__init__.py
+    env = os.environ.copy()
+    env[str('PIP_DISABLE_PIP_VERSION_CHECK')] = str('1')
+
     s_cmd = subprocess.Popen(
-        ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE
+        ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+        env=env
     )
     packages = s_cmd.communicate()[0].splitlines()
     dockerpy_installed = len(


### PR DESCRIPTION
Replace #4624 

Using the environment variable instead of the command-line option allows us to support versions of pip before the option was introduced.

Reference: https://github.com/pypa/pip/issues/2269#issuecomment-68002027