### PR TITLE
Fix double 'silent' argument value for service.pull

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -467,7 +467,7 @@ class Project(object):
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, True, silent=silent)
+                service.pull(ignore_pull_failures, silent=silent)
 
             parallel.parallel_execute(
                 services,


### PR DESCRIPTION
Currently pull crashes with: "TypeError: pull() got multiple values for keyword argument 'silent'."
This [change](https://github.com/docker/compose/commit/e9b6cc23fcf01d4768c7e082b7bc91b43ff84e7e#diff-c8c735e30c07f4c7494904b4570d1541R470) caused additional value to be passed for the 'silent' argument, that was initially passed [there](https://github.com/docker/compose/commit/f85da99ef3273794e855afda8678174419d3bf4f#diff-c8c735e30c07f4c7494904b4570d1541R459). 