### PR TITLE
Validate if duplicate keys in yaml exist (fixes #5267)

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -53,6 +53,7 @@ from .validation import validate_pid_mode
 from .validation import validate_service_constraints
 from .validation import validate_top_level_object
 from .validation import validate_ulimits
+from .validation import validate_yaml
 
 
 DOCKER_CONFIG_KEYS = [
@@ -1293,6 +1294,9 @@ def has_uppercase(name):
 def load_yaml(filename):
     try:
         with open(filename, 'r') as fh:
+            validate_yaml(fh)
+            # stream has been read by validation function, seek to beginning before parsing yaml
+            fh.seek(0)
             return yaml.safe_load(fh)
     except (IOError, yaml.YAMLError) as e:
         error_name = getattr(e, '__module__', '') + '.' + e.__class__.__name__

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ six==1.10.0
 texttable==0.9.1
 urllib3==1.21.1
 websocket-client==0.32.0
+yamllint==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ install_requires = [
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',
+    'yamllint >=1.9.0',
 ]
 
 

--- a/tests/fixtures/duplicate-keys/docker-compose.yml
+++ b/tests/fixtures/duplicate-keys/docker-compose.yml
@@ -1,0 +1,8 @@
+service:
+  image: busybox:latest
+  command: top
+  command: duplicate
+
+  environment:
+    foo: bar
+    foo: bar

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1507,6 +1507,17 @@ class ConfigTest(unittest.TestCase):
 
         assert 'line 3, column 32' in exc.exconly()
 
+    def test_load_yaml_with_duplicate_keys(self):
+        project_dir = 'tests/fixtures/duplicate-keys'
+
+        with pytest.raises(ConfigurationError) as exc:
+            config.find(
+                project_dir, None, Environment.from_env_file(project_dir)
+            )
+
+        assert 'duplication of key "command"' in exc.exconly()
+        assert 'duplication of key "foo"' in exc.exconly()
+
     def test_validate_extra_hosts_invalid(self):
         with pytest.raises(ConfigurationError) as exc:
             config.load(build_config_details({


### PR DESCRIPTION
Implemented using a python yaml linter (`yamllint`: http://yamllint.readthedocs.io/).

YAML files are linted before being parsed by PyYAML in function `load_yaml`, only the rule to detect duplicate keys is applied. If linting errors are found a `ConfigurationError` is raised.

Given a compose file with duplicates such as:
```
service:
  image: busybox:latest
    command: top
    command: duplicate

  environment:
    foo: bar
    foo: bar
```

Compose commands produce the following output:
```
$ docker-compose config
ERROR: The Compose file ./docker-compose.yml is invalid:
line 4, column 3: duplication of key "command" in mapping (key-duplicates)
line 8, column 5: duplication of key "foo" in mapping (key-duplicates)
```

Signed-off-by: Guillermo Arribas <garribas@gmail.com>