### PR TITLE
Add bash completion for `up {--always-recreate-deps,--renew-anon-volumes}`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -550,7 +550,7 @@ _docker_compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--abort-on-container-exit --build -d --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --no-start --remove-orphans --scale --timeout -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --build -d --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all


### PR DESCRIPTION
This adds support for two new options for `docker-compose up` that will be added in 1.19.0, see #5602.
- `--always-recreate-deps` was added in #5541
- `--renew-anon-volumes|-V` was added in #5596

Please include in 1.19.0 so that features and completion are in sync.