### PR TITLE
Always silence pull output with --parallel

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -467,7 +467,7 @@ class Project(object):
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, silent=silent)
+                service.pull(ignore_pull_failures, True)
 
             parallel.parallel_execute(
                 services,


### PR DESCRIPTION
This is how things were prior to the addition of the --quiet flag.
Making it not silent produces output that's weird and difficult to read.

Signed-off-by: Evan Shaw <evan@vendhq.com>