### PR TITLE
Better installation instruction in release notes

### DIFF
--- a/project/RELEASE-PROCESS.md
+++ b/project/RELEASE-PROCESS.md
@@ -89,7 +89,7 @@ When prompted build the non-linux binaries and test them.
         Alternatively, you can use the usual commands to install or upgrade Compose:
 
         ```
-        curl -L https://github.com/docker/compose/releases/download/1.16.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+        curl -L https://github.com/docker/compose/releases/download/1.16.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
         chmod +x /usr/local/bin/docker-compose
         ```
 


### PR DESCRIPTION
Changed sample download script to use the built in `-o` optoin in `curl` instead of redicrecting stdout's output.

This allows users to prepend `sudo` to the snippet to make it work in common use cases where root permissions are needed to create the output file.

From `curl`:
    -o, --output <file>
              Write output to <file> instead of stdout.