### PR TITLE
Allow limiting of the number of containers restarted in parallel for a scaled service

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -433,7 +433,8 @@ class Project(object):
            remove_orphans=False,
            scale_override=None,
            rescale=True,
-           start=True):
+           start=True,
+           rollout_factor=None):
 
         warn_for_swarm_mode(self.client)
 
@@ -461,7 +462,8 @@ class Project(object):
                 scale_override=scale_override.get(service.name),
                 rescale=rescale,
                 start=start,
-                project_services=scaled_services
+                project_services=scaled_services,
+                rollout_factor=rollout_factor,
             )
 
         def get_deps(service):

--- a/compose/service.py
+++ b/compose/service.py
@@ -405,7 +405,7 @@ class Service(object):
 
             return containers
 
-    def _execute_convergence_recreate(self, containers, scale, timeout, detached, start):
+    def _execute_convergence_recreate(self, containers, scale, timeout, detached, start, rollout_factor):
             if scale is not None and len(containers) > scale:
                 self._downscale(containers[scale:], timeout)
                 containers = containers[:scale]
@@ -420,6 +420,7 @@ class Service(object):
                 recreate,
                 lambda c: c.name,
                 "Recreating",
+                limit=rollout_factor,
             )
             for error in errors.values():
                 raise OperationFailedError(error)
@@ -464,7 +465,8 @@ class Service(object):
         )
 
     def execute_convergence_plan(self, plan, timeout=None, detached=False,
-                                 start=True, scale_override=None, rescale=True, project_services=None):
+                                 start=True, scale_override=None, rescale=True, project_services=None,
+                                 rollout_factor=None):
         (action, containers) = plan
         scale = scale_override if scale_override is not None else self.scale_num
         containers = sorted(containers, key=attrgetter('number'))
@@ -483,7 +485,7 @@ class Service(object):
 
         if action == 'recreate':
             return self._execute_convergence_recreate(
-                containers, scale, timeout, detached, start
+                containers, scale, timeout, detached, start, rollout_factor
             )
 
         if action == 'start':


### PR DESCRIPTION
This patch addresses #5124 and adds a new command line flag for `docker-compose up` called the `rollout-factor`. The flag limits the number of containers that will be restarted in parallel, allowing the service to restart with zero-downtime.