### PR TITLE
add exception for windows networking

### DIFF
--- a/compose/network.py
+++ b/compose/network.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 
 OPTS_EXCEPTIONS = [
     'com.docker.network.driver.overlay.vxlanid_list',
+    'com.docker.network.windowsshim.hnsid'
 ]
 
 


### PR DESCRIPTION
Fixes this:

```
λ docker-compose -f docker-compose.windows.yml up
ERROR: Network "musicstore_default" needs to be recreated - option "com.docker.network.windowsshim.hnsid" has changed
```