### PR TITLE
Add bash completion for `--no-ansi`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -179,7 +179,7 @@ _docker_compose_docker_compose() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "$top_level_boolean_options  $top_level_options_with_args --help -h --verbose --version -v" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "$top_level_boolean_options $top_level_options_with_args --help -h --no-ansi --verbose --version -v" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "${commands[*]}" -- "$cur" ) )
@@ -569,8 +569,10 @@ _docker_compose() {
 		version
 	)
 
-	# options for the docker daemon that have to be passed to secondary calls to
-	# docker-compose executed by this script
+	# Options for the docker daemon that have to be passed to secondary calls to
+	# docker-compose executed by this script.
+	# Other global otions that are not relevant for secondary calls are defined in
+	# `_docker_compose_docker_compose`.
 	local top_level_boolean_options="
 		--skip-hostname-check
 		--tls


### PR DESCRIPTION
This adds bash completion for #5093.

Also added a comment to make clear why there are two places where global options are defined.

Please add this to _v1.16.0_ as the corresponding feature is added in that release.