### PR TITLE
Bump 1.16.0 rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,12 @@ Change log
 
 ### New features
 
-#### Compose file version 3.4
-
-- Introduced version 3.4 of the `docker-compose.yml` specification.
-  This version requires to be used with Docker Engine 17.06.0 or above.
-
 #### Compose file version 2.3
 
 - Introduced version 2.3 of the `docker-compose.yml` specification.
   This version requires to be used with Docker Engine 17.06.0 or above.
 
 - Added support for the `target` parameter in network configurations
-  (also available in 3.4)
 
 - Added support for the `start_period` parameter in healthcheck
   configurations
@@ -44,6 +38,9 @@ Change log
 - Fixed issues where logs of TTY-enabled services were being printed
   incorrectly and causing `MemoryError` exceptions
 
+- Fixed a bug where printing application logs would sometimes be interrupted
+  by a `UnicodeEncodeError` exception on Python 3
+
 - The `$` character in the output of `docker-compose config` is now
   properly escaped
 
@@ -57,6 +54,9 @@ Change log
 
 - Fixed an issue where the `logging` options in the output of
   `docker-compose config` would be set to `null`, an invalid value
+
+- Fixed the output of the `docker-compose images` command when an image
+  would come from a private repository using an explicit port number
 
 - Fixed the output of `docker-compose config` when a port definition used
   `0` as the value for the published port

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.16.0-rc1'
+__version__ = '1.16.0-rc2'

--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -102,8 +102,18 @@ class LogPrinter(object):
                 # active containers to tail, so continue
                 continue
 
+            self.write(line)
+
+    def write(self, line):
+        try:
             self.output.write(line)
-            self.output.flush()
+        except UnicodeEncodeError:
+            # This may happen if the user's locale settings don't support UTF-8
+            # and UTF-8 characters are present in the log line. The following
+            # will output a "degraded" log with unsupported characters
+            # replaced by `?`
+            self.output.write(line.encode('ascii', 'replace').decode())
+        self.output.flush()
 
 
 def remove_stopped_threads(thread_map):

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -506,7 +506,7 @@ class TopLevelCommand(object):
             rows = []
             for container in containers:
                 image_config = container.image_config
-                repo_tags = image_config['RepoTags'][0].split(':')
+                repo_tags = image_config['RepoTags'][0].rsplit(':', 1)
                 image_id = image_config['Id'].split(':')[1][:12]
                 size = human_readable_file_size(image_config['Size'])
                 rows.append([

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -97,8 +97,10 @@ def dispatch():
         {'options_first': True, 'version': get_version_info('compose')})
 
     options, handler, command_options = dispatcher.parse(sys.argv[1:])
-    setup_console_handler(console_handler, options.get('--verbose'))
+    setup_console_handler(console_handler, options.get('--verbose'), options.get('--no-ansi'))
     setup_parallel_logger(options.get('--no-ansi'))
+    if options.get('--no-ansi'):
+        command_options['--no-color'] = True
     return functools.partial(perform_command, options, handler, command_options)
 
 
@@ -134,8 +136,8 @@ def setup_parallel_logger(noansi):
         compose.parallel.ParallelStreamWriter.set_noansi()
 
 
-def setup_console_handler(handler, verbose):
-    if handler.stream.isatty():
+def setup_console_handler(handler, verbose, noansi=False):
+    if handler.stream.isatty() and noansi is False:
         format_class = ConsoleWarningFormatter
     else:
         format_class = logging.Formatter

--- a/compose/config/config_schema_v3.4-beta.json
+++ b/compose/config/config_schema_v3.4-beta.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "config_schema_v3.4.json",
+  "id": "config_schema_v3.4-beta.json",
   "type": "object",
   "required": ["version"],
 

--- a/compose/const.py
+++ b/compose/const.py
@@ -31,7 +31,7 @@ COMPOSEFILE_V3_0 = ComposeVersion('3.0')
 COMPOSEFILE_V3_1 = ComposeVersion('3.1')
 COMPOSEFILE_V3_2 = ComposeVersion('3.2')
 COMPOSEFILE_V3_3 = ComposeVersion('3.3')
-COMPOSEFILE_V3_4 = ComposeVersion('3.4')
+COMPOSEFILE_V3_4 = ComposeVersion('3.4-beta')
 
 API_VERSIONS = {
     COMPOSEFILE_V1: '1.21',

--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -49,16 +49,16 @@ def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None):
 
     for obj, result, exception in events:
         if exception is None:
-            writer.write(get_name(obj), green('done'))
+            writer.write(get_name(obj), 'done', green)
             results.append(result)
         elif isinstance(exception, APIError):
             errors[get_name(obj)] = exception.explanation
-            writer.write(get_name(obj), red('error'))
+            writer.write(get_name(obj), 'error', red)
         elif isinstance(exception, (OperationFailedError, HealthCheckFailed, NoHealthCheckConfigured)):
             errors[get_name(obj)] = exception.msg
-            writer.write(get_name(obj), red('error'))
+            writer.write(get_name(obj), 'error', red)
         elif isinstance(exception, UpstreamError):
-            writer.write(get_name(obj), red('error'))
+            writer.write(get_name(obj), 'error', red)
         else:
             errors[get_name(obj)] = exception
             error_to_reraise = exception
@@ -263,13 +263,13 @@ class ParallelStreamWriter(object):
                           status, width=self.width))
         self.stream.flush()
 
