### PR TITLE
Add exception for networkname in windows networking

### DIFF
--- a/compose/network.py
+++ b/compose/network.py
@@ -18,7 +18,8 @@ log = logging.getLogger(__name__)
 
 OPTS_EXCEPTIONS = [
     'com.docker.network.driver.overlay.vxlanid_list',
-    'com.docker.network.windowsshim.hnsid'
+    'com.docker.network.windowsshim.hnsid',
+    'com.docker.network.windowsshim.networkname'
 ]
 
 


### PR DESCRIPTION
Similar to #4794

Fixes:
`ERROR: Network "musicstore_default" needs to be recreated - option "com.docker.network.windowsshim.networkname" has changed`

![docker_networkname](https://user-images.githubusercontent.com/14277509/28579508-de02e938-712a-11e7-8fc6-b8b5bbee228a.PNG)
