### PR TITLE
use docker instead of docker-py when print version

### DIFF
--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -89,7 +89,7 @@ def get_version_info(scope):
     if scope == 'full':
         return (
             "{}\n"
-            "docker-py version: {}\n"
+            "docker version: {}\n"
             "{} version: {}\n"
             "OpenSSL version: {}"
         ).format(


### PR DESCRIPTION
"docker-py" python package was renamed to "docker" on commit https://github.com/docker/docker-py/commit/04e943798691ba2663b91eaedd8ae2410f016d2c .

Use docker when printing the version message, to avoid confusion between the new name and the old name of the package.