### PR TITLE
Fix bash completion for running services

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -98,7 +98,7 @@ __docker_compose_complete_services() {
 
 # The services for which at least one running container exists
 __docker_compose_complete_running_services() {
-	local names=$(__docker_compose_complete_services --filter status=running)
+	local names=$(__docker_compose_services --filter status=running)
 	COMPREPLY=( $(compgen -W "$names" -- "$cur") )
 }
 


### PR DESCRIPTION
In #5867, I introduced a regression: Bash completion for running services, e.g. in `docker-compose stop <tab>` does no longer complete services.

This PR fixes the bug.