### PR TITLE
Prevent null logging options in `docker-compose config` output

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1044,8 +1044,8 @@ def merge_logging(base, override):
     md.merge_scalar('driver')
     if md.get('driver') == base.get('driver') or base.get('driver') is None:
         md.merge_mapping('options', lambda m: m or {})
-    else:
-        md['options'] = override.get('options')
+    elif override.get('options'):
+        md['options'] = override.get('options', {})
     return dict(md)
 
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1864,7 +1864,6 @@ class ConfigTest(unittest.TestCase):
             'image': 'alpine:edge',
             'logging': {
                 'driver': 'syslog',
-                'options': None
             }
         }
 


### PR DESCRIPTION
Fix #5097 