### PR TITLE
Specify osx_image to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
       services:
       - docker
     - os: osx
+      osx_image: xcode7.3
       language: generic
 
 install: ./script/travis/install


### PR DESCRIPTION
Recently, Travis CI updated its default osx image:
https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce

Previous default is 7.3:
https://travis-ci.org/docker/compose/jobs/308615153

Currently, our CI is failing so let's specify the version.