-    def write(self, obj_index, status):
+    def write(self, obj_index, status, color_func):
         if self.msg is None:
             return
         if self.noansi:
             self._write_noansi(obj_index, status)
         else:
-            self._write_ansi(obj_index, status)
+            self._write_ansi(obj_index, color_func(status))
 
 
 def parallel_operation(containers, operation, options, message):

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -179,7 +179,7 @@ _docker_compose_docker_compose() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "$top_level_boolean_options  $top_level_options_with_args --help -h --verbose --version -v" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "$top_level_boolean_options $top_level_options_with_args --help -h --no-ansi --verbose --version -v" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "${commands[*]}" -- "$cur" ) )
@@ -569,8 +569,10 @@ _docker_compose() {
 		version
 	)
 
-	# options for the docker daemon that have to be passed to secondary calls to
-	# docker-compose executed by this script
+	# Options for the docker daemon that have to be passed to secondary calls to
+	# docker-compose executed by this script.
+	# Other global otions that are not relevant for secondary calls are defined in
+	# `_docker_compose_docker_compose`.
 	local top_level_boolean_options="
 		--skip-hostname-check
 		--tls

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -149,7 +149,7 @@ _docker_compose_config() {
 _docker_compose_create() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--force-recreate --help --no-build --no-recreate" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--build --force-recreate --help --no-build --no-recreate" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all

--- a/docker-compose.spec
+++ b/docker-compose.spec
@@ -63,6 +63,11 @@ exe = EXE(pyz,
                 'DATA'
             ),
             (
+                'compose/config/config_schema_v3.4-beta.json',
+                'compose/config/config_schema_v3.4-beta.json',
+                'DATA'
+            ),
+            (
                 'compose/GITSHA',
                 'compose/GITSHA',
                 'DATA'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
 colorama==0.3.9; sys_platform == 'win32'
-docker==2.5.0
+docker==2.5.1
 docker-pycreds==0.2.1
 dockerpty==0.4.1
 docopt==0.6.2

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.16.0"
+VERSION="1.16.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, < 2.12',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker >= 2.5.0, < 3.0',
+    'docker >= 2.5.1, < 3.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -133,17 +133,31 @@ def test_parallel_execute_alignment(capsys):
     assert a.index('...') == b.index('...')
 
 
-def test_parallel_execute_alignment_noansi(capsys):
-    ParallelStreamWriter.set_noansi()
+def test_parallel_execute_ansi(capsys):
+    ParallelStreamWriter.set_noansi(value=False)
     results, errors = parallel_execute(
-        objects=["short", "a very long name"],
+        objects=["something", "something more"],
         func=lambda x: x,
         get_name=six.text_type,
-        msg="Aligning",
+        msg="Control characters",
     )
 
     assert errors == {}
 
     _, err = capsys.readouterr()
-    a, b, c, d = err.split('\n')[:4]
-    assert a.index('...') == b.index('...') == c.index('...') == d.index('...')
+    assert "\x1b" in err
+
+
+def test_parallel_execute_noansi(capsys):
+    ParallelStreamWriter.set_noansi()
+    results, errors = parallel_execute(
+        objects=["something", "something more"],
+        func=lambda x: x,
+        get_name=six.text_type,
+        msg="Control characters",
+    )
+
+    assert errors == {}
+
+    _, err = capsys.readouterr()
+    assert "\x1b" not in err


### PR DESCRIPTION
### New features

#### Compose file version 2.3

- Introduced version 2.3 of the `docker-compose.yml` specification.
  This version requires to be used with Docker Engine 17.06.0 or above.

- Added support for the `target` parameter in network configurations

- Added support for the `start_period` parameter in healthcheck
  configurations

#### Compose file version 2.x

- Added support for the `blkio_config` parameter in service definitions

- Added support for setting a custom name in volume definitions using
  the `name` parameter (not available for version 2.0)

#### All formats

- Added new CLI flag `--no-ansi` to suppress ANSI control characters in
  output

### Bugfixes

- Fixed a bug where nested `extends` instructions weren't resolved
  properly, causing "file not found" errors

- Fixed several issues with `.dockerignore` parsing

- Fixed issues where logs of TTY-enabled services were being printed
  incorrectly and causing `MemoryError` exceptions

- Fixed a bug where printing application logs would sometimes be interrupted
  by a `UnicodeEncodeError` exception on Python 3

- The `$` character in the output of `docker-compose config` is now
  properly escaped

- Fixed a bug where running `docker-compose top` would sometimes fail
  with an uncaught exception

- Fixed a bug where `docker-compose pull` with the `--parallel` flag
  would return a `0` exit code when failing

- Fixed an issue where keys in `deploy.resources` were not being validated

- Fixed an issue where the `logging` options in the output of
  `docker-compose config` would be set to `null`, an invalid value

- Fixed the output of the `docker-compose images` command when an image
  would come from a private repository using an explicit port number

- Fixed the output of `docker-compose config` when a port definition used
  `0` as the value for the published port