### PR TITLE
Add `init` support in 3.7 schema

### DIFF
--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -154,6 +154,7 @@
         "healthcheck": {"$ref": "#/definitions/healthcheck"},
         "hostname": {"type": "string"},
         "image": {"type": "string"},
+	"init": {"type": "boolean"},
         "ipc": {"type": "string"},
         "isolation": {"type": "string"},
         "labels": {"$ref": "#/definitions/list_or_dict"},


### PR DESCRIPTION
> Run an init inside the container that forwards signals and reaps
> processes

This is already supported in 2.4 schema

:lion: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
