### PR TITLE
Bump 1.22.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Change log
 - Fixed an issue that prevented proper parsing of UTF-8 BOM encoded
   Compose files on Windows
 
+- Fixed an issue with handling of the double-wildcard (`**`) pattern in `.dockerignore` files when using `docker-compose build`
+
+- Fixed a bug that caused auth values in legacy `.dockercfg` files to be ignored
+- `docker-compose build` will no longer attempt to create image names starting with an invalid character
+
 1.21.2 (2018-05-03)
 -------------------
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.22.0-rc1'
+__version__ = '1.22.0-rc2'

--- a/compose/service.py
+++ b/compose/service.py
@@ -363,7 +363,9 @@ class Service(object):
 
     @property
     def image_name(self):
-        return self.options.get('image', '{s.project}_{s.name}'.format(s=self))
+        return self.options.get('image', '{project}_{s.name}'.format(
+            s=self, project=self.project.lstrip('_-')
+        ))
 
     @property
     def platform(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
-docker==3.4.0
+docker==3.4.1
 docker-pycreds==0.3.0
 dockerpty==0.4.1
 docopt==0.6.2

--- a/script/release/release.py
+++ b/script/release/release.py
@@ -58,11 +58,8 @@ def create_bump_commit(repository, release_branch, bintray_user, bintray_org):
     repository.push_branch_to_remote(release_branch)
 
     bintray_api = BintrayAPI(os.environ['BINTRAY_TOKEN'], bintray_user)
-    if not bintray_api.repository_exists(bintray_org, release_branch.name):
-        print('Creating data repository {} on bintray'.format(release_branch.name))
-        bintray_api.create_repository(bintray_org, release_branch.name, 'generic')
-    else:
-        print('Bintray repository {} already exists. Skipping'.format(release_branch.name))
+    print('Creating data repository {} on bintray'.format(release_branch.name))
+    bintray_api.create_repository(bintray_org, release_branch.name, 'generic')
 
 
 def monitor_pr_status(pr_data):

--- a/script/release/release.sh
+++ b/script/release/release.sh
@@ -17,6 +17,7 @@ fi
 
 docker run -e GITHUB_TOKEN=$GITHUB_TOKEN -e BINTRAY_TOKEN=$BINTRAY_TOKEN -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK -it \
     --mount type=bind,source=$(pwd),target=/src \
+    --mount type=bind,source=$(pwd)/.git,target=/src/.git \
     --mount type=bind,source=$HOME/.docker,target=/root/.docker \
     --mount type=bind,source=$HOME/.gitconfig,target=/root/.gitconfig \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \

--- a/script/release/release/bintray.py
+++ b/script/release/release/bintray.py
@@ -25,19 +25,7 @@ class BintrayAPI(requests.Session):
             'desc': 'Automated release for {}: {}'.format(NAME, repo_name),
             'labels': ['docker-compose', 'docker', 'release-bot'],
         }
-        result = self.post_json(url, data)
-        result.raise_for_status()
-        return result
-
-    def repository_exists(self, subject, repo_name):
-        url = '{base}/repos/{subject}/{repo_name}'.format(
-            base=self.base_url, subject=subject, repo_name=repo_name,
-        )
-        result = self.get(url)
-        if result.status_code == 404:
-            return False
-        result.raise_for_status()
-        return True
+        return self.post_json(url, data)
 
     def delete_repository(self, subject, repo_name):
         url = '{base}/repos/{subject}/{repo_name}'.format(

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.22.0-rc1"
+VERSION="1.22.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.19',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
-    'docker >= 3.4.0, < 4.0',
+    'docker >= 3.4.1, < 4.0',
     'dockerpty >= 0.4.1, < 0.5',
     'six >= 1.3.0, < 2',
     'jsonschema >= 2.5.1, < 3',

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -1137,6 +1137,21 @@ class ServiceTest(DockerClientTestCase):
         service.build()
         assert service.image()
 
+    def test_build_with_illegal_leading_chars(self):
+        base_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, base_dir)
+        with open(os.path.join(base_dir, 'Dockerfile'), 'w') as f:
+            f.write('FROM busybox\nRUN echo "Embodiment of Scarlet Devil"\n')
+        service = Service(
+            'build_leading_slug', client=self.client,
+            project='___-composetest', build={
+                'context': text_type(base_dir)
+            }
+        )
+        assert service.image_name == 'composetest_build_leading_slug'
+        service.build()
+        assert service.image()
+
     def test_start_container_stays_unprivileged(self):
         service = self.create_service('web')
         container = create_and_start_container(service).inspect()


### PR DESCRIPTION
Automated release for docker-compose 1.22.0-rc2


### Features

#### Compose format version 3.7

- Introduced version 3.7 of the `docker-compose.yml` specification.
  This version requires Docker Engine 18.06.0 or above.

- Added support for `rollback_config` in the deploy configuration

- Added support for the `init` parameter in service configurations

- Added support for extension fields in service, network, volume, secret,
  and config configurations

#### Compose format version 2.4

- Added support for extension fields in service, network,
  and volume configurations

### Bugfixes

- Fixed a bug that prevented deployment with some Compose files when
  `DOCKER_DEFAULT_PLATFORM` was set

- Compose will no longer try to create containers or volumes with
  invalid starting characters

- Fixed several bugs that prevented Compose commands from working properly
  with containers created with an older version of Compose

- Fixed an issue with the output of `docker-compose config` with the
  `--compatibility-mode` flag enabled when the source file contains
  attachable networks

- Fixed a bug that prevented the `gcloud` credential store from working
  properly when used with the Compose binary on UNIX

- Fixed a bug that caused connection errors when trying to operate
  over a non-HTTPS TCP connection on Windows

- Fixed a bug that caused builds to fail on Windows if the Dockerfile
  was located in a subdirectory of the build context

- Fixed an issue that prevented proper parsing of UTF-8 BOM encoded
  Compose files on Windows

- Fixed an issue with handling of the double-wildcard (`**`) pattern in `.dockerignore` files when using `docker-compose build`

- Fixed a bug that caused auth values in legacy `.dockercfg` files to be ignored
- `docker-compose build` will no longer attempt to create image names starting with an invalid character
