### PR TITLE
Implement 'overwrite_mutlivals' config option

### DIFF
--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -255,7 +255,8 @@
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "overwrite_multivals": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
       },
 
       "dependencies": {


### PR DESCRIPTION
In your `docker-compose.override.yml`, the `overwrite_multivals` config option allows you to specify which multivalue fields should be _overwritten_ instead of _concatenated with the base_. 

For example:

```
services:
  gateway:
    ports:
      - "80"
    overwrite_multivals:
      - ports
```

I am totally ripping off this guy's idea: #3939 

*This PR is a work in progress. Todo:*
* compose/config/validation.py
* Unit tests
* Documentation