### PR TITLE
Fix bash completion on systems where extglob is not set

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -16,6 +16,8 @@
 #    below to your .bashrc after bash completion features are loaded
 #    . ~/.docker-compose-completion.sh
 
+__docker_compose_previous_extglob_setting=$(shopt -p extglob)
+shopt -s extglob
 
 __docker_compose_q() {
 	docker-compose 2>/dev/null "${top_level_options[@]}" "$@"
@@ -657,5 +659,8 @@ _docker_compose() {
 	eval "$previous_extglob_setting"
 	return 0
 }
+
+eval "$__docker_compose_previous_extglob_setting"
+unset __docker_compose_previous_extglob_setting
 
 complete -F _docker_compose docker-compose docker-compose.exe


### PR DESCRIPTION
Apply same fix as https://github.com/docker/cli/commit/7fa96238a6c78e6b35a8e9a0758bef0c07a96b15

Fixes #5658