### PR TITLE
Bump 1.14.0 RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Change log
 
 - Introduced version 3.3 of the `docker-compose.yml` specification.
   This version requires to be used with Docker Engine 17.06.0 or above.
-  Note: the `credential_spec` key only applies to Swarm services and will
-  be ignored by Compose
+  Note: the `credential_spec` and `configs` keys only apply to Swarm services
+  and will be ignored by Compose
 
 #### Compose file version 2.2
 
@@ -49,6 +49,9 @@ Change log
 
 - Fixed a bug where services declaring ports would cause crashes on some
   versions of Python 3
+
+- Fixed a bug where the output of `docker-compose config` would sometimes
+  contain invalid port definitions
 
 1.13.0 (2017-05-02)
 -------------------

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.14.0-rc1'
+__version__ = '1.14.0-rc2'

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -507,12 +507,20 @@ def process_config_file(config_file, environment, service_name=None):
             config_file.get_networks(),
             'network',
             environment)
-        if config_file.version in (const.COMPOSEFILE_V3_1, const.COMPOSEFILE_V3_2):
+        if config_file.version in (const.COMPOSEFILE_V3_1, const.COMPOSEFILE_V3_2,
+                                   const.COMPOSEFILE_V3_3):
             processed_config['secrets'] = interpolate_config_section(
                 config_file,
                 config_file.get_secrets(),
                 'secrets',
                 environment)
+        if config_file.version in (const.COMPOSEFILE_V3_3):
+            processed_config['configs'] = interpolate_config_section(
+                config_file,
+                config_file.get_configs(),
+                'configs',
+                environment
+            )
     else:
         processed_config = services
 

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -238,8 +238,7 @@ class ServiceLink(namedtuple('_ServiceLink', 'target alias')):
         return self.alias
 
 
-class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
-
+class ServiceConfigBase(namedtuple('_ServiceConfigBase', 'source target uid gid mode')):
     @classmethod
     def parse(cls, spec):
         if isinstance(spec, six.string_types):
@@ -260,6 +259,14 @@ class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
         return dict(
             [(k, v) for k, v in zip(self._fields, self) if v is not None]
         )
+
+
+class ServiceSecret(ServiceConfigBase):
+    pass
+
+
+class ServiceConfig(ServiceConfigBase):
+    pass
 
 
 class ServicePort(namedtuple('_ServicePort', 'target published protocol mode external_ip')):

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -263,6 +263,22 @@ class ServiceSecret(namedtuple('_ServiceSecret', 'source target uid gid mode')):
 
 
 class ServicePort(namedtuple('_ServicePort', 'target published protocol mode external_ip')):
+    def __new__(cls, target, published, *args, **kwargs):
+        try:
+            if target:
+                target = int(target)
+        except ValueError:
+            raise ConfigurationError('Invalid target port: {}'.format(target))
+
+        try:
+            if published:
+                published = int(published)
+        except ValueError:
+            raise ConfigurationError('Invalid published port: {}'.format(published))
+
+        return super(ServicePort, cls).__new__(
+            cls, target, published, *args, **kwargs
+        )
 
     @classmethod
     def parse(cls, spec):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyYAML==3.11
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.2.0
 colorama==0.3.7
-docker==2.2.1
+docker==2.3.0
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4; python_version < '3.4'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.14.0-rc1"
+VERSION="1.14.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -258,8 +258,6 @@ class CLITestCase(DockerClientTestCase):
                     'restart': ''
                 },
             },
-            'networks': {},
-            'volumes': {},
         }
 
     def test_config_external_network(self):
@@ -311,8 +309,6 @@ class CLITestCase(DockerClientTestCase):
                     'network_mode': 'service:net',
                 },
             },
-            'networks': {},
-            'volumes': {},
         }
 
     @v3_only()
@@ -322,8 +318,6 @@ class CLITestCase(DockerClientTestCase):
 
         assert yaml.load(result.stdout) == {
             'version': '3.2',
-            'networks': {},
-            'secrets': {},
             'volumes': {
                 'foobar': {
                     'labels': {

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -40,7 +40,9 @@ def build_config(**kwargs):
         services=kwargs.get('services'),
         volumes=kwargs.get('volumes'),
         networks=kwargs.get('networks'),
-        secrets=kwargs.get('secrets'))
+        secrets=kwargs.get('secrets'),
+        configs=kwargs.get('configs'),
+    )
 
 
 class ProjectTest(DockerClientTestCase):

--- a/tests/unit/bundle_test.py
+++ b/tests/unit/bundle_test.py
@@ -78,7 +78,9 @@ def test_to_bundle():
         services=services,
         volumes={'special': {}},
         networks={'extra': {}},
-        secrets={})
+        secrets={},
+        configs={}
+    )
 
     with mock.patch('compose.bundle.log.warn', autospec=True) as mock_log:
         output = bundle.to_bundle(config, image_digests)

