### PR TITLE
Add docker-compose exec -u to docs and completion

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -391,7 +391,7 @@ class TopLevelCommand(object):
         Options:
             -d                Detached mode: Run command in the background.
             --privileged      Give extended privileges to the process.
-            --user USER       Run the command as this user.
+            -u, --user USER   Run the command as this user.
             -T                Disable pseudo-tty allocation. By default `docker-compose exec`
                               allocates a TTY.
             --index=index     index of the container if there are multiple

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -224,14 +224,14 @@ _docker_compose_events() {
 
 _docker_compose_exec() {
 	case "$prev" in
-		--index|--user)
+		--index|--user|-u)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "-d --help --index --privileged -T --user" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-d --help --index --privileged -T --user -u" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_running

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -241,7 +241,7 @@ __docker-compose_subcommand() {
                 $opts_help \
                 '-d[Detached mode: Run command in the background.]' \
                 '--privileged[Give extended privileges to the process.]' \
-                '--user=[Run the command as this user.]:username:_users' \
+		'(-u --user)'{-u,--user=}'[Run the command as this user.]:username:_users' \
                 '-T[Disable pseudo-tty allocation. By default `docker-compose exec` allocates a TTY.]' \
                 '--index=[Index of the container if there are multiple instances of a service \[default: 1\]]:index: ' \
                 '(-):running services:__docker-compose_runningservices' \


### PR DESCRIPTION
Fixes #3205

Actally, `docker-compose exec` already supports `-u` as an alias to `--user`.
It's only missing in the help output and therefore was not added to the completions.

If this PR is merged, I will create a follow-up for https://github.com/docker/docker.github.io/blob/master/compose/reference/exec.md

Ping @sdurrheimer PTAL at zsh completion. I just copied the corresponding code from `docker-compose run`.