### PR TITLE
Fix depends on restart behavior, fixes #3397

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -895,7 +895,7 @@ class TopLevelCommand(object):
             --no-deps                  Don't start linked services.
             --force-recreate           Recreate containers even if their configuration
                                        and image haven't changed.
-            --always-recreate-deps     Recreate dependant containers.
+            --always-recreate-deps     Recreate dependent containers.
                                        Incompatible with --no-recreate.
             --no-recreate              If containers already exist, don't recreate them.
                                        Incompatible with --force-recreate.

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -895,6 +895,7 @@ class TopLevelCommand(object):
             --no-deps                  Don't start linked services.
             --force-recreate           Recreate containers even if their configuration
                                        and image haven't changed.
+            --always-recreate-deps     Recreate dependant containers.
                                        Incompatible with --no-recreate.
             --no-recreate              If containers already exist, don't recreate them.
                                        Incompatible with --force-recreate.
@@ -914,6 +915,7 @@ class TopLevelCommand(object):
                                        setting in the Compose file if present.
         """
         start_deps = not options['--no-deps']
+        always_recreate_deps = options['--always-recreate-deps']
         exit_value_from = exitval_from_opts(options, self.project)
         cascade_stop = options['--abort-on-container-exit']
         service_names = options['SERVICE']
@@ -940,7 +942,8 @@ class TopLevelCommand(object):
                 detached=detached,
                 remove_orphans=remove_orphans,
                 scale_override=parse_scale_args(options['--scale']),
-                start=not no_start
+                start=not no_start,
+                always_recreate_deps=always_recreate_deps
             )
 
             if detached or no_start:

--- a/compose/project.py
+++ b/compose/project.py
@@ -510,8 +510,8 @@ class Project(object):
                 log.debug('%s has upstream changes (%s)',
                           service.name,
                           ", ".join(updated_dependencies))
-                containers_stopped = any((not c.is_paused and not c.is_restarting and not c.is_running
-                                         for c in service.containers(stopped=True)))
+                containers_stopped = len(
+                    service.containers(stopped=True, filters={'status': ['created', 'exited']})) > 0
                 has_links = any(c.get('HostConfig.Links') for c in service.containers())
                 if always_recreate_deps or containers_stopped or not has_links:
                     plan = service.convergence_plan(ConvergenceStrategy.always)

--- a/compose/project.py
+++ b/compose/project.py
@@ -510,8 +510,8 @@ class Project(object):
                 log.debug('%s has upstream changes (%s)',
                           service.name,
                           ", ".join(updated_dependencies))
-                containers_stopped = len(
-                    service.containers(stopped=True, filters={'status': ['created', 'exited']})) > 0
+                containers_stopped = any(
+                    service.containers(stopped=True, filters={'status': ['created', 'exited']}))
                 has_links = any(c.get('HostConfig.Links') for c in service.containers())
                 if always_recreate_deps or containers_stopped or not has_links:
                     plan = service.convergence_plan(ConvergenceStrategy.always)

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -114,10 +114,7 @@ class ProjectWithDependenciesTest(ProjectTestCase):
 
     def test_up(self):
         containers = self.run_up(self.cfg)
-        self.assertEqual(
-            set(c.name_without_project for c in containers),
-            set(['db_1', 'web_1', 'nginx_1']),
-        )
+        assert set(c.name_without_project for c in containers) == {'db_1', 'web_1', 'nginx_1'}
 
     def test_change_leaf(self):
         old_containers = self.run_up(self.cfg)
@@ -125,10 +122,7 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         self.cfg['nginx']['environment'] = {'NEW_VAR': '1'}
         new_containers = self.run_up(self.cfg)
 
-        self.assertEqual(
-            set(c.name_without_project for c in new_containers - old_containers),
-            set(['nginx_1']),
-        )
+        assert set(c.name_without_project for c in new_containers - old_containers) == {'nginx_1'}
 
     def test_change_middle(self):
         old_containers = self.run_up(self.cfg)
@@ -136,10 +130,7 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         self.cfg['web']['environment'] = {'NEW_VAR': '1'}
         new_containers = self.run_up(self.cfg)
 
-        self.assertEqual(
-            set(c.name_without_project for c in new_containers - old_containers),
-            set(['web_1']),
-        )
+        assert set(c.name_without_project for c in new_containers - old_containers) == {'web_1'}
 
     def test_change_middle_always_recreate_deps(self):
         old_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
@@ -147,10 +138,8 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         self.cfg['web']['environment'] = {'NEW_VAR': '1'}
         new_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
 
-        self.assertEqual(
-            set(c.name_without_project for c in new_containers - old_containers),
-            set(['web_1', 'nginx_1']),
-        )
+        assert set(c.name_without_project
+                   for c in new_containers - old_containers) == {'web_1', 'nginx_1'}
 
     def test_change_root(self):
         old_containers = self.run_up(self.cfg)
@@ -158,10 +147,7 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         self.cfg['db']['environment'] = {'NEW_VAR': '1'}
         new_containers = self.run_up(self.cfg)
 
-        self.assertEqual(
-            set(c.name_without_project for c in new_containers - old_containers),
-            set(['db_1']),
-        )
+        assert set(c.name_without_project for c in new_containers - old_containers) == {'db_1'}
 
     def test_change_root_always_recreate_deps(self):
         old_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
@@ -169,10 +155,8 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         self.cfg['db']['environment'] = {'NEW_VAR': '1'}
         new_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
 
-        self.assertEqual(
-            set(c.name_without_project for c in new_containers - old_containers),
-            set(['db_1', 'web_1', 'nginx_1']),
-        )
+        assert set(c.name_without_project
+                   for c in new_containers - old_containers) == {'db_1', 'web_1', 'nginx_1'}
 
     def test_change_root_no_recreate(self):
         old_containers = self.run_up(self.cfg)
@@ -182,7 +166,7 @@ class ProjectWithDependenciesTest(ProjectTestCase):
             self.cfg,
             strategy=ConvergenceStrategy.never)
 
-        self.assertEqual(new_containers - old_containers, set())
+        assert set(c.name_without_project for c in new_containers - old_containers) == set()
 
     def test_service_removed_while_down(self):
         next_cfg = {
@@ -194,26 +178,26 @@ class ProjectWithDependenciesTest(ProjectTestCase):
         }
 
         containers = self.run_up(self.cfg)
-        self.assertEqual(len(containers), 3)
+        assert len(containers) == 3
 
         project = self.make_project(self.cfg)
         project.stop(timeout=1)
 
         containers = self.run_up(next_cfg)
-        self.assertEqual(len(containers), 2)
+        assert len(containers) == 2
 
     def test_service_recreated_when_dependency_created(self):
         containers = self.run_up(self.cfg, service_names=['web'], start_deps=False)
-        self.assertEqual(len(containers), 1)
+        assert len(containers) == 1
 
         containers = self.run_up(self.cfg)
-        self.assertEqual(len(containers), 3)
+        assert len(containers) == 3
 
         web, = [c for c in containers if c.service == 'web']
         nginx, = [c for c in containers if c.service == 'nginx']
 
-        self.assertEqual(set(get_links(web)), {'composetest_db_1', 'db', 'db_1'})
-        self.assertEqual(set(get_links(nginx)), {'composetest_web_1', 'web', 'web_1'})
+        assert set(get_links(web)) == {'composetest_db_1', 'db', 'db_1'}
+        assert set(get_links(nginx)) == {'composetest_web_1', 'web', 'web_1'}
 
 
 class ServiceStateTest(DockerClientTestCase):

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -138,6 +138,17 @@ class ProjectWithDependenciesTest(ProjectTestCase):
 
         self.assertEqual(
             set(c.name_without_project for c in new_containers - old_containers),
+            set(['web_1']),
+        )
+
+    def test_change_middle_always_recreate_deps(self):
+        old_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
+
+        self.cfg['web']['environment'] = {'NEW_VAR': '1'}
+        new_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
+
+        self.assertEqual(
+            set(c.name_without_project for c in new_containers - old_containers),
             set(['web_1', 'nginx_1']),
         )
 
@@ -146,6 +157,17 @@ class ProjectWithDependenciesTest(ProjectTestCase):
 
         self.cfg['db']['environment'] = {'NEW_VAR': '1'}
         new_containers = self.run_up(self.cfg)
+
+        self.assertEqual(
+            set(c.name_without_project for c in new_containers - old_containers),
+            set(['db_1']),
+        )
+
+    def test_change_root_always_recreate_deps(self):
+        old_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
+
+        self.cfg['db']['environment'] = {'NEW_VAR': '1'}
+        new_containers = self.run_up(self.cfg, **{"always_recreate_deps": True})
 
         self.assertEqual(
             set(c.name_without_project for c in new_containers - old_containers),


### PR DESCRIPTION
Signed-off-by: Drew Romanyk <drewiswaycool@gmail.com>

This fixes the #3397 issue and adds an option flag to revert to the old behavior. 

ASSUMPTIONS:
If containers are stopped, recreate them
If containers have no links and have updated dependencies, recreate them