### PR TITLE
Add --no-labels option in docker-compose run

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -729,6 +729,10 @@ class TopLevelCommand(object):
         running. If you do not want to start linked services, use
         `docker-compose run --no-deps SERVICE COMMAND [ARGS...]`.
 
+        Same for labels, by default, defined labels will be used.
+        If you do not want to use labels, use
+        `docker-compose run --no-labels SERVICE COMMAND [ARGS...]`.
+
         Usage: run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] SERVICE [COMMAND] [ARGS...]
 
         Options:
@@ -747,6 +751,7 @@ class TopLevelCommand(object):
             -T                    Disable pseudo-tty allocation. By default `docker-compose run`
                                   allocates a TTY.
             -w, --workdir=""      Working directory inside the container
+            --no-labels           Remove defined labels
         """
         service = self.project.get_service(options['SERVICE'])
         detach = options['-d']
@@ -1155,6 +1160,9 @@ def build_container_options(options, detach, command):
     if options['--volume']:
         volumes = [VolumeSpec.parse(i) for i in options['--volume']]
         container_options['volumes'] = volumes
+
+    if options['--no-labels']:
+        container_options['labels'] = []
 
     return container_options
 

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -123,6 +123,7 @@ class CLITestCase(unittest.TestCase):
                 '--rm': None,
                 '--name': None,
                 '--workdir': None,
+                '--no-labels': None,
             })
 
         _, _, call_kwargs = mock_run_operation.mock_calls[0]
@@ -158,6 +159,7 @@ class CLITestCase(unittest.TestCase):
             '--rm': None,
             '--name': None,
             '--workdir': None,
+            '--no-labels': None,
         })
 
         self.assertEqual(
@@ -181,6 +183,7 @@ class CLITestCase(unittest.TestCase):
             '--rm': True,
             '--name': None,
             '--workdir': None,
+            '--no-labels': None,
         })
 
         self.assertFalse(


### PR DESCRIPTION
Signed-off-by: Jimmy Leger <jimmy.leger@gmail.com>

**- What I did**

I add the `--no-labels` option to `docker-compose run`.

**- Why I did it**

The labels defined in the service configuration can create some conflicts with other services.

By example, I used `traefik` has proxy therefore I add the following label `traefik.enable=true` in the service configuration but if I want to run a one-off command on my service (e.g `docker-compose run --rm my-service rake db:create`) traefik will reference this container as a new backend which will create some issues on the proxy.

The aim of this option is to remove defined labels in the service configuration.

**- How to verify it**

1. Create a docker-compose.yml

```yaml
services:
  web:
    image: nginx:alpine
    labels:
      - foo=bar
```

2. Run the service and inspect labels

```bash
$ docker-compose up -d
Creating labeltest_web_1 ...
Creating labeltest_web_1 ... done
$ docker inspect labeltest_web_1 -f '{{json .Config.Labels }}' | jq ''
{
  "com.docker.compose.config-hash": "788a61f4d19633ae7248d96a4101a82ec9bfac3072909b828e70dd880b220d69",
  "com.docker.compose.container-number": "1",
  "com.docker.compose.oneoff": "False",
  "com.docker.compose.project": "labeltest",
  "com.docker.compose.service": "web",
  "com.docker.compose.version": "1.17.0dev",
  "foo": "bar"
}
```

4. Run a one-off command on the service


```bash
$ docker-compose run -d web top
$ docker inspect labeltest_web_run_1 -f '{{json .Config.Labels }}' | jq ''
{
  "com.docker.compose.container-number": "1",
  "com.docker.compose.oneoff": "True",
  "com.docker.compose.project": "labeltest",
  "com.docker.compose.service": "web",
  "com.docker.compose.version": "1.17.0dev",
  "foo": "bar"
}
```

5. Run a one-off command on the service with --no-labels option

```bash
$ docker-compose run --d --no-labels web top
$ docker inspect labeltest_web_run_2 -f '{{json .Config.Labels }}' | jq ''
{
  "com.docker.compose.container-number": "2",
  "com.docker.compose.oneoff": "True",
  "com.docker.compose.project": "labeltest",
  "com.docker.compose.service": "web",
  "com.docker.compose.version": "1.17.0dev"
}
```