### PR TITLE
Implement subnet config validation (fixes #4552)

### DIFF
--- a/compose/config/config_schema_v3.0.json
+++ b/compose/config/config_schema_v3.0.json
@@ -294,7 +294,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string"}
+                  "subnet": {"type": "string", "format": "subnet_ip_address"}
                 },
                 "additionalProperties": false
               }

--- a/compose/config/config_schema_v3.1.json
+++ b/compose/config/config_schema_v3.1.json
@@ -323,7 +323,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string"}
+                  "subnet": {"type": "string", "format": "subnet_ip_address"}
                 },
                 "additionalProperties": false
               }

--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -368,7 +368,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string"}
+                  "subnet": {"type": "string", "format": "subnet_ip_address"}
                 },
                 "additionalProperties": false
               }

--- a/compose/config/config_schema_v3.3.json
+++ b/compose/config/config_schema_v3.3.json
@@ -412,7 +412,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string"}
+                  "subnet": {"type": "string", "format": "subnet_ip_address"}
                 },
                 "additionalProperties": false
               }

--- a/compose/config/config_schema_v3.4.json
+++ b/compose/config/config_schema_v3.4.json
@@ -420,7 +420,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string"}
+                  "subnet": {"type": "string", "format": "subnet_ip_address"}
                 },
                 "additionalProperties": false
               }

--- a/compose/config/config_schema_v3.5.json
+++ b/compose/config/config_schema_v3.5.json
@@ -418,7 +418,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string"}
+                  "subnet": {"type": "string", "format": "subnet_ip_address"}
                 },
                 "additionalProperties": false
               }

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -72,22 +72,24 @@ def format_expose(instance):
 def format_subnet_ip_address(instance):
     if isinstance(instance, six.string_types):
         if '/' not in instance:
-            raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
+            raise ValidationError("'{0}' 75 should be of the format 'IP_ADDRESS/CIDR'".format(instance))
 
         ip_address, cidr = instance.split('/')
 
         if re.match(VALID_IPV4_FORMAT, ip_address):
             if not (re.match(VALID_IPV4_CIDR_FORMAT, cidr) and
                     all(0 <= int(component) <= 255 for component in ip_address.split("."))):
-                raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
+                raise ValidationError(
+                    "'{0}' 83 should be of the format 'IP_ADDRESS/CIDR'".format(instance))
         elif re.match(VALID_IPV6_CIDR_FORMAT, cidr) and hasattr(socket, "inet_pton"):
             try:
                 if not (socket.inet_pton(socket.AF_INET6, ip_address)):
-                    raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
+                    raise ValidationError(
+                        "'{0}' 88 should be of the format 'IP_ADDRESS/CIDR'".format(instance))
             except socket.error as e:
                 raise ValidationError(six.text_type(e))
         else:
-            raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
+            raise ValidationError("'{0}' 92 should be of the format 'IP_ADDRESS/CIDR'".format(instance))
 
     return True
 

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -45,13 +45,11 @@ VALID_NAME_CHARS = '[a-zA-Z0-9\._\-]'
 VALID_EXPOSE_FORMAT = r'^\d+(\-\d+)?(\/[a-zA-Z]+)?$'
 
 VALID_IPV4_SEG = r'(\d{1,2}|1\d{2}|2[0-4]\d|25[0-5])'
-VALID_REGEX_IPV4_CIDR = r'^(\d|[1-2]\d|3[0-2])$'
 VALID_IPV4_ADDR = "({IPV4_SEG}\.){{3}}{IPV4_SEG}".format(IPV4_SEG=VALID_IPV4_SEG)
-VALID_REGEX_IPV4_ADDR = "^{IPV4_ADDR}$".format(IPV4_ADDR=VALID_IPV4_ADDR)
+VALID_REGEX_IPV4_CIDR = "^{IPV4_ADDR}/(\d|[1-2]\d|3[0-2])$".format(IPV4_ADDR=VALID_IPV4_ADDR)
 
 VALID_IPV6_SEG = r'[0-9a-fA-F]{1,4}'
