### PR TITLE
Bump 1.15.0 RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,50 @@
 Change log
 ==========
 
+1.15.0 (2017-07-18)
+-------------------
+
+### New features
+
+#### Compose file version 2.2
+
+- Added support for the `network` parameter in build configurations.
+
+#### Compose file version 2.1 and up
+
+- The `pid` option in a service's definition now supports a `service:<name>`
+  value.
+
+- Added support for the `storage_opt` parameter in in service definitions.
+  This option is not available for the v3 format
+
+#### All formats
+
+- Added `--quiet` flag to `docker-compose pull`, suppressing progress output
+
+- Some improvements to CLI output
+
+### Bugfixes
+
+- Volumes specified through the `--volume` flag of `docker-compose run` now
+  complement volumes declared in the service's defintion instead of replacing
+  them
+
+- Fixed a bug where using multiple Compose files would unset the scale value
+  defined inside the Compose file.
+
+- Fixed an issue where the `credHelpers` entries in the `config.json` file
+  were not being honored by Compose
+
+- Fixed a bug where using multiple Compose files with port declarations
+  would cause failures in Python 3 environments
+
+- Fixed a bug where some proxy-related options present in the user's
+  environment would prevent Compose from running
+
+- Fixed an issue where the output of `docker-compose config` would be invalid
+  if the original file used `Y` or `N` values
+
 1.14.0 (2017-06-19)
 -------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,34 +19,47 @@ RUN set -ex; \
 
 RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.8.3 \
         -o /usr/local/bin/docker && \
+    SHA256=f024bc65c45a3778cf07213d26016075e8172de8f6e4b5702bedde06c241650f; \
+    echo "${SHA256}  /usr/local/bin/docker" | sha256sum -c - && \
     chmod +x /usr/local/bin/docker
 
 # Build Python 2.7.13 from source
 RUN set -ex; \
-    curl -L https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz | tar -xz; \
+    curl -LO https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz && \
+    SHA256=a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1; \
+    echo "${SHA256}  Python-2.7.13.tgz" | sha256sum -c - && \
+    tar -xzf Python-2.7.13.tgz; \
     cd Python-2.7.13; \
     ./configure --enable-shared; \
     make; \
     make install; \
     cd ..; \
-    rm -rf /Python-2.7.13
+    rm -rf /Python-2.7.13; \
+    rm Python-2.7.13.tgz
 
 # Build python 3.4 from source
 RUN set -ex; \
-    curl -L https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tgz | tar -xz; \
+    curl -LO https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tgz && \
+    SHA256=fe59daced99549d1d452727c050ae486169e9716a890cffb0d468b376d916b48; \
+    echo "${SHA256}  Python-3.4.6.tgz" | sha256sum -c - && \
+    tar -xzf Python-3.4.6.tgz; \
     cd Python-3.4.6; \
     ./configure --enable-shared; \
     make; \
     make install; \
     cd ..; \
-    rm -rf /Python-3.4.6
+    rm -rf /Python-3.4.6; \
+    rm Python-3.4.6.tgz
 
 # Make libpython findable
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Install pip
 RUN set -ex; \
-    curl -L https://bootstrap.pypa.io/get-pip.py | python
+    curl -LO https://bootstrap.pypa.io/get-pip.py && \
+    SHA256=19dae841a150c86e2a09d475b5eb0602861f2a5b7761ec268049a662dbd2bd0c; \
+    echo "${SHA256}  get-pip.py" | sha256sum -c - && \
+    python get-pip.py
 
 # Python3 requires a valid locale
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15,6 +15,7 @@
 			"bfirsh",
 			"dnephin",
 			"mnowster",
+			"shin-",
 		]
 
 [people]
@@ -44,3 +45,8 @@
 	Name = "Mazz Mosley"
 	Email = "mazz@houseofmnowster.com"
 	GitHub = "mnowster"
+
+	[People.shin-]
+	Name = "Joffrey F"
+	Email = "joffrey@docker.com"
+	GitHub = "shin-"

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.15.0dev'
+__version__ = '1.15.0-rc1'

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.14.0'
+__version__ = '1.15.0dev'

--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -17,6 +17,8 @@ try:
     env[str('PIP_DISABLE_PIP_VERSION_CHECK')] = str('1')
 
     s_cmd = subprocess.Popen(
+        # DO NOT replace this call with a `sys.executable` call. It breaks the binary
+        # distribution (with the binary calling itself recursively over and over).
         ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
         env=env
     )

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -634,11 +634,13 @@ class TopLevelCommand(object):
         Options:
             --ignore-pull-failures  Pull what it can and ignores images with pull failures.
             --parallel              Pull multiple images in parallel.
