### PR TITLE
Attach logger to containers after crashing.

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -210,9 +210,14 @@ def start_producer_thread(thread_args):
 
 
 def watch_events(thread_map, event_stream, presenters, thread_args):
+    crashed_containers = set()
     for event in event_stream:
         if event['action'] == 'stop':
             thread_map.pop(event['id'], None)
+
+        if event['action'] == 'die':
+            thread_map.pop(event['id'], None)
+            crashed_containers.add(event['id'])
 
         if event['action'] != 'start':
             continue
@@ -222,6 +227,11 @@ def watch_events(thread_map, event_stream, presenters, thread_args):
                 continue
             # Container was stopped and started, we need a new thread
             thread_map.pop(event['id'], None)
+
+        # Container crashed so we should reattach to it
+        if event['id'] in crashed_containers:
+            event['container'].attach_log_stream()
+            crashed_containers.remove(event['id'])
 
         thread_map[event['id']] = build_thread(
             event['container'],

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -2253,6 +2253,22 @@ class CLITestCase(DockerClientTestCase):
         assert 'logs-composefile_another_1 exited with code 0' in result.stdout
         assert 'logs-composefile_simple_1 exited with code 137' in result.stdout
 
+    def test_logs_follow_logs_from_restarted_containers(self):
+        self.base_dir = 'tests/fixtures/logs-restart-composefile'
+        proc = start_process(self.base_dir, ['up'])
+
+        wait_on_condition(ContainerStateCondition(
+            self.project.client,
+            'logs-restart-composefile_another_1',
+            'exited'))
+
+        self.dispatch(['kill', 'simple'])
+
+        result = wait_on_process(proc)
+
+        assert result.stdout.count('logs-restart-composefile_another_1 exited with code 1') == 3
+        assert result.stdout.count('world') == 3
+
     def test_logs_default(self):
         self.base_dir = 'tests/fixtures/logs-composefile'
         self.dispatch(['up', '-d'])

--- a/tests/fixtures/logs-restart-composefile/docker-compose.yml
+++ b/tests/fixtures/logs-restart-composefile/docker-compose.yml
@@ -1,0 +1,7 @@
+simple:
+  image: busybox:latest
+  command: sh -c "echo hello && tail -f /dev/null"
+another:
+  image: busybox:latest
+  command: sh -c "sleep 0.5 && echo world && /bin/false"
+  restart: "on-failure:2"


### PR DESCRIPTION
Ensure the logger keeps track of the containers which have crashed so it can reattach to them when it gets the next start event. 

This is not a perfect solution as the events are asynchronous and therefore there is some delay between the container starting and the logger reattaching which can result in some missing logs (as seen by the fact that the test has a half second sleep in it).

Signed-off-by: Nicholas Higgins <nickhiggins42@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6060
