### PR TITLE
Implement 'overwrite_ports' config option

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -125,6 +125,7 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'network_mode',
     'init',
     'scale',
+    'overwrite_ports'
 ]
 
 DOCKER_VALID_URL_PREFIXES = (
@@ -1002,8 +1003,12 @@ def merge_ports(md, base, override):
     if not md.needs_merge(field):
         return
 
-    merged = parse_sequence_func(md.base.get(field, []))
-    merged.update(parse_sequence_func(md.override.get(field, [])))
+    if ('overwrite_ports' in override and override['overwrite_ports']):
+        merged = parse_sequence_func(md.override.get(field, []))
+    else:
+        merged = parse_sequence_func(md.base.get(field, []))
+        merged.update(parse_sequence_func(md.override.get(field, [])))
+
     md[field] = [item for item in sorted(merged.values(), key=lambda x: x.target)]
 
 

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -255,7 +255,8 @@
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "overwrite_ports": {"type": "boolean"}
       },
 
       "dependencies": {


### PR DESCRIPTION
An alternative to the `overwrite_multivals` config option proposed in #5354 .

In your `docker-compose.override.yml`, the `overwrite_ports` config option allows you to toggle whether ports should be _concatenated with the base_ (false) or _overwritten_ (true).

_This PR is a work in progress. Todo:_

* compose/config/validation.py
* Unit tests
* Documentation