### PR TITLE
WIP: Add support for cidfile

### DIFF
--- a/compose/config/config_schema_v1.json
+++ b/compose/config/config_schema_v1.json
@@ -22,6 +22,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -67,6 +67,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -68,6 +68,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v2.2.json
+++ b/compose/config/config_schema_v2.2.json
@@ -69,6 +69,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v3.0.json
+++ b/compose/config/config_schema_v3.0.json
@@ -69,6 +69,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v3.1.json
+++ b/compose/config/config_schema_v3.1.json
@@ -80,6 +80,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -81,6 +81,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/config/config_schema_v3.3.json
+++ b/compose/config/config_schema_v3.3.json
@@ -93,6 +93,7 @@
         "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup_parent": {"type": "string"},
+        "cidfile": {"type": "string"},
         "command": {
           "oneOf": [
             {"type": "string"},

--- a/compose/service.py
+++ b/compose/service.py
@@ -850,6 +850,7 @@ class Service(object):
             security_opt=options.get('security_opt'),
             ipc_mode=options.get('ipc'),
             cgroup_parent=options.get('cgroup_parent'),
+            container_id_file=options.get('cidfile'),
             cpu_quota=options.get('cpu_quota'),
             shm_size=options.get('shm_size'),
             sysctls=options.get('sysctls'),

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2361,6 +2361,52 @@ class ConfigTest(unittest.TestCase):
         assert service_sort(service_dicts) == service_sort(expected)
 
 
+def test_cidfile_v1():
+    config_details = build_config_details({
+        'simple': {
+            'image': 'busybox',
+            'cidfile': '/var/cid.txt',
+        },
+    })
+    cfg = config.load(config_details)
+    assert cfg.services == [
+        {
+            'name': 'simple',
+            'image': 'busybox',
+            'cidfile': '/var/cid.txt',
+        },
+    ]
+
+
+@pytest.mark.parametrize('version', [
+    '2',
+    '2.1',
+    '2.2',
+    '3',
+    '3.1',
+    '3.2',
+    '3.3',
+])
+def test_cidfile_v2_and_up(version):
+    config_details = build_config_details({
+        'version': version,
+        'services': {
+            'simple': {
+                'image': 'busybox',
+                'cidfile': '/var/cid.txt',
+            }
+        },
+    })
+    cfg = config.load(config_details)
+    assert cfg.services == [
+        {
+            'name': 'simple',
+            'image': 'busybox',
+            'cidfile': '/var/cid.txt',
+        },
+    ]
+
+
 class NetworkModeTest(unittest.TestCase):
 
     def test_network_mode_standard(self):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -210,6 +210,23 @@ class ServiceTest(unittest.TestCase):
             'test'
         )
 
+    def test_cidfile(self):
+        self.mock_client.create_host_config.return_value = {}
+
+        service = Service(
+            name='foo',
+            image='foo',
+            hostname='name',
+            client=self.mock_client,
+            cidfile='/var/run/cid.txt')
+        service._get_container_create_options({'some': 'overrides'}, 1)
+
+        self.assertTrue(self.mock_client.create_host_config.called)
+        self.assertEqual(
+            self.mock_client.create_host_config.call_args[1]['container_id_file'],
+            '/var/run/cid.txt'
+        )
+
     def test_log_opt(self):
         self.mock_client.create_host_config.return_value = {}
 


### PR DESCRIPTION
**Warning**: Do not merge this (yet)!  `docker-py` does not yet support the CID file option when creating a container (see docker/docker-py#967 for a tentative PR that adds it).

This is a tentative change to add a `cidfile` option to services.

Fixes #940.