### PR TITLE
Allow unsetting entrypoint in run command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1232,8 +1232,7 @@ def build_container_options(options, detach, command):
     if options['--label']:
         container_options['labels'] = parse_labels(options['--label'])
 
-    if options['--entrypoint']:
-        container_options['entrypoint'] = options.get('--entrypoint')
+    _build_container_entrypoint_options(container_options, options)
 
     if options['--rm']:
         container_options['restart'] = None
@@ -1258,6 +1257,16 @@ def build_container_options(options, detach, command):
         container_options['volumes'] = volumes
 
     return container_options
+
+
+def _build_container_entrypoint_options(container_options, options):
+    if options['--entrypoint']:
+        if options['--entrypoint'].strip() == '':
+            # Set an empty entry point. Refer https://github.com/moby/moby/pull/23718
+            log.info("Overriding the entrypoint")
+            container_options['entrypoint'] = [""]
+        else:
+            container_options['entrypoint'] = options.get('--entrypoint')
 
 
 def run_one_off_container(container_options, project, service, options, toplevel_options,

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1232,7 +1232,10 @@ def build_container_options(options, detach, command):
     if options['--label']:
         container_options['labels'] = parse_labels(options['--label'])
 
-    _build_container_entrypoint_options(container_options, options)
+    if options.get('--entrypoint') is not None:
+        container_options['entrypoint'] = (
+            [""] if options['--entrypoint'] == '' else options['--entrypoint']
+        )
 
     if options['--rm']:
         container_options['restart'] = None
@@ -1257,16 +1260,6 @@ def build_container_options(options, detach, command):
         container_options['volumes'] = volumes
 
     return container_options
-
-
-def _build_container_entrypoint_options(container_options, options):
-    if options['--entrypoint']:
-        if options['--entrypoint'].strip() == '':
-            # Set an empty entry point. Refer https://github.com/moby/moby/pull/23718
-            log.info("Overriding the entrypoint")
-            container_options['entrypoint'] = [""]
-        else:
-            container_options['entrypoint'] = options.get('--entrypoint')
 
 
 def run_one_off_container(container_options, project, service, options, toplevel_options,

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1697,6 +1697,18 @@ class CLITestCase(DockerClientTestCase):
         assert container.get('Config.Entrypoint') == ['printf']
         assert container.get('Config.Cmd') == ['default', 'args']
 
+    def test_run_service_with_unset_entrypoint(self):
+        self.base_dir = 'tests/fixtures/entrypoint-dockerfile'
+        self.dispatch(['run', '--entrypoint=""', 'test', 'true'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') is None
+        assert container.get('Config.Cmd') == ['true']
+
+        self.dispatch(['run', '--entrypoint', '""', 'test', 'true'])
+        container = self.project.containers(stopped=True, one_off=OneOffFilter.only)[0]
+        assert container.get('Config.Entrypoint') is None
+        assert container.get('Config.Cmd') == ['true']
+
     def test_run_service_with_dockerfile_entrypoint_overridden(self):
         self.base_dir = 'tests/fixtures/entrypoint-dockerfile'
         self.dispatch(['run', '--entrypoint', 'echo', 'test'])


### PR DESCRIPTION
Rebase of #5619 , with added test
Fixes #5582 
Closes #5619 