### PR TITLE
Bump 1.20.0 RC2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     - checkout
     - run:
         name: install python3
-        command: brew update > /dev/null && brew install python3
+        command: brew update > /dev/null && brew upgrade python
     - run:
         name: install tox
         command: sudo pip install --upgrade tox==2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,11 @@ Change log
 - Proxy configuration found in the `~/.docker/config.json` file now populates
   environment and build args for containers created by Compose
 
-- Added a `--use-aliases` flag to `docker-compose run`, indicating that
+- Added the `--use-aliases` flag to `docker-compose run`, indicating that
   network aliases declared in the service's config should be used for the
   running container
+
+- Added the `--include-deps` flag to `docker-compose pull`
 
 - `docker-compose run` now kills and removes the running container upon
   receiving `SIGHUP`
@@ -54,6 +56,9 @@ Change log
 
 - Fixed `.dockerignore` handling, notably with regard to absolute paths
   and last-line precedence rules
+
+- Fixed an issue where Compose would make costly DNS lookups when connecting
+  to the Engine when using Docker For Mac
 
 - Fixed a bug introduced in 1.19.0 which caused the default certificate path
   to not be honored by Compose
@@ -69,6 +74,9 @@ Change log
 
 - A `seccomp:<filepath>` entry in the `security_opt` config now correctly
   sends the contents of the file to the engine
+
+- ANSI output for `up` and `down` operations should no longer affect the wrong
+  lines
 
 - Improved support for non-unicode locales
 

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,42 +1,20 @@
-FROM sgerrand/glibc-builder as glibc
-RUN apt-get install -yq bison
-
-ENV PKGDIR /pkgdata
-
-RUN mkdir -p /usr/glibc-compat/etc && touch /usr/glibc-compat/etc/ld.so.conf
-RUN /builder 2.27 /usr/glibc-compat || true
-RUN mkdir -p $PKGDIR
-RUN tar -xf /glibc-bin-2.27.tar.gz -C $PKGDIR
-RUN rm "$PKGDIR"/usr/glibc-compat/etc/rpc && \
-    rm -rf "$PKGDIR"/usr/glibc-compat/bin && \
-    rm -rf "$PKGDIR"/usr/glibc-compat/sbin && \
-    rm -rf "$PKGDIR"/usr/glibc-compat/lib/gconv && \
-    rm -rf "$PKGDIR"/usr/glibc-compat/lib/getconf && \
-    rm -rf "$PKGDIR"/usr/glibc-compat/lib/audit && \
-    rm -rf "$PKGDIR"/usr/glibc-compat/share && \
-    rm -rf "$PKGDIR"/usr/glibc-compat/var
-
-
 FROM alpine:3.6
 
-RUN apk update && apk add --no-cache openssl ca-certificates
-COPY --from=glibc /pkgdata/ /
+ENV GLIBC 2.27-r0
+ENV DOCKERBINS_SHA 1270dce1bd7e1838d62ae21d2505d87f16efc1d9074645571daaefdfd0c14054
 
-RUN mkdir -p /lib /lib64 /usr/glibc-compat/lib/locale /etc && \
+RUN apk update && apk add --no-cache openssl ca-certificates curl && \
+    curl -fsSL -o /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+    curl -fsSL -o glibc-$GLIBC.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC/glibc-$GLIBC.apk && \
+    apk add --no-cache glibc-$GLIBC.apk && \
     ln -s /lib/libz.so.1 /usr/glibc-compat/lib/ && \
     ln -s /lib/libc.musl-x86_64.so.1 /usr/glibc-compat/lib && \
-    ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib/ld-linux-x86-64.so.2 && \
-    ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 && \
-    ln -s /usr/glibc-compat/etc/ld.so.cache /etc/ld.so.cache
-
-RUN apk add --no-cache curl && \
-    curl -fsSL -o dockerbins.tgz "https://download.docker.com/linux/static/stable/x86_64/docker-17.12.0-ce.tgz" && \
-    SHA256=692e1c72937f6214b1038def84463018d8e320c8eaf8530546c84c2f8f9c767d; \
-    echo "${SHA256}  dockerbins.tgz" | sha256sum -c - && \
+    curl -fsSL -o dockerbins.tgz "https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz" && \
+    echo "${DOCKERBINS_SHA}  dockerbins.tgz" | sha256sum -c - && \
     tar xvf dockerbins.tgz docker/docker --strip-components 1 && \
     mv docker /usr/local/bin/docker && \
     chmod +x /usr/local/bin/docker && \
