### PR TITLE
Use random suffixes when naming containers instead of sequential numbers

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -413,12 +413,12 @@ class TopLevelCommand(object):
             -u, --user USER   Run the command as this user.
             -T                Disable pseudo-tty allocation. By default `docker-compose exec`
                               allocates a TTY.
-            --index=index     index of the container if there are multiple
-                              instances of a service [default: 1]
+            --uid=uid         uid of the container if there are multiple
+                              instances of a service
             -e, --env KEY=VAL Set environment variables (can be used multiple times,
                               not supported in API < 1.25)
         """
-        index = int(options.get('--index'))
+        uid = options.get('--uid')
         service = self.project.get_service(options['SERVICE'])
         detach = options['-d']
 
@@ -426,7 +426,7 @@ class TopLevelCommand(object):
             raise UserError("Setting environment for exec is not supported in API < 1.25'")
 
         try:
-            container = service.get_container(number=index)
+            container = service.get_container(uid)
         except ValueError as e:
             raise UserError(str(e))
         command = [options['COMMAND']] + options['ARGS']
@@ -583,13 +583,13 @@ class TopLevelCommand(object):
 
         Options:
             --protocol=proto  tcp or udp [default: tcp]
-            --index=index     index of the container if there are multiple
-                              instances of a service [default: 1]
+            --uid=uid         uid of the container if there are multiple
+                              instances of a service
         """
-        index = int(options.get('--index'))
+        uid = options.get('--uid')
         service = self.project.get_service(options['SERVICE'])
         try:
-            container = service.get_container(number=index)
+            container = service.get_container(uid)
         except ValueError as e:
             raise UserError(str(e))
         print(container.get_local_port(

--- a/compose/const.py
+++ b/compose/const.py
@@ -9,7 +9,7 @@ DEFAULT_TIMEOUT = 10
 HTTP_TIMEOUT = 60
 IMAGE_EVENTS = ['delete', 'import', 'load', 'pull', 'push', 'save', 'tag', 'untag']
 IS_WINDOWS_PLATFORM = (sys.platform == "win32")
-LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
+LABEL_CONTAINER_UID = 'com.docker.compose.container-uid'
 LABEL_ONE_OFF = 'com.docker.compose.oneoff'
 LABEL_PROJECT = 'com.docker.compose.project'
 LABEL_SERVICE = 'com.docker.compose.service'

--- a/compose/container.py
+++ b/compose/container.py
@@ -5,7 +5,7 @@ from functools import reduce
 
 import six
 
-from .const import LABEL_CONTAINER_NUMBER
+from .const import LABEL_CONTAINER_UID
 from .const import LABEL_PROJECT
 from .const import LABEL_SERVICE
 
@@ -75,17 +75,17 @@ class Container(object):
         project = self.labels.get(LABEL_PROJECT)
 
         if self.name.startswith('{0}_{1}'.format(project, self.service)):
-            return '{0}_{1}'.format(self.service, self.number)
+            return '{0}_{1}'.format(self.service, self.uid)
         else:
             return self.name
 
     @property
-    def number(self):
-        number = self.labels.get(LABEL_CONTAINER_NUMBER)
-        if not number:
+    def uid(self):
+        uid = self.labels.get(LABEL_CONTAINER_UID)
+        if not uid:
             raise ValueError("Container {0} does not have a {1} label".format(
-                self.short_id, LABEL_CONTAINER_NUMBER))
-        return int(number)
+                self.short_id, LABEL_CONTAINER_UID))
+        return uid
 
     @property
     def ports(self):

--- a/compose/project.py
+++ b/compose/project.py
@@ -32,6 +32,7 @@ from .service import Service
 from .service import ServiceName
 from .service import ServiceNetworkMode
 from .service import ServicePidMode
+from .utils import generate_uid
 from .utils import microseconds_from_time_nano
 from .volume import ProjectVolumes
 
@@ -193,12 +194,12 @@ class Project(object):
 
     def get_scaled_services(self, services, scale_override):
         """
-        Returns a list of this project's services as scaled ServiceName objects.
+        Returns a dict from service to list of scaled ServiceName objects.
 
         services: a list of Service objects
         scale_override: a dict with the scale to apply to each service (k: service_name, v: scale)
         """
