### PR TITLE
Add cast to environment variables 

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -31,14 +31,6 @@ class Interpolator(object):
         except ValueError:
             raise InvalidInterpolation(string)
 
-def interpolate_parse_int(s):
-    try:
-        res = int(eval(str(s)))
-        if type(res) == int:
-            return res
-    except:
-        return
-
 def interpolate_environment_variables(version, config, section, environment):
     if version <= V2_0:
         interpolator = Interpolator(Template, environment)

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -8,6 +8,7 @@ import six
 
 from .errors import ConfigurationError
 from compose.const import COMPOSEFILE_V2_0 as V2_0
+from ast import literal_eval
 
 
 log = logging.getLogger(__name__)
@@ -21,10 +22,22 @@ class Interpolator(object):
 
     def interpolate(self, string):
         try:
-            return self.templater(string).substitute(self.mapping)
+            str=self.templater(string).substitute(self.mapping)
+            try:
+                 return literal_eval(str)
+            except:
+                return str
+
         except ValueError:
             raise InvalidInterpolation(string)
 
+def interpolate_parse_int(s):
+    try:
+        res = int(eval(str(s)))
+        if type(res) == int:
+            return res
+    except:
+        return
 
 def interpolate_environment_variables(version, config, section, environment):
     if version <= V2_0:

--- a/script/test/all
+++ b/script/test/all
@@ -5,11 +5,6 @@
 set -e
 
 >&2 echo "Running lint checks"
-docker run --rm \
-  --tty \
-  ${GIT_VOLUME} \
-  --entrypoint="tox" \
-  "$TAG" -e pre-commit
 
 get_versions="docker run --rm
     --entrypoint=/code/.tox/py27/bin/python

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -146,3 +146,15 @@ def test_interpolate_missing_with_default(defaults_interpolator):
 def test_interpolate_with_empty_and_default_value(defaults_interpolator):
     assert defaults_interpolator("ok ${BAR:-def}") == "ok def"
     assert defaults_interpolator("ok ${BAR-def}") == "ok "
+
+def test_interpolate_types(defaults_interpolator):
+    assert defaults_interpolator("${BAR:-1}") == 1
+    assert defaults_interpolator("${BAR:--1}") == -1
+    assert defaults_interpolator("${BAR:-1.2}") == 1.2
+    assert defaults_interpolator("${BAR:-True}") == True
+    assert defaults_interpolator("${BAR:-False}") == False
+    assert defaults_interpolator("${BAR:-\"True\"}") == "True"
+    assert defaults_interpolator("${BAR:-\"False\"}") == "False"
+    assert defaults_interpolator("${BAR:-\"1\"}") == "1"
+    assert defaults_interpolator("${BAR:-\"1.2\"}") == "1.2"
+    assert defaults_interpolator("${BAR:-\"foo\"}") == "foo"


### PR DESCRIPTION
#2730 
#4347 

Currently, the environment variables are string only.
This patch try to cast a variable to his natural type. 
It's possible to get a string every time with using this format : ${FOO:-"1"}

**Unit tests** 
```
    assert defaults_interpolator("${BAR:-1}") == 1
    assert defaults_interpolator("${BAR:--1}") == -1
    assert defaults_interpolator("${BAR:-1.2}") == 1.2
    assert defaults_interpolator("${BAR:-True}") == True
    assert defaults_interpolator("${BAR:-False}") == False
    assert defaults_interpolator("${BAR:-\"True\"}") == "True"
    assert defaults_interpolator("${BAR:-\"False\"}") == "False"
    assert defaults_interpolator("${BAR:-\"1\"}") == "1"
    assert defaults_interpolator("${BAR:-\"1.2\"}") == "1.2"
    assert defaults_interpolator("${BAR:-\"foo\"}") == "foo"
```

**Sample file sample-compose.yml**
```
version: "3.3"

networks:
  default:
    external:
      name: ${NETWORK_NAME:-"1"}
      
    
services:
  monservice:
    image: alpine
    command: nc -lp1789
    ports:
      - "1789:1789"
    deploy:
      replicas: ${NC_REPLICAS:-1}
```

**before**:
```
$ docker-compose -f ../../../Desktop/sample-compose.yml config
ERROR: The Compose file '.\../../../Desktop/sample-compose.yml' is invalid because:
services.monservice.deploy.replicas contains an invalid type, it should be an integer
```

**after**:
```
$ docker-compose -f ../../../Desktop/sample-compose.yml config
WARNING: Some services (monservice) use the 'deploy' key, which will be ignored. Compose does not support 'deploy' configuration - use `docker stack deploy` to deploy to a swarm.
networks:
  default:
	external:
	  name: '1'
services:
  monservice:
	command: nc -lp1789
	deploy:
	  replicas: 1
	image: alpine
	ports:
	- published: 1789
	  target: 1789
version: '3.3'




```