### PR TITLE
Adds support for a memory build-arg in docker-compose build.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -232,6 +232,7 @@ class TopLevelCommand(object):
             --force-rm              Always remove intermediate containers.
             --no-cache              Do not use cache when building the image.
             --pull                  Always attempt to pull a newer version of the image.
+            -m, --memory MEM        Sets memory limit for the bulid container.
             --build-arg key=val     Set build-time variables for one service.
         """
         service_names = options['SERVICE']
@@ -248,6 +249,7 @@ class TopLevelCommand(object):
             no_cache=bool(options.get('--no-cache', False)),
             pull=bool(options.get('--pull', False)),
             force_rm=bool(options.get('--force-rm', False)),
+            memory=options.get('--memory'),
             build_args=build_args)
 
     def bundle(self, config_options, options):

--- a/compose/project.py
+++ b/compose/project.py
@@ -357,10 +357,11 @@ class Project(object):
         )
         return containers
 
-    def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, build_args=None):
+    def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, memory=None,
+              build_args=None):
         for service in self.get_services(service_names):
             if service.can_be_built():
-                service.build(no_cache, pull, force_rm, build_args)
+                service.build(no_cache, pull, force_rm, memory, build_args)
             else:
                 log.info('%s uses an image, skipping' % service.name)
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -900,7 +900,7 @@ class Service(object):
 
         return [build_spec(secret) for secret in self.secrets]
 
-    def build(self, no_cache=False, pull=False, force_rm=False, build_args_override=None):
+    def build(self, no_cache=False, pull=False, force_rm=False, memory=None, build_args_override=None):
         log.info('Building %s' % self.name)
 
         build_opts = self.options.get('build', {})
@@ -931,6 +931,9 @@ class Service(object):
             target=build_opts.get('target', None),
             shmsize=parse_bytes(build_opts.get('shm_size')) if build_opts.get('shm_size') else None,
             extra_hosts=build_opts.get('extra_hosts', None),
+            container_limits={
+                'memory': parse_bytes(memory) if memory else None
+            },
         )
 
         try:

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -120,7 +120,7 @@ _docker_compose_build() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--build-arg --force-rm --help --no-cache --pull" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--build-arg --force-rm --help --memory --no-cache --pull" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_from_build

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -196,6 +196,7 @@ __docker-compose_subcommand() {
                 $opts_help \
                 "*--build-arg=[Set build-time variables for one service.]:<varname>=<value>: " \
                 '--force-rm[Always remove intermediate containers.]' \
+                '--memory[Memory limit for the build container.]' \
                 '--no-cache[Do not use cache when building the image.]' \
                 '--pull[Always attempt to pull a newer version of the image.]' \
                 '*:services:__docker-compose_services_from_build' && ret=0

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -584,6 +584,12 @@ class CLITestCase(DockerClientTestCase):
         result = self.dispatch(['build', '--no-cache'], None)
         assert 'shm_size: 96' in result.stdout
 
+    def test_build_memory_build_option(self):
+        pull_busybox(self.client)
+        self.base_dir = 'tests/fixtures/build-memory'
+        result = self.dispatch(['build', '--no-cache', '--memory', '96m', 'service'], None)
+        assert 'memory: 100663296' in result.stdout  # 96 * 1024 * 1024
+
     def test_bundle_with_digests(self):
         self.base_dir = 'tests/fixtures/bundle-with-digests/'
         tmpdir = pytest.ensuretemp('cli_test_bundle')

--- a/tests/fixtures/build-memory/Dockerfile
+++ b/tests/fixtures/build-memory/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+
+# Report the memory (through the size of the group memory)
+RUN echo "memory:" $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)

--- a/tests/fixtures/build-memory/docker-compose.yml
+++ b/tests/fixtures/build-memory/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.5'
+
+services:
+  service:
+    build:
+      context: .

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -499,6 +499,7 @@ class ServiceTest(unittest.TestCase):
             target=None,
             shmsize=None,
             extra_hosts=None,
+            container_limits={'memory': None},
         )
 
     def test_ensure_image_exists_no_build(self):
@@ -541,6 +542,7 @@ class ServiceTest(unittest.TestCase):
             target=None,
             shmsize=None,
             extra_hosts=None,
+            container_limits={'memory': None},
         )
 
     def test_build_does_not_pull(self):


### PR DESCRIPTION
Implements #5374. You can now use memory as a build-arg to docker-compose build.

Signed-off-by: Samantha Miller <samantha.a.miller123@gmail.com>