### PR TITLE
Fixes pipe handling in container mode.

### DIFF
--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -47,10 +47,11 @@ if [ -n "$HOME" ]; then
 fi
 
 # Only allocate tty if we detect one
-if [ -t 1 ]; then
-    DOCKER_RUN_OPTIONS="-t"
-fi
 if [ -t 0 ]; then
+    if [ -t 1 ]; then
+        DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -t"
+    fi
+else
     DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
 fi
 


### PR DESCRIPTION
Closes #4599, #4460

- adds a way to provide options from env in both cases (tty & non tty)
- allocates TTY only if both stdin & stdout are TTYs
- enables interactive mode if stdin is not TTY

Signed-off-by: Arkadiusz Dzięgiel <arkadiusz.dziegiel@glorpen.pl>