### PR TITLE
only require colorama on windows

### DIFF
--- a/compose/cli/colors.py
+++ b/compose/cli/colors.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import colorama
+from ..const import IS_WINDOWS_PLATFORM
 
 NAMES = [
     'grey',
@@ -33,7 +33,9 @@ def make_color_fn(code):
     return lambda s: ansi_color(code, s)
 
 
-colorama.init(strip=False)
+if IS_WINDOWS_PLATFORM:
+    import colorama
+    colorama.init(strip=False)
 for (name, code) in get_pairs():
     globals()[name] = make_color_fn(code)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
-colorama==0.3.9
+colorama==0.3.9; sys_platform == 'win32'
 docker==2.4.2
 docker-pycreds==0.2.1
 dockerpty==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ def find_version(*file_paths):
 
 install_requires = [
     'cached-property >= 1.2.0, < 2',
-    'colorama >= 0.3.7, < 0.4',
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
     'requests >= 2.6.1, != 2.11.0, < 2.12',
@@ -56,6 +55,7 @@ extras_require = {
     ':python_version < "3.4"': ['enum34 >= 1.0.4, < 2'],
     ':python_version < "3.5"': ['backports.ssl_match_hostname >= 3.5'],
     ':python_version < "3.3"': ['ipaddress >= 1.0.16'],
+    ':sys_platform == "win32"': ['colorama >= 0.3.7, < 0.4'],
     'socks': ['PySocks >= 1.5.6, != 1.5.7, < 2'],
 }
 


### PR DESCRIPTION
Colorama is only useful on Windows by design.  Since it has no effect on other platforms, it makes sense to not require it universially.