### PR TITLE
i3415: only prefix id once during recreate

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -521,7 +521,8 @@ class Service(object):
         """
 
         container.stop(timeout=self.stop_timeout(timeout))
-        container.rename_to_tmp_name()
+        if not container.name.startswith(container.short_id):
+            container.rename_to_tmp_name()
         new_container = self.create_container(
             previous_container=container,
             number=container.labels.get(LABEL_CONTAINER_NUMBER),

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -419,6 +419,10 @@ class ServiceTest(unittest.TestCase):
     @mock.patch('compose.service.Container', autospec=True)
     def test_recreate_container(self, _):
         mock_container = mock.create_autospec(Container)
+        type(mock_container).name = mock.PropertyMock(return_value='somename')
+        type(mock_container).short_id = mock.PropertyMock(
+            return_value='someshort_id'
+        )
         service = Service('foo', client=self.mock_client, image='someimage')
         service.image = lambda: {'Id': 'abc123'}
         new_container = service.recreate_container(mock_container)


### PR DESCRIPTION
Fix https://github.com/docker/compose/issues/3415