### PR TITLE
Bump 1.20.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         command: brew update > /dev/null && brew upgrade python
     - run:
         name: install tox
-        command: sudo pip install --upgrade tox==2.1.1
+        command: sudo pip3 install --upgrade tox==2.1.1
     - run:
         name: unit tests
         command: tox -e py27,py36 -- tests/unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Change log
 - Fixed a bug occurring during builds caused by files with a negative `mtime`
   values in the build context
 
+- Fixed an encoding bug when streaming build progress
+
 1.19.0 (2018-02-07)
 -------------------
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.20.0-rc2'
+__version__ = '1.20.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
-docker==3.1.1
+docker==3.1.3
 docker-pycreds==0.2.1
 dockerpty==0.4.1
 docopt==0.6.2

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.20.0-rc2"
+VERSION="1.20.0"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.19',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker >= 3.1.1, < 4.0',
+    'docker >= 3.1.3, < 4.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',


### PR DESCRIPTION
### New features

#### Compose file version 3.6

- Introduced version 3.6 of the `docker-compose.yml` specification.
  This version requires to be used with Docker Engine 18.02.0 or above.

- Added support for the `tmpfs.size` property in volume mappings

#### Compose file version 3.2 and up

- The `--build-arg` option can now be used without specifying a service
  in `docker-compose build`

#### Compose file version 2.3

- Added support for `device_cgroup_rules` in service definitions

- Added support for the `tmpfs.size` property in long-form volume mappings

- The `--build-arg` option can now be used without specifying a service
  in `docker-compose build`

#### All formats

- Added a `--log-level` option to the top-level `docker-compose` command.
  Accepted values are `debug`, `info`, `warning`, `error`, `critical`.
  Default log level is `info`

- `docker-compose run` now allows users to unset the container's entrypoint

- Proxy configuration found in the `~/.docker/config.json` file now populates
  environment and build args for containers created by Compose

- Added the `--use-aliases` flag to `docker-compose run`, indicating that
  network aliases declared in the service's config should be used for the
  running container

- Added the `--include-deps` flag to `docker-compose pull`

- `docker-compose run` now kills and removes the running container upon
  receiving `SIGHUP`

- `docker-compose ps` now shows the containers' health status if available

- Added the long-form `--detach` option to the `exec`, `run` and `up`
  commands

### Bugfixes

- Fixed `.dockerignore` handling, notably with regard to absolute paths
  and last-line precedence rules

- Fixed an issue where Compose would make costly DNS lookups when connecting
  to the Engine when using Docker For Mac

- Fixed a bug introduced in 1.19.0 which caused the default certificate path
  to not be honored by Compose

- Fixed a bug where Compose would incorrectly check whether a symlink's
  destination was accessible when part of a build context

- Fixed a bug where `.dockerignore` files containing lines of whitespace
  caused Compose to error out on Windows

- Fixed a bug where `--tls*` and `--host` options wouldn't be properly honored
  for interactive `run` and `exec` commands

- A `seccomp:<filepath>` entry in the `security_opt` config now correctly
  sends the contents of the file to the engine

- ANSI output for `up` and `down` operations should no longer affect the wrong
  lines

- Improved support for non-unicode locales

- Fixed a crash occurring on Windows when the user's home directory name
  contained non-ASCII characters

- Fixed a bug occurring during builds caused by files with a negative `mtime`
  values in the build context

- Fixed an encoding bug when streaming build progress
