### PR TITLE
Faster package querying

### DIFF
--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import subprocess
 import sys
 
@@ -13,9 +12,6 @@ try:
     # https://github.com/docker/compose/issues/4425
     # https://github.com/docker/compose/issues/4481
     # https://github.com/pypa/pip/blob/master/pip/_vendor/__init__.py
-    env = os.environ.copy()
-    env[str('PIP_DISABLE_PIP_VERSION_CHECK')] = str('1')
-
     s_cmd = subprocess.Popen(
         [
             sys.executable, '-c',

--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -16,8 +16,7 @@ try:
         [
             sys.executable, '-c',
             """import pkg_resources as pr; print "\\n".join([d.project_name for d in pr.working_set])"""
-        ], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-        env=env
+        ], stderr=subprocess.PIPE, stdout=subprocess.PIPE
     )
     packages = s_cmd.communicate()[0].splitlines()
     if 'docker-py' in packages:

--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -17,12 +17,15 @@ try:
     env[str('PIP_DISABLE_PIP_VERSION_CHECK')] = str('1')
 
     s_cmd = subprocess.Popen(
-        ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+        [
+            sys.executable, '-c',
+            'import pkg_resources; print("\\n".join(map(str, [distr for distr in pkg_resources.working_set if distr.project_name])))'
+        ], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
         env=env
     )
     packages = s_cmd.communicate()[0].splitlines()
     dockerpy_installed = len(
-        list(filter(lambda p: p.startswith(b'docker-py=='), packages))
+        list(filter(lambda p: p.startswith(b'docker-py '), packages))
     ) > 0
     if dockerpy_installed:
         from .colors import yellow

--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -19,15 +19,12 @@ try:
     s_cmd = subprocess.Popen(
         [
             sys.executable, '-c',
-            'import pkg_resources; print("\\n".join(map(str, [distr for distr in pkg_resources.working_set if distr.project_name])))'
+            """import pkg_resources as pr; print "\\n".join([d.project_name for d in pr.working_set])"""
         ], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
         env=env
     )
     packages = s_cmd.communicate()[0].splitlines()
-    dockerpy_installed = len(
-        list(filter(lambda p: p.startswith(b'docker-py '), packages))
-    ) > 0
-    if dockerpy_installed:
+    if 'docker-py' in packages:
         from .colors import yellow
         print(
             yellow('WARNING:'),
@@ -39,7 +36,7 @@ try:
         )
 
 except OSError:
-    # pip command is not available, which indicates it's probably the binary
+    # python command is not available, which indicates it's probably the binary
     # distribution of Compose which is not affected
     pass
 except UnicodeDecodeError:


### PR DESCRIPTION
During the `docker-py` distribution check, `pip freeze` can be terribly slow if you have a lot of packages installed. Here's my case:

    $ time pip freeze > /dev/null
    real    0m3,930s
    user    0m3,787s
     sys     0m0,093s

    $ pip freeze | wc -l
    173

    $ time docker-compose 2> /dev/null
    real    0m3,443s
    user    0m3,277s
    sys     0m0,143s

After this fix it becomes more than 3x faster:

    $ time docker-compose 2> /dev/null 
    real    0m0,935s
    user    0m0,827s
    sys     0m0,100s

This feature was tested in Python 2.7 & 3.6.
