### PR TITLE
Make self.project_dir not hardcoded to '.' in TopLevelCommand

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -203,7 +203,7 @@ class TopLevelCommand(object):
 
     def __init__(self, project, project_dir='.'):
         self.project = project
-        self.project_dir = '.'
+        self.project_dir = project_dir
 
     def build(self, options):
         """

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -111,7 +111,7 @@ def perform_command(options, handler, command_options):
         handler(command, options, command_options)
         return
 
-    project = project_from_options('.', options)
+    project = project_from_options(self.project_dir, options)
     command = TopLevelCommand(project)
     with errors.handle_connection_errors(project.client):
         handler(command, command_options)
@@ -256,7 +256,7 @@ class TopLevelCommand(object):
             -o, --output PATH          Path to write the bundle file to.
                                        Defaults to "<project name>.dab".
         """
-        self.project = project_from_options('.', config_options)
+        self.project = project_from_options(self.project_dir, config_options)
         compose_config = get_config_from_options(self.project_dir, config_options)
 
         output = options["--output"]
@@ -289,7 +289,7 @@ class TopLevelCommand(object):
         image_digests = None
 
         if options['--resolve-image-digests']:
-            self.project = project_from_options('.', config_options)
+            self.project = project_from_options(self.project_dir, config_options)
             image_digests = image_digests_for_project(self.project)
 
         if options['--quiet']:


### PR DESCRIPTION
I was digging through cli/main.py to try to figure some stuff out and I noticed something a bit odd. Figured I'd open a PR for a fix. 