### PR TITLE
Add support for `platform` to composefile v3.7 too

### DIFF
--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -203,7 +203,7 @@
           ]
         },
         "pid": {"type": ["string", "null"]},
-
+	"platform": {"type": "string"},
         "ports": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Bump composefile version to 3.7 too.

This is related to https://github.com/docker/cli/issues/1050

> That being said, I think one *easy fix* to that issue would be to add `platform` to v3 schema(s) — but it would start at schema `3.7` — **and** printing a warning when issuing a `docker stack deploy` that this field is not supported (same way we do it for `build`). It would allow to more easily updated from v2 to v3 for users and help us not make v2 and v3 schema diverge that much — at least not having elements in v2 that are not in v3…

Also linked to https://github.com/docker/cli/pull/1081

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
