### PR TITLE
Add missing `-q|--quiet` options to increase consistency

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -503,14 +503,14 @@ class TopLevelCommand(object):
         Usage: images [options] [SERVICE...]
 
         Options:
-        -q     Only display IDs
+            -q, --quiet  Only display IDs
         """
         containers = sorted(
             self.project.containers(service_names=options['SERVICE'], stopped=True) +
             self.project.containers(service_names=options['SERVICE'], one_off=OneOffFilter.only),
             key=attrgetter('name'))
 
-        if options['-q']:
+        if options['--quiet']:
             for image in set(c.image for c in containers):
                 print(image.split(':')[1])
         else:
@@ -624,12 +624,12 @@ class TopLevelCommand(object):
         Usage: ps [options] [SERVICE...]
 
         Options:
-            -q                   Only display IDs
+            -q, --quiet          Only display IDs
             --services           Display services
             --filter KEY=VAL     Filter services by a property
         """
-        if options['-q'] and options['--services']:
-            raise UserError('-q and --services cannot be combined')
+        if options['--quiet'] and options['--services']:
+            raise UserError('--quiet and --services cannot be combined')
 
         if options['--services']:
             filt = build_filter(options.get('--filter'))
@@ -644,7 +644,7 @@ class TopLevelCommand(object):
             self.project.containers(service_names=options['SERVICE'], one_off=OneOffFilter.only),
             key=attrgetter('name'))
 
-        if options['-q']:
+        if options['--quiet']:
             for container in containers:
                 print(container.id)
         else:
@@ -676,7 +676,7 @@ class TopLevelCommand(object):
         Options:
             --ignore-pull-failures  Pull what it can and ignores images with pull failures.
             --parallel              Pull multiple images in parallel.
-            --quiet                 Pull without printing progress information
+            -q, --quiet             Pull without printing progress information
         """
         self.project.pull(
             service_names=options['SERVICE'],

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -259,7 +259,7 @@ _docker_compose_help() {
 _docker_compose_images() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help -q" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --quiet -q" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all
@@ -361,7 +361,7 @@ _docker_compose_ps() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help -q --services --filter" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --quiet -q --services --filter" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all
@@ -373,7 +373,7 @@ _docker_compose_ps() {
 _docker_compose_pull() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --ignore-pull-failures --parallel --quiet" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --ignore-pull-failures --parallel --quiet -q" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_from_image

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -207,13 +207,13 @@ class CLITestCase(DockerClientTestCase):
         self.base_dir = None
         result = self.dispatch([
             '-f', 'tests/fixtures/invalid-composefile/invalid.yml',
-            'config', '-q'
+            'config', '--quiet'
         ], returncode=1)
         assert "'notaservice' must be a mapping" in result.stderr
 
     def test_config_quiet(self):
         self.base_dir = 'tests/fixtures/v2-full'
-        assert self.dispatch(['config', '-q']).stdout == ''
+        assert self.dispatch(['config', '--quiet']).stdout == ''
 
     def test_config_default(self):
         self.base_dir = 'tests/fixtures/v2-full'


### PR DESCRIPTION
Some commands have `-q`, `pull` has `--quiet` and `config` has both:

```bash
$ for cmd in config images ps pull ; do docker-compose $cmd --help | grep -e -q ; done
    -q, --quiet              Only validate the configuration, don't print
-q     Only display IDs
    -q    Only display IDs
    --quiet                 Pull without printing progress information
```

This PR adds the missing short/long forms to the CLI and to bash completion:
```bash
$ for cmd in config images ps pull ; do docker-compose $cmd --help | grep -e -q ; done
    -q, --quiet              Only validate the configuration, don't print
    -q, --quiet  Only display IDs
    -q, --quiet          Only display IDs
    -q, --quiet             Pull without printing progress information
```