### PR TITLE
Add a flag --no-ansi to remove control characters on parallel executions

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -31,6 +31,7 @@ def project_from_options(project_dir, options):
         get_config_path_from_options(project_dir, options, environment),
         project_name=options.get('--project-name'),
         verbose=options.get('--verbose'),
+        noansi=options.get('--no-ansi'),
         host=host,
         tls_config=tls_config_from_options(options),
         environment=environment,
@@ -81,7 +82,7 @@ def get_client(environment, verbose=False, version=None, tls_config=None, host=N
 
 
 def get_project(project_dir, config_path=None, project_name=None, verbose=False,
-                host=None, tls_config=None, environment=None, override_dir=None):
+                noansi=False, host=None, tls_config=None, environment=None, override_dir=None):
     if not environment:
         environment = Environment.from_env_file(project_dir)
     config_details = config.find(project_dir, config_path, environment, override_dir)
@@ -100,7 +101,7 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
     )
 
     with errors.handle_connection_errors(client):
-        return Project.from_config(project_name, config_data, client)
+        return Project.from_config(project_name, config_data, client, noansi=noansi)
 
 
 def get_project_name(working_dir, project_name=None, environment=None):

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -159,6 +159,7 @@ class TopLevelCommand(object):
       -f, --file FILE             Specify an alternate compose file (default: docker-compose.yml)
       -p, --project-name NAME     Specify an alternate project name (default: directory name)
       --verbose                   Show more output
+      --no-ansi                   Do not print ANSI control characters
       -v, --version               Print version and exit
       -H, --host HOST             Daemon socket to connect to
 

--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 STOP = object()
 
 
-def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None):
+def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None, noansi=False):
     """Runs func on objects in parallel while ensuring that func is
     ran on object only after it is ran on all its dependencies.
 
@@ -36,7 +36,7 @@ def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None):
     objects = list(objects)
     stream = get_output_stream(sys.stderr)
 
-    writer = ParallelStreamWriter(stream, msg)
+    writer = ParallelStreamWriter(stream, msg, noansi)
     for obj in objects:
         writer.add_object(get_name(obj))
     writer.write_initial()
@@ -221,11 +221,12 @@ class ParallelStreamWriter(object):
     to jump to the correct line, and write over the line.
     """
 
-    def __init__(self, stream, msg):
+    def __init__(self, stream, msg, noansi):
         self.stream = stream
         self.msg = msg
         self.lines = []
         self.width = 0
+        self.noansi = noansi
 
     def add_object(self, obj_index):
         self.lines.append(obj_index)
@@ -239,9 +240,7 @@ class ParallelStreamWriter(object):
                               width=self.width))
         self.stream.flush()
 
-    def write(self, obj_index, status):
-        if self.msg is None:
-            return
+    def _write_ansi(self, obj_index, status):
         position = self.lines.index(obj_index)
         diff = len(self.lines) - position
         # move up
@@ -254,27 +253,41 @@ class ParallelStreamWriter(object):
         self.stream.write("%c[%dB" % (27, diff))
         self.stream.flush()
 
+    def _write_noansi(self, obj_index, status):
+        self.stream.write("{} {:<{width}} ... {}\r\n".format(self.msg, obj_index,
+                          status, width=self.width))
+        self.stream.flush()
 
-def parallel_operation(containers, operation, options, message):
+    def write(self, obj_index, status):
+        if self.msg is None:
+            return
+        if self.noansi:
+            self._write_noansi(obj_index, status)
+        else:
+            self._write_ansi(obj_index, status)
+
+
+def parallel_operation(containers, operation, options, message, noansi=False):
     parallel_execute(
         containers,
         operator.methodcaller(operation, **options),
         operator.attrgetter('name'),
-        message)
+        message,
+        noansi=noansi)
 
 
-def parallel_remove(containers, options):
+def parallel_remove(containers, options, noansi=False):
     stopped_containers = [c for c in containers if not c.is_running]
