### PR TITLE
Add bash completion for `pull --quiet`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -341,7 +341,7 @@ _docker_compose_ps() {
 _docker_compose_pull() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --ignore-pull-failures --parallel" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --ignore-pull-failures --parallel --quiet" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_from_image


### PR DESCRIPTION
Just found this new option in the [1.15.0-rc1 release notes](https://github.com/docker/compose/releases/tag/1.15.0-rc1).
Ping @sdurrheimer for zsh completion.