### PR TITLE
Improve spelling in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Installation and documentation
 
 - Full documentation is available on [Docker's website](https://docs.docker.com/compose/).
 - If you have any questions, you can talk in real-time with other developers in the #docker-compose IRC channel on Freenode. [Click here to join using IRCCloud.](https://www.irccloud.com/invite?hostname=irc.freenode.net&channel=%23docker-compose)
-- Code repository for Compose is on [Github](https://github.com/docker/compose)
+- Code repository for Compose is on [GitHub](https://github.com/docker/compose)
 - If you find any problems please fill out an [issue](https://github.com/docker/compose/issues/new)
 
 Contributing


### PR DESCRIPTION
Improve spelling of the brand names:
- GitHub instead of Github