### PR TITLE
Change --volume behavior to add instead of replace mounts

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -716,6 +716,8 @@ class Service(object):
         container_options = dict(
             (k, self.options[k])
             for k in DOCKER_CONFIG_KEYS if k in self.options)
+        override_options['volumes'] = (container_options.get('volumes', []) +
+                                       override_options.get('volumes', []))
         container_options.update(override_options)
 
         if not container_options.get('name'):


### PR DESCRIPTION
Potential solution to #4728.

When using the `docker-compose run` command, rather than replacing all mount when using the `-v/--volume`, this will add to the list of mounts (potentially overriding mounts already in the `docker-compose.yml` file).

- [ ] Need to add unit tests
