### PR TITLE
Use CLI for interactive exec on all platforms by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,13 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.8.3 \
-        -o /usr/local/bin/docker && \
-    SHA256=f024bc65c45a3778cf07213d26016075e8172de8f6e4b5702bedde06c241650f; \
-    echo "${SHA256}  /usr/local/bin/docker" | sha256sum -c - && \
-    chmod +x /usr/local/bin/docker
+RUN curl -fsSL -o dockerbins.tgz "https://download.docker.com/linux/static/stable/x86_64/docker-17.12.0-ce.tgz" && \
+    SHA256=692e1c72937f6214b1038def84463018d8e320c8eaf8530546c84c2f8f9c767d; \
+    echo "${SHA256}  dockerbins.tgz" | sha256sum -c - && \
+    tar xvf dockerbins.tgz docker/docker --strip-components 1 && \
+    mv docker /usr/local/bin/docker && \
+    chmod +x /usr/local/bin/docker && \
+    rm dockerbins.tgz
 
 # Build Python 2.7.13 from source
 RUN set -ex; \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -17,9 +17,11 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl https://get.docker.com/builds/Linux/armel/docker-1.8.3 \
-        -o /usr/local/bin/docker && \
-    chmod +x /usr/local/bin/docker
+RUN curl -fsSL -o dockerbins.tgz "https://download.docker.com/linux/static/stable/armhf/docker-17.12.0-ce.tgz" && \
+    tar xvf dockerbins.tgz docker/docker --strip-components 1 && \
+    mv docker /usr/local/bin/docker && \
+    chmod +x /usr/local/bin/docker && \
+    rm dockerbins.tgz
 
 # Build Python 2.7.13 from source
 RUN set -ex; \

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -434,6 +434,8 @@ class TopLevelCommand(object):
             -e, --env KEY=VAL Set environment variables (can be used multiple times,
                               not supported in API < 1.25)
         """
+        environment = Environment.from_env_file(self.project_dir)
+        use_cli = not environment.get_boolean('COMPOSE_EXEC_NO_CLI')
         index = int(options.get('--index'))
         service = self.project.get_service(options['SERVICE'])
         detach = options['-d']
@@ -448,14 +450,14 @@ class TopLevelCommand(object):
         command = [options['COMMAND']] + options['ARGS']
         tty = not options["-T"]
 
-        if IS_WINDOWS_PLATFORM and not detach:
+        if IS_WINDOWS_PLATFORM or use_cli and not detach:
             sys.exit(call_docker(build_exec_command(options, container.id, command)))
 
         create_exec_options = {
             "privileged": options["--privileged"],
             "user": options["--user"],
             "tty": tty,
-            "stdin": tty,
+            "stdin": True,
         }
 
         if docker.utils.version_gte(self.project.client.api_version, '1.25'):

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -97,7 +97,9 @@ class CLITestCase(unittest.TestCase):
     @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason="requires dockerpty")
     @mock.patch('compose.cli.main.RunOperation', autospec=True)
     @mock.patch('compose.cli.main.PseudoTerminal', autospec=True)
+    @mock.patch.dict(os.environ)
     def test_run_interactive_passes_logs_false(self, mock_pseudo_terminal, mock_run_operation):
+        os.environ['COMPOSE_INTERACTIVE_NO_CLI'] = 'true'
         mock_client = mock.create_autospec(docker.APIClient)
         mock_client.api_version = DEFAULT_DOCKER_API_VERSION
         project = Project.from_config(


### PR DESCRIPTION
This change expands the Windows client behavior of shelling out to the `docker` CLI for interactive exec/run operations. See #3980

Add environment setting `COMPOSE_INTERACTIVE_NO_CLI` to enable old behavior (UNIX only)


Fixes #5578 
Fixes #3352 
Fixes #4290 