### PR TITLE
Implemented --url option to specify url of compose file to use.

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -35,6 +35,7 @@ def project_from_options(project_dir, options):
         tls_config=tls_config_from_options(options),
         environment=environment,
         override_dir=options.get('--project-directory'),
+        url=options.get('--url'),
     )
 
 
@@ -44,7 +45,7 @@ def get_config_from_options(base_dir, options):
         base_dir, options, environment
     )
     return config.load(
-        config.find(base_dir, config_path, environment)
+        config.find(base_dir, config_path, environment, url=options.get('--url'))
     )
 
 
@@ -81,10 +82,10 @@ def get_client(environment, verbose=False, version=None, tls_config=None, host=N
 
 
 def get_project(project_dir, config_path=None, project_name=None, verbose=False,
-                host=None, tls_config=None, environment=None, override_dir=None):
+                host=None, tls_config=None, environment=None, override_dir=None, url=None):
     if not environment:
         environment = Environment.from_env_file(project_dir)
-    config_details = config.find(project_dir, config_path, environment, override_dir)
+    config_details = config.find(project_dir, config_path, environment, override_dir, url=url)
     project_name = get_project_name(
         config_details.working_dir, project_name, environment
     )

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -172,6 +172,7 @@ class TopLevelCommand(object):
       -p, --project-name NAME     Specify an alternate project name (default: directory name)
       --verbose                   Show more output
       --no-ansi                   Do not print ANSI control characters
+      --url URL                   Specify url of compose file to use
       -v, --version               Print version and exit
       -H, --host HOST             Daemon socket to connect to
 

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -257,11 +257,18 @@ class ServiceConfig(namedtuple('_ServiceConfig', 'working_dir filename name conf
             config)
 
 
-def find(base_dir, filenames, environment, override_dir=None):
+def find(base_dir, filenames, environment, override_dir=None, url=None):
     if filenames == ['-']:
         return ConfigDetails(
             os.path.abspath(override_dir) if override_dir else os.getcwd(),
             [ConfigFile(None, yaml.safe_load(sys.stdin))],
+            environment
+        )
+    if url:
+        response = six.moves.urllib.request.urlopen(url)
+        return ConfigDetails(
+            os.path.abspath(override_dir) if override_dir else os.getcwd(),
+            [ConfigFile(None, yaml.safe_load(response.read()))],
             environment
         )
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -782,6 +782,19 @@ class CLITestCase(DockerClientTestCase):
         assert 'Removing network v2full_default' in result.stderr
         assert 'Removing network v2full_front' in result.stderr
 
+    def test_down_url(self):
+        self.base_dir = '.'
+        url = 'https://raw.githubusercontent.com/docker/compose/' \
+              '771bf5f7ea059f1efede26bd9b164e05467d289e/tests/fixtures/' \
+              'simple-composefile/docker-compose.yml'
+        self._project = get_project(self.base_dir, override_dir=self.override_dir, url=url)
+
+        self.dispatch(['--url', url, 'up', '-d'])
+        wait_on_condition(ContainerCountCondition(self.project, 2))
+
+        self.dispatch(['--url', url, 'down'])
+        assert len(self.project.containers()) == 0
+
     def test_down_timeout(self):
         self.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')
@@ -815,6 +828,18 @@ class CLITestCase(DockerClientTestCase):
         self.assertFalse(container.get('Config.AttachStderr'))
         self.assertFalse(container.get('Config.AttachStdout'))
         self.assertFalse(container.get('Config.AttachStdin'))
+
+    def test_up_url(self):
+        self.base_dir = '.'
+        url = 'https://raw.githubusercontent.com/docker/compose/' \
+              '771bf5f7ea059f1efede26bd9b164e05467d289e/tests/fixtures/' \
+              'simple-composefile/docker-compose.yml'
+        self._project = get_project(self.base_dir, override_dir=self.override_dir, url=url)
+        self.dispatch(['--url', url, 'up', '-d'])
+        service = self.project.get_service('simple')
+        another = self.project.get_service('another')
+        self.assertEqual(len(service.containers()), 1)
+        self.assertEqual(len(another.containers()), 1)
 
     def test_up_attached(self):
         self.base_dir = 'tests/fixtures/echo-services'


### PR DESCRIPTION
Implemented `--url` option for `docker-compose` that specifies a url to load the compose file from.
`docker-compose --url <url> [command]`

Fix #2313
Signed-off-by: Madeline Stager <stager.madeline@gmail.com>