### PR TITLE
[armhf] Make Dockerfile.armhf compatible with main

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,54 +1,20 @@
-FROM armhf/debian:wheezy
+FROM python:3.6
 
 RUN set -ex; \
     apt-get update -qq; \
     apt-get install -y \
         locales \
-        gcc \
-        make \
-        zlib1g \
-        zlib1g-dev \
-        libssl-dev \
-        git \
-        ca-certificates \
         curl \
-        libsqlite3-dev \
-        libbz2-dev \
-    ; \
-    rm -rf /var/lib/apt/lists/*
+        python-dev \
+        git
 
 RUN curl -fsSL -o dockerbins.tgz "https://download.docker.com/linux/static/stable/armhf/docker-17.12.0-ce.tgz" && \
+    SHA256=f8de6378dad825b9fd5c3c2f949e791d22f918623c27a72c84fd6975a0e5d0a2; \
+    echo "${SHA256}  dockerbins.tgz" | sha256sum -c - && \
     tar xvf dockerbins.tgz docker/docker --strip-components 1 && \
     mv docker /usr/local/bin/docker && \
     chmod +x /usr/local/bin/docker && \
     rm dockerbins.tgz
-
-# Build Python 2.7.13 from source
-RUN set -ex; \
-    curl -L https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz | tar -xz; \
-    cd Python-2.7.13; \
-    ./configure --enable-shared; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf /Python-2.7.13
-
-# Build python 3.6 from source
-RUN set -ex; \
-    curl -L https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz | tar -xz; \
-    cd Python-3.6.4; \
-    ./configure --enable-shared; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf /Python-3.6.4
-
-# Make libpython findable
-ENV LD_LIBRARY_PATH /usr/local/lib
-
-# Install pip
-RUN set -ex; \
-    curl -L https://bootstrap.pypa.io/get-pip.py | python
 
 # Python3 requires a valid locale
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
@@ -70,4 +36,4 @@ RUN tox --notest
 ADD . /code/
 RUN chown -R user /code/
 
-ENTRYPOINT ["/code/.tox/py27/bin/docker-compose"]
+ENTRYPOINT ["/code/.tox/py36/bin/docker-compose"]


### PR DESCRIPTION
Dockerfile now uses python:3.6 image while Dockerfile.armhf uses
debian. Python image is officially supported in ARM archtecture hence,
the now both dockerfiles differs only on dockerbins.tgz file version.

This was tested on a RaspberryPi3.

May we use environmental variables to select dockerbins.tgz?

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>


<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6167
