### PR TITLE
Fix docker-compose zsh running service name completion when using custom psFormat

### DIFF
--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -88,7 +88,7 @@ __docker-compose_get_services() {
     shift
     [[ $kind =~ (stopped|all) ]] && args=($args -a)
 
-    lines=(${(f)"$(_call_program commands docker $docker_options ps $args)"})
+    lines=(${(f)"$(_call_program commands docker $docker_options ps --format 'table' $args)"})
     services=(${(f)"$(_call_program commands docker-compose 2>/dev/null $compose_options ps -q)"})
 
     # Parse header line to find columns


### PR DESCRIPTION
This applies to commands that operate on running services. For example: `top`, `stop`, `restart`, etc.

Configuring a custom `psFormat` in `~/.docker/config.json` can break zsh running service name completion that depends upon default `docker ps` output. This breaks when you don't include the output needed by completion.

Steps to reproduce:
1. Create custom psFormat in the docker client config `~/.docker/config.json`, for example:
    - `"psFormat" : "table {{.ID}}\\t{{.Image}}\\t{{.Status}}\\t{{.Names}}"`
2. `docker-compose up -d` # start at least one service
3. `docker-compose top<TAB>` # invoke zsh completion
4. Failed completion returns `__docker-compose_get_services:38: bad math expression: empty string` five times. 

The fix specifies the explicit format needed for completion and is based on a previous fix in the docker CLI completion: https://github.com/docker/cli/commit/8b38343e46e46b589bf556651c10dc3dbee3f88b

What needs to be done to merge this? I did notice another call to `docker ps` that might also need fixed but I have yet to find what that breaks, if anything. Also, this was a quick fix without a review of implications, I'll do that when I have some free time. 