### PR TITLE
Add COMPOSE_PROJECT_DIRECTORY env cli variablie

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -34,7 +34,7 @@ def project_from_options(project_dir, options):
         host=host,
         tls_config=tls_config_from_options(options),
         environment=environment,
-        override_dir=options.get('--project-directory'),
+        override_dir=options.get('--project-directory') or environment.get('COMPOSE_PROJECT_DIRECTORY'),
     )
 
 


### PR DESCRIPTION
Be able to get correct project name from directory in cases where
docker-compose file(s) are included from sub directories, without having
to always specify `--project-directory` in all commands.

Fixes #5058 

Note, this does not depend on #5026, however the use cases around this will be a lot easier with both these two in.