-    rm dockerbins.tgz && \
+    rm dockerbins.tgz /etc/apk/keys/sgerrand.rsa.pub glibc-$GLIBC.apk && \
     apk del curl
 
 COPY dist/docker-compose-Linux-x86_64 /usr/local/bin/docker-compose

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.20.0-rc1'
+__version__ = '1.20.0-rc2'

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1039,6 +1039,7 @@ def merge_service_dicts(base, override, version):
     md.merge_sequence('links', ServiceLink.parse)
     md.merge_sequence('secrets', types.ServiceSecret.parse)
     md.merge_sequence('configs', types.ServiceConfig.parse)
+    md.merge_sequence('security_opt', types.SecurityOpt.parse)
     md.merge_mapping('extra_hosts', parse_extra_hosts)
 
     for field in ['volumes', 'devices']:
@@ -1046,7 +1047,7 @@ def merge_service_dicts(base, override, version):
 
     for field in [
         'cap_add', 'cap_drop', 'expose', 'external_links',
-        'security_opt', 'volumes_from', 'device_cgroup_rules',
+        'volumes_from', 'device_cgroup_rules',
     ]:
         md.merge_field(field, merge_unique_items_lists, default=[])
 

--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -464,6 +464,8 @@ def normalize_port_dict(port):
 class SecurityOpt(namedtuple('_SecurityOpt', 'value src_file')):
     @classmethod
     def parse(cls, value):
+        if not isinstance(value, six.string_types):
+            return value
         # based on https://github.com/docker/cli/blob/9de1b162f/cli/command/container/opts.go#L673-L697
         con = value.split('=', 2)
         if len(con) == 1 and con[0] != 'no-new-privileges':
@@ -485,4 +487,8 @@ class SecurityOpt(namedtuple('_SecurityOpt', 'value src_file')):
     def repr(self):
         if self.src_file is not None:
             return 'seccomp:{}'.format(self.src_file)
+        return self.value
+
+    @property
+    def merge_field(self):
         return self.value

--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import logging
 import operator
 import sys
+from threading import Lock
 from threading import Semaphore
 from threading import Thread
 
