### PR TITLE
Network label mismatch now prints a warning instead of raising an error

### DIFF
--- a/compose/network.py
+++ b/compose/network.py
@@ -188,10 +188,13 @@ def check_remote_network_config(remote, local):
     local_labels = local.labels or {}
     remote_labels = remote.get('Labels', {})
     for k in set.union(set(remote_labels.keys()), set(local_labels.keys())):
-        if k.startswith('com.docker.compose.'):  # We are only interested in user-specified labels
+        if k.startswith('com.docker.'):  # We are only interested in user-specified labels
             continue
         if remote_labels.get(k) != local_labels.get(k):
-            raise NetworkConfigChangedError(local.full_name, 'label "{}"'.format(k))
+            log.warn(
+                'Network {}: label "{}" has changed. It may need to be'
+                ' recreated.'.format(local.full_name, k)
+            )
 
 
 def build_networks(name, config_data, client):

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import pytest
 
+from .. import mock
 from .. import unittest
 from compose.network import check_remote_network_config
 from compose.network import Network
@@ -152,7 +153,9 @@ class NetworkTest(unittest.TestCase):
                 'com.project.touhou.character': 'marisa.kirisame',
             }
         }
-        with pytest.raises(NetworkConfigChangedError) as e:
+        with mock.patch('compose.network.log') as mock_log:
             check_remote_network_config(remote, net)
 
-        assert 'label "com.project.touhou.character" has changed' in str(e.value)
+        mock_log.warn.assert_called_once_with(mock.ANY)
+        _, args, kwargs = mock_log.warn.mock_calls[0]
+        assert 'label "com.project.touhou.character" has changed' in args[0]


### PR DESCRIPTION
It's common for some backends to add labels on the resources (e.g. to manage access rights). This change ensures we simply log a warning instead of preventing a redeploy entirely in those cases.