### PR TITLE
Update types.py

### DIFF
--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -258,7 +258,7 @@ class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
 
     def repr(self):
         return dict(
-            [(k, v) for k, v in self._asdict().items() if v is not None]
+            [(k, v) for k, v in zip(self._fields, self) if v is not None]
         )
 
 


### PR DESCRIPTION
fix python3 _asdict() return None

```
Python 3.4.3 (default, Nov 17 2016, 01:08:31) 
# docker-compose -v
docker-compose version 1.13.0, build 1719ceb
```