### PR TITLE
Add update-docker-composer bash update script

### DIFF
--- a/bin/update-docker-compose
+++ b/bin/update-docker-compose
@@ -14,7 +14,7 @@ if [ ! -z $COMPOSE ]; then
   cd compose
   git fetch --all
   LATEST_RELEASE=$(git tag -l | grep ^1 | sort -Vr | head -1)
-  RC=$(git tag -l | grep ^1 | sort -Vr | head -1 | grep -e '[[:print:]]')
+  RC=$(echo $LATEST_RELEASE | grep -e '[a-zA-Z]')
   if [ ! -z $RC ]; then
     STABLE_RELEASE=${LATEST_RELEASE/[\-a-zA-Z]*[0-9]*/}
     RELEASES=$(git tag -l | grep ^1 | sort -Vr | xargs)

--- a/bin/update-docker-compose
+++ b/bin/update-docker-compose
@@ -14,6 +14,17 @@ if [ ! -z $COMPOSE ]; then
   cd compose
   git fetch --all
   LATEST_RELEASE=$(git tag -l | grep ^1 | sort -Vr | head -1)
+  RC=$(git tag -l | grep ^1 | sort -Vr | head -1 | grep -e '[[:print:]]')
+  if [ ! -z $RC ]; then
+    STABLE_RELEASE=${LATEST_RELEASE/[\-a-zA-Z]*[0-9]*/}
+    RELEASES=$(git tag -l | grep ^1 | sort -Vr | xargs)
+    for R in $RELEASES; do
+      if [ $R == $STABLE_RELEASE ]; then
+        LATEST_RELEASE=$R
+        break
+      fi
+    done
+  fi
   if [ $INSTALLED_RELEASE != $LATEST_RELEASE ]; then
     sudo curl -L https://github.com/docker/compose/releases/download/$LATEST_RELEASE/docker-compose-$(uname -s)-$(uname -m) -o $COMPOSE
     sudo chmod +x $COMPOSE

--- a/bin/update-docker-compose
+++ b/bin/update-docker-compose
@@ -1,0 +1,26 @@
+#!/bin/bash
+CMDS="curl git"
+for C in $CMDS; do
+  command -v $C > /dev/null && continue || { echo "$C command not found."; exit 1; }
+done
+COMPOSE=$(command -v docker-compose)
+if [ ! -z $COMPOSE ]; then
+  echo "Updating docker-compose..."
+  INSTALLED_RELEASE=$(docker-compose --version | cut -d',' -f1 | cut -d' ' -f3)
+  if [ -d compose/ ]; then
+    rm -rf compose/
+  fi
+  git clone https://github.com/docker/compose.git
+  cd compose
+  git fetch --all
+  LATEST_RELEASE=$(git tag -l | grep ^1 | sort -Vr | head -1)
+  if [ $INSTALLED_RELEASE != $LATEST_RELEASE ]; then
+    sudo curl -L https://github.com/docker/compose/releases/download/$LATEST_RELEASE/docker-compose-$(uname -s)-$(uname -m) -o $COMPOSE
+    sudo chmod +x $COMPOSE
+    echo "docker-compose updated from $INSTALLED_RELEASE to $LATEST_RELEASE."
+  else
+    echo "docker-compose $LATEST_RELEASE is up to date."
+  fi
+  cd -
+  rm -rf compose/
+fi


### PR DESCRIPTION
Keeping docker-compose updated is a challenge since this binary is not included in package updates.  This commit provides a bash shell script to update docker-compose to the latest version.