-VALID_REGEX_IPV6_CIDR = r'^(\d|[1-9]\d|1[0-1]\d|12[0-8])$'
-VALID_REGEX_IPV6_ADDR = "".join("""
+VALID_REGEX_IPV6_CIDR = "".join("""
 ^
 (
     (({IPV6_SEG}:){{7}}{IPV6_SEG})|
@@ -67,6 +65,7 @@ VALID_REGEX_IPV6_ADDR = "".join("""
     (::(ffff(:0{{1,4}}){{0,1}}:){{0,1}}{IPV4_ADDR})|
     (({IPV6_SEG}:){{1,4}}:{IPV4_ADDR})
 )
+/(\d|[1-9]\d|1[0-1]\d|12[0-8])
 $
 """.format(IPV6_SEG=VALID_IPV6_SEG, IPV4_ADDR=VALID_IPV4_ADDR).split())
 
@@ -93,19 +92,9 @@ def format_expose(instance):
 @FormatChecker.cls_checks("subnet_ip_address", raises=ValidationError)
 def format_subnet_ip_address(instance):
     if isinstance(instance, six.string_types):
-        if '/' not in instance:
-            raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
-
-        ip_address, cidr = instance.split('/')
-
-        if re.match(VALID_REGEX_IPV4_ADDR, ip_address):
-            if not re.match(VALID_REGEX_IPV4_CIDR, cidr):
-                raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
-        elif re.match(VALID_REGEX_IPV6_ADDR, ip_address):
-            if not re.match(VALID_REGEX_IPV6_CIDR, cidr):
-                raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
-        else:
-            raise ValidationError("should be of the format 'IP_ADDRESS/CIDR'")
+        if not re.match(VALID_REGEX_IPV4_CIDR, instance) and \
+                not re.match(VALID_REGEX_IPV6_CIDR, instance):
+            raise ValidationError("should use the CIDR format")
 
     return True
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2865,10 +2865,7 @@ class SubnetTest(unittest.TestCase):
         "fe80:0000:0000:0000:0204:61ff:fe9d:f156/129",
         "fe80:0000:0000:0000:0204:61ff:fe9d:f156/01",
         "fe80:0000:0000:0000:0204:61ff:fe9d:f156",
-    ]
-
-    ILLEGAL_SUBNET_MAPPINGS = [
-        "ge80:0000:0000:0000:0204:61ff:fe9d:f156/128"
+        "ge80:0000:0000:0000:0204:61ff:fe9d:f156/128",
     ]
 
     VALID_SUBNET_MAPPINGS = [
@@ -2876,6 +2873,21 @@ class SubnetTest(unittest.TestCase):
         "192.168.0.1/32",
         "fe80:0000:0000:0000:0204:61ff:fe9d:f156/0",
         "fe80:0000:0000:0000:0204:61ff:fe9d:f156/128",
+        "1:2:3:4:5:6:7:8/0",
+        "1::/0",
+        "1:2:3:4:5:6:7::/0",
+        "1::8/0",
+        "1:2:3:4:5:6::8/0",
+        "::/0",
+        "::8/0",
+        "::2:3:4:5:6:7:8/0",
+        "fe80::7:8%eth0/0",
+        "fe80::7:8%1/0",
+        "::255.255.255.255/0",
+        "::ffff:255.255.255.255/0",
+        "::ffff:0:255.255.255.255/0",
+        "2001:db8:3:4::192.0.2.33/0",
+        "64:ff9b::192.0.2.33/0",
     ]
 
     def test_config_invalid_subnet_type_validation(self):
@@ -2891,16 +2903,6 @@ class SubnetTest(unittest.TestCase):
                 self.check_config(invalid_subnet)
 
             assert "should be of the format 'IP_ADDRESS/CIDR'" in exc.value.msg
-
-    def test_config_illegal_subnet_type_validation(self):
-        for invalid_subnet in self.ILLEGAL_SUBNET_MAPPINGS:
-            with pytest.raises(ConfigurationError) as exc:
-                self.check_config(invalid_subnet)
-            if IS_WINDOWS_PLATFORM:
-                assert "An invalid argument was supplied" in exc.value.msg or \
-                       "illegal IP address string" in exc.value.msg
-            else:
-                assert "illegal IP address string" in exc.value.msg
 
     def test_config_valid_subnet_format_validation(self):
         for valid_subnet in self.VALID_SUBNET_MAPPINGS:

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2866,6 +2866,7 @@ class SubnetTest(unittest.TestCase):
         "fe80:0000:0000:0000:0204:61ff:fe9d:f156/01",
         "fe80:0000:0000:0000:0204:61ff:fe9d:f156",
         "ge80:0000:0000:0000:0204:61ff:fe9d:f156/128",
+        "192.168.0.1/31/31",
     ]
 
     VALID_SUBNET_MAPPINGS = [
@@ -2902,7 +2903,7 @@ class SubnetTest(unittest.TestCase):
             with pytest.raises(ConfigurationError) as exc:
                 self.check_config(invalid_subnet)
 
-            assert "should be of the format 'IP_ADDRESS/CIDR'" in exc.value.msg
+            assert "should use the CIDR format" in exc.value.msg
 
     def test_config_valid_subnet_format_validation(self):
         for valid_subnet in self.VALID_SUBNET_MAPPINGS:

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2896,8 +2896,11 @@ class SubnetTest(unittest.TestCase):
         for invalid_subnet in self.ILLEGAL_SUBNET_MAPPINGS:
             with pytest.raises(ConfigurationError) as exc:
                 self.check_config(invalid_subnet)
-
-            assert "illegal IP address string" in exc.value.msg
+            if IS_WINDOWS_PLATFORM:
+                assert "An invalid argument was supplied" in exc.value.msg or \
+                       "illegal IP address string" in exc.value.msg
+            else:
+                assert "illegal IP address string" in exc.value.msg
 
     def test_config_valid_subnet_format_validation(self):
         for valid_subnet in self.VALID_SUBNET_MAPPINGS:


### PR DESCRIPTION
Add enhancement to config validation for subnet validation. This is my first Docker Compose PR, so please let me know if I missed anything!

ASSUMPTIONS:
* Only apply this to version 3.5
* Valid/Invalid as shown in the tests are correct for all subnets used by Docker Compose
* OS has support for socket.inet_pton() (As implemented by http://python-jsonschema.readthedocs.io/en/latest/validate/#validating-formats)

EDIT:
It seems that I am failing the Windows py27, as it appears to not support socket.inet_pton(). Should I make the solution not have to support socket.inet_pton(), but rather a very long regex to support all notations of ipv6 such as (https://www.regexpal.com/93988)?