### PR TITLE
Bump Docker SDK -> 3.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
-docker==3.1.1
+docker==3.1.3
 docker-pycreds==0.2.1
 dockerpty==0.4.1
 docopt==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.19',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker >= 3.1.1, < 4.0',
+    'docker >= 3.1.3, < 4.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',


### PR DESCRIPTION
> Fixed a bug that led to a Dockerfile not being included in the build context in some situations when the Dockerfile's path was prefixed with `./`