### PR TITLE
Allow using COMPOSE_PROJECT_NAME in environment substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change log
 ==========
 
+Unreleased
+----------
+
+#### All formats
+
+- The `COMPOSE_PROJECT_NAME` environment variable is now always available for
+  substitutions even when the value is not explicitly set.
+
 1.14.0 (2017-06-19)
 -------------------
 

--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -88,6 +88,9 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
     project_name = get_project_name(
         config_details.working_dir, project_name, environment
     )
+    # Provide ``COMPOSE_PROJECT_NAME`` for substitutions even
+    # when the value is inferred from the directory name.
+    environment.setdefault('COMPOSE_PROJECT_NAME', project_name)
     config_data = config.load(config_details)
 
     api_version = environment.get(

--- a/tests/fixtures/longer-filename-composefile/docker-compose.yaml
+++ b/tests/fixtures/longer-filename-composefile/docker-compose.yaml
@@ -1,3 +1,5 @@
 definedinyamlnotyml:
   image: busybox:latest
   command: top
+  environment:
+    CONTAINER_GLOB: "${COMPOSE_PROJECT_NAME}_*"

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -82,6 +82,12 @@ class CLITestCase(unittest.TestCase):
         self.assertEqual(project.name, 'longerfilenamecomposefile')
         self.assertTrue(project.client)
         self.assertTrue(project.services)
+        self.assertEqual(
+            project.get_service('definedinyamlnotyml').options['environment'],
+            {
+                'CONTAINER_GLOB': 'longerfilenamecomposefile_*',
+            },
+        )
 
     def test_command_help(self):
         with mock.patch('sys.stdout', new=StringIO()) as fake_stdout:


### PR DESCRIPTION
When the `COMPOSE_PROJECT_NAME` is defined in the calling environment, it is
available for substitution in the `docker-compose.yml` file.  However, this
cannot be relied upon because the project name can be inferred from the
parent directory name.

This change ensures the `COMPOSE_PROJECT_NAME` environment variable is always
available for subtitution in `docker-compose.yml` file regardless of the
provenance of the project name.

Signed-off-by: Andre Caron <andre.l.caron@gmail.com>