### PR TITLE
Fix ServicePort.legacy_repr bug for `ext_ip::target` notation

### DIFF
--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -267,7 +267,7 @@ class ServicePort(namedtuple('_ServicePort', 'target published protocol mode ext
     @classmethod
     def parse(cls, spec):
         if isinstance(spec, cls):
-            # WHen extending a service with ports, the port definitions have already been parsed
+            # When extending a service with ports, the port definitions have already been parsed
             return [spec]
 
         if not isinstance(spec, dict):
@@ -316,7 +316,7 @@ class ServicePort(namedtuple('_ServicePort', 'target published protocol mode ext
 def normalize_port_dict(port):
     return '{external_ip}{has_ext_ip}{published}{is_pub}{target}/{protocol}'.format(
         published=port.get('published', ''),
-        is_pub=(':' if port.get('published') else ''),
+        is_pub=(':' if port.get('published') or port.get('external_ip') else ''),
         target=port.get('target'),
         protocol=port.get('protocol', 'tcp'),
         external_ip=port.get('external_ip', ''),

--- a/tests/unit/config/types_test.py
+++ b/tests/unit/config/types_test.py
@@ -71,6 +71,16 @@ class TestServicePort(object):
         }
         assert ports[0].legacy_repr() == port_def
 
+    def test_parse_ext_ip_no_published_port(self):
+        port_def = '1.1.1.1::3000'
+        ports = ServicePort.parse(port_def)
+        assert len(ports) == 1
+        assert ports[0].legacy_repr() == port_def + '/tcp'
+        assert ports[0].repr() == {
+            'target': '3000',
+            'external_ip': '1.1.1.1',
+        }
+
     def test_parse_port_range(self):
         ports = ServicePort.parse('25000-25001:4000-4001')
         assert len(ports) == 2


### PR DESCRIPTION
Fixes #4722 