### PR TITLE
Partial configs support

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -507,12 +507,20 @@ def process_config_file(config_file, environment, service_name=None):
             config_file.get_networks(),
             'network',
             environment)
-        if config_file.version in (const.COMPOSEFILE_V3_1, const.COMPOSEFILE_V3_2):
+        if config_file.version in (const.COMPOSEFILE_V3_1, const.COMPOSEFILE_V3_2,
+                                   const.COMPOSEFILE_V3_3):
             processed_config['secrets'] = interpolate_config_section(
                 config_file,
                 config_file.get_secrets(),
                 'secrets',
                 environment)
+        if config_file.version in (const.COMPOSEFILE_V3_3):
+            processed_config['configs'] = interpolate_config_section(
+                config_file,
+                config_file.get_configs(),
+                'configs',
+                environment
+            )
     else:
         processed_config = services
 

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -238,8 +238,7 @@ class ServiceLink(namedtuple('_ServiceLink', 'target alias')):
         return self.alias
 
 
-class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
-
+class ServiceConfigBase(namedtuple('_ServiceConfigBase', 'source target uid gid mode')):
     @classmethod
     def parse(cls, spec):
         if isinstance(spec, six.string_types):
@@ -260,6 +259,14 @@ class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
         return dict(
             [(k, v) for k, v in zip(self._fields, self) if v is not None]
         )
+
+
+class ServiceSecret(ServiceConfigBase):
+    pass
+
+
+class ServiceConfig(ServiceConfigBase):
+    pass
 
 
 class ServicePort(namedtuple('_ServicePort', 'target published protocol mode external_ip')):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -258,8 +258,6 @@ class CLITestCase(DockerClientTestCase):
                     'restart': ''
                 },
             },
-            'networks': {},
-            'volumes': {},
         }
 
     def test_config_external_network(self):
@@ -311,8 +309,6 @@ class CLITestCase(DockerClientTestCase):
                     'network_mode': 'service:net',
                 },
             },
-            'networks': {},
-            'volumes': {},
         }
 
     @v3_only()
@@ -322,8 +318,6 @@ class CLITestCase(DockerClientTestCase):
 
         assert yaml.load(result.stdout) == {
             'version': '3.2',
-            'networks': {},
-            'secrets': {},
             'volumes': {
                 'foobar': {
                     'labels': {

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -40,7 +40,9 @@ def build_config(**kwargs):
         services=kwargs.get('services'),
         volumes=kwargs.get('volumes'),
         networks=kwargs.get('networks'),
-        secrets=kwargs.get('secrets'))
+        secrets=kwargs.get('secrets'),
+        configs=kwargs.get('configs'),
+    )
 
 
 class ProjectTest(DockerClientTestCase):

--- a/tests/unit/bundle_test.py
+++ b/tests/unit/bundle_test.py
@@ -78,7 +78,9 @@ def test_to_bundle():
         services=services,
         volumes={'special': {}},
         networks={'extra': {}},
-        secrets={})
+        secrets={},
+        configs={}
+    )
 
     with mock.patch('compose.bundle.log.warn', autospec=True) as mock_log:
         output = bundle.to_bundle(config, image_digests)

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -37,6 +37,7 @@ class ProjectTest(unittest.TestCase):
             networks=None,
             volumes=None,
             secrets=None,
+            configs=None,
         )
         project = Project.from_config(
             name='composetest',
@@ -66,6 +67,7 @@ class ProjectTest(unittest.TestCase):
             networks=None,
             volumes=None,
             secrets=None,
+            configs=None,
         )
         project = Project.from_config('composetest', config, None)
         self.assertEqual(len(project.services), 2)
@@ -173,6 +175,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         assert project.get_service('test')._get_volumes_from() == [container_id + ":rw"]
@@ -206,6 +209,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         assert project.get_service('test')._get_volumes_from() == [container_name + ":rw"]
@@ -232,6 +236,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         with mock.patch.object(Service, 'containers') as mock_return:
@@ -366,6 +371,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         service = project.get_service('test')
@@ -391,6 +397,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         service = project.get_service('test')
@@ -425,6 +432,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
 
@@ -446,6 +454,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
 
@@ -467,6 +476,7 @@ class ProjectTest(unittest.TestCase):
                 networks={'custom': {}},
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
 
@@ -498,6 +508,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         self.assertEqual([c.id for c in project.containers()], ['1'])
@@ -515,6 +526,7 @@ class ProjectTest(unittest.TestCase):
                 networks={'default': {}},
                 volumes={'data': {}},
                 secrets=None,
+                configs=None,
             ),
         )
         self.mock_client.remove_network.side_effect = NotFound(None, None, 'oops')


### PR DESCRIPTION
cc @cpuguy83 @dnephin 

I'm not sure if there was a plan to have support for this feature similar to secrets in `docker-compose`. In the meantime, this PR ensures valid `docker-compose config` output and prints the appropriate warnings.