### PR TITLE
Enable environment variable chaining

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -82,10 +82,12 @@ class TemplateWithDefaults(Template):
             if named is not None:
                 if ':-' in named:
                     var, _, default = named.partition(':-')
-                    return mapping.get(var) or default
+                    interpolated = self.__class__(default).substitute(mapping)
+                    return mapping.get(var) or interpolated or default
                 if '-' in named:
                     var, _, default = named.partition('-')
-                    return mapping.get(var, default)
+                    interpolated = self.__class__(default).substitute(mapping)
+                    return mapping.get(var, interpolated or default)
                 val = mapping[named]
                 return '%s' % (val,)
             if mo.group('escaped') is not None:

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -146,3 +146,9 @@ def test_interpolate_missing_with_default(defaults_interpolator):
 def test_interpolate_with_empty_and_default_value(defaults_interpolator):
     assert defaults_interpolator("ok ${BAR:-def}") == "ok def"
     assert defaults_interpolator("ok ${BAR-def}") == "ok "
+
+
+def test_interpolate_with_chained_fallback_variables(defaults_interpolator):
+    assert defaults_interpolator("ok ${BAR:-$FOO}") == "ok first"
+    assert defaults_interpolator("ok ${BAR:-$BAZ:-$FOO}") == "ok first"
+    assert defaults_interpolator("ok ${BAR-$FOO}") == "ok "


### PR DESCRIPTION
closes #4836

This patch let users to set things like...

```
services:
    mysql:
        image: mysql
        enviroment:
            MYSQL_PASSWORD: default_password
            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-$MYSQL_PASSWORD}
```

signed-off-by: Evandro Oliveira <evandrofranco@gmail.com>