### PR TITLE
config_hash using oderdict to fix bug for sometimes no change services receated by compose using python3

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 import sys
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from operator import attrgetter
 
 import enum
@@ -597,17 +597,14 @@ class Service(object):
         return json_hash(self.config_dict())
 
     def config_dict(self):
-        return {
-            'options': self.options,
-            'image_id': self.image()['Id'],
-            'links': self.get_link_names(),
-            'net': self.network_mode.id,
-            'networks': self.networks,
-            'volumes_from': [
-                (v.source.name, v.mode)
-                for v in self.volumes_from if isinstance(v.source, Service)
-            ],
-        }
+        return OrderedDict(
+            [('options', self.options),
+             ('image_id', self.image()['Id']),
+             ('links', self.get_link_names()),
+             ('net', self.network_mode.id),
+             ('networks', self.networks),
+             ('volumes_from', [(v.source.name, v.mode) for v in self.volumes_from if isinstance(v.source, Service)])]
+        )
 
     def get_dependency_names(self):
         net_name = self.network_mode.service_name


### PR DESCRIPTION
Like the code diff, in python2 dict() is almost ordered in the same way, however in python3, dict() is almost randomly ordered, so we need to use oderdict to make sure the same key-value dict is saved in the same order, and so the hash of the service config 'config_hash' will be the same if the config is the same, however, now for python3 it is not（python2.7 is ok, like what mentioned above）, and this is what this PR fix for. Thanks for PTAL~

Signed-off-by: Xin He <hexin@jiedaibao.com>