### PR TITLE
Add config validation for service volumes, fixes #5352

### DIFF
--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -244,6 +244,7 @@
               {
                 "type": "object",
                 "required": ["type"],
+                "additionalProperties": false,
                 "properties": {
                   "type": {"type": "string"},
                   "source": {"type": "string"},

--- a/compose/config/config_schema_v3.3.json
+++ b/compose/config/config_schema_v3.3.json
@@ -278,6 +278,7 @@
               {
                 "type": "object",
                 "required": ["type"],
+                "additionalProperties": false,
                 "properties": {
                   "type": {"type": "string"},
                   "source": {"type": "string"},

--- a/compose/config/config_schema_v3.4.json
+++ b/compose/config/config_schema_v3.4.json
@@ -282,6 +282,7 @@
               {
                 "type": "object",
                 "required": ["type"],
+                "additionalProperties": false,
                 "properties": {
                   "type": {"type": "string"},
                   "source": {"type": "string"},

--- a/compose/config/config_schema_v3.5.json
+++ b/compose/config/config_schema_v3.5.json
@@ -281,6 +281,7 @@
               {
                 "type": "object",
                 "required": ["type"],
+                "additionalProperties": false,
                 "properties": {
                   "type": {"type": "string"},
                   "source": {"type": "string"},

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -2631,6 +2631,33 @@ class ConfigTest(unittest.TestCase):
         ]
         assert service_sort(service_dicts) == service_sort(expected)
 
+    def test_service_volume_invalid_config(self):
+        config_details = build_config_details(
+            {
+                'version': '3.2',
+                'services': {
+                    'web': {
+                        'build': {
+                            'context': '.',
+                            'args': None,
+                        },
+                        'volumes': [
+                            {
+                                "type": "volume",
+                                "source": "/data",
+                                "garbage": {
+                                    "and": "error"
+                                }
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+        with pytest.raises(ConfigurationError) as exc:
+            config.load(config_details)
+        assert "services.web.volumes contains unsupported option: 'garbage'" in exc.exconly()
+
 
 class NetworkModeTest(unittest.TestCase):
 


### PR DESCRIPTION
Signed-off-by: Drew Romanyk <drewiswaycool@gmail.com>

Adds validation for service config by enforcing no additional properties & adds a test

ASSUMPTIONS:
no additional properties are allowed for service volumes