### PR TITLE
 Update docker-compose run --rm doc

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -813,6 +813,7 @@ class TopLevelCommand(object):
             -u, --user=""         Run as specified username or uid
             --no-deps             Don't start linked services.
             --rm                  Remove container after run. Ignored in detached mode.
+                                  Overrides the container's restart policy.
             -p, --publish=[]      Publish a container's port(s) to the host
             --service-ports       Run command with the service's ports enabled and mapped
                                   to the host.

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -320,7 +320,7 @@ __docker-compose_subcommand() {
                 '--entrypoint[Overwrite the entrypoint of the image.]:entry point: ' \
                 '--name=[Assign a name to the container]:name: ' \
                 '(-p --publish)'{-p,--publish=}"[Publish a container's port(s) to the host]" \
-                '--rm[Remove container after run. Ignored in detached mode.]' \
+                "--rm[Remove container after run. Ignored in detached mode. Overrides the container's restart policy]" \
                 "--service-ports[Run command with the service's ports enabled and mapped to the host.]" \
                 '-T[Disable pseudo-tty allocation. By default `docker-compose run` allocates a TTY.]' \
                 '(-u --user)'{-u,--user=}'[Run as specified username or uid]:username or uid:_users' \


### PR DESCRIPTION
This PR updates the `docker-compose run --rm` doc to explicitly state the change made here:
https://github.com/funkyfuture/docker-compose/commit/24ab933ebfd3169491beeb18f0041cabebe4d2d2

Following this issue:
https://github.com/docker/compose/issues/1013

I had to use Google to and follow the discussion in #1013 in order to know how to properly achieve what I wanted, after not finding the answer in `docker-compose run --help`.

Resolves #1013
