### PR TITLE
Pass-through keyword arguments to Docker client for image push and pull

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -537,12 +537,13 @@ class Project(object):
 
         return plans
 
-    def pull(self, service_names=None, ignore_pull_failures=False, parallel_pull=False, silent=False):
+    def pull(self, service_names=None, ignore_pull_failures=False,
+             parallel_pull=False, silent=False, **kwargs):
         services = self.get_services(service_names, include_deps=False)
 
         if parallel_pull:
             def pull_service(service):
-                service.pull(ignore_pull_failures, True)
+                service.pull(ignore_pull_failures, True, **kwargs)
 
             _, errors = parallel.parallel_execute(
                 services,
@@ -555,11 +556,11 @@ class Project(object):
                 raise ProjectError(b"\n".join(errors.values()))
         else:
             for service in services:
-                service.pull(ignore_pull_failures, silent=silent)
+                service.pull(ignore_pull_failures, silent=silent, **kwargs)
 
-    def push(self, service_names=None, ignore_push_failures=False):
+    def push(self, service_names=None, ignore_push_failures=False, **kwargs):
         for service in self.get_services(service_names, include_deps=False):
-            service.push(ignore_push_failures)
+            service.push(ignore_push_failures, **kwargs)
 
     def _labeled_containers(self, stopped=False, one_off=OneOffFilter.exclude):
         return list(filter(None, [

--- a/compose/service.py
+++ b/compose/service.py
@@ -1083,7 +1083,7 @@ class Service(object):
 
         return any(has_host_port(binding) for binding in self.options.get('ports', []))
 
-    def pull(self, ignore_pull_failures=False, silent=False):
+    def pull(self, ignore_pull_failures=False, silent=False, **kwargs):
         if 'image' not in self.options:
             return
 
@@ -1092,7 +1092,7 @@ class Service(object):
         if not silent:
             log.info('Pulling %s (%s%s%s)...' % (self.name, repo, separator, tag))
         try:
-            output = self.client.pull(repo, tag=tag, stream=True)
+            output = self.client.pull(repo, tag=tag, stream=True, **kwargs)
             if silent:
                 with open(os.devnull, 'w') as devnull:
                     return progress_stream.get_digest_from_pull(
@@ -1106,14 +1106,14 @@ class Service(object):
             else:
                 log.error(six.text_type(e))
 
-    def push(self, ignore_push_failures=False):
+    def push(self, ignore_push_failures=False, **kwargs):
         if 'image' not in self.options or 'build' not in self.options:
             return
 
         repo, tag, separator = parse_repository_tag(self.options['image'])
         tag = tag or 'latest'
         log.info('Pushing %s (%s%s%s)...' % (self.name, repo, separator, tag))
-        output = self.client.push(repo, tag=tag, stream=True)
+        output = self.client.push(repo, tag=tag, stream=True, **kwargs)
 
         try:
             return progress_stream.get_digest_from_push(

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -560,3 +560,50 @@ class ProjectTest(unittest.TestCase):
     def test_no_such_service_unicode(self):
         assert NoSuchService('十六夜　咲夜'.encode('utf-8')).msg == 'No such service: 十六夜　咲夜'
         assert NoSuchService('十六夜　咲夜').msg == 'No such service: 十六夜　咲夜'
+
+    @mock.patch('compose.service.Service.pull')
+    def test_pull_image_with_auth_config(self, mock_pull):
+        web = Service(
+            project='guppy-phony-havana',
+            name='web',
+            image='hoc/breath-filename'
+        )
+        auth_config = {
+            'username': 'modest-dogma',
+            'password': 'sallow-exclude'
+        }
+        project = Project('doorjamb-gather-butane', [web], None)
+        project.pull(auth_config=auth_config)
+        mock_pull.assert_called_once_with(
+            False, auth_config=auth_config, silent=False
+        )
+
+    @mock.patch('compose.service.Service.pull')
+    def test_parallel_pull_image_with_auth_config(self, mock_pull):
+        web = Service(
+            project='beeline-compel-croft',
+            name='web',
+            image='irenic/dunce-iroquois'
+        )
+        auth_config = {
+            'username': 'cohere-bluefish',
+            'password': 'deeply-seclude'
+        }
+        project = Project('beeline-compel-croft', [web], None)
+        project.pull(auth_config=auth_config, parallel_pull=True)
+        mock_pull.assert_called_once_with(False, True, auth_config=auth_config)
+
+    @mock.patch('compose.service.Service.push')
+    def test_push_image_with_auth_config(self, mock_push):
+        web = Service(
+            project='divan-georgian-molecule',
+            name='web',
+            image='manikin/simple-nobleman'
+        )
+        auth_config = {
+            'username': 'guild-send',
+            'password': 'pungent-missing'
+        }
+        project = Project('bairn-billet-hirsute', [web], None)
+        project.push(auth_config=auth_config)
+        mock_push.assert_called_once_with(False, auth_config=auth_config)

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -416,6 +416,30 @@ class ServiceTest(unittest.TestCase):
             stream=True)
         mock_log.info.assert_called_once_with('Pulling foo (someimage@sha256:1234)...')
 
+    def test_pull_image_with_auth_config(self):
+        service = Service('foo', client=self.mock_client,
+                          image='moisture/penman-adieu')
+        auth_config = {'username': 'avatar-bilious',
+                       'password': 'infinite-wingspan'}
+        service.pull(auth_config=auth_config)
+        self.mock_client.pull.assert_called_once_with(
+            'moisture/penman-adieu',
+            tag='latest',
+            stream=True,
+            auth_config=auth_config)
+
+    def test_push_image_with_auth_config(self):
+        service = Service('foo', client=self.mock_client,
+                          image='drier/stunt-snare', build={'context': '.'})
+        auth_config = {'username': 'valiancy-forelock',
+                       'password': 'reliant-wombat'}
+        service.push(auth_config=auth_config)
+        self.mock_client.push.assert_called_once_with(
+            'drier/stunt-snare',
+            tag='latest',
+            stream=True,
+            auth_config=auth_config)
+
     @mock.patch('compose.service.Container', autospec=True)
     def test_recreate_container(self, _):
         mock_container = mock.create_autospec(Container)


### PR DESCRIPTION
Allow pushing to and pulling from private image repositories without having to store credentials in a config file. The Docker client already allows this via auth_config parameter. By passing through extra keyword arguments, new parameters can also be used when they become available.

This doesn't affect the command-line interface.  It only adds to the Python API.