### PR TITLE
Allow x-project-name property in Compose file to define project name

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -225,6 +225,11 @@ class ConfigFile(namedtuple('_ConfigFile', 'filename config')):
     def get_configs(self):
         return {} if self.version < const.COMPOSEFILE_V3_3 else self.config.get('configs', {})
 
+    def get_x_properties(self):
+        if self.version == V1:
+            return {}
+        return dict((k, v) for k, v in self.config.items() if k.startswith('x-'))
+
 
 class Config(namedtuple('_Config', 'version services volumes networks secrets configs')):
     """

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -20,45 +20,54 @@ from compose.cli.command import get_project_name
 from compose.cli.docopt_command import NoSuchCommand
 from compose.cli.errors import UserError
 from compose.cli.main import TopLevelCommand
+from compose.config.config import ConfigDetails
+from compose.config.config import ConfigFile
 from compose.const import IS_WINDOWS_PLATFORM
 from compose.project import Project
 
 
 class CLITestCase(unittest.TestCase):
 
+    @staticmethod
+    def get_config_details(working_dir, x_project_name=None):
+        config = {'version': '2.3'}
+        if x_project_name:
+            config['x-project-name'] = x_project_name
+        return ConfigDetails(working_dir, [ConfigFile('base.yml', config)])
+
     def test_default_project_name(self):
         test_dir = py._path.local.LocalPath('tests/fixtures/simple-composefile')
         with test_dir.as_cwd():
-            project_name = get_project_name('.')
+            project_name = get_project_name(self.get_config_details('.'))
             self.assertEqual('simplecomposefile', project_name)
 
     def test_project_name_with_explicit_base_dir(self):
         base_dir = 'tests/fixtures/simple-composefile'
-        project_name = get_project_name(base_dir)
+        project_name = get_project_name(self.get_config_details(base_dir))
         self.assertEqual('simplecomposefile', project_name)
 
     def test_project_name_with_explicit_uppercase_base_dir(self):
         base_dir = 'tests/fixtures/UpperCaseDir'
-        project_name = get_project_name(base_dir)
+        project_name = get_project_name(self.get_config_details(base_dir))
         self.assertEqual('uppercasedir', project_name)
 
     def test_project_name_with_explicit_project_name(self):
         name = 'explicit-project-name'
-        project_name = get_project_name(None, project_name=name)
+        project_name = get_project_name(self.get_config_details('.'), project_name=name)
         self.assertEqual('explicitprojectname', project_name)
 
     @mock.patch.dict(os.environ)
     def test_project_name_from_environment_new_var(self):
         name = 'namefromenv'
         os.environ['COMPOSE_PROJECT_NAME'] = name
-        project_name = get_project_name(None)
+        project_name = get_project_name(self.get_config_details('.'))
         self.assertEqual(project_name, name)
 
     def test_project_name_with_empty_environment_var(self):
         base_dir = 'tests/fixtures/simple-composefile'
         with mock.patch.dict(os.environ):
             os.environ['COMPOSE_PROJECT_NAME'] = ''
-            project_name = get_project_name(base_dir)
+            project_name = get_project_name(self.get_config_details(base_dir))
         self.assertEqual('simplecomposefile', project_name)
 
     @mock.patch.dict(os.environ)
@@ -68,14 +77,50 @@ class CLITestCase(unittest.TestCase):
             name = 'namefromenvfile'
             with open(os.path.join(base_dir, '.env'), 'w') as f:
                 f.write('COMPOSE_PROJECT_NAME={}'.format(name))
-            project_name = get_project_name(base_dir)
+            project_name = get_project_name(self.get_config_details(base_dir))
             assert project_name == name
 
             # Environment has priority over .env file
             os.environ['COMPOSE_PROJECT_NAME'] = 'namefromenv'
-            assert get_project_name(base_dir) == os.environ['COMPOSE_PROJECT_NAME']
+            assert get_project_name(
+                self.get_config_details(base_dir)) == os.environ['COMPOSE_PROJECT_NAME']
         finally:
             shutil.rmtree(base_dir)
+
+    @mock.patch.dict(os.environ)
+    def test_project_name_from_config_file(self):
+        base_dir = 'tests/fixtures/simple-composefile'
+        config_details = self.get_config_details(base_dir, 'namefromcomposefile')
+        # Ignored if env switch is unset
+        assert get_project_name(config_details) == 'simplecomposefile'
+
+        # Ignored if env switch is set to falsy value
+        os.environ['COMPOSE_X_PROJECT_NAME'] = 'false'
+        assert get_project_name(config_details) == 'simplecomposefile'
+
+        # Env switch and no higher precedence value
+        os.environ['COMPOSE_X_PROJECT_NAME'] = '1'
+        assert get_project_name(config_details) == 'namefromcomposefile'
+
+        # --project-name takes precedence
+        assert get_project_name(config_details, 'cliname') == 'cliname'
+
+        # COMPOSE_PROJECT_NAME env takes precedence
+        os.environ['COMPOSE_PROJECT_NAME'] = 'namefromenv'
+        assert get_project_name(config_details) == 'namefromenv'
+
+    @mock.patch.dict(os.environ)
+    def test_project_name_conflict_from_config_file(self):
+        base_dir = 'tests/fixtures/simple-composefile'
+        config_details = ConfigDetails(base_dir, [
+            ConfigFile('base.yml', {'version': '2.3', 'x-project-name': 'foo'}),
+            ConfigFile('override.yml', {'version': '2.3', 'x-project-name': 'bar'})
+        ])
+
+        os.environ['COMPOSE_X_PROJECT_NAME'] = 'true'
+        with pytest.raises(UserError) as excinfo:
+            get_project_name(config_details)
+        assert '"foo" (base.yml) does not match "bar" (override.yml)' in str(excinfo)
 
     def test_get_project(self):
         base_dir = 'tests/fixtures/longer-filename-composefile'


### PR DESCRIPTION
Fixes #745 

Notes:
- This is not meant as an official addition to the Compose file format. Other implementations may or may not offer similar functionality.
- The order of precedence is as follows: `--project-name` CLI option > `COMPOSE_PROJECT_NAME` environment variable > `x-project-name` value (iff `COMPOSE_X_PROJECT_NAME` is enabled) > directory name
