### PR TITLE
allows to use dash in COMPOSE_PROJECT_NAME

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -105,7 +105,7 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
 
 def get_project_name(working_dir, project_name=None, environment=None):
     def normalize_name(name):
-        return re.sub(r'[^a-z0-9]', '', name.lower())
+        return re.sub(r'[^a-z0-9-]', '', name.lower())
 
     if not environment:
         environment = Environment.from_env_file(working_dir)


### PR DESCRIPTION
I created this containers with docker-py

```
docker ps -f name=vps --format {{.Names}}
svc-vps-manager.fpm
svc-vps-manager.mysql
svc-vps-manager.redis
```

Why I cannot use dashes in COMPOSE_PROJECT_NAME? 

There is no containers in `docker-compose ps`, because dashes were trimmed
```
docker-compose ps
Name   Command   State   Ports 
------------------------------
```