### PR TITLE
Prevent dependencies rescaling when executing `docker-compose run`

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1138,7 +1138,9 @@ def run_one_off_container(container_options, project, service, options):
             project.up(
                 service_names=deps,
                 start_deps=True,
-                strategy=ConvergenceStrategy.never)
+                strategy=ConvergenceStrategy.never,
+                rescale=False
+            )
 
     project.initialize()
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -382,7 +382,8 @@ class Project(object):
            timeout=None,
            detached=False,
            remove_orphans=False,
-           scale_override=None):
+           scale_override=None,
+           rescale=True):
 
         warn_for_swarm_mode(self.client)
 
@@ -405,7 +406,8 @@ class Project(object):
                 plans[service.name],
                 timeout=timeout,
                 detached=detached,
-                scale_override=scale_override.get(service.name)
+                scale_override=scale_override.get(service.name),
+                rescale=rescale
             )
 
         def get_deps(service):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1211,6 +1211,17 @@ class CLITestCase(DockerClientTestCase):
         self.assertEqual(len(db.containers()), 1)
         self.assertEqual(len(console.containers()), 0)
 
+    def test_run_service_with_scaled_dependencies(self):
+        self.base_dir = 'tests/fixtures/v2-dependencies'
+        self.dispatch(['up', '-d', '--scale', 'db=2', '--scale', 'console=0'])
+        db = self.project.get_service('db')
+        console = self.project.get_service('console')
+        assert len(db.containers()) == 2
+        assert len(console.containers()) == 0
+        self.dispatch(['run', 'web', '/bin/true'], None)
+        assert len(db.containers()) == 2
+        assert len(console.containers()) == 0
+
     def test_run_with_no_deps(self):
         self.base_dir = 'tests/fixtures/links-composefile'
         self.dispatch(['run', '--no-deps', 'web', '/bin/true'])


### PR DESCRIPTION
Fixes #4803 