### PR TITLE
Fix secret location with absolute paths

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -880,9 +880,12 @@ class Service(object):
 
     def get_secret_volumes(self):
         def build_spec(secret):
-            target = '{}/{}'.format(
-                const.SECRETS_PATH,
-                secret['secret'].target or secret['secret'].source)
+            if secret['secret'].target is not None and secret['secret'].target.startswith('/'):
+                target = secret['secret'].target
+            else:
+                target = '{}/{}'.format(
+                    const.SECRETS_PATH,
+                    secret['secret'].target or secret['secret'].source)
             return VolumeSpec(secret['file'], target, 'ro')
 
         return [build_spec(secret) for secret in self.secrets]


### PR DESCRIPTION
With the following service:
```
  db:
    container_name: db
    image: mysql:8.0
    secrets:
      - source: mysql_init_sql
        target: /docker-entrypoint-initdb.d/init.sql
```

I would expect to find the `mysql_init_sql` secret as a file in `/docker-entrypoint-initdb.d/init.sql`. In the latest version of docker-compose this does not happen due to a bug and the secret is mounted incorrectly under `/run/secrets/docker-entrypoint-initdb.d/init.sql`. With this pull request the secrets are placed in the correct folder if the user specifies an absolute path in the `target` field