### PR TITLE
Show what's in progress when running parallel

### DIFF
--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -106,15 +106,15 @@ def test_parallel_execute_with_upstream_errors():
     assert log == [cache]
 
     events = [
-        (obj, result, type(exception))
-        for obj, result, exception
+        (status, obj, result, type(exception))
+        for status, obj, result, exception
         in parallel_execute_iter(objects, process, get_deps, None)
     ]
 
-    assert (cache, None, type(None)) in events
-    assert (data_volume, None, APIError) in events
-    assert (db, None, UpstreamError) in events
-    assert (web, None, UpstreamError) in events
+    assert ('done', cache, None, type(None)) in events
+    assert ('error', data_volume, None, APIError) in events
+    assert ('error', db, None, UpstreamError) in events
+    assert ('error', web, None, UpstreamError) in events
 
 
 def test_parallel_execute_alignment(capsys):


### PR DESCRIPTION
Prior to this commit, docker-compose only showed "done" or "error" once a parallel task was finished. This made it hard to tell which task(s) were actually in progress.

Now there's an additional "working" status that's shown in yellow when a task is in-progress. The main goal was to get this feedback when using `docker-compose pull --parallel`, as that's the only parallel task with a concurrency limit.

I implemented this by adding an additional "status" field to the result tuple in parallel.py. I'm happy to discuss alternatives, bikeshed over status names, whether constants should be used, etc.

Updates #4556

Signed-off-by: Evan Shaw <evan@vendhq.com>