### PR TITLE
Ignore NotFound for external overlay networks

### DIFF
--- a/compose/network.py
+++ b/compose/network.py
@@ -42,6 +42,11 @@ class Network(object):
 
     def ensure(self):
         if self.external:
+            if self.driver == 'overlay':
+                # Swarm nodes do not register overlay networks that were
+                # created on a different node unless they're in use.
+                # See docker/compose#4399
+                return
             try:
                 self.inspect()
                 log.debug(

--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import pytest
+
 from .testcases import DockerClientTestCase
+from compose.config.errors import ConfigurationError
 from compose.const import LABEL_NETWORK
 from compose.const import LABEL_PROJECT
 from compose.network import Network
@@ -15,3 +18,20 @@ class NetworkTest(DockerClientTestCase):
         labels = net_data['Labels']
         assert labels[LABEL_NETWORK] == net.name
         assert labels[LABEL_PROJECT] == net.project
+
+    def test_network_external_default_ensure(self):
+        net = Network(
+            self.client, 'composetest', 'foonet',
+            external=True
+        )
+
+        with pytest.raises(ConfigurationError):
+            net.ensure()
+
+    def test_network_external_overlay_ensure(self):
+        net = Network(
+            self.client, 'composetest', 'foonet',
+            driver='overlay', external=True
+        )
+
+        assert net.ensure() is None


### PR DESCRIPTION
Fixes #4399 
Fixes #4601 

Note: If the network indeed does not exist, the error will be raised later when trying to create a container that uses it.

```
$ docker-compose up
WARNING: The Docker Engine you're using is running in swarm mode.
[...]
Creating repro4399_abc_1 ... error

ERROR: for repro4399_abc_1  Cannot start service abc: Could not attach to network foo: rpc error: code = NotFound desc = network foo not found

ERROR: for abc  Cannot start service abc: Could not attach to network foo: rpc error: code = NotFound desc = network foo not found
ERROR: Encountered errors while bringing up the project.