-        service_names = []
+        service_names = {}
         for service in services:
             if service.name in scale_override:
                 scale = scale_override[service.name]
@@ -206,7 +207,9 @@ class Project(object):
                 scale = service.scale_num
 
             for i in range(1, scale + 1):
-                service_names.append(ServiceName(self.name, service.name, i))
+                if not service_names.get(service.name):
+                    service_names[service.name] = []
+                service_names[service.name].append(ServiceName(self.name, service.name, generate_uid()))
 
         return service_names
 

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -7,6 +7,7 @@ import json
 import json.decoder
 import logging
 import ntpath
+import uuid
 
 import six
 from docker.errors import DockerException
@@ -143,3 +144,7 @@ def parse_bytes(n):
         return sdk_parse_bytes(n)
     except DockerException:
         return None
+
+
+def generate_uid():
+    return str(uuid.uuid4().hex)

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -84,9 +84,8 @@ class ProjectTest(DockerClientTestCase):
         project.up()
 
         containers = project.containers(['web'])
-        self.assertEqual(
-            [c.name for c in containers],
-            ['composetest_web_1'])
+        self.assertEqual(len(containers), 1)
+        self.assertEqual(containers[0].name, 'composetest_web_%s' % containers[0].uid)
 
     def test_containers_with_extra_service(self):
         web = self.create_service('web')

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -23,7 +23,6 @@ from compose.config.types import VolumeFromSpec
 from compose.config.types import VolumeSpec
 from compose.const import IS_WINDOWS_PLATFORM
 from compose.const import LABEL_CONFIG_HASH
-from compose.const import LABEL_CONTAINER_NUMBER
 from compose.const import LABEL_ONE_OFF
 from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
@@ -60,7 +59,7 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(foo)
 
         self.assertEqual(len(foo.containers()), 1)
-        self.assertEqual(foo.containers()[0].name, 'composetest_foo_1')
+        self.assertTrue(foo.containers()[0].name, 'composetest_foo_%s' % foo.containers()[0].uid)
         self.assertEqual(len(bar.containers()), 0)
 
         create_and_start_container(bar)
@@ -69,9 +68,8 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(len(foo.containers()), 1)
         self.assertEqual(len(bar.containers()), 2)
 
-        names = [c.name for c in bar.containers()]
-        self.assertIn('composetest_bar_1', names)
-        self.assertIn('composetest_bar_2', names)
+        for c in bar.containers():
+            self.assertEqual(c.name, "composetest_bar_%s" % c.uid)
 
     def test_containers_one_off(self):
         db = self.create_service('db')
@@ -82,18 +80,18 @@ class ServiceTest(DockerClientTestCase):
     def test_project_is_added_to_container_name(self):
         service = self.create_service('web')
         create_and_start_container(service)
-        self.assertEqual(service.containers()[0].name, 'composetest_web_1')
+        self.assertTrue(service.containers()[0].name.startswith('composetest_web_'))
 
     def test_create_container_with_one_off(self):
         db = self.create_service('db')
         container = db.create_container(one_off=True)
-        self.assertEqual(container.name, 'composetest_db_run_1')
+        self.assertTrue(container.name.startswith('composetest_db_run_'))
 
     def test_create_container_with_one_off_when_existing_container_is_running(self):
         db = self.create_service('db')
         db.start()
         container = db.create_container(one_off=True)
-        self.assertEqual(container.name, 'composetest_db_run_1')
+        self.assertTrue(container.name.startswith('composetest_db_run_'))
 
     def test_create_container_with_unspecified_volume(self):
         service = self.create_service('db', volumes=[VolumeSpec.parse('/var/db')])
@@ -378,7 +376,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(old_container.get('Config.Entrypoint'), ['top'])
         self.assertEqual(old_container.get('Config.Cmd'), ['-d', '1'])
         self.assertIn('FOO=1', old_container.get('Config.Env'))
