### PR TITLE
Add support for labels during build

### DIFF
--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -72,6 +72,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"$ref": "#/definitions/list_of_strings"}
               },
               "additionalProperties": false

--- a/compose/service.py
+++ b/compose/service.py
@@ -831,6 +831,7 @@ class Service(object):
             nocache=no_cache,
             dockerfile=build_opts.get('dockerfile', None),
             cache_from=build_opts.get('cache_from', None),
+            labels=build_opts.get('labels', None),
             buildargs=build_args
         )
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -845,8 +845,7 @@ class ConfigTest(unittest.TestCase):
         ).services[0]
         assert 'labels' in service['build']
         assert 'label1' in service['build']['labels']
-        assert isinstance(service['build']['labels']['label1'], str)
-        assert service['build']['labels']['label1'] == '42'
+        assert service['build']['labels']['label1'] == 42
         assert service['build']['labels']['label2'] == 'foobar'
 
     def test_build_args_allow_empty_properties(self):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -821,6 +821,34 @@ class ConfigTest(unittest.TestCase):
         assert service['build']['args']['opt1'] == '42'
         assert service['build']['args']['opt2'] == 'foobar'
 
+    def test_load_with_labels(self):
+        service = config.load(
+            build_config_details(
+                {
+                    'version': '3.2',
+                    'services': {
+                        'web': {
+                            'build': {
+                                'context': '.',
+                                'dockerfile': 'Dockerfile-alt',
+                                'labels': {
+                                    'label1': 42,
+                                    'label2': 'foobar'
+                                }
+                            }
+                        }
+                    }
+                },
+                'tests/fixtures/extends',
+                'filename.yml'
+            )
+        ).services[0]
+        assert 'labels' in service['build']
+        assert 'label1' in service['build']['labels']
+        assert isinstance(service['build']['labels']['label1'], str)
+        assert service['build']['labels']['label1'] == '42'
+        assert service['build']['labels']['label2'] == 'foobar'
+
     def test_build_args_allow_empty_properties(self):
         service = config.load(
             build_config_details(

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -471,6 +471,7 @@ class ServiceTest(unittest.TestCase):
             nocache=False,
             rm=True,
             buildargs={},
+            labels=None,
             cache_from=None,
         )
 
@@ -508,6 +509,7 @@ class ServiceTest(unittest.TestCase):
             nocache=False,
             rm=True,
             buildargs={},
+            labels=None,
             cache_from=None,
         )
 


### PR DESCRIPTION
Adds support for labels when building an images.
cf.
https://github.com/docker/docker-py/blob/0a97df1abc7236793b82041626088f54ad8d204f/docker/api/build.py#L94

Fixes #4038