### PR TITLE
Bump 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Change log
 ==========
 
-1.14.0 (2017-06-06)
+1.14.0 (2017-06-19)
 -------------------
 
 ### New features
@@ -39,6 +39,9 @@ Change log
   behaving properly when provided with a list of services to remove
 
 - Fixed a bug where `cache_from` in the build section would be ignored when
+  using more than one Compose file.
+
+- Fixed a bug that prevented binding the same port to different IPs when
   using more than one Compose file.
 
 - Fixed a bug where override files would not be picked up by Compose if they

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.14.0-rc2'
+__version__ = '1.14.0'

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -325,7 +325,7 @@ class ServicePort(namedtuple('_ServicePort', 'target published protocol mode ext
 
     @property
     def merge_field(self):
-        return (self.target, self.published)
+        return (self.target, self.published, self.external_ip, self.protocol)
 
     def repr(self):
         return dict(

--- a/compose/container.py
+++ b/compose/container.py
@@ -96,12 +96,16 @@ class Container(object):
     def human_readable_ports(self):
         def format_port(private, public):
             if not public:
-                return private
-            return '{HostIp}:{HostPort}->{private}'.format(
-                private=private, **public[0])
+                return [private]
+            return [
+                '{HostIp}:{HostPort}->{private}'.format(private=private, **pub)
+                for pub in public
+            ]
 
-        return ', '.join(format_port(*item)
-                         for item in sorted(six.iteritems(self.ports)))
+        return ', '.join(
+            ','.join(format_port(*item))
+            for item in sorted(six.iteritems(self.ports))
+        )
 
     @property
     def labels(self):

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.14.0-rc2"
+VERSION="1.14.0"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1865,7 +1865,7 @@ class ConfigTest(unittest.TestCase):
                 {
                     'target': '1245',
                     'published': '1245',
-                    'protocol': 'tcp',
+                    'protocol': 'udp',
                 }
             ]
         }


### PR DESCRIPTION
### New features

#### Compose file version 3.3

- Introduced version 3.3 of the `docker-compose.yml` specification.
  This version requires to be used with Docker Engine 17.06.0 or above.
  Note: the `credential_spec` and `configs` keys only apply to Swarm services
  and will be ignored by Compose

#### Compose file version 2.2

- Added the following parameters in service definitions: `cpu_count`,
  `cpu_percent`, `cpus`

#### Compose file version 2.1

- Added support for build labels. This feature is also available in the
  2.2 and 3.3 formats.

#### All formats

- Added shorthand `-u` for `--user` flag in `docker-compose exec`

- Differences in labels between the Compose file and remote network
  will now print a warning instead of preventing redeployment.

### Bugfixes

- Fixed a bug where service's dependencies were being rescaled to their
  default scale when running a `docker-compose run` command

- Fixed a bug where `docker-compose rm` with the `--stop` flag was not
  behaving properly when provided with a list of services to remove

- Fixed a bug where `cache_from` in the build section would be ignored when
  using more than one Compose file.

- Fixed a bug that prevented binding the same port to different IPs when
  using more than one Compose file.

- Fixed a bug where override files would not be picked up by Compose if they
  had the `.yaml` extension

- Fixed a bug on Windows Engine where networks would be incorrectly flagged
  for recreation

- Fixed a bug where services declaring ports would cause crashes on some
  versions of Python 3

- Fixed a bug where the output of `docker-compose config` would sometimes
  contain invalid port definitions