### PR TITLE
Fix unicode error - python2

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -703,7 +703,7 @@ def warn_for_swarm_mode(client):
 
 class NoSuchService(Exception):
     def __init__(self, name):
-        self.name = name
+        self.name = name.decode('utf8')
         self.msg = "No such service: %s" % self.name
 
     def __str__(self):


### PR DESCRIPTION
If the name of a container doesn't exist and its name isn't utf-8 encoded you receive a stacktrace