### PR TITLE
Bump 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Change log
 #### Compose file version 3.5
 
 - Introduced version 3.5 of the `docker-compose.yml` specification.
-  This version requires to be used with Docker Engine 17.06.0 or above
+  This version requires Docker Engine 17.06.0 or above
 
 - Added support for the `shm_size` parameter in build configurations
 
@@ -21,20 +21,15 @@ Change log
 
 - Added support for `extra_hosts` in build configuration
 
-- Added support for the
-  [long syntax](https://docs.docker.com/compose/compose-file/#long-syntax-3)
-  for volume entries, as previously introduced in the 3.2 format.
-  Note that using this syntax will create
-  [mounts](https://docs.docker.com/engine/admin/volumes/bind-mounts/)
-  instead of volumes.
+- Added support for the [long syntax](https://docs.docker.com/compose/compose-file/#long-syntax-3) for volume entries, as previously introduced in the 3.2 format.
+  Note that using this syntax will create [mounts](https://docs.docker.com/engine/admin/volumes/bind-mounts/) instead of volumes.
 
 #### Compose file version 2.1 and up
 
 - Added support for the `oom_kill_disable` parameter in service definitions
   (2.x only)
 
-- Added support for custom names for network, secret and config definitions
-  (2.x only)
+- Added support for custom names for network definitions (2.x only)
 
 
 #### All formats
@@ -61,6 +56,12 @@ Change log
 
 - Fixed an issue with CLI logging causing duplicate messages and inelegant
   output to occur
+
+- Fixed an issue that caused `stop_grace_period` to be ignored when using
+  multiple Compose files
+
+- Fixed a bug that caused `docker-compose images` to crash when using
+  untagged images
 
 - Fixed a bug where the valid `${VAR:-}` syntax would cause Compose to
   error out

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.18.0-rc2'
+__version__ = '1.18.0'

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -365,17 +365,17 @@ class TopLevelCommand(object):
         Usage: down [options]
 
         Options:
-            --rmi type          Remove images. Type must be one of:
-                                'all': Remove all images used by any service.
-                                'local': Remove only images that don't have a custom tag
-                                set by the `image` field.
-            -v, --volumes       Remove named volumes declared in the `volumes` section
-                                of the Compose file and anonymous volumes
-                                attached to containers.
-            --remove-orphans    Remove containers for services not defined in the
-                                Compose file
-            -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
-                                     (default: 10)
+            --rmi type              Remove images. Type must be one of:
+                                      'all': Remove all images used by any service.
+                                      'local': Remove only images that don't have a
+                                      custom tag set by the `image` field.
+            -v, --volumes           Remove named volumes declared in the `volumes`
+                                    section of the Compose file and anonymous volumes
+                                    attached to containers.
+            --remove-orphans        Remove containers for services not defined in the
+                                    Compose file
+            -t, --timeout TIMEOUT   Specify a shutdown timeout in seconds.
+                                    (default: 10)
         """
         image_type = image_type_from_opt('--rmi', options['--rmi'])
         timeout = timeout_from_opts(options)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -511,7 +511,10 @@ class TopLevelCommand(object):
             rows = []
             for container in containers:
                 image_config = container.image_config
-                repo_tags = image_config['RepoTags'][0].rsplit(':', 1)
+                repo_tags = (
+                    image_config['RepoTags'][0].rsplit(':', 1) if image_config['RepoTags']
+                    else ('<none>', '<none>')
+                )
                 image_id = image_config['Id'].split(':')[1][:12]
                 size = human_readable_file_size(image_config['Size'])
                 rows.append([

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -126,6 +126,7 @@ ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
     'network_mode',
     'init',
     'scale',
+    'stop_grace_period',
 ]
 
 DOCKER_VALID_URL_PREFIXES = (

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.18.0-rc2"
+VERSION="1.18.0"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/tests/fixtures/tagless-image/Dockerfile
+++ b/tests/fixtures/tagless-image/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox:latest
+RUN touch /blah

--- a/tests/fixtures/tagless-image/docker-compose.yml
+++ b/tests/fixtures/tagless-image/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '2.3'
+services:
+  foo:
+    image: ${IMAGE_ID}
+    command: top

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1150,7 +1150,8 @@ class ConfigTest(unittest.TestCase):
                         'volumes': [
                             {'source': '/a', 'target': '/b', 'type': 'bind'},
                             {'source': 'vol', 'target': '/x', 'type': 'volume', 'read_only': True}
-                        ]
+                        ],
+                        'stop_grace_period': '30s',
                     }
                 },
                 'volumes': {'vol': {}}
@@ -1177,6 +1178,7 @@ class ConfigTest(unittest.TestCase):
                 '/c:/b:rw',
                 {'source': 'vol', 'target': '/x', 'type': 'volume', 'read_only': True}
             ]
+        assert service_dicts[0]['stop_grace_period'] == '30s'
 
     @mock.patch.dict(os.environ)
     def test_volume_mode_override(self):


### PR DESCRIPTION
### New features

#### Compose file version 3.5

- Introduced version 3.5 of the `docker-compose.yml` specification.
  This version requires Docker Engine 17.06.0 or above

- Added support for the `shm_size` parameter in build configurations

- Added support for the `isolation` parameter in service definitions

- Added support for custom names for network, secret and config definitions

#### Compose file version 2.3

- Added support for `extra_hosts` in build configuration

- Added support for the
  [long syntax](https://docs.docker.com/compose/compose-file/#long-syntax-3)
  for volume entries, as previously introduced in the 3.2 format.
  Note that using this syntax will create
  [mounts](https://docs.docker.com/engine/admin/volumes/bind-mounts/)
  instead of volumes.

#### Compose file version 2.1 and up

- Added support for the `oom_kill_disable` parameter in service definitions
  (2.x only)

- Added support for custom names for network, secret and config definitions
  (2.x only)


#### All formats

- Values interpolated from the environment will now be converted to the
  proper type when used in non-string fields.

- Added support for `--label` in `docker-compose run`

- Added support for `--timeout` in `docker-compose down`

- Added support for `--memory` in `docker-compose build`

- Setting `stop_grace_period` in service definitions now also sets the
  container's `stop_timeout`

### Bugfixes

- Fixed an issue where Compose was still handling service hostname according
  to legacy engine behavior, causing hostnames containing dots to be cut up

- Fixed a bug where the `X-Y:Z` syntax for ports was considered invalid
  by Compose

- Fixed an issue with CLI logging causing duplicate messages and inelegant
  output to occur

- Fixed an issue that caused `stop_grace_period` to be ignored when using
  multiple Compose files

- Fixed a bug that caused `docker-compose images` to crash when using
  untagged images

- Fixed a bug where the valid `${VAR:-}` syntax would cause Compose to
  error out

- Fixed a bug where `env_file` entries using an UTF-8 BOM were being read
  incorrectly

- Fixed a bug where missing secret files would generate an empty directory
  in their place

- Fixed character encoding issues in the CLI's error handlers

- Added validation for the `test` field in healthchecks

- Added validation for the `subnet` field in IPAM configurations

- Added validation for `volumes` properties when using the long syntax in
  service definitions

- The CLI now explicit prevents using `-d` and `--timeout` together
  in `docker-compose up`
