### PR TITLE
Improve performance by replacing call to pip freeze with import of do…

### DIFF
--- a/compose/cli/__init__.py
+++ b/compose/cli/__init__.py
@@ -2,43 +2,42 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import subprocess
 import sys
+from ast import literal_eval as make_tuple
 
 # Attempt to detect https://github.com/docker/compose/issues/4344
 try:
-    # We don't try importing pip because it messes with package imports
-    # on some Linux distros (Ubuntu, Fedora)
-    # https://github.com/docker/compose/issues/4425
-    # https://github.com/docker/compose/issues/4481
-    # https://github.com/pypa/pip/blob/master/pip/_vendor/__init__.py
-    env = os.environ.copy()
-    env[str('PIP_DISABLE_PIP_VERSION_CHECK')] = str('1')
-
     s_cmd = subprocess.Popen(
         # DO NOT replace this call with a `sys.executable` call. It breaks the binary
         # distribution (with the binary calling itself recursively over and over).
-        ['pip', 'freeze'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-        env=env
+        [
+            'python',
+            '-c',
+            'from __future__ import print_function; from docker import version_info; print(version_info)'
+        ],
+        stderr=subprocess.PIPE, stdout=subprocess.PIPE
     )
-    packages = s_cmd.communicate()[0].splitlines()
-    dockerpy_installed = len(
-        list(filter(lambda p: p.startswith(b'docker-py=='), packages))
-    ) > 0
-    if dockerpy_installed:
-        from .colors import yellow
-        print(
-            yellow('WARNING:'),
-            "Dependency conflict: an older version of the 'docker-py' package "
-            "may be polluting the namespace. "
-            "If you're experiencing crashes, run the following command to remedy the issue:\n"
-            "pip uninstall docker-py; pip uninstall docker; pip install docker",
-            file=sys.stderr
-        )
+
+    stdout, stderr = s_cmd.communicate()
+
+    # only check docker-py version if it's installed
+    if not stderr:
+        version = make_tuple(stdout.decode('utf-8'))
+        # version 1.10.6 was the latest release of docker python client released as docker-py
+        if version <= (1, 10, 6):
+            from .colors import yellow
+            print(
+                yellow('WARNING:'),
+                "Dependency conflict: an older version of the 'docker-py' package "
+                "may be polluting the namespace. "
+                "If you're experiencing crashes, run the following command to remedy the issue:\n"
+                "pip uninstall docker-py; pip uninstall docker; pip install docker",
+                file=sys.stderr
+            )
 
 except OSError:
-    # pip command is not available, which indicates it's probably the binary
+    # python binary is not available, which indicates it's probably the binary
     # distribution of Compose which is not affected
     pass
 except UnicodeDecodeError:


### PR DESCRIPTION
…cker.version_info (fixes #5038)

Replaced call to pip freeze with a python one-liner that imports docker.version_info. Version 1.10.6 was the latest release of docker python client released as docker-py. This change results in executions of docker-compose being about 1.5x faster (affects all commands: help, info, etc.)

With call to pip freeze:

> $ time docker-compose
> 
> real	0m1.033s
> user	0m0.894s
> sys	0m0.130s

With call to import docker.version_info:

> $ time docker-compose
> 
> real	0m0.676s
> user	0m0.568s
> sys	0m0.085s

Signed-off-by: Guillermo Arribas <garribas@gmail.com>