### PR TITLE
'pip' isn't always the python we're running under

### DIFF
--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -17,7 +17,7 @@ try:
     env[str('PIP_DISABLE_PIP_VERSION_CHECK')] = str('1')
 
     s_cmd = subprocess.Popen(
-        ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+        [sys.executable, '-m', 'pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
         env=env
     )
     packages = s_cmd.communicate()[0].splitlines()


### PR DESCRIPTION
On distributions that allow parallel python2 and python3 installation, the `pip` binary may not be the python we're running under.  Specifically, we ran into a case where we needed docker-py in python2 to support a specific version of Ansible, and decided to install docker-compose via python3 pip to avoid a collision.  Much to our chagrin, python3 docker-compose continued to complain about docker-py, because of its naive usage of `pip`.  And yes, I hear you when you say virtualenv.