### PR TITLE
Allow unsetting an entrypoint (resolves #5582)

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1197,8 +1197,7 @@ def build_container_options(options, detach, command):
     if options['--label']:
         container_options['labels'] = parse_labels(options['--label'])
 
-    if options['--entrypoint']:
-        container_options['entrypoint'] = options.get('--entrypoint')
+    _build_container_entrypoint_options(container_options, options)
 
     if options['--rm']:
         container_options['restart'] = None
@@ -1223,6 +1222,16 @@ def build_container_options(options, detach, command):
         container_options['volumes'] = volumes
 
     return container_options
+
+
+def _build_container_entrypoint_options(container_options, options):
+    if options['--entrypoint']:
+        if options['--entrypoint'].strip() == '':
+            # Set an empty entry point. Refer https://github.com/moby/moby/pull/23718
+            log.info("Overriding the entrypoint")
+            container_options['entrypoint'] = [""]
+        else:
+            container_options['entrypoint'] = options.get('--entrypoint')
 
 
 def run_one_off_container(container_options, project, service, options, project_dir='.'):


### PR DESCRIPTION
When an empty string is passed to the 'entrypoint' parameter, for example
`docker-compose run --entrypoint='' ...`
OR
`docker-compose run --entrypoint '' ...`
It allows the default entrypoint to be overriden by empty value.

Signed-off-by: Ganesh Satpute <ghsatpute@gmail.com>