### PR TITLE
Allow `x-*` extension on 3rd level objects

### DIFF
--- a/compose/config/config_schema_v2.4.json
+++ b/compose/config/config_schema_v2.4.json
@@ -346,6 +346,7 @@
       "dependencies": {
         "memswap_limit": ["mem_limit"]
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 
@@ -409,6 +410,7 @@
         "labels": {"$ref": "#/definitions/labels"},
         "name": {"type": "string"}
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 
@@ -451,6 +453,7 @@
         "labels": {"$ref": "#/definitions/labels"},
         "name": {"type": "string"}
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 

--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -319,6 +319,7 @@
         },
         "working_dir": {"type": "string"}
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 
@@ -489,6 +490,7 @@
         "attachable": {"type": "boolean"},
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 
@@ -513,6 +515,7 @@
         },
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 
@@ -530,6 +533,7 @@
         },
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 
@@ -547,6 +551,7 @@
         },
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
 


### PR DESCRIPTION
As for top-level key, any 3rd-level key which starts with `x-` will be
ignored by compose. This allows for users to:
* include additional metadata in their compose files
* create YAML anchor objects that can be re-used in other parts of the config

This matches a similar feature in the swagger spec definition:
https://swagger.io/specification/#specificationExtensions

This means a composefile like the following is valid

```
verison: "3.7"
services:
  foo:
    image: foo/bar
    x-foo: bar
network:
  bar:
    x-bar: baz
```

It concerns services, volumes, networks, configs and secrets.

@shin- @thaJeztah is v2.4 already released ? if yes, I'll have to update the PR to add a new 2.5 version :angel: :sweat_smile: 

Linked to https://github.com/docker/cli/pull/1097. 

cc @dnephin @shin- @thaJeztah 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
