### PR TITLE
Rename 3.4 schema to 3.4-beta

### DIFF
--- a/compose/config/config_schema_v3.4-beta.json
+++ b/compose/config/config_schema_v3.4-beta.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "config_schema_v3.4.json",
+  "id": "config_schema_v3.4-beta.json",
   "type": "object",
   "required": ["version"],
 

--- a/compose/const.py
+++ b/compose/const.py
@@ -31,7 +31,7 @@ COMPOSEFILE_V3_0 = ComposeVersion('3.0')
 COMPOSEFILE_V3_1 = ComposeVersion('3.1')
 COMPOSEFILE_V3_2 = ComposeVersion('3.2')
 COMPOSEFILE_V3_3 = ComposeVersion('3.3')
-COMPOSEFILE_V3_4 = ComposeVersion('3.4')
+COMPOSEFILE_V3_4 = ComposeVersion('3.4-beta')
 
 API_VERSIONS = {
     COMPOSEFILE_V1: '1.21',

--- a/docker-compose.spec
+++ b/docker-compose.spec
@@ -63,6 +63,11 @@ exe = EXE(pyz,
                 'DATA'
             ),
             (
+                'compose/config/config_schema_v3.4-beta.json',
+                'compose/config/config_schema_v3.4-beta.json',
+                'DATA'
+            ),
+            (
                 'compose/GITSHA',
                 'compose/GITSHA',
                 'DATA'


### PR DESCRIPTION
On the Docker Engine side, the 3.4 format is still in development until the 17.08 release. This change will let people use the current version using the `3.4-beta` version marker.

Also adding the schema to `docker-compose.spec`, fixes #5128 
