### PR TITLE
Avoid CLI crash if image has no tags

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -511,7 +511,10 @@ class TopLevelCommand(object):
             rows = []
             for container in containers:
                 image_config = container.image_config
-                repo_tags = image_config['RepoTags'][0].rsplit(':', 1)
+                repo_tags = (
+                    image_config['RepoTags'][0].rsplit(':', 1) if image_config['RepoTags']
+                    else ('<none>', '<none>')
+                )
                 image_id = image_config['Id'].split(':')[1][:12]
                 size = human_readable_file_size(image_config['Size'])
                 rows.append([

--- a/tests/fixtures/tagless-image/Dockerfile
+++ b/tests/fixtures/tagless-image/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox:latest
+RUN touch /blah

--- a/tests/fixtures/tagless-image/docker-compose.yml
+++ b/tests/fixtures/tagless-image/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '2.3'
+services:
+  foo:
+    image: ${IMAGE_ID}
+    command: top


### PR DESCRIPTION
Fixes #5414 