### PR TITLE
Allow empty default values in variable interpolation (fixes #5185)

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -71,7 +71,7 @@ def recursive_interpolate(obj, interpolator):
 
 
 class TemplateWithDefaults(Template):
-    idpattern = r'[_a-z][_a-z0-9]*(?::?-[^}]+)?'
+    idpattern = r'[_a-z][_a-z0-9]*(?::?-[^}]*)?'
 
     # Modified from python2.7/string.py
     def substitute(self, mapping):

--- a/tests/fixtures/environment-interpolation-with-defaults/docker-compose.yml
+++ b/tests/fixtures/environment-interpolation-with-defaults/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2.1"
+
+services:
+  web:
+    # set value with default, default must be ignored
+    image: ${IMAGE:-alpine}
+
+    # unset value with default value
+    ports:
+      - "${HOST_PORT:-80}:8000"
+
+    # unset value with empty default
+    hostname: "host-${UNSET_VALUE:-}"

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2854,6 +2854,28 @@ class InterpolationTest(unittest.TestCase):
         ])
 
     @mock.patch.dict(os.environ)
+    def test_config_file_with_environment_variable_with_defaults(self):
+        project_dir = 'tests/fixtures/environment-interpolation-with-defaults'
+        os.environ.update(
+            IMAGE="busybox",
+        )
+
+        service_dicts = config.load(
+            config.find(
+                project_dir, None, Environment.from_env_file(project_dir)
+            )
+        ).services
+
+        self.assertEqual(service_dicts, [
+            {
+                'name': 'web',
+                'image': 'busybox',
+                'ports': types.ServicePort.parse('80:8000'),
+                'hostname': 'host-',
+            }
+        ])
+
+    @mock.patch.dict(os.environ)
     def test_unset_variable_produces_warning(self):
         os.environ.pop('FOO', None)
         os.environ.pop('BAR', None)


### PR DESCRIPTION
Signed-off-by: Guillermo Arribas <garribas@gmail.com>