### PR TITLE
Config command generates invalid volumes (fixes #5176)

### DIFF
--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -9,7 +9,7 @@ from compose.const import COMPOSEFILE_V1 as V1
 from compose.const import COMPOSEFILE_V2_1 as V2_1
 from compose.const import COMPOSEFILE_V3_0 as V3_0
 from compose.const import COMPOSEFILE_V3_2 as V3_2
-from compose.const import COMPOSEFILE_V3_2 as V3_4
+from compose.const import COMPOSEFILE_V3_4 as V3_4
 
 
 def serialize_config_type(dumper, data):
@@ -66,7 +66,7 @@ def denormalize_config(config, image_digests=None):
                 del conf['external_name']
 
             if 'name' in conf:
-                if config.version < V2_1 or (config.version > V3_0 and config.version < V3_4):
+                if config.version < V2_1 or (config.version >= V3_0 and config.version < V3_4):
                     del conf['name']
                 elif 'external' in conf:
                     conf['external'] = True

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -285,15 +285,63 @@ class CLITestCase(DockerClientTestCase):
             }
         }
 
-    def test_config_external_volume(self):
+    def test_config_external_volume_v2(self):
         self.base_dir = 'tests/fixtures/volumes'
-        result = self.dispatch(['-f', 'external-volumes.yml', 'config'])
+        result = self.dispatch(['-f', 'external-volumes-v2.yml', 'config'])
         json_result = yaml.load(result.stdout)
         assert 'volumes' in json_result
         assert json_result['volumes'] == {
             'foo': {
                 'external': True,
-                'name': 'foo',
+            },
+            'bar': {
+                'external': {
+                    'name': 'some_bar',
+                },
+            }
+        }
+
+    def test_config_external_volume_v2_x(self):
+        self.base_dir = 'tests/fixtures/volumes'
+        result = self.dispatch(['-f', 'external-volumes-v2-x.yml', 'config'])
+        json_result = yaml.load(result.stdout)
+        assert 'volumes' in json_result
+        assert json_result['volumes'] == {
+            'foo': {
+                'external': True,
+                'name': 'some_foo',
+            },
+            'bar': {
+                'external': True,
+                'name': 'some_bar',
+            }
+        }
+
+    def test_config_external_volume_v3_x(self):
+        self.base_dir = 'tests/fixtures/volumes'
+        result = self.dispatch(['-f', 'external-volumes-v3-x.yml', 'config'])
+        json_result = yaml.load(result.stdout)
+        assert 'volumes' in json_result
+        assert json_result['volumes'] == {
+            'foo': {
+                'external': True,
+            },
+            'bar': {
+                'external': {
+                    'name': 'some_bar',
+                },
+            }
+        }
+
+    def test_config_external_volume_v3_4(self):
+        self.base_dir = 'tests/fixtures/volumes'
+        result = self.dispatch(['-f', 'external-volumes-v3-4.yml', 'config'])
+        json_result = yaml.load(result.stdout)
+        assert 'volumes' in json_result
+        assert json_result['volumes'] == {
+            'foo': {
+                'external': True,
+                'name': 'some_foo',
             },
             'bar': {
                 'external': True,

--- a/tests/fixtures/volumes/external-volumes-v2-x.yml
+++ b/tests/fixtures/volumes/external-volumes-v2-x.yml
@@ -11,6 +11,7 @@ services:
 volumes:
   foo:
     external: true
+    name: some_foo
   bar:
     external:
       name: some_bar

--- a/tests/fixtures/volumes/external-volumes-v2.yml
+++ b/tests/fixtures/volumes/external-volumes-v2.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+services:
+  web:
+    image: busybox
+    command: top
+    volumes:
+      - foo:/var/lib/
+      - bar:/etc/
+
+volumes:
+  foo:
+    external: true
+  bar:
+    external:
+      name: some_bar

--- a/tests/fixtures/volumes/external-volumes-v3-4.yml
+++ b/tests/fixtures/volumes/external-volumes-v3-4.yml
@@ -1,0 +1,17 @@
+version: "3.4"
+
+services:
+  web:
+    image: busybox
+    command: top
+    volumes:
+      - foo:/var/lib/
+      - bar:/etc/
+
+volumes:
+  foo:
+    external: true
+    name: some_foo
+  bar:
+    external:
+      name: some_bar

--- a/tests/fixtures/volumes/external-volumes-v3-x.yml
+++ b/tests/fixtures/volumes/external-volumes-v3-x.yml
@@ -1,0 +1,16 @@
+version: "3.0"
+
+services:
+  web:
+    image: busybox
+    command: top
+    volumes:
+      - foo:/var/lib/
+      - bar:/etc/
+
+volumes:
+  foo:
+    external: true
+  bar:
+    external:
+      name: some_bar


### PR DESCRIPTION
Signed-off-by: Guillermo Arribas <garribas@gmail.com>

- Fixed the config.validate_external function so that validation condition matches condition used during serialization
- serialize.py: fixed constant V3_4  which was pointing to version 3.2
- serialize.py: v3.0 volumes must be serialized as in versions 3.1 to 3.3
- added acceptance test cases for all combinations of versions - volumes format