### PR TITLE
Adds '--cleanup-on-container-exit' to 'up' command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1026,7 +1026,10 @@ class TopLevelCommand(object):
         if ignore_orphans and remove_orphans:
             raise UserError("COMPOSE_IGNORE_ORPHANS and --remove-orphans cannot be combined.")
 
-        opts = ['--detach', '--abort-on-container-exit', '--exit-code-from', '--cleanup-on-container-exit']
+        opts = ['--detach',
+                '--abort-on-container-exit',
+                '--exit-code-from',
+                '--cleanup-on-container-exit']
         for excluded in [x for x in opts if options.get(x) and no_start]:
             raise UserError('--no-start and {} cannot be combined.'.format(excluded))
 
@@ -1087,7 +1090,7 @@ class TopLevelCommand(object):
                     exit_value_from, attached_containers, cascade_starter, all_containers
                 )
                 sys.exit(exit_code)
-                
+
             if cleanup_on_container_exit:
                 print("Cleaning up on container exit...")
                 all_containers = self.project.containers(service_names=options['SERVICE'], stopped=True)

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1513,6 +1513,20 @@ class CLITestCase(DockerClientTestCase):
         proc.wait()
         assert proc.returncode == 1
 
+    def test_up_handles_cleanup_on_container_exit(self):
+        self.base_dir = 'tests/fixtures/abort-on-container-exit-0'
+        proc = start_process(self.base_dir, ['up', '--cleanup-on-container-exit'])
+        wait_on_condition(ContainerCountCondition(self.project, 0))
+        proc.wait()
+        assert proc.returncode == 0
+
+    def test_up_handles_cleanup_on_container_exit_code(self):
+        self.base_dir = 'tests/fixtures/abort-on-container-exit-1'
+        proc = start_process(self.base_dir, ['up', '--cleanup-on-container-exit'])
+        wait_on_condition(ContainerCountCondition(self.project, 0))
+        proc.wait()
+        assert proc.returncode == 1
+
     @v2_only()
     @no_cluster('Container PID mode does not work across clusters')
     def test_up_with_pid_mode(self):


### PR DESCRIPTION
Signed-off-by: Matthias Lochbrunner <matthias_lochbrunner@web.de>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves: Adds option for cleaning up containers, networks and volumes after one service exited.

## Usage

Run

```sh
docker-compose up --cleanup-on-container-exit
```

does the same as 

```sh
docker-compose up --abort-on-container-exit
```

but cleans up everything after aborting.

This is very helpful when running regression tests of compositions in the CI for instance.
