### PR TITLE
Make result of docker-compose config with order

### DIFF
--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -5,6 +5,7 @@ import codecs
 import contextlib
 import logging
 import os
+from collections import OrderedDict
 
 import six
 
@@ -31,7 +32,7 @@ def env_vars_from_file(filename):
         raise ConfigurationError("Couldn't find env file: %s" % filename)
     elif not os.path.isfile(filename):
         raise ConfigurationError("%s is not a file." % (filename))
-    env = {}
+    env = OrderedDict()
     with contextlib.closing(codecs.open(filename, 'r', 'utf-8')) as fileobj:
         for line in fileobj:
             line = line.strip()

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
+from collections import OrderedDict
 from string import Template
 
 import six
@@ -33,12 +34,12 @@ def interpolate_environment_variables(version, config, section, environment):
         interpolator = Interpolator(TemplateWithDefaults, environment)
 
     def process_item(name, config_dict):
-        return dict(
+        return OrderedDict(
             (key, interpolate_value(name, key, val, section, interpolator))
             for key, val in (config_dict or {}).items()
         )
 
-    return dict(
+    return OrderedDict(
         (name, process_item(name, config_dict or {}))
         for name, config_dict in config.items()
     )
@@ -61,7 +62,7 @@ def recursive_interpolate(obj, interpolator):
     if isinstance(obj, six.string_types):
         return interpolator.interpolate(obj)
     if isinstance(obj, dict):
-        return dict(
+        return OrderedDict(
             (key, recursive_interpolate(val, interpolator))
             for (key, val) in obj.items()
         )


### PR DESCRIPTION
Signed-off-by: Li Yi <denverdino@gmail.com>

In current implementation, the config is using the dict, so the order for the result of ```docker-compose config``` is not ensured. 

In this PR, we replace the dict with OrderedDict, so we can make the result of docker-compose config consistent with the original template