### PR TITLE
[cli] Lift artificial limitation on --build-arg

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -230,19 +230,15 @@ class TopLevelCommand(object):
             --force-rm              Always remove intermediate containers.
             --no-cache              Do not use cache when building the image.
             --pull                  Always attempt to pull a newer version of the image.
-            --build-arg key=val     Set build-time variables for one service.
+            --build-arg key=val     Set build-time variables for service(s).
         """
-        service_names = options['SERVICE']
         build_args = options.get('--build-arg', None)
         if build_args:
             environment = Environment.from_env_file(self.project_dir)
             build_args = resolve_build_args(build_args, environment)
 
-        if not service_names and build_args:
-            raise UserError("Need service name for --build-arg option")
-
         self.project.build(
-            service_names=service_names,
+            service_names=options['SERVICE'],
             no_cache=bool(options.get('--no-cache', False)),
             pull=bool(options.get('--pull', False)),
             force_rm=bool(options.get('--force-rm', False)),
@@ -969,7 +965,8 @@ class TopLevelCommand(object):
 
             if cascade_stop:
                 print("Aborting on container exit...")
-                all_containers = self.project.containers(service_names=options['SERVICE'], stopped=True)
+                all_containers = self.project.containers(
+                    service_names=options['SERVICE'], stopped=True)
                 exit_code = compute_exit_code(
                     exit_value_from, attached_containers, cascade_starter, all_containers
                 )


### PR DESCRIPTION
Currently, `docker-compose --build-arg` requires that a service be
specified as part of the command-line invocation. So,

  $ docker-compose build --build-arg nocache=`git rev-parse @` foom

works. However, when using out-of-band scripts to automate the build
process of several Docker containers (in a CI system, for instance), it
becomes difficult to specify exactly which service requires the
build-arg. Docker has supported Dockerfiles that ignore build-args for a
long time, so there is no problem is specifying spurious build-args to
builds that don't consume it.

The limitation on `docker-compose build` today is artificial, and there
are no other commands that require specifying a service. Allow
`--build-arg` to also match all services so this is possible:

  $ docker-compose build --build-arg nocache=`git rev-parse @`

Please refer to #3790 for discussion on the original feature.

Signed-off-by: Ramkumar Ramachandra <artagnon@gmail.com>