### PR TITLE
Simple patch to allow s390x images to be built

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,0 +1,6 @@
+FROM s390x/python:3.6.2-slim
+ARG COMPOSE_VERSION=1.16.1
+
+RUN pip install --no-cache-dir docker-compose==$COMPOSE_VERSION
+
+ENTRYPOINT ["docker-compose"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,6 +1,15 @@
-FROM s390x/python:3.6.2-slim
+FROM s390x/alpine:3.6
+
 ARG COMPOSE_VERSION=1.16.1
 
-RUN pip install --no-cache-dir docker-compose==$COMPOSE_VERSION
+RUN apk add --update --no-cache \
+    python \
+    py-pip \
+  && pip install --no-cache-dir docker-compose==$COMPOSE_VERSION \
+  && rm -rf /var/cache/apk/*
+
+WORKDIR /data
+VOLUME /data
+
 
 ENTRYPOINT ["docker-compose"]


### PR DESCRIPTION
Needs integration with CI and s390x machine integration
Build is currently manual and will need full CI integration or better build. 
Pyinstaller currently doesn't support Z machine thus can't build the compact binary.

/cc @shin- 