### PR TITLE
connect networks in alphabetical order

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -549,7 +549,7 @@ class Service(object):
     def connect_container_to_networks(self, container):
         connected_networks = container.get('NetworkSettings.Networks')
 
-        for network, netdefs in sorted(self.networks.iteritems()):
+        for network, netdefs in sorted(self.networks.items()):
             if network in connected_networks:
                 if short_id_alias_exists(container, network):
                     continue

--- a/compose/service.py
+++ b/compose/service.py
@@ -549,7 +549,7 @@ class Service(object):
     def connect_container_to_networks(self, container):
         connected_networks = container.get('NetworkSettings.Networks')
 
-        for network, netdefs in self.networks.items():
+        for network, netdefs in sorted(self.networks.iteritems()):
             if network in connected_networks:
                 if short_id_alias_exists(container, network):
                     continue


### PR DESCRIPTION
Ran into issue https://github.com/docker/compose/issues/4645 myself and looked for a temporary fix that attaches the networks in alphabetical order to match  the behaviour of docker network connect to a container before launch.

This patch simply walks the networks in alphabetical order when connecting them to the container. 

A better way of fixing this issue would be to honour the  sorted list of networks provided in the YAML file, but such a fix is beyond my skills and will require changes from dict to ordered list. 

 
