### PR TITLE
Bump 1.19.0 rc2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,12 @@ jobs:
       - run:
           name: API trigger
           command: |
-            curl -X POST -H "Content-Type: application/json" \
-            -u ${OSX_RELEASE_TOKEN} -d "{\
+            curl -X POST -H "Content-Type: application/json" -d "{\
               \"build_parameters\": {\
                 \"COMPOSE_BRANCH\": \"${CIRCLE_BRANCH}\"\
               }\
-            }" https://circleci.com/api/v1.1/project/github/docker/compose-osx-release > /dev/null
+            }" https://circleci.com/api/v1.1/project/github/docker/compose-osx-release?circle-token=${OSX_RELEASE_TOKEN} \
+            > /dev/null
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
               \"build_parameters\": {\
                 \"COMPOSE_BRANCH\": \"${CIRCLE_BRANCH}\"\
               }\
-            }" https://circleci.com/api/v1.1/project/github/docker/compose-osx-release
+            }" https://circleci.com/api/v1.1/project/github/docker/compose-osx-release > /dev/null
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,10 @@ jobs:
       - store_artifacts:
           path: dist/docker-compose-Darwin-x86_64
           destination: docker-compose-Darwin-x86_64
-      - deploy:
-          name: Deploy binary to bintray
-          command: |
-            OS_NAME=Darwin PKG_NAME=osx ./script/circle/bintray-deploy.sh
+      # - deploy:
+      #     name: Deploy binary to bintray
+      #     command: |
+      #       OS_NAME=Darwin PKG_NAME=osx ./script/circle/bintray-deploy.sh
 
 
   build-linux-binary:
@@ -53,6 +53,30 @@ jobs:
           name: Deploy binary to bintray
           command: |
             OS_NAME=Linux PKG_NAME=linux ./script/circle/bintray-deploy.sh
+
+  trigger-osx-binary-deploy:
+    # We use a separate repo to build OSX binaries meant for distribution
+    # with support for OSSX 10.11 (xcode 7). This job triggers a build on
+    # that repo.
+    docker:
+      - image: alpine:3.6
+
+    steps:
+      - run:
+          name: install curl
+          command: apk update && apk add curl
+
+      - run:
+          name: API trigger
+          command: |
+            curl -X POST -H "Content-Type: application/json" \
+            -u ${OSX_RELEASE_TOKEN} -d "{\
+              \"build_parameters\": {\
+                \"COMPOSE_BRANCH\": \"${CIRCLE_BRANCH}\"\
+              }\
+            }" https://circleci.com/api/v1.1/project/github/docker/compose-osx-release
+
+
 workflows:
   version: 2
   all:
@@ -60,3 +84,9 @@ workflows:
       - test
       - build-linux-binary
       - build-osx-binary
+      - trigger-osx-binary-deploy:
+          filters:
+            branches:
+              only:
+                - master
+                - /bump-.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Change log
 - Fixed a bug where the recreation of a service would break if the image
   associated with the previous container had been removed
 
+- Fixed a bug where updating a mount's target would break Compose when
+  trying to recreate the associated service
+
 - Fixed a bug where `tmpfs` volumes declared using the extended syntax in
   Compose files using version 3.2 would be erroneously created as anonymous
   volumes instead

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.19.0-rc1'
+__version__ = '1.19.0-rc2'

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -550,7 +550,7 @@ _docker_compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--abort-on-container-exit --build -d --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --no-start --remove-orphans --scale --timeout -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --build -d --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.19.0-rc1"
+VERSION="1.19.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 


### PR DESCRIPTION
### Breaking changes

- On UNIX platforms, interactive `run` and `exec` commands now require
  the `docker` CLI to be installed on the client by default. To revert
  to the previous behavior, users may set the `COMPOSE_INTERACTIVE_NO_CLI`
  environment variable.

### New features

#### Compose file version 3.x

- The output of the `config` command should now merge `deploy` options from
  several Compose files in a more accurate manner

#### Compose file version 2.3

- Added support for the `runtime` option in service definitions

#### Compose file version 2.1 and up

- Added support for the `${VAR:?err}` and `${VAR?err}` variable interpolation
  syntax to indicate mandatory variables

#### Compose file version 2.x

- Added `priority` key to service network mappings, allowing the user to
  define in which order the specified service will connect to each network

#### All formats

- Added `--renew-anon-volumes` (shorthand `-V`) to the `up` command,
  preventing Compose from recovering volume data from previous containers for
  anonymous volumes

- Added limit for number of simulatenous parallel operations, which should
  prevent accidental resource exhaustion of the server. Default is 64 and
  can be configured using the `COMPOSE_PARALLEL_LIMIT` environment variable

- Added `--always-recreate-deps` flag to the `up` command to force recreating
  dependent services along with the dependency owner

- Added `COMPOSE_IGNORE_ORPHANS` environment variable to forgo orphan
  container detection and suppress warnings

- Added `COMPOSE_FORCE_WINDOWS_HOST` environment variable to force Compose
  to parse volume definitions as if the Docker host was a Windows system,
  even if Compose itself is currently running on UNIX

- Bash completion should now be able to better differentiate between running,
  stopped and paused services

### Bugfixes

- Fixed a bug that would cause the `build` command to report a connection
  error when the build context contained unreadable files or FIFO objects.
  These file types will now be handled appropriately

- Fixed various issues around interactive `run`/`exec` sessions.

- Fixed a bug where setting TLS options with environment and CLI flags
  simultaneously would result in part of the configuration being ignored

- Fixed a bug where the `-d` and `--timeout` flags in `up` were erroneously
  marked as incompatible

- Fixed a bug where the recreation of a service would break if the image
  associated with the previous container had been removed

- Fixed a bug where updating a mount's target would break Compose when
  trying to recreate the associated service

- Fixed a bug where `tmpfs` volumes declared using the extended syntax in
  Compose files using version 3.2 would be erroneously created as anonymous
  volumes instead

- Fixed a bug where type conversion errors would print a stacktrace instead
  of exiting gracefully

- Fixed some errors related to unicode handling

- Dependent services no longer get recreated along with the dependency owner
  if their configuration hasn't changed

- Added better validation of `labels` fields in Compose files. Label values
  containing scalar types (number, boolean) now get automatically converted
  to strings