### PR TITLE
Add --ignore-orphan-warning

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -330,9 +330,16 @@ class Project(object):
             service_names, stopped=True, one_off=one_off
         ), options)
 
-    def down(self, remove_image_type, include_volumes, remove_orphans=False, timeout=None):
+    def down(
+            self,
+            remove_image_type,
+            include_volumes,
+            remove_orphans=False,
+            timeout=None,
+            ignore_orphans=False):
         self.stop(one_off=OneOffFilter.include, timeout=timeout)
-        self.find_orphan_containers(remove_orphans)
+        if not ignore_orphans:
+            self.find_orphan_containers(remove_orphans)
         self.remove_stopped(v=include_volumes, one_off=OneOffFilter.include)
 
         self.networks.remove()
@@ -432,6 +439,7 @@ class Project(object):
            timeout=None,
            detached=False,
            remove_orphans=False,
+           ignore_orphans=False,
            scale_override=None,
            rescale=True,
            start=True):
@@ -439,7 +447,8 @@ class Project(object):
         warn_for_swarm_mode(self.client)
 
         self.initialize()
-        self.find_orphan_containers(remove_orphans)
+        if not ignore_orphans:
+            self.find_orphan_containers(remove_orphans)
 
         if scale_override is None:
             scale_override = {}

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1337,6 +1337,12 @@ class CLITestCase(DockerClientTestCase):
         result = self.dispatch(['up', '-d', '-t', '1'], returncode=1)
         assert "-d and --timeout cannot be combined." in result.stderr
 
+    @mock.patch.dict(os.environ)
+    def test_up_with_ignore_remove_orphans(self):
+        os.environ["COMPOSE_IGNORE_ORPHANS"] = "True"
+        result = self.dispatch(['up', '-d', '--remove-orphans'], returncode=1)
+        assert "COMPOSE_IGNORE_ORPHANS and --remove-orphans cannot be combined." in result.stderr
+
     def test_up_handles_sigint(self):
         proc = start_process(self.base_dir, ['up', '-t', '2'])
         wait_on_condition(ContainerCountCondition(self.project, 2))


### PR DESCRIPTION
Addresses #3573.

This change means that you can specify `--remove-orphans` and `--ignore-orphan-warning` and it will just remove them. There is a different (better?) implementation that makes those two flags incompatible and specifying the `--ignore-orphan-warning` flag just skips even looking for orphans. If this flag is deemed useful enough to merge, then I may change the implementation in that direction to remove useless work.