-    parallel_operation(stopped_containers, 'remove', options, 'Removing')
+    parallel_operation(stopped_containers, 'remove', options, 'Removing', noansi=noansi)
 
 
-def parallel_pause(containers, options):
-    parallel_operation(containers, 'pause', options, 'Pausing')
+def parallel_pause(containers, options, noansi=False):
+    parallel_operation(containers, 'pause', options, 'Pausing', noansi=noansi)
 
 
-def parallel_unpause(containers, options):
-    parallel_operation(containers, 'unpause', options, 'Unpausing')
+def parallel_unpause(containers, options, noansi=False):
+    parallel_operation(containers, 'unpause', options, 'Unpausing', noansi=noansi)
 
 
-def parallel_kill(containers, options):
-    parallel_operation(containers, 'kill', options, 'Killing')
+def parallel_kill(containers, options, noansi=False):
+    parallel_operation(containers, 'kill', options, 'Killing', noansi=noansi)

--- a/compose/service.py
+++ b/compose/service.py
@@ -158,6 +158,7 @@ class Service(object):
         secrets=None,
         scale=None,
         pid_mode=None,
+        noansi=False,
         **options
     ):
         self.name = name
@@ -171,6 +172,7 @@ class Service(object):
         self.networks = networks or {}
         self.secrets = secrets or []
         self.scale_num = scale or 1
+        self.noansi = noansi
         self.options = options
 
     def __repr__(self):
@@ -392,7 +394,8 @@ class Service(object):
                 range(i, i + scale),
                 lambda n: create_and_start(self, n),
                 lambda n: self.get_container_name(n),
-                "Creating"
+                "Creating",
+                noansi=self.noansi,
             )
             for error in errors.values():
                 raise OperationFailedError(error)
@@ -413,7 +416,8 @@ class Service(object):
                 containers,
                 recreate,
                 lambda c: c.name,
-                "Recreating"
+                "Recreating",
+                noansi=self.noansi,
             )
             for error in errors.values():
                 raise OperationFailedError(error)
@@ -433,7 +437,8 @@ class Service(object):
                     containers,
                     lambda c: self.start_container_if_stopped(c, attach_logs=not detached),
                     lambda c: c.name,
-                    "Starting"
+                    "Starting",
+                    noansi=self.noansi,
                 )
 
                 for error in errors.values():
@@ -455,6 +460,7 @@ class Service(object):
             stop_and_remove,
             lambda c: c.name,
             "Stopping and removing",
+            noansi=self.noansi,
         )
 
     def execute_convergence_plan(self, plan, timeout=None, detached=False,

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -130,3 +130,19 @@ def test_parallel_execute_alignment(capsys):
     _, err = capsys.readouterr()
     a, b = err.split('\n')[:2]
     assert a.index('...') == b.index('...')
+
+
+def test_parallel_execute_alignment_noansi(capsys):
+    results, errors = parallel_execute(
+        objects=["short", "a very long name"],
+        func=lambda x: x,
+        get_name=six.text_type,
+        msg="Aligning",
+        noansi=True,
+    )
+
+    assert errors == {}
+
+    _, err = capsys.readouterr()
+    a, b, c, d = err.split('\n')[:4]
+    assert a.index('...') == b.index('...') == c.index('...') == d.index('...')


### PR DESCRIPTION
As discussed in #4780 with @shin- , I made this PR which adds a flag to disable the control characters of the parallel executions. It's handy when logging the output of Docker Compose to a file for instance.

I tried to respect the existing code styling but don't hesitate to make any remark.

I haven't make any test, I'm not sure what kind of test you would want.

Example:

```
[0] [14:18:08] ~/r/app-swarm-ui dev > ~/repos/compose/bin/docker-compose --no-ansi rm -vf resource | cat -
Removing appswarmui_resource_1 ... 
Removing appswarmui_resource_1: done
Going to remove appswarmui_resource_1
```