### PR TITLE
support newer minor version of requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
 pypiwin32==220; sys_platform == 'win32' and python_version >= '3.6'
 PySocks==1.6.7
 PyYAML==3.12
-requests==2.18.4
+requests==2.19.1
 six==1.10.0
 texttable==0.9.1
 urllib3==1.21.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'cached-property >= 1.2.0, < 2',
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.19',
+    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.20',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
     'docker >= 3.4.1, < 4.0',


### PR DESCRIPTION
@shin- Upon reviewing https://github.com/docker/docker-py/pull/2089 and https://github.com/requests/requests/blob/master/HISTORY.rst#2190-2018-06-12 I realized we can support `requests` 2.19.x for those of us who pin that without modifying Compose's `urllib3` support at all. :smile: 

2.19.x also includes better compatibility with Python 3.7!!! https://github.com/requests/requests/pull/4501

How does this sound?