### PR TITLE
Search .env file in parent directories

### DIFF
--- a/compose/config/default_config.py
+++ b/compose/config/default_config.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import logging
+import os
+
+from .errors import ComposeFileNotFound
+from .errors import DuplicateOverrideFileFound
+
+log = logging.getLogger(__name__)
+
+DEFAULT_OVERRIDE_FILENAMES = ('docker-compose.override.yml', 'docker-compose.override.yaml')
+
+
+def find(filenames, base_dir):
+    (candidates, path) = find_candidates_in_parent_dirs(filenames, base_dir)
+
+    if not candidates:
+        raise ComposeFileNotFound(filenames)
+
+    winner = candidates[0]
+
+    if len(candidates) > 1:
+        log.warn("Found multiple config files with supported names: %s", ", ".join(candidates))
+        log.warn("Using %s\n", winner)
+
+    return [os.path.join(path, winner)] + get_default_override_file(path)
+
+
+def get_default_override_file(path):
+    override_files_in_path = [os.path.join(path, override_filename) for override_filename
+                              in DEFAULT_OVERRIDE_FILENAMES
+                              if os.path.exists(os.path.join(path, override_filename))]
+    if len(override_files_in_path) > 1:
+        raise DuplicateOverrideFileFound(override_files_in_path)
+    return override_files_in_path
+
+
+def find_candidates_in_parent_dirs(filenames, path):
+    """
+    Given a directory path to start, looks for filenames in the
+    directory, and then each parent directory successively,
+    until found.
+
+    Returns tuple (candidates, path).
+    """
+    candidates = [filename for filename in filenames
+                  if os.path.exists(os.path.join(path, filename))]
+
+    if not candidates:
+        parent_dir = os.path.join(path, '..')
+        if os.path.abspath(parent_dir) != os.path.abspath(path):
+            return find_candidates_in_parent_dirs(filenames, parent_dir)
+
+    return (candidates, path)

--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -8,7 +8,9 @@ import os
 
 import six
 
+from . import default_config
 from ..const import IS_WINDOWS_PLATFORM
+from .errors import ComposeFileNotFound
 from .errors import ConfigurationError
 
 log = logging.getLogger(__name__)
@@ -52,9 +54,13 @@ class Environment(dict):
             result = cls()
             if base_dir is None:
                 return result
-            env_file_path = os.path.join(base_dir, '.env')
             try:
-                return cls(env_vars_from_file(env_file_path))
+                env_file_path = default_config.find(['.env'], base_dir)
+            except ComposeFileNotFound:
+                return result
+            # FIXME: Shouldn't we try all candidates?
+            try:
+                return cls(env_vars_from_file(env_file_path[0]))
             except ConfigurationError:
                 pass
             return result

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -4175,7 +4175,7 @@ class GetDefaultConfigFilesTestCase(unittest.TestCase):
             self.assertEqual(
                 filename,
                 get_config_filename_for_files(self.files[index:]))
-        with self.assertRaises(config.ComposeFileNotFound):
+        with self.assertRaises(config.default_config.ComposeFileNotFound):
             get_config_filename_for_files([])
 
     def test_get_config_path_default_file_in_parent_dir(self):
@@ -4186,7 +4186,7 @@ class GetDefaultConfigFilesTestCase(unittest.TestCase):
 
         for index, filename in enumerate(self.files):
             self.assertEqual(filename, get_config_in_subdir(self.files[index:]))
-        with self.assertRaises(config.ComposeFileNotFound):
+        with self.assertRaises(config.default_config.ComposeFileNotFound):
             get_config_in_subdir([])
 
 
@@ -4203,7 +4203,7 @@ def get_config_filename_for_files(filenames, subdir=None):
             base_dir = tempfile.mkdtemp(dir=project_dir)
         else:
             base_dir = project_dir
-        filename, = config.get_default_config_files(base_dir)
+        filename, = config.default_config.find(filenames, base_dir)
         return os.path.basename(filename)
     finally:
         shutil.rmtree(project_dir)


### PR DESCRIPTION
Extracts the methods responsible for this into their own module and uses this
module for searching yml and .env files. This follows the same rules as the yml
files.

So you can have base_dir/.env and no project_dir/.env or project_dir/.env.
Before .env file was only used if you invoke from the base directory.