### PR TITLE
Add COMPOSE_PARALLEL_LIMIT to restrict global number of parallel oper…

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -99,8 +99,13 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
         host=host, environment=environment
     )
 
+    global_parallel_limit = environment.get('COMPOSE_PARALLEL_LIMIT')
+    if global_parallel_limit:
+        global_parallel_limit = int(global_parallel_limit)
+
     with errors.handle_connection_errors(client):
-        return Project.from_config(project_name, config_data, client)
+        return Project.from_config(project_name, config_data, client,
+                                   global_parallel_limit=global_parallel_limit)
 
 
 def get_project_name(working_dir, project_name=None, environment=None):

--- a/compose/const.py
+++ b/compose/const.py
@@ -18,6 +18,7 @@ LABEL_VERSION = 'com.docker.compose.version'
 LABEL_VOLUME = 'com.docker.compose.volume'
 LABEL_CONFIG_HASH = 'com.docker.compose.config-hash'
 NANOCPUS_SCALE = 1000000000
+PARALLEL_LIMIT = 64
 
 SECRETS_PATH = '/run/secrets'
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -61,13 +61,15 @@ class Project(object):
     """
     A collection of services.
     """
-    def __init__(self, name, services, client, networks=None, volumes=None, config_version=None):
+    def __init__(self, name, services, client, networks=None, volumes=None, config_version=None,
+                 parallel_limit=None):
         self.name = name
         self.services = services
         self.client = client
         self.volumes = volumes or ProjectVolumes({})
         self.networks = networks or ProjectNetworks({}, False)
         self.config_version = config_version
+        parallel.GlobalLimit.set_global_limit(value=parallel_limit)
 
     def labels(self, one_off=OneOffFilter.exclude):
         labels = ['{0}={1}'.format(LABEL_PROJECT, self.name)]
@@ -76,7 +78,7 @@ class Project(object):
         return labels
 
     @classmethod
-    def from_config(cls, name, config_data, client):
+    def from_config(cls, name, config_data, client, global_parallel_limit=None):
         """
         Construct a Project from a config.Config object.
         """
@@ -87,7 +89,8 @@ class Project(object):
             networks,
             use_networking)
         volumes = ProjectVolumes.from_config(name, config_data, client)
-        project = cls(name, [], client, project_networks, volumes, config_data.version)
+        project = cls(name, [], client, project_networks, volumes, config_data.version,
+                      parallel_limit=global_parallel_limit)
 
         for service_dict in config_data.services:
             service_dict = dict(service_dict)

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -7,6 +7,7 @@ from threading import Lock
 import six
 from docker.errors import APIError
 
+from .. import mock
 from compose.parallel import get_configured_limit
 from compose.parallel import parallel_execute
 from compose.parallel import parallel_execute_iter
@@ -69,6 +70,7 @@ def test_parallel_execute_with_limit():
     assert errors == {}
 
 
+@mock.patch.dict(os.environ)
 def test_parallel_execute_with_global_limit():
     os.environ['COMPOSE_PARALLEL_LIMIT'] = '1'
     tasks = 20

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import os
 from threading import Lock
 
 import six
 from docker.errors import APIError
 
-from .. import mock
-from compose.parallel import get_configured_limit
+from compose.parallel import GlobalLimit
 from compose.parallel import parallel_execute
 from compose.parallel import parallel_execute_iter
 from compose.parallel import ParallelStreamWriter
@@ -70,13 +68,10 @@ def test_parallel_execute_with_limit():
     assert errors == {}
 
 
-@mock.patch.dict(os.environ)
 def test_parallel_execute_with_global_limit():
-    os.environ['COMPOSE_PARALLEL_LIMIT'] = '1'
+    GlobalLimit.set_global_limit(1)
     tasks = 20
     lock = Lock()
-
-    assert get_configured_limit() == 1
 
     def f(obj):
         locked = lock.acquire(False)


### PR DESCRIPTION
…ations

Addresses #3033 and #1828 

Adds a global limit configurable by setting a COMPOSE_PARALLEL_LIMIT environment variable, defaulting to 64.

Signed-off-by: Shea Rozmiarek <uberpanzermensch@gmail.com>