### PR TITLE
Allow dependencies to be brought down after 'run'

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1707,6 +1707,18 @@ class CLITestCase(DockerClientTestCase):
         assert name in volume_names
         assert anonymous_name not in volume_names
 
+    def test_run_rm_deps(self):
+        self.base_dir = 'tests/fixtures/v2-dependencies'
+        proc = start_process(self.base_dir, ['run', '--rm', '--rm-deps', 'web'])
+        wait_on_condition(ContainerStateCondition(
+            self.project.client,
+            'v2-dependencies_web_run_1',
+            'running'))
+        assert len(self.project.containers(one_off=OneOffFilter.include)) == 2
+        os.kill(proc.pid, signal.SIGINT)
+        wait_on_process(proc, 1)
+        assert len(self.project.containers(one_off=OneOffFilter.include, stopped=True)) == 0
+
     def test_run_service_with_dockerfile_entrypoint(self):
         self.base_dir = 'tests/fixtures/entrypoint-dockerfile'
         self.dispatch(['run', 'test'])

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -128,6 +128,7 @@ class CLITestCase(unittest.TestCase):
                 '--publish': [],
                 '--volume': [],
                 '--rm': None,
+                '--rm-deps': None,
                 '--name': None,
                 '--workdir': None,
             })
@@ -167,6 +168,7 @@ class CLITestCase(unittest.TestCase):
             '--publish': [],
             '--volume': [],
             '--rm': None,
+            '--rm-deps': None,
             '--name': None,
             '--workdir': None,
         })
@@ -189,6 +191,7 @@ class CLITestCase(unittest.TestCase):
             '--publish': [],
             '--volume': [],
             '--rm': True,
+            '--rm-deps': None,
             '--name': None,
             '--workdir': None,
         })


### PR DESCRIPTION
Use case: Using `docker-compose run --rm -p $BUILD_NUM` in a CI environment to bring up all dependencies and run a set of tests and return an exit code reflecting the result of the test process.

Problem: Dependencies are left running after the container running the tests has terminated. Something similar to the following block must be used to ensure the desired behavior of stopping and removing all containers and returning the exit code from the test container.
~~~
docker-compose run --rm -p $BUILD_NUM app scripts/run_tests.sh
exit_code = $?
docker-compose down
exit $exit_code
~~~

This PR allows the above to be done with the following line:
~~~
docker-compose run --rm --rm-deps -p $BUILD_NUM app scripts/run_tests.sh
~~~

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
