### PR TITLE
Add ipam default driver, fixes #5248

### DIFF
--- a/compose/network.py
+++ b/compose/network.py
@@ -116,7 +116,7 @@ def create_ipam_config_from_dict(ipam_dict):
         return None
 
     return IPAMConfig(
-        driver=ipam_dict.get('driver'),
+        driver=ipam_dict.get('driver') or 'default',
         pool_configs=[
             IPAMPool(
                 subnet=config.get('subnet'),


### PR DESCRIPTION
Signed-off-by: Drew Romanyk <drewiswaycool@gmail.com>

This adds a default value for ipam network driver

ASSUMPTIONS:
Just set default driver for ipam as 'driver' and only for ipam according to shin-'s comments on the issue