### PR TITLE
add errors detail message for up project failure

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -454,7 +454,8 @@ class Project(object):
         )
         if errors:
             raise ProjectError(
-                'Encountered errors while bringing up the project.'
+                'Encountered errors while bringing up the project.\n{0}'.format
+                ('\n'.join(['\t{0}: {1}'.format(service, error) for service, error in errors.items()]))
             )
 
         return [


### PR DESCRIPTION
we find out that if we got a failure of `docker-compose up`, we cannot get the detail errors from log or stdout, this is not good for us maybe also other compose users, we hope compose maintainers could accept this PR for improving this problem. thanks~