### PR TITLE
Adds a --rm option to docker-compose build

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -234,6 +234,7 @@ class TopLevelCommand(object):
             --no-cache              Do not use cache when building the image.
             --pull                  Always attempt to pull a newer version of the image.
             -m, --memory MEM        Sets memory limit for the bulid container.
+            --rm=true               Remove intermediate containers after a successful build.
             --build-arg key=val     Set build-time variables for one service.
         """
         service_names = options['SERVICE']
@@ -251,6 +252,7 @@ class TopLevelCommand(object):
             pull=bool(options.get('--pull', False)),
             force_rm=bool(options.get('--force-rm', False)),
             memory=options.get('--memory'),
+            rm=(options.get('--rm') == 'true'),
             build_args=build_args)
 
     def bundle(self, config_options, options):

--- a/compose/project.py
+++ b/compose/project.py
@@ -358,10 +358,10 @@ class Project(object):
         return containers
 
     def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, memory=None,
-              build_args=None):
+              rm=True, build_args=None):
         for service in self.get_services(service_names):
             if service.can_be_built():
-                service.build(no_cache, pull, force_rm, memory, build_args)
+                service.build(no_cache, pull, force_rm, memory, rm, build_args)
             else:
                 log.info('%s uses an image, skipping' % service.name)
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -912,7 +912,8 @@ class Service(object):
 
         return [build_spec(secret) for secret in self.secrets]
 
-    def build(self, no_cache=False, pull=False, force_rm=False, memory=None, build_args_override=None):
+    def build(self, no_cache=False, pull=False, force_rm=False, memory=None, rm=True,
+              build_args_override=None):
         log.info('Building %s' % self.name)
 
         build_opts = self.options.get('build', {})
@@ -931,7 +932,7 @@ class Service(object):
             path=path,
             tag=self.image_name,
             stream=True,
-            rm=True,
+            rm=rm,
             forcerm=force_rm,
             pull=pull,
             nocache=no_cache,

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -578,6 +578,17 @@ class CLITestCase(DockerClientTestCase):
         ]
         assert not containers
 
+    def test_build_rm(self):
+        self.base_dir = 'tests/fixtures/simple-dockerfile'
+        self.dispatch(['build', '--rm=false', 'simple'], returncode=0)
+
+        containers = [
+            Container.from_ps(self.project.client, c)
+            for c in self.project.client.containers(
+                all=True)
+        ]
+        assert containers
+
     def test_build_shm_size_build_option(self):
         pull_busybox(self.client)
         self.base_dir = 'tests/fixtures/build-shm-size'


### PR DESCRIPTION
Fixes #4608. Adds a --rm= option to docker-compose build to specify behavior of intermediate containers upon successful build.

Signed-off-by: Samantha Miller <samantha.a.miller123@gmail.com>