### PR TITLE
Placing dots in hostname no longer populates domainname if api >= 1.2…

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -14,6 +14,7 @@ from docker.errors import APIError
 from docker.errors import ImageNotFound
 from docker.errors import NotFound
 from docker.types import LogConfig
+from docker.utils import version_lt
 from docker.utils.ports import build_port_bindings
 from docker.utils.ports import split_port
 from docker.utils.utils import convert_tmpfs_mounts
@@ -747,9 +748,10 @@ class Service(object):
 
         # If a qualified hostname was given, split it into an
         # unqualified hostname and a domainname unless domainname
-        # was also given explicitly. This matches the behavior of
-        # the official Docker CLI in that scenario.
-        if ('hostname' in container_options and
+        # was also given explicitly. This matches behavior
+        # until Docker Engine 1.11.0 - Docker API 1.23.
+        if (version_lt(self.client.api_version, '1.23') and
+                'hostname' in container_options and
                 'domainname' not in container_options and
                 '.' in container_options['hostname']):
             parts = container_options['hostname'].partition('.')

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -10,6 +10,7 @@ from io import StringIO
 import docker
 import py
 import pytest
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 
 from .. import mock
 from .. import unittest
@@ -98,6 +99,7 @@ class CLITestCase(unittest.TestCase):
     @mock.patch('compose.cli.main.PseudoTerminal', autospec=True)
     def test_run_interactive_passes_logs_false(self, mock_pseudo_terminal, mock_run_operation):
         mock_client = mock.create_autospec(docker.APIClient)
+        mock_client.api_version = DEFAULT_DOCKER_API_VERSION
         project = Project.from_config(
             name='composetest',
             client=mock_client,
@@ -130,6 +132,7 @@ class CLITestCase(unittest.TestCase):
 
     def test_run_service_with_restart_always(self):
         mock_client = mock.create_autospec(docker.APIClient)
+        mock_client.api_version = DEFAULT_DOCKER_API_VERSION
 
         project = Project.from_config(
             name='composetest',


### PR DESCRIPTION
…3 (fixes #4128)

Signed-off-by: Guillermo Arribas <garribas@gmail.com>

Since Docker Engine 1.11.0 (Docker API 1.23) placing dots in the --hostname no longer populates domainname as before.

API docs:
https://docs.docker.com/release-notes/docker-engine/#1110-2016-04-13
https://docs.docker.com/engine/api/version-history/#v123-api-changes

Relevant PRs and issues:
https://github.com/moby/moby/pull/20200
https://github.com/moby/moby/issues/13378