### PR TITLE
Bump 1.15.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ coverage-html
 docs/_site
 venv
 .tox
+**/__pycache__
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Change log
 ==========
 
-1.15.0 (2017-07-18)
+1.15.0 (2017-07-26)
 -------------------
 
 ### New features
@@ -44,6 +44,9 @@ Change log
 
 - Fixed an issue where the output of `docker-compose config` would be invalid
   if the original file used `Y` or `N` values
+
+- Fixed an issue preventing `up` operations on a previously created stack on
+  Windows Engine.
 
 1.14.0 (2017-06-19)
 -------------------

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.15.0-rc1'
+__version__ = '1.15.0'

--- a/compose/network.py
+++ b/compose/network.py
@@ -18,7 +18,8 @@ log = logging.getLogger(__name__)
 
 OPTS_EXCEPTIONS = [
     'com.docker.network.driver.overlay.vxlanid_list',
-    'com.docker.network.windowsshim.hnsid'
+    'com.docker.network.windowsshim.hnsid',
+    'com.docker.network.windowsshim.networkname'
 ]
 
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -493,7 +493,7 @@ class Project(object):
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, silent=silent)
+                service.pull(ignore_pull_failures, True)
 
             parallel.parallel_execute(
                 services,

--- a/compose/project.py
+++ b/compose/project.py
@@ -493,7 +493,7 @@ class Project(object):
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, True)
+                service.pull(ignore_pull_failures, True, silent=silent)
 
             parallel.parallel_execute(
                 services,

--- a/compose/project.py
+++ b/compose/project.py
@@ -493,7 +493,7 @@ class Project(object):
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, True, silent=silent)
+                service.pull(ignore_pull_failures, silent=silent)
 
             parallel.parallel_execute(
                 services,

--- a/script/build/test-image
+++ b/script/build/test-image
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    >&2 echo "First argument must be image tag."
+    exit 1
+fi
+
+TAG=$1
+
+docker build -t docker-compose-tests:tmp .
+ctnr_id=$(docker create --entrypoint=tox docker-compose-tests:tmp)
+docker commit $ctnr_id docker/compose-tests:latest
+docker tag docker/compose-tests:latest docker/compose-tests:$TAG
+docker rm -f $ctnr_id
+docker rmi -f docker-compose-tests:tmp

--- a/script/release/build-binaries
+++ b/script/release/build-binaries
@@ -27,6 +27,9 @@ script/build/linux
 echo "Building the container distribution"
 script/build/image $VERSION
 
+echo "Building the compose-tests image"
+script/build/test-image $VERSION
+
 echo "Create a github release"
 # TODO: script more of this https://developer.github.com/v3/repos/releases/
 browser https://github.com/$REPO/releases/new

--- a/script/release/push-release
+++ b/script/release/push-release
@@ -54,6 +54,10 @@ git push $GITHUB_REPO $VERSION
 echo "Uploading the docker image"
 docker push docker/compose:$VERSION
 
+echo "Uploading the compose-tests image"
+docker push docker/compose-tests:latest
+docker push docker/compose-tests:$VERSION
+
 echo "Uploading package to PyPI"
 pandoc -f markdown -t rst README.md -o README.rst
 sed -i -e 's/logo.png?raw=true/https:\/\/github.com\/docker\/compose\/raw\/master\/logo.png?raw=true/' README.rst

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.15.0-rc1"
+VERSION="1.15.0"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/tests/fixtures/ports-composefile/expanded-notation.yml
+++ b/tests/fixtures/ports-composefile/expanded-notation.yml
@@ -6,10 +6,10 @@ services:
       ports:
         - target: 3000
         - target: 3001
-          published: 49152
+          published: 53222
         - target: 3002
-          published: 49153
+          published: 53223
           protocol: tcp
         - target: 3003
-          published: 49154
+          published: 53224
           protocol: udp

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import functools
 import os
-
-from docker.errors import APIError
-from pytest import skip
 
 from compose.config.config import ConfigDetails
 from compose.config.config import ConfigFile
@@ -48,34 +44,3 @@ def create_host_file(client, filename):
                 "Container exited with code {}:\n{}".format(exitcode, output))
     finally:
         client.remove_container(container, force=True)
-
-
-def is_cluster(client):
-    nodes = None
-
-    def get_nodes_number():
-        try:
-            return len(client.nodes())
-        except APIError:
-            # If the Engine is not part of a Swarm, the SDK will raise
-            # an APIError
-            return 0
-
-    if nodes is None:
-        # Only make the API call if the value hasn't been cached yet
-        nodes = get_nodes_number()
-
-    return nodes > 1
-
-
-def no_cluster(reason):
-    def decorator(f):
-        @functools.wraps(f)
-        def wrapper(self, *args, **kwargs):
-            if is_cluster(self.client):
-                skip("Test will not be run in cluster mode: %s" % reason)
-                return
-            return f(self, *args, **kwargs)
-        return wrapper
-
-    return decorator

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -12,8 +12,6 @@ from docker.errors import NotFound
 from .. import mock
 from ..helpers import build_config as load_config
 from ..helpers import create_host_file
