### PR TITLE
Fix ports sorting on Python 3

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -959,7 +959,7 @@ def merge_ports(md, base, override):
 
     merged = parse_sequence_func(md.base.get(field, []))
     merged.update(parse_sequence_func(md.override.get(field, [])))
-    md[field] = [item for item in sorted(merged.values())]
+    md[field] = [item for item in sorted(merged.values(), key=lambda x: x.target)]
 
 
 def merge_build(output, base, override):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1615,6 +1615,22 @@ class ConfigTest(unittest.TestCase):
             'ports': types.ServicePort.parse('5432')
         }
 
+    def test_merge_service_dicts_ports_sorting(self):
+        base = {
+            'ports': [5432]
+        }
+        override = {
+            'image': 'alpine:edge',
+            'ports': ['5432/udp']
+        }
+        actual = config.merge_service_dicts_from_files(
+            base,
+            override,
+            DEFAULT_VERSION)
+        assert len(actual['ports']) == 2
+        assert types.ServicePort.parse('5432')[0] in actual['ports']
+        assert types.ServicePort.parse('5432/udp')[0] in actual['ports']
+
     def test_merge_service_dicts_heterogeneous_volumes(self):
         base = {
             'volumes': ['/a:/b', '/x:/z'],


### PR DESCRIPTION
Fixes #4943