--- a/tests/unit/config/types_test.py
+++ b/tests/unit/config/types_test.py
@@ -57,15 +57,15 @@ class TestServicePort(object):
     def test_parse_simple_target_port(self):
         ports = ServicePort.parse(8000)
         assert len(ports) == 1
-        assert ports[0].target == '8000'
+        assert ports[0].target == 8000
 
     def test_parse_complete_port_definition(self):
         port_def = '1.1.1.1:3000:3000/udp'
         ports = ServicePort.parse(port_def)
         assert len(ports) == 1
         assert ports[0].repr() == {
-            'target': '3000',
-            'published': '3000',
+            'target': 3000,
+            'published': 3000,
             'external_ip': '1.1.1.1',
             'protocol': 'udp',
         }
@@ -77,7 +77,7 @@ class TestServicePort(object):
         assert len(ports) == 1
         assert ports[0].legacy_repr() == port_def + '/tcp'
         assert ports[0].repr() == {
-            'target': '3000',
+            'target': 3000,
             'external_ip': '1.1.1.1',
         }
 
@@ -86,13 +86,18 @@ class TestServicePort(object):
         assert len(ports) == 2
         reprs = [p.repr() for p in ports]
         assert {
-            'target': '4000',
-            'published': '25000'
+            'target': 4000,
+            'published': 25000
         } in reprs
         assert {
-            'target': '4001',
-            'published': '25001'
+            'target': 4001,
+            'published': 25001
         } in reprs
+
+    def test_parse_invalid_port(self):
+        port_def = '4000p'
+        with pytest.raises(ConfigurationError):
+            ServicePort.parse(port_def)
 
 
 class TestVolumeSpec(object):

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -37,6 +37,7 @@ class ProjectTest(unittest.TestCase):
             networks=None,
             volumes=None,
             secrets=None,
+            configs=None,
         )
         project = Project.from_config(
             name='composetest',
@@ -66,6 +67,7 @@ class ProjectTest(unittest.TestCase):
             networks=None,
             volumes=None,
             secrets=None,
+            configs=None,
         )
         project = Project.from_config('composetest', config, None)
         self.assertEqual(len(project.services), 2)
@@ -173,6 +175,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         assert project.get_service('test')._get_volumes_from() == [container_id + ":rw"]
@@ -206,6 +209,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         assert project.get_service('test')._get_volumes_from() == [container_name + ":rw"]
@@ -232,6 +236,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         with mock.patch.object(Service, 'containers') as mock_return:
@@ -366,6 +371,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         service = project.get_service('test')
@@ -391,6 +397,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         service = project.get_service('test')
@@ -425,6 +432,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
 
@@ -446,6 +454,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
 
@@ -467,6 +476,7 @@ class ProjectTest(unittest.TestCase):
                 networks={'custom': {}},
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
 
@@ -498,6 +508,7 @@ class ProjectTest(unittest.TestCase):
                 networks=None,
                 volumes=None,
                 secrets=None,
+                configs=None,
             ),
         )
         self.assertEqual([c.id for c in project.containers()], ['1'])
@@ -515,6 +526,7 @@ class ProjectTest(unittest.TestCase):
                 networks={'default': {}},
                 volumes={'data': {}},
                 secrets=None,
+                configs=None,
             ),
         )
         self.mock_client.remove_network.side_effect = NotFound(None, None, 'oops')


### PR DESCRIPTION
### New features

#### Compose file version 3.3

- Introduced version 3.3 of the `docker-compose.yml` specification.
  This version requires to be used with Docker Engine 17.06.0 or above.
  Note: the `credential_spec` and `configs` keys only apply to Swarm services
  and will be ignored by Compose

#### Compose file version 2.2

- Added the following parameters in service definitions: `cpu_count`,
  `cpu_percent`, `cpus`

#### Compose file version 2.1

- Added support for build labels. This feature is also available in the
  2.2 and 3.3 formats.

#### All formats

- Added shorthand `-u` for `--user` flag in `docker-compose exec`

- Differences in labels between the Compose file and remote network
  will now print a warning instead of preventing redeployment.

### Bugfixes

- Fixed a bug where service's dependencies were being rescaled to their
  default scale when running a `docker-compose run` command

- Fixed a bug where `docker-compose rm` with the `--stop` flag was not
  behaving properly when provided with a list of services to remove

- Fixed a bug where `cache_from` in the build section would be ignored when
  using more than one Compose file.

- Fixed a bug where override files would not be picked up by Compose if they
  had the `.yaml` extension

- Fixed a bug on Windows Engine where networks would be incorrectly flagged
  for recreation

- Fixed a bug where services declaring ports would cause crashes on some
  versions of Python 3

- Fixed a bug where the output of `docker-compose config` would sometimes
  contain invalid port definitions