-from ..helpers import is_cluster
-from ..helpers import no_cluster
 from .testcases import DockerClientTestCase
 from .testcases import SWARM_SKIP_CONTAINERS_ALL
 from compose.config import config
@@ -33,6 +31,8 @@ from compose.errors import NoHealthCheckConfigured
 from compose.project import Project
 from compose.project import ProjectError
 from compose.service import ConvergenceStrategy
+from tests.integration.testcases import is_cluster
+from tests.integration.testcases import no_cluster
 from tests.integration.testcases import v2_1_only
 from tests.integration.testcases import v2_2_only
 from tests.integration.testcases import v2_only

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -30,6 +30,7 @@ from compose.const import LABEL_ONE_OFF
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
 from compose.const import LABEL_VERSION
+from compose.const import IS_WINDOWS_PLATFORM
 from compose.container import Container
 from compose.errors import OperationFailedError
 from compose.project import OneOffFilter

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -30,7 +30,6 @@ from compose.const import LABEL_ONE_OFF
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
 from compose.const import LABEL_VERSION
-from compose.const import IS_WINDOWS_PLATFORM
 from compose.container import Container
 from compose.errors import OperationFailedError
 from compose.project import OneOffFilter

--- a/tests/integration/testcases.py
+++ b/tests/integration/testcases.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import functools
 import os
 
 import pytest
+from docker.errors import APIError
 from docker.utils import version_lt
 
 from .. import unittest
-from ..helpers import is_cluster
 from compose.cli.docker_client import docker_client
 from compose.config.config import resolve_environment
 from compose.config.environment import Environment
@@ -26,6 +27,7 @@ from compose.service import Service
 SWARM_SKIP_CONTAINERS_ALL = os.environ.get('SWARM_SKIP_CONTAINERS_ALL', '0') != '0'
 SWARM_SKIP_CPU_SHARES = os.environ.get('SWARM_SKIP_CPU_SHARES', '0') != '0'
 SWARM_SKIP_RM_VOLUMES = os.environ.get('SWARM_SKIP_RM_VOLUMES', '0') != '0'
+SWARM_ASSUME_MULTINODE = os.environ.get('SWARM_ASSUME_MULTINODE', '0') != '0'
 
 
 def pull_busybox(client):
@@ -142,3 +144,35 @@ class DockerClientTestCase(unittest.TestCase):
         volumes = self.client.volumes(filters={'name': volume_name})['Volumes']
         assert len(volumes) > 0
         return self.client.inspect_volume(volumes[0]['Name'])
+
+
+def is_cluster(client):
+    if SWARM_ASSUME_MULTINODE:
+        return True
+
+    def get_nodes_number():
+        try:
+            return len(client.nodes())
+        except APIError:
+            # If the Engine is not part of a Swarm, the SDK will raise
+            # an APIError
+            return 0
+
+    if not hasattr(is_cluster, 'nodes') or is_cluster.nodes is None:
+        # Only make the API call if the value hasn't been cached yet
+        is_cluster.nodes = get_nodes_number()
+
+    return is_cluster.nodes > 1
+
+
+def no_cluster(reason):
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            if is_cluster(self.client):
+                pytest.skip("Test will not be run in cluster mode: %s" % reason)
+                return
+            return f(self, *args, **kwargs)
+        return wrapper
+
+    return decorator

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 from docker.errors import DockerException
 
-from ..helpers import no_cluster
 from .testcases import DockerClientTestCase
+from .testcases import no_cluster
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_VOLUME
 from compose.volume import Volume

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ passenv =
     DOCKER_CERT_PATH
     DOCKER_TLS_VERIFY
     DOCKER_VERSION
+    SWARM_SKIP_*
+    SWARM_ASSUME_MULTINODE
 setenv =
     HOME=/tmp
 deps =


### PR DESCRIPTION
### New features

#### Compose file version 2.2

- Added support for the `network` parameter in build configurations.

#### Compose file version 2.1 and up

- The `pid` option in a service's definition now supports a `service:<name>`
  value.

- Added support for the `storage_opt` parameter in in service definitions.
  This option is not available for the v3 format

#### All formats

- Added `--quiet` flag to `docker-compose pull`, suppressing progress output

- Some improvements to CLI output

### Bugfixes

- Volumes specified through the `--volume` flag of `docker-compose run` now
  complement volumes declared in the service's defintion instead of replacing
  them

- Fixed a bug where using multiple Compose files would unset the scale value
  defined inside the Compose file.

- Fixed an issue where the `credHelpers` entries in the `config.json` file
  were not being honored by Compose

- Fixed a bug where using multiple Compose files with port declarations
  would cause failures in Python 3 environments

- Fixed a bug where some proxy-related options present in the user's
  environment would prevent Compose from running

- Fixed an issue where the output of `docker-compose config` would be invalid
  if the original file used `Y` or `N` values

- Fixed an issue preventing `up` operations on a previously created stack on
  Windows Engine.