+            --quiet                 Pull without printing progress information
         """
         self.project.pull(
             service_names=options['SERVICE'],
             ignore_pull_failures=options.get('--ignore-pull-failures'),
-            parallel_pull=options.get('--parallel')
+            parallel_pull=options.get('--parallel'),
+            silent=options.get('--quiet'),
         )
 
     def push(self, options):

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -975,6 +975,7 @@ def merge_build(output, base, override):
     md = MergeDict(to_dict(base), to_dict(override))
     md.merge_scalar('context')
     md.merge_scalar('dockerfile')
+    md.merge_scalar('network')
     md.merge_mapping('args', parse_build_arguments)
     md.merge_field('cache_from', merge_unique_items_lists, default=[])
     md.merge_mapping('labels', parse_labels)

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -44,6 +44,7 @@ from .validation import validate_depends_on
 from .validation import validate_extends_file_path
 from .validation import validate_links
 from .validation import validate_network_mode
+from .validation import validate_pid_mode
 from .validation import validate_service_constraints
 from .validation import validate_top_level_object
 from .validation import validate_ulimits
@@ -667,6 +668,7 @@ def validate_service(service_config, service_names, config_file):
     validate_cpu(service_config)
     validate_ulimits(service_config)
     validate_network_mode(service_config, service_names)
+    validate_pid_mode(service_config, service_names)
     validate_depends_on(service_config, service_names)
     validate_links(service_config, service_names)
 

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -959,7 +959,7 @@ def merge_ports(md, base, override):
 
     merged = parse_sequence_func(md.base.get(field, []))
     merged.update(parse_sequence_func(md.override.get(field, [])))
-    md[field] = [item for item in sorted(merged.values())]
+    md[field] = [item for item in sorted(merged.values(), key=lambda x: x.target)]
 
 
 def merge_build(output, base, override):

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -570,12 +570,21 @@ class ServiceExtendsResolver(object):
         config_path = self.get_extended_config_path(extends)
         service_name = extends['service']
 
-        extends_file = ConfigFile.from_filename(config_path)
-        validate_config_version([self.config_file, extends_file])
-        extended_file = process_config_file(
-            extends_file, self.environment, service_name=service_name
-        )
-        service_config = extended_file.get_service(service_name)
+        if config_path == self.service_config.filename:
+            try:
+                service_config = self.config_file.get_service(service_name)
+            except KeyError:
+                raise ConfigurationError(
+                    "Cannot extend service '{}' in {}: Service not found".format(
+                        service_name, config_path)
+                )
+        else:
+            extends_file = ConfigFile.from_filename(config_path)
+            validate_config_version([self.config_file, extends_file])
+            extended_file = process_config_file(
+                extends_file, self.environment, service_name=service_name
+            )
+            service_config = extended_file.get_service(service_name)
 
         return config_path, service_config, service_name
 

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -116,6 +116,7 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'logging',
     'network_mode',
     'init',
+    'scale',
 ]
 
 DOCKER_VALID_URL_PREFIXES = (

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -229,6 +229,7 @@
         "stdin_open": {"type": "boolean"},
         "stop_grace_period": {"type": "string", "format": "duration"},
         "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
         "tmpfs": {"$ref": "#/definitions/string_or_list"},
         "tty": {"type": "boolean"},
         "ulimits": {

--- a/compose/config/config_schema_v2.2.json
+++ b/compose/config/config_schema_v2.2.json
@@ -235,6 +235,7 @@
         "stdin_open": {"type": "boolean"},
         "stop_grace_period": {"type": "string", "format": "duration"},
         "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
         "tmpfs": {"$ref": "#/definitions/string_or_list"},
         "tty": {"type": "boolean"},
         "ulimits": {

--- a/compose/config/config_schema_v2.2.json
+++ b/compose/config/config_schema_v2.2.json
@@ -60,7 +60,8 @@
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},
-                "cache_from": {"$ref": "#/definitions/list_of_strings"}
+                "cache_from": {"$ref": "#/definitions/list_of_strings"},
+                "network": {"type": "string"}
               },
               "additionalProperties": false
             }

--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -72,6 +72,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"$ref": "#/definitions/list_of_strings"}
               },
               "additionalProperties": false

--- a/compose/config/errors.py
+++ b/compose/config/errors.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 VERSION_EXPLANATION = (
     'You might be seeing this error because you\'re using the wrong Compose file version. '
-    'Either specify a supported version ("2.0", "2.1", "3.0", "3.1", "3.2") and place '
+    'Either specify a supported version (e.g "2.2" or "3.3") and place '
     'your service definitions under the `services` key, or omit the `version` key '
     'and place your service definitions at the root of the file to use '
     'version 1.\nFor more on the Compose file format versions, see '

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -7,7 +7,6 @@ from string import Template
 import six
 
 from .errors import ConfigurationError
-from compose.const import COMPOSEFILE_V1 as V1
 from compose.const import COMPOSEFILE_V2_0 as V2_0
 
 
@@ -28,7 +27,7 @@ class Interpolator(object):
 
 
 def interpolate_environment_variables(version, config, section, environment):
-    if version in (V2_0, V1):
+    if version <= V2_0:
         interpolator = Interpolator(Template, environment)
     else:
         interpolator = Interpolator(TemplateWithDefaults, environment)

--- a/compose/config/sort_services.py
+++ b/compose/config/sort_services.py
@@ -38,6 +38,7 @@ def get_service_dependents(service_dict, services):
         if (name in get_service_names(service.get('links', [])) or
             name in get_service_names_from_volumes_from(service.get('volumes_from', [])) or
             name == get_service_name_from_network_mode(service.get('network_mode')) or
+            name == get_service_name_from_network_mode(service.get('pid')) or
             name in service.get('depends_on', []))
     ]
 

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -295,24 +295,28 @@ class ServicePort(namedtuple('_ServicePort', 'target published protocol mode ext
 
         if not isinstance(spec, dict):
             result = []
-            for k, v in build_port_bindings([spec]).items():
-                if '/' in k:
-                    target, proto = k.split('/', 1)
-                else:
-                    target, proto = (k, None)
-                for pub in v:
-                    if pub is None:
-                        result.append(
-                            cls(target, None, proto, None, None)
-                        )
-                    elif isinstance(pub, tuple):
-                        result.append(
-                            cls(target, pub[1], proto, None, pub[0])
-                        )
+            try:
+                for k, v in build_port_bindings([spec]).items():
+                    if '/' in k:
+                        target, proto = k.split('/', 1)
                     else:
-                        result.append(
-                            cls(target, pub, proto, None, None)
-                        )
+                        target, proto = (k, None)
+                    for pub in v:
+                        if pub is None:
+                            result.append(
+                                cls(target, None, proto, None, None)
+                            )
+                        elif isinstance(pub, tuple):
+                            result.append(
+                                cls(target, pub[1], proto, None, pub[0])
+                            )
+                        else:
+                            result.append(
+                                cls(target, pub, proto, None, None)
+                            )
+            except ValueError as e:
+                raise ConfigurationError(str(e))
+
             return result
 
         return [cls(

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -172,6 +172,21 @@ def validate_network_mode(service_config, service_names):
             "is undefined.".format(s=service_config, dep=dependency))
 
 
+def validate_pid_mode(service_config, service_names):
+    pid_mode = service_config.config.get('pid')
+    if not pid_mode:
+        return
+
+    dependency = get_service_name_from_network_mode(pid_mode)
+    if not dependency:
+        return
+    if dependency not in service_names:
+        raise ConfigurationError(
+            "Service '{s.name}' uses the PID namespace of service '{dep}' which "
+            "is undefined.".format(s=service_config, dep=dependency)
+        )
+
+
 def validate_links(service_config, service_names):
     for link in service_config.config.get('links', []):
         if link.split(':')[0] not in service_names:

--- a/compose/const.py
+++ b/compose/const.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import sys
 
+from .version import ComposeVersion
+
 DEFAULT_TIMEOUT = 10
 HTTP_TIMEOUT = 60
 IMAGE_EVENTS = ['delete', 'import', 'load', 'pull', 'push', 'save', 'tag', 'untag']
@@ -19,15 +21,15 @@ NANOCPUS_SCALE = 1000000000
 
 SECRETS_PATH = '/run/secrets'
 
-COMPOSEFILE_V1 = '1'
-COMPOSEFILE_V2_0 = '2.0'
-COMPOSEFILE_V2_1 = '2.1'
-COMPOSEFILE_V2_2 = '2.2'
+COMPOSEFILE_V1 = ComposeVersion('1')
+COMPOSEFILE_V2_0 = ComposeVersion('2.0')
+COMPOSEFILE_V2_1 = ComposeVersion('2.1')
+COMPOSEFILE_V2_2 = ComposeVersion('2.2')
 
-COMPOSEFILE_V3_0 = '3.0'
-COMPOSEFILE_V3_1 = '3.1'
-COMPOSEFILE_V3_2 = '3.2'
-COMPOSEFILE_V3_3 = '3.3'
+COMPOSEFILE_V3_0 = ComposeVersion('3.0')
+COMPOSEFILE_V3_1 = ComposeVersion('3.1')
+COMPOSEFILE_V3_2 = ComposeVersion('3.2')
+COMPOSEFILE_V3_3 = ComposeVersion('3.3')
 
 API_VERSIONS = {
     COMPOSEFILE_V1: '1.21',

--- a/compose/project.py
+++ b/compose/project.py
@@ -462,12 +462,12 @@ class Project(object):
 
         return plans
 
-    def pull(self, service_names=None, ignore_pull_failures=False, parallel_pull=False):
+    def pull(self, service_names=None, ignore_pull_failures=False, parallel_pull=False, silent=False):
         services = self.get_services(service_names, include_deps=False)
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, True)
+                service.pull(ignore_pull_failures, True, silent=silent)
 
             parallel.parallel_execute(
                 services,
@@ -477,7 +477,7 @@ class Project(object):
                 limit=5)
         else:
             for service in services:
-                service.pull(ignore_pull_failures)
+                service.pull(ignore_pull_failures, silent=silent)
 
     def push(self, service_names=None, ignore_push_failures=False):
         for service in self.get_services(service_names, include_deps=False):

--- a/compose/project.py
+++ b/compose/project.py
@@ -467,7 +467,7 @@ class Project(object):
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, silent=silent)
+                service.pull(ignore_pull_failures, True)
 
             parallel.parallel_execute(
                 services,

--- a/compose/project.py
+++ b/compose/project.py
@@ -467,7 +467,7 @@ class Project(object):
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, True, silent=silent)
+                service.pull(ignore_pull_failures, silent=silent)
 
             parallel.parallel_execute(
                 services,

--- a/compose/service.py
+++ b/compose/service.py
@@ -736,8 +736,7 @@ class Service(object):
         container_options = dict(
             (k, self.options[k])
             for k in DOCKER_CONFIG_KEYS if k in self.options)
-        override_options['volumes'] = (container_options.get('volumes', []) +
-                                       override_options.get('volumes', []))
+        override_volumes = override_options.pop('volumes', [])
         container_options.update(override_options)
 
         if not container_options.get('name'):
@@ -760,6 +759,11 @@ class Service(object):
             container_options['ports'] = build_container_ports(
                 formatted_ports(container_options.get('ports', [])),
                 self.options)
+
+        if 'volumes' in container_options or override_volumes:
+            container_options['volumes'] = list(set(
+                container_options.get('volumes', []) + override_volumes
+            ))
 
         container_options['environment'] = merge_environment(
             self.options.get('environment'),

--- a/compose/service.py
+++ b/compose/service.py
@@ -736,6 +736,8 @@ class Service(object):
         container_options = dict(
             (k, self.options[k])
             for k in DOCKER_CONFIG_KEYS if k in self.options)
+        override_options['volumes'] = (container_options.get('volumes', []) +
+                                       override_options.get('volumes', []))
         container_options.update(override_options)
 
         if not container_options.get('name'):

--- a/compose/service.py
+++ b/compose/service.py
@@ -82,6 +82,7 @@ HOST_CONFIG_KEYS = [
     'restart',
     'security_opt',
     'shm_size',
+    'storage_opt',
     'sysctls',
     'userns_mode',
     'volumes_from',
@@ -854,6 +855,7 @@ class Service(object):
             volume_driver=options.get('volume_driver'),
             cpuset_cpus=options.get('cpuset'),
             cpu_shares=options.get('cpu_shares'),
+            storage_opt=options.get('storage_opt')
         )
 
     def get_secret_volumes(self):

--- a/compose/service.py
+++ b/compose/service.py
@@ -56,7 +56,9 @@ HOST_CONFIG_KEYS = [
     'cpu_count',
     'cpu_percent',
     'cpu_quota',
+    'cpu_shares',
     'cpus',
+    'cpuset',
     'devices',
     'dns',
     'dns_search',
@@ -83,6 +85,7 @@ HOST_CONFIG_KEYS = [
     'sysctls',
     'userns_mode',
     'volumes_from',
+    'volume_driver',
 ]
 
 CONDITION_STARTED = 'service_started'
@@ -848,6 +851,9 @@ class Service(object):
             cpu_count=options.get('cpu_count'),
             cpu_percent=options.get('cpu_percent'),
             nano_cpus=nano_cpus,
+            volume_driver=options.get('volume_driver'),
+            cpuset_cpus=options.get('cpuset'),
+            cpu_shares=options.get('cpu_shares'),
         )
 
     def get_secret_volumes(self):

--- a/compose/service.py
+++ b/compose/service.py
@@ -906,7 +906,8 @@ class Service(object):
             dockerfile=build_opts.get('dockerfile', None),
             cache_from=build_opts.get('cache_from', None),
             labels=build_opts.get('labels', None),
-            buildargs=build_args
+            buildargs=build_args,
+            network_mode=build_opts.get('network', None),
         )
 
         try:

--- a/compose/version.py
+++ b/compose/version.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from distutils.version import LooseVersion
+
+
+class ComposeVersion(LooseVersion):
+    """ A hashable version object """
+    def __hash__(self):
+        return hash(self.vstring)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,22 @@
-PyYAML==3.11
+PySocks==1.6.7
+PyYAML==3.12
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
-cached-property==1.2.0
-colorama==0.3.7
+cached-property==1.3.0
+certifi==2017.4.17
+chardet==3.0.4
+colorama==0.3.9
 docker==2.4.2
+docker-pycreds==0.2.1
 dockerpty==0.4.1
-docopt==0.6.1
-enum34==1.0.4; python_version < '3.4'
+docopt==0.6.2
+enum34==1.1.6; python_version < '3.4'
 functools32==3.2.3.post2; python_version < '3.2'
-ipaddress==1.0.16
-jsonschema==2.5.1
+idna==2.5
+ipaddress==1.0.18
+jsonschema==2.6.0
 pypiwin32==219; sys_platform == 'win32'
 requests==2.11.1
 six==1.10.0
-texttable==0.8.4
+texttable==0.8.8
+urllib3==1.21.1
 websocket-client==0.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyYAML==3.11
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.2.0
 colorama==0.3.7
-docker==2.3.0
+docker==2.4.2
 dockerpty==0.4.1
 docopt==0.6.1
 enum34==1.0.4; python_version < '3.4'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.14.0"
+VERSION="1.15.0-rc1"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/script/test/all
+++ b/script/test/all
@@ -48,7 +48,7 @@ for version in $DOCKER_VERSIONS; do
     --privileged \
     --volume="/var/lib/docker" \
     "$repo:$version" \
-    docker daemon -H tcp://0.0.0.0:2375 $DOCKER_DAEMON_ARGS \
+    dockerd -H tcp://0.0.0.0:2375 $DOCKER_DAEMON_ARGS \
     2>&1 | tail -n 10
 
   docker run \

--- a/script/test/all
+++ b/script/test/all
@@ -14,7 +14,7 @@ docker run --rm \
 get_versions="docker run --rm
     --entrypoint=/code/.tox/py27/bin/python
     $TAG
-    /code/script/test/versions.py docker/docker"
+    /code/script/test/versions.py docker/docker-ce,moby/moby"
 
 if [ "$DOCKER_VERSIONS" == "" ]; then
   DOCKER_VERSIONS="$($get_versions default)"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, < 2.12',
     'texttable >= 0.8.1, < 0.9',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker >= 2.3.0, < 3.0',
+    'docker >= 2.4.2, < 3.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ extras_require = {
     ':python_version < "3.4"': ['enum34 >= 1.0.4, < 2'],
     ':python_version < "3.5"': ['backports.ssl_match_hostname >= 3.5'],
     ':python_version < "3.3"': ['ipaddress >= 1.0.16'],
+    'socks': ['PySocks >= 1.5.6, != 1.5.7, < 2'],
 }
 
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -850,8 +850,13 @@ class CLITestCase(DockerClientTestCase):
         # Two networks were created: back and front
         assert sorted(n['Name'].split('/')[-1] for n in networks) == [back_name, front_name]
 
-        back_network = [n for n in networks if n['Name'] == back_name][0]
-        front_network = [n for n in networks if n['Name'] == front_name][0]
+        # lookup by ID instead of name in case of duplicates
+        back_network = self.client.inspect_network(
+            [n for n in networks if n['Name'] == back_name][0]['Id']
+        )
+        front_network = self.client.inspect_network(
+            [n for n in networks if n['Name'] == front_name][0]['Id']
+        )
 
         web_container = self.project.get_service('web').containers()[0]
         app_container = self.project.get_service('app').containers()[0]

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -431,6 +431,10 @@ class CLITestCase(DockerClientTestCase):
         assert ('repository nonexisting-image not found' in result.stderr or
                 'image library/nonexisting-image:latest not found' in result.stderr)
 
+    def test_pull_with_quiet(self):
+        assert self.dispatch(['pull', '--quiet']).stderr == ''
+        assert self.dispatch(['pull', '--quiet']).stdout == ''
+
     def test_build_plain(self):
         self.base_dir = 'tests/fixtures/simple-dockerfile'
         self.dispatch(['build', 'simple'])

--- a/tests/fixtures/override-files/docker-compose.override.yml
+++ b/tests/fixtures/override-files/docker-compose.override.yml
@@ -1,6 +1,7 @@
-
-web:
+version: '2.2'
+services:
+  web:
     command: "top"
 
-db:
+  db:
     command: "top"

--- a/tests/fixtures/override-files/docker-compose.yml
+++ b/tests/fixtures/override-files/docker-compose.yml
@@ -1,10 +1,10 @@
-
-web:
+version: '2.2'
+services:
+  web:
     image: busybox:latest
     command: "sleep 200"
-    links:
+    depends_on:
         - db
-
-db:
+  db:
     image: busybox:latest
     command: "sleep 200"

--- a/tests/fixtures/override-files/extra.yml
+++ b/tests/fixtures/override-files/extra.yml
@@ -1,9 +1,10 @@
-
-web:
-    links:
+version: '2.2'
+services:
+  web:
+    depends_on:
         - db
         - other
 
-other:
+  other:
     image: busybox:latest
     command: "top"

--- a/tests/fixtures/pid-mode/docker-compose.yml
+++ b/tests/fixtures/pid-mode/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2.2"
+
+services:
+  service:
+    image: busybox
+    command: top
+    pid: "service:container"
+
+  container:
+    image: busybox
+    command: top
+    pid: "container:composetest_pid_mode_container"
+
+  host:
+    image: busybox
+    command: top
+    pid: host

--- a/tests/fixtures/simple-composefile-volume-ready/docker-compose.merge.yml
+++ b/tests/fixtures/simple-composefile-volume-ready/docker-compose.merge.yml
@@ -1,0 +1,9 @@
+version: '2.2'
+services:
+  simple:
+    image: busybox:latest
+    volumes:
+      - datastore:/data1
+
+volumes:
+    datastore:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import functools
 import os
+
+from docker.errors import APIError
+from pytest import skip
 
 from compose.config.config import ConfigDetails
 from compose.config.config import ConfigFile
@@ -44,3 +48,34 @@ def create_host_file(client, filename):
                 "Container exited with code {}:\n{}".format(exitcode, output))
     finally:
         client.remove_container(container, force=True)
+
+
+def is_cluster(client):
+    nodes = None
+
+    def get_nodes_number():
+        try:
+            return len(client.nodes())
+        except APIError:
+            # If the Engine is not part of a Swarm, the SDK will raise
+            # an APIError
+            return 0
+
+    if nodes is None:
+        # Only make the API call if the value hasn't been cached yet
+        nodes = get_nodes_number()
+
+    return nodes > 1
+
+
+def no_cluster(reason):
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            if is_cluster(self.client):
+                skip("Test will not be run in cluster mode: %s" % reason)
+                return
+            return f(self, *args, **kwargs)
+        return wrapper
+
+    return decorator

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -34,6 +34,7 @@ from compose.project import Project
 from compose.project import ProjectError
 from compose.service import ConvergenceStrategy
 from tests.integration.testcases import v2_1_only
+from tests.integration.testcases import v2_2_only
 from tests.integration.testcases import v2_only
 from tests.integration.testcases import v3_only
 
@@ -150,7 +151,7 @@ class ProjectTest(DockerClientTestCase):
             name='composetest',
             client=self.client,
             config_data=load_config({
-                'version': V2_0,
+                'version': str(V2_0),
                 'services': {
                     'net': {
                         'image': 'busybox:latest',
@@ -178,7 +179,7 @@ class ProjectTest(DockerClientTestCase):
             return Project.from_config(
                 name='composetest',
                 config_data=load_config({
-                    'version': V2_0,
+                    'version': str(V2_0),
                     'services': {
                         'web': {
                             'image': 'busybox:latest',
@@ -820,7 +821,7 @@ class ProjectTest(DockerClientTestCase):
     def test_up_with_enable_ipv6(self):
         self.require_api_version('1.23')
         config_data = build_config(
-            version=V2_0,
+            version=V2_1,
             services=[{
                 'name': 'web',
                 'image': 'busybox:latest',
@@ -1003,7 +1004,7 @@ class ProjectTest(DockerClientTestCase):
         network_name = 'network_with_label'
 
         config_data = build_config(
-            version=V2_0,
+            version=V2_1,
             services=[{
                 'name': 'web',
                 'image': 'busybox:latest',
@@ -1063,7 +1064,7 @@ class ProjectTest(DockerClientTestCase):
         volume_name = 'volume_with_label'
 
         config_data = build_config(
-            version=V2_0,
+            version=V2_1,
             services=[{
                 'name': 'web',
                 'image': 'busybox:latest',
@@ -1103,7 +1104,7 @@ class ProjectTest(DockerClientTestCase):
         base_file = config.ConfigFile(
             'base.yml',
             {
-                'version': V2_0,
+                'version': str(V2_0),
                 'services': {
                     'simple': {'image': 'busybox:latest', 'command': 'top'},
                     'another': {
@@ -1122,7 +1123,7 @@ class ProjectTest(DockerClientTestCase):
         override_file = config.ConfigFile(
             'override.yml',
             {
-                'version': V2_0,
+                'version': str(V2_0),
                 'services': {
                     'another': {
                         'logging': {
@@ -1155,7 +1156,7 @@ class ProjectTest(DockerClientTestCase):
         base_file = config.ConfigFile(
             'base.yml',
             {
-                'version': V2_0,
+                'version': str(V2_0),
                 'services': {
                     'simple': {
                         'image': 'busybox:latest',
@@ -1168,7 +1169,7 @@ class ProjectTest(DockerClientTestCase):
         override_file = config.ConfigFile(
             'override.yml',
             {
-                'version': V2_0,
+                'version': str(V2_0),
                 'services': {
                     'simple': {
                         'ports': ['1234:1234']
@@ -1186,6 +1187,7 @@ class ProjectTest(DockerClientTestCase):
         containers = project.containers()
         self.assertEqual(len(containers), 1)
 
+    @v2_2_only()
     def test_project_up_config_scale(self):
         config_data = build_config(
             version=V2_2,
@@ -1454,7 +1456,7 @@ class ProjectTest(DockerClientTestCase):
         base_file = config.ConfigFile(
             'base.yml',
             {
-                'version': V2_0,
+                'version': str(V2_0),
                 'services': {
                     'simple': {
                         'image': 'busybox:latest',

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -26,6 +26,7 @@ from compose.const import LABEL_ONE_OFF
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
 from compose.const import LABEL_VERSION
+from compose.const import IS_WINDOWS_PLATFORM
 from compose.container import Container
 from compose.errors import OperationFailedError
 from compose.project import OneOffFilter

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -26,7 +26,6 @@ from compose.const import LABEL_ONE_OFF
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
 from compose.const import LABEL_VERSION
-from compose.const import IS_WINDOWS_PLATFORM
 from compose.container import Container
 from compose.errors import OperationFailedError
 from compose.project import OneOffFilter

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -36,6 +36,7 @@ from compose.project import OneOffFilter
 from compose.service import ConvergencePlan
 from compose.service import ConvergenceStrategy
 from compose.service import NetworkMode
+from compose.service import PidMode
 from compose.service import Service
 from tests.integration.testcases import v2_1_only
 from tests.integration.testcases import v2_2_only
@@ -968,12 +969,12 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(container.get('HostConfig.NetworkMode'), 'host')
 
     def test_pid_mode_none_defined(self):
-        service = self.create_service('web', pid=None)
+        service = self.create_service('web', pid_mode=None)
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.PidMode'), '')
 
     def test_pid_mode_host(self):
-        service = self.create_service('web', pid='host')
+        service = self.create_service('web', pid_mode=PidMode('host'))
         container = create_and_start_container(service)
         self.assertEqual(container.get('HostConfig.PidMode'), 'host')
 

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -208,6 +208,13 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(set(container.get('HostConfig.SecurityOpt')), set(security_opt))
 
+    def test_create_container_with_storage_opt(self):
+        storage_opt = {'size': '1G'}
+        service = self.create_service('db', storage_opt=storage_opt)
+        container = service.create_container()
+        service.start_container(container)
+        self.assertEqual(container.get('HostConfig.StorageOpt'), storage_opt)
+
     def test_create_container_with_mac_address(self):
         service = self.create_service('db', mac_address='02:42:ac:11:65:43')
         container = service.create_container()

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -208,6 +208,7 @@ class ServiceTest(DockerClientTestCase):
         service.start_container(container)
         self.assertEqual(set(container.get('HostConfig.SecurityOpt')), set(security_opt))
 
+    @pytest.mark.xfail(True, reason='Not supported on most drivers')
     def test_create_container_with_storage_opt(self):
         storage_opt = {'size': '1G'}
         service = self.create_service('db', storage_opt=storage_opt)

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -251,7 +251,7 @@ class ServiceStateTest(DockerClientTestCase):
         container = web.create_container()
 
         # update the image
-        c = self.client.create_container(image, ['touch', '/hello.txt'])
+        c = self.client.create_container(image, ['touch', '/hello.txt'], host_config={})
         self.client.commit(c, repository=repo, tag=tag)
         self.client.remove_container(c)
 

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -17,6 +17,7 @@ from compose.const import COMPOSEFILE_V2_0 as V2_0
 from compose.const import COMPOSEFILE_V2_0 as V2_1
 from compose.const import COMPOSEFILE_V2_2 as V2_2
 from compose.const import COMPOSEFILE_V3_0 as V3_0
+from compose.const import COMPOSEFILE_V3_2 as V3_2
 from compose.const import COMPOSEFILE_V3_3 as V3_3
 from compose.const import LABEL_PROJECT
 from compose.progress_stream import stream_output
@@ -52,7 +53,7 @@ def engine_max_version():
     if version_lt(version, '1.13'):
         return V2_1
     if version_lt(version, '17.06'):
-        return V2_2
+        return V3_2
     return V3_3
 
 
@@ -72,7 +73,7 @@ def v2_1_only():
 
 
 def v2_2_only():
-    return min_version_skip(V2_0)
+    return min_version_skip(V2_2)
 
 
 def v3_only():

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from docker.errors import DockerException
 
+from ..helpers import no_cluster
 from .testcases import DockerClientTestCase
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_VOLUME
@@ -35,26 +36,28 @@ class VolumeTest(DockerClientTestCase):
     def test_create_volume(self):
         vol = self.create_volume('volume01')
         vol.create()
-        info = self.client.inspect_volume(vol.full_name)
-        assert info['Name'] == vol.full_name
+        info = self.get_volume_data(vol.full_name)
+        assert info['Name'].split('/')[-1] == vol.full_name
 
     def test_recreate_existing_volume(self):
         vol = self.create_volume('volume01')
 
         vol.create()
-        info = self.client.inspect_volume(vol.full_name)
-        assert info['Name'] == vol.full_name
+        info = self.get_volume_data(vol.full_name)
+        assert info['Name'].split('/')[-1] == vol.full_name
 
         vol.create()
-        info = self.client.inspect_volume(vol.full_name)
-        assert info['Name'] == vol.full_name
+        info = self.get_volume_data(vol.full_name)
+        assert info['Name'].split('/')[-1] == vol.full_name
 
+    @no_cluster('inspect volume by name defect on Swarm Classic')
     def test_inspect_volume(self):
         vol = self.create_volume('volume01')
         vol.create()
         info = vol.inspect()
         assert info['Name'] == vol.full_name
 
+    @no_cluster('remove volume by name defect on Swarm Classic')
     def test_remove_volume(self):
         vol = Volume(self.client, 'composetest', 'volume01')
         vol.create()
@@ -62,6 +65,7 @@ class VolumeTest(DockerClientTestCase):
         volumes = self.client.volumes()['Volumes']
         assert len([v for v in volumes if v['Name'] == vol.full_name]) == 0
 
+    @no_cluster('inspect volume by name defect on Swarm Classic')
     def test_external_volume(self):
         vol = self.create_volume('composetest_volume_ext', external=True)
         assert vol.external is True
@@ -70,6 +74,7 @@ class VolumeTest(DockerClientTestCase):
         info = vol.inspect()
         assert info['Name'] == vol.name
 
+    @no_cluster('inspect volume by name defect on Swarm Classic')
     def test_external_aliased_volume(self):
         alias_name = 'composetest_alias01'
         vol = self.create_volume('volume01', external=alias_name)
@@ -79,24 +84,28 @@ class VolumeTest(DockerClientTestCase):
         info = vol.inspect()
         assert info['Name'] == alias_name
 
+    @no_cluster('inspect volume by name defect on Swarm Classic')
     def test_exists(self):
         vol = self.create_volume('volume01')
         assert vol.exists() is False
         vol.create()
         assert vol.exists() is True
 
+    @no_cluster('inspect volume by name defect on Swarm Classic')
     def test_exists_external(self):
         vol = self.create_volume('volume01', external=True)
         assert vol.exists() is False
         vol.create()
         assert vol.exists() is True
 
+    @no_cluster('inspect volume by name defect on Swarm Classic')
     def test_exists_external_aliased(self):
         vol = self.create_volume('volume01', external='composetest_alias01')
         assert vol.exists() is False
         vol.create()
         assert vol.exists() is True
 
+    @no_cluster('inspect volume by name defect on Swarm Classic')
     def test_volume_default_labels(self):
         vol = self.create_volume('volume01')
         vol.create()

--- a/tests/unit/bundle_test.py
+++ b/tests/unit/bundle_test.py
@@ -9,6 +9,7 @@ from compose import bundle
 from compose import service
 from compose.cli.errors import UserError
 from compose.config.config import Config
+from compose.const import COMPOSEFILE_V2_0 as V2_0
 
 
 @pytest.fixture
@@ -74,7 +75,7 @@ def test_to_bundle():
         {'name': 'b', 'build': './b'},
     ]
     config = Config(
-        version=2,
+        version=V2_0,
         services=services,
         volumes={'special': {}},
         networks={'extra': {}},

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2098,6 +2098,19 @@ class ConfigTest(unittest.TestCase):
         actual = config.merge_service_dicts(base, override, V3_3)
         assert actual['credential_spec'] == override['credential_spec']
 
+    def test_merge_scale(self):
+        base = {
+            'image': 'bar',
+            'scale': 2,
+        }
+
+        override = {
+            'scale': 4,
+        }
+
+        actual = config.merge_service_dicts(base, override, V2_2)
+        assert actual == {'image': 'bar', 'scale': 4}
+
     def test_external_volume_config(self):
         config_details = build_config_details({
             'version': '2',

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1615,6 +1615,22 @@ class ConfigTest(unittest.TestCase):
             'ports': types.ServicePort.parse('5432')
         }
 
+    def test_merge_service_dicts_ports_sorting(self):
+        base = {
+            'ports': [5432]
+        }
+        override = {
+            'image': 'alpine:edge',
+            'ports': ['5432/udp']
+        }
+        actual = config.merge_service_dicts_from_files(
+            base,
+            override,
+            DEFAULT_VERSION)
+        assert len(actual['ports']) == 2
+        assert types.ServicePort.parse('5432')[0] in actual['ports']
+        assert types.ServicePort.parse('5432/udp')[0] in actual['ports']
+
     def test_merge_service_dicts_heterogeneous_volumes(self):
         base = {
             'volumes': ['/a:/b', '/x:/z'],

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -4163,3 +4163,21 @@ class SerializeTest(unittest.TestCase):
         assert secret_sort(serialized_service['configs']) == secret_sort(service_dict['configs'])
         assert 'configs' in serialized_config
         assert serialized_config['configs']['two'] == configs_dict['two']
+
+    def test_serialize_bool_string(self):
+        cfg = {
+            'version': '2.2',
+            'services': {
+                'web': {
+                    'image': 'example/web',
+                    'command': 'true',
+                    'environment': {'FOO': 'Y', 'BAR': 'on'}
+                }
+            }
+        }
+        config_dict = config.load(build_config_details(cfg))
+
+        serialized_config = serialize_config(config_dict)
+        assert 'command: "true"\n' in serialized_config
+        assert 'FOO: "Y"\n' in serialized_config
+        assert 'BAR: "on"\n' in serialized_config

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -378,7 +378,7 @@ class ConfigTest(unittest.TestCase):
         base_file = config.ConfigFile(
             'base.yaml',
             {
-                'version': V2_1,
+                'version': str(V2_1),
                 'services': {
                     'web': {
                         'image': 'example/web',
@@ -830,7 +830,7 @@ class ConfigTest(unittest.TestCase):
         service = config.load(
             build_config_details(
                 {
-                    'version': V3_3,
+                    'version': str(V3_3),
                     'services': {
                         'web': {
                             'build': {
@@ -1523,7 +1523,7 @@ class ConfigTest(unittest.TestCase):
 
     def test_isolation_option(self):
         actual = config.load(build_config_details({
-            'version': V2_1,
+            'version': str(V2_1),
             'services': {
                 'web': {
                     'image': 'win10',
@@ -4122,7 +4122,7 @@ class SerializeTest(unittest.TestCase):
         assert serialized_config['secrets']['two'] == secrets_dict['two']
 
     def test_serialize_ports(self):
-        config_dict = config.Config(version='2.0', services=[
+        config_dict = config.Config(version=V2_0, services=[
             {
                 'ports': [types.ServicePort('80', '8080', None, None, None)],
                 'image': 'alpine',

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -8,6 +8,8 @@ from compose.config.interpolation import interpolate_environment_variables
 from compose.config.interpolation import Interpolator
 from compose.config.interpolation import InvalidInterpolation
 from compose.config.interpolation import TemplateWithDefaults
+from compose.const import COMPOSEFILE_V2_0 as V2_0
+from compose.const import COMPOSEFILE_V3_1 as V3_1
 
 
 @pytest.fixture
@@ -50,7 +52,7 @@ def test_interpolate_environment_variables_in_services(mock_env):
             }
         }
     }
-    value = interpolate_environment_variables("2.0", services, 'service', mock_env)
+    value = interpolate_environment_variables(V2_0, services, 'service', mock_env)
     assert value == expected
 
 
@@ -75,7 +77,7 @@ def test_interpolate_environment_variables_in_volumes(mock_env):
         },
         'other': {},
     }
-    value = interpolate_environment_variables("2.0", volumes, 'volume', mock_env)
+    value = interpolate_environment_variables(V2_0, volumes, 'volume', mock_env)
     assert value == expected
 
 
@@ -100,7 +102,7 @@ def test_interpolate_environment_variables_in_secrets(mock_env):
         },
         'other': {},
     }
-    value = interpolate_environment_variables("3.1", secrets, 'volume', mock_env)
+    value = interpolate_environment_variables(V3_1, secrets, 'volume', mock_env)
     assert value == expected
 
 

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -115,3 +115,18 @@ def test_parallel_execute_with_upstream_errors():
     assert (data_volume, None, APIError) in events
     assert (db, None, UpstreamError) in events
     assert (web, None, UpstreamError) in events
+
+
+def test_parallel_execute_alignment(capsys):
+    results, errors = parallel_execute(
+        objects=["short", "a very long name"],
+        func=lambda x: x,
+        get_name=six.text_type,
+        msg="Aligning",
+    )
+
+    assert errors == {}
+
+    _, err = capsys.readouterr()
+    a, b = err.split('\n')[:2]
+    assert a.index('...') == b.index('...')

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -10,6 +10,8 @@ from .. import mock
 from .. import unittest
 from compose.config.config import Config
 from compose.config.types import VolumeFromSpec
+from compose.const import COMPOSEFILE_V1 as V1
+from compose.const import COMPOSEFILE_V2_0 as V2_0
 from compose.const import LABEL_SERVICE
 from compose.container import Container
 from compose.project import Project
@@ -21,9 +23,9 @@ class ProjectTest(unittest.TestCase):
     def setUp(self):
         self.mock_client = mock.create_autospec(docker.APIClient)
 
-    def test_from_config(self):
+    def test_from_config_v1(self):
         config = Config(
-            version=None,
+            version=V1,
             services=[
                 {
                     'name': 'web',
@@ -53,7 +55,7 @@ class ProjectTest(unittest.TestCase):
 
     def test_from_config_v2(self):
         config = Config(
-            version=2,
+            version=V2_0,
             services=[
                 {
                     'name': 'web',
@@ -166,7 +168,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=None,
+                version=V2_0,
                 services=[{
                     'name': 'test',
                     'image': 'busybox:latest',
@@ -194,7 +196,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=None,
+                version=V2_0,
                 services=[
                     {
                         'name': 'vol',
@@ -221,7 +223,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=None,
             config_data=Config(
-                version=None,
+                version=V2_0,
                 services=[
                     {
                         'name': 'vol',
@@ -361,7 +363,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=None,
+                version=V1,
                 services=[
                     {
                         'name': 'test',
@@ -386,7 +388,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=None,
+                version=V2_0,
                 services=[
                     {
                         'name': 'test',
@@ -417,7 +419,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=None,
+                version=V2_0,
                 services=[
                     {
                         'name': 'aaa',
@@ -444,7 +446,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=2,
+                version=V2_0,
                 services=[
                     {
                         'name': 'foo',
@@ -465,7 +467,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=2,
+                version=V2_0,
                 services=[
                     {
                         'name': 'foo',
@@ -500,7 +502,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version=None,
+                version=V2_0,
                 services=[{
                     'name': 'web',
                     'image': 'busybox:latest',
@@ -518,7 +520,7 @@ class ProjectTest(unittest.TestCase):
             name='test',
             client=self.mock_client,
             config_data=Config(
-                version='2',
+                version=V2_0,
                 services=[{
                     'name': 'web',
                     'image': 'busybox:latest',

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -473,6 +473,7 @@ class ServiceTest(unittest.TestCase):
             buildargs={},
             labels=None,
             cache_from=None,
+            network_mode=None,
         )
 
     def test_ensure_image_exists_no_build(self):
@@ -511,6 +512,7 @@ class ServiceTest(unittest.TestCase):
             buildargs={},
             labels=None,
             cache_from=None,
+            network_mode=None,
         )
 
     def test_build_does_not_pull(self):


### PR DESCRIPTION
### New features

#### Compose file version 2.2

- Added support for the `network` parameter in build configurations.

#### Compose file version 2.1 and up

- The `pid` option in a service's definition now supports a `service:<name>`
  value.

- Added support for the `storage_opt` parameter in in service definitions.
  This option is not available for the v3 format

#### All formats

- Added `--quiet` flag to `docker-compose pull`, suppressing progress output

- Some improvements to CLI output

### Bugfixes

- Volumes specified through the `--volume` flag of `docker-compose run` now
  complement volumes declared in the service's defintion instead of replacing 
  them

- Fixed a bug where using multiple Compose files would unset the scale value
  defined inside the Compose file.

- Fixed an issue where the `credHelpers` entries in the `config.json` file
  were not being honored by Compose

- Fixed a bug where using multiple Compose files with port declarations 
  would cause failures in Python 3 environments

- Fixed a bug where some proxy-related options present in the user's
  environment would prevent Compose from running

- Fixed an issue where the output of `docker-compose config` would be invalid
  if the original file used `Y` or `N` values