-        self.assertEqual(old_container.name, 'composetest_db_1')
+        self.assertTrue(old_container.name.startswith('composetest_db_'))
         service.start_container(old_container)
         old_container.inspect()  # reload volume data
         volume_path = old_container.get_mount('/etc')['Source']
@@ -392,7 +390,7 @@ class ServiceTest(DockerClientTestCase):
         self.assertEqual(new_container.get('Config.Entrypoint'), ['top'])
         self.assertEqual(new_container.get('Config.Cmd'), ['-d', '1'])
         self.assertIn('FOO=2', new_container.get('Config.Env'))
-        self.assertEqual(new_container.name, 'composetest_db_1')
+        self.assertTrue(new_container.name.startswith('composetest_db_'))
         self.assertEqual(new_container.get_mount('/etc')['Source'], volume_path)
         if not is_cluster(self.client):
             assert (
@@ -583,13 +581,11 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(db)
         create_and_start_container(web)
 
-        self.assertEqual(
-            set(get_links(web.containers()[0])),
-            set([
-                'composetest_db_1', 'db_1',
-                'composetest_db_2', 'db_2',
-                'db'])
-        )
+        links = get_links(web.containers()[0])
+        self.assertEqual(len(links), 5)
+        self.assertEqual(len(list(l for l in links if l.startswith('composetest_db_'))), 2)
+        self.assertEqual(len(list(l for l in links if l.startswith('db_'))), 2)
+        self.assertIn('db', links)
 
     @no_cluster('No legacy links support in Swarm')
     def test_start_container_creates_links_with_names(self):
@@ -600,32 +596,32 @@ class ServiceTest(DockerClientTestCase):
         create_and_start_container(db)
         create_and_start_container(web)
 
-        self.assertEqual(
-            set(get_links(web.containers()[0])),
-            set([
-                'composetest_db_1', 'db_1',
-                'composetest_db_2', 'db_2',
-                'custom_link_name'])
-        )
+        links = get_links(web.containers()[0])
+        self.assertEqual(len(links), 5)
+        self.assertEqual(len(list(l for l in links if l.startswith('composetest_db_'))), 2)
+        self.assertEqual(len(list(l for l in links if l.startswith('db_'))), 2)
+        self.assertIn('custom_link_name', links)
 
     @no_cluster('No legacy links support in Swarm')
     def test_start_container_with_external_links(self):
         db = self.create_service('db')
-        web = self.create_service('web', external_links=['composetest_db_1',
-                                                         'composetest_db_2',
-                                                         'composetest_db_3:db_3'])
+        print(db.containers())
 
         for _ in range(3):
             create_and_start_container(db)
+        print(db.containers())
+        db_containers = db.containers()
+        self.assertEqual(len(db_containers), 3)
+        external_links = [db_containers[0].name, db_containers[1].name]
+        external_links.append('%s:%s' % (db_containers[2].name, db_containers[2].name_without_project))
+        web = self.create_service('web', external_links=external_links)
+
         create_and_start_container(web)
 
-        self.assertEqual(
-            set(get_links(web.containers()[0])),
-            set([
-                'composetest_db_1',
-                'composetest_db_2',
-                'db_3']),
-        )
+        links = get_links(web.containers()[0])
+        self.assertEqual(len(links), 3)
+        self.assertEqual(len(list(l for l in links if l.startswith('composetest_db_'))), 2)
+        self.assertEqual(len(list(l for l in links if l.startswith('db_'))), 1)
 
     @no_cluster('No legacy links support in Swarm')
     def test_start_normal_container_does_not_create_links_to_its_own_service(self):
@@ -646,13 +642,11 @@ class ServiceTest(DockerClientTestCase):
 
         c = create_and_start_container(db, one_off=OneOffFilter.only)
 
-        self.assertEqual(
-            set(get_links(c)),
-            set([
-                'composetest_db_1', 'db_1',
-                'composetest_db_2', 'db_2',
-                'db'])
-        )
+        links = get_links(c)
+        self.assertEqual(len(links), 5)
+        self.assertEqual(len(list(l for l in links if l.startswith('composetest_db_'))), 2)
+        self.assertEqual(len(list(l for l in links if l.startswith('db_'))), 2)
+        self.assertIn('db', links)
 
     def test_start_container_builds_images(self):
         service = Service(
@@ -953,16 +947,13 @@ class ServiceTest(DockerClientTestCase):
         test that those containers are restarted and not removed/recreated.
         """
         service = self.create_service('web')
-        next_number = service._next_container_number()
-        valid_numbers = [next_number, next_number + 1]
-        service.create_container(number=next_number)
-        service.create_container(number=next_number + 1)
+        service.create_container()
+        service.create_container()
 
         with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
             service.scale(2)
         for container in service.containers():
             self.assertTrue(container.is_running)
-            self.assertTrue(container.number in valid_numbers)
 
         captured_output = mock_stderr.getvalue()
         self.assertNotIn('Creating', captured_output)
@@ -975,8 +966,7 @@ class ServiceTest(DockerClientTestCase):
         test that those containers are restarted and required number are created.
         """
         service = self.create_service('web')
-        next_number = service._next_container_number()
-        service.create_container(number=next_number, quiet=True)
+        service.create_container(quiet=True)
 
         for container in service.containers():
             self.assertFalse(container.is_running)
@@ -997,8 +987,7 @@ class ServiceTest(DockerClientTestCase):
         and the remaining threads continue.
         """
         service = self.create_service('web')
-        next_number = service._next_container_number()
-        service.create_container(number=next_number, quiet=True)
+        service.create_container(quiet=True)
 
         with mock.patch(
             'compose.container.Container.create',
@@ -1012,18 +1001,15 @@ class ServiceTest(DockerClientTestCase):
 
         assert len(service.containers()) == 1
         assert service.containers()[0].is_running
-        assert (
-            "ERROR: for composetest_web_2  Cannot create container for service"
-            " web: Boom" in mock_stderr.getvalue()
-        )
+        assert "ERROR: for composetest_web_" in mock_stderr.getvalue()
+        assert "Cannot create container for service web: Boom" in mock_stderr.getvalue()
 
     def test_scale_with_unexpected_exception(self):
         """Test that when scaling if the API returns an error, that is not of type
         APIError, that error is re-raised.
         """
         service = self.create_service('web')
-        next_number = service._next_container_number()
-        service.create_container(number=next_number, quiet=True)
+        service.create_container(quiet=True)
 
         with mock.patch(
             'compose.container.Container.create',
@@ -1042,8 +1028,7 @@ class ServiceTest(DockerClientTestCase):
         number of containers already running results in no change.
         """
         service = self.create_service('web')
-        next_number = service._next_container_number()
-        container = service.create_container(number=next_number, quiet=True)
+        container = service.create_container(quiet=True)
         container.start()
 
         container.inspect()
@@ -1287,7 +1272,6 @@ class ServiceTest(DockerClientTestCase):
         }
 
         compose_labels = {
-            LABEL_CONTAINER_NUMBER: '1',
             LABEL_ONE_OFF: 'False',
             LABEL_PROJECT: 'composetest',
             LABEL_SERVICE: 'web',
@@ -1361,7 +1345,7 @@ class ServiceTest(DockerClientTestCase):
     def test_duplicate_containers(self):
         service = self.create_service('web')
 
-        options = service._get_container_create_options({}, 1)
+        options = service._get_container_create_options({})
         original = Container.create(service.client, **options)
 
         self.assertEqual(set(service.containers(stopped=True)), set([original]))

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -30,7 +30,7 @@ class ContainerTest(unittest.TestCase):
                 "Labels": {
                     "com.docker.compose.project": "composetest",
                     "com.docker.compose.service": "web",
-                    "com.docker.compose.container-number": 7,
+                    "com.docker.compose.container-uid": "7",
                 },
             }
         }
@@ -79,7 +79,7 @@ class ContainerTest(unittest.TestCase):
 
     def test_number(self):
         container = Container(None, self.container_dict, has_been_inspected=True)
-        self.assertEqual(container.number, 7)
+        self.assertEqual(container.uid, "7")
 
     def test_name(self):
         container = Container.from_ps(None,


### PR DESCRIPTION
Fix #1516

This required a lot of changes to tests that relied on containers being sequentially numbered.