### PR TITLE
Use mock compatibility import

### DIFF
--- a/tests/unit/bundle_test.py
+++ b/tests/unit/bundle_test.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import docker
-import mock
 import pytest
 
+from .. import mock
 from compose import bundle
 from compose import service
 from compose.cli.errors import UserError


### PR DESCRIPTION
`tests/__init__.py` already has a try/except statement to use mock from the standard library when possible.  Take advantage of it like other tests already do.