@@ -251,6 +252,7 @@ class ParallelStreamWriter(object):
     """
 
     noansi = False
+    lock = Lock()
 
     @classmethod
     def set_noansi(cls, value=True):
@@ -274,6 +276,7 @@ class ParallelStreamWriter(object):
         self.stream.flush()
 
     def _write_ansi(self, obj_index, status):
+        self.lock.acquire()
         position = self.lines.index(obj_index)
         diff = len(self.lines) - position
         # move up
@@ -285,6 +288,7 @@ class ParallelStreamWriter(object):
         # move back down
         self.stream.write("%c[%dB" % (27, diff))
         self.stream.flush()
+        self.lock.release()
 
     def _write_noansi(self, obj_index, status):
         self.stream.write("{} {:<{width}} ... {}\r\n".format(self.msg, obj_index,

--- a/compose/service.py
+++ b/compose/service.py
@@ -402,8 +402,7 @@ class Service(object):
                 [ServiceName(self.project, self.name, index) for index in range(i, i + scale)],
                 lambda service_name: create_and_start(self, service_name.number),
                 lambda service_name: self.get_container_name(service_name.service, service_name.number),
-                "Creating",
-                parent_objects=project_services
+                "Creating"
             )
             for error in errors.values():
                 raise OperationFailedError(error)

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -179,18 +179,22 @@ _docker_compose_docker_compose() {
 			_filedir "y?(a)ml"
 			return
 			;;
+		--log-level)
+			COMPREPLY=( $( compgen -W "debug info warning error critical" -- "$cur" ) )
+			return
+			;;
 		--project-directory)
 			_filedir -d
 			return
 			;;
-		$(__docker_compose_to_extglob "$top_level_options_with_args") )
+		$(__docker_compose_to_extglob "$daemon_options_with_args") )
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "$top_level_boolean_options $top_level_options_with_args --help -h --no-ansi --verbose --version -v" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "$daemon_boolean_options $daemon_options_with_args $top_level_options_with_args --help -h --no-ansi --verbose --version -v" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "${commands[*]}" -- "$cur" ) )
@@ -375,7 +379,7 @@ _docker_compose_ps() {
 _docker_compose_pull() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --ignore-pull-failures --parallel --quiet -q" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --ignore-pull-failures --include-deps --parallel --quiet -q" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_from_image
@@ -444,7 +448,7 @@ _docker_compose_run() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "-d --detach --entrypoint -e --help --label -l --name --no-deps --publish -p --rm --service-ports -T --user -u --volume -v --workdir -w" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --entrypoint -e --help --label -l --name --no-deps --publish -p --rm --service-ports -T --use-aliases --user -u --volume -v --workdir -w" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_services_all
@@ -605,14 +609,12 @@ _docker_compose() {
 
 	# Options for the docker daemon that have to be passed to secondary calls to
 	# docker-compose executed by this script.
-	# Other global otions that are not relevant for secondary calls are defined in
-	# `_docker_compose_docker_compose`.
-	local top_level_boolean_options="
+	local daemon_boolean_options="
 		--skip-hostname-check
 		--tls
 		--tlsverify
 	"
-	local top_level_options_with_args="
+	local daemon_options_with_args="
 		--file -f
 		--host -H
 		--project-directory
@@ -620,6 +622,11 @@ _docker_compose() {
 		--tlscacert
 		--tlscert
 		--tlskey
+	"
+
+	# These options are require special treatment when searching the command.
+	local top_level_options_with_args="
+		--log-level
 	"
 
 	COMPREPLY=()
@@ -634,14 +641,17 @@ _docker_compose() {
 
 	while [ $counter -lt $cword ]; do
 		case "${words[$counter]}" in
-			$(__docker_compose_to_extglob "$top_level_boolean_options") )
+			$(__docker_compose_to_extglob "$daemon_boolean_options") )
 				local opt=${words[counter]}
 				top_level_options+=($opt)
 				;;
-			$(__docker_compose_to_extglob "$top_level_options_with_args") )
+			$(__docker_compose_to_extglob "$daemon_options_with_args") )
 				local opt=${words[counter]}
 				local arg=${words[++counter]}
 				top_level_options+=($opt $arg)
+				;;
+			$(__docker_compose_to_extglob "$top_level_options_with_args") )
+				(( counter++ ))
 				;;
 			-*)
 				;;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
-docker==3.1.0
+docker==3.1.1
 docker-pycreds==0.2.1
 dockerpty==0.4.1
 docopt==0.6.2

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.20.0-rc1"
+VERSION="1.20.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.19',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker >= 3.1.0, < 4.0',
+    'docker >= 3.1.1, < 4.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -35,6 +35,7 @@ from compose.const import LABEL_SERVICE
 from compose.const import LABEL_VERSION
 from compose.container import Container
 from compose.errors import OperationFailedError
+from compose.parallel import ParallelStreamWriter
 from compose.project import OneOffFilter
 from compose.service import ConvergencePlan
 from compose.service import ConvergenceStrategy
@@ -1197,6 +1198,7 @@ class ServiceTest(DockerClientTestCase):
         service.create_container(number=next_number)
         service.create_container(number=next_number + 1)
 
+        ParallelStreamWriter.instance = None
         with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
             service.scale(2)
         for container in service.containers():
@@ -1220,6 +1222,7 @@ class ServiceTest(DockerClientTestCase):
         for container in service.containers():
             assert not container.is_running
 
+        ParallelStreamWriter.instance = None
         with mock.patch('sys.stderr', new_callable=StringIO) as mock_stderr:
             service.scale(2)
 

--- a/tests/unit/parallel_test.py
+++ b/tests/unit/parallel_test.py
@@ -143,6 +143,7 @@ class ParallelTest(unittest.TestCase):
 
 
 def test_parallel_execute_alignment(capsys):
+    ParallelStreamWriter.instance = None
     results, errors = parallel_execute(
         objects=["short", "a very long name"],
         func=lambda x: x,
@@ -158,6 +159,7 @@ def test_parallel_execute_alignment(capsys):
 
 
 def test_parallel_execute_ansi(capsys):
+    ParallelStreamWriter.instance = None
     ParallelStreamWriter.set_noansi(value=False)
     results, errors = parallel_execute(
         objects=["something", "something more"],
@@ -173,6 +175,7 @@ def test_parallel_execute_ansi(capsys):
 
 
 def test_parallel_execute_noansi(capsys):
+    ParallelStreamWriter.instance = None
     ParallelStreamWriter.set_noansi()
     results, errors = parallel_execute(
         objects=["something", "something more"],

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -20,6 +20,7 @@ from compose.const import LABEL_PROJECT
 from compose.const import LABEL_SERVICE
 from compose.const import SECRETS_PATH
 from compose.container import Container
+from compose.parallel import ParallelStreamWriter
 from compose.project import OneOffFilter
 from compose.service import build_ulimits
 from compose.service import build_volume_binding
@@ -727,6 +728,7 @@ class ServiceTest(unittest.TestCase):
     @mock.patch('compose.service.log', autospec=True)
     def test_only_log_warning_when_host_ports_clash(self, mock_log):
         self.mock_client.inspect_image.return_value = {'Id': 'abcd'}
+        ParallelStreamWriter.instance = None
         name = 'foo'
         service = Service(
             name,


### PR DESCRIPTION
### New features

#### Compose file version 3.6

- Introduced version 3.6 of the `docker-compose.yml` specification.
  This version requires to be used with Docker Engine 18.02.0 or above.

- Added support for the `tmpfs.size` property in volume mappings

#### Compose file version 3.2 and up

- The `--build-arg` option can now be used without specifying a service
  in `docker-compose build`

#### Compose file version 2.3

- Added support for `device_cgroup_rules` in service definitions

- Added support for the `tmpfs.size` property in long-form volume mappings

- The `--build-arg` option can now be used without specifying a service
  in `docker-compose build`

#### All formats

- Added a `--log-level` option to the top-level `docker-compose` command.
  Accepted values are `debug`, `info`, `warning`, `error`, `critical`.
  Default log level is `info`

- `docker-compose run` now allows users to unset the container's entrypoint

- Proxy configuration found in the `~/.docker/config.json` file now populates
  environment and build args for containers created by Compose

- Added the `--use-aliases` flag to `docker-compose run`, indicating that
  network aliases declared in the service's config should be used for the
  running container

- Added the `--include-deps` flag to `docker-compose pull`

- `docker-compose run` now kills and removes the running container upon
  receiving `SIGHUP`

- `docker-compose ps` now shows the containers' health status if available

- Added the long-form `--detach` option to the `exec`, `run` and `up`
  commands

### Bugfixes

- Fixed `.dockerignore` handling, notably with regard to absolute paths
  and last-line precedence rules

- Fixed an issue where Compose would make costly DNS lookups when connecting
  to the Engine when using Docker For Mac

- Fixed a bug introduced in 1.19.0 which caused the default certificate path
  to not be honored by Compose

- Fixed a bug where Compose would incorrectly check whether a symlink's
  destination was accessible when part of a build context

- Fixed a bug where `.dockerignore` files containing lines of whitespace
  caused Compose to error out on Windows

- Fixed a bug where `--tls*` and `--host` options wouldn't be properly honored
  for interactive `run` and `exec` commands

- A `seccomp:<filepath>` entry in the `security_opt` config now correctly
  sends the contents of the file to the engine

- ANSI output for `up` and `down` operations should no longer affect the wrong
  lines

- Improved support for non-unicode locales

- Fixed a crash occurring on Windows when the user's home directory name
  contained non-ASCII characters

- Fixed a bug occurring during builds caused by files with a negative `mtime`
  values in the build context