### PR TITLE
[#6026] Added -q, --quiet option to 'up' and 'down' commands to suppress parallel stream messages.

### DIFF
--- a/compose/utils.py
+++ b/compose/utils.py
@@ -7,6 +7,7 @@ import json
 import json.decoder
 import logging
 import ntpath
+import os
 
 import six
 from docker.errors import DockerException
@@ -19,9 +20,18 @@ from .timeparse import timeparse
 
 json_decoder = json.JSONDecoder()
 log = logging.getLogger(__name__)
+keep_quiet = False
+
+
+def set_quiet(quiet=True):
+    global keep_quiet
+    keep_quiet = quiet
 
 
 def get_output_stream(stream):
+    global keep_quiet
+    if keep_quiet:
+        stream = open(os.devnull, "w")
     if six.PY3:
         return stream
     return codecs.getwriter('utf-8')(stream)

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -195,6 +195,9 @@ _docker_compose_down() {
 		--timeout|-t)
 			return
 			;;
+		--quiet|-q)
+			return
+			;;
 	esac
 
 	case "$cur" in
@@ -533,6 +536,9 @@ _docker_compose_up() {
 			return
 			;;
 		--timeout|-t)
+			return
+			;;
+		--quiet|-q)
 			return
 			;;
 	esac

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -969,6 +969,12 @@ class CLITestCase(DockerClientTestCase):
         assert 'Removing network v2-full_default' in result.stderr
         assert 'Removing network v2-full_front' in result.stderr
 
+    @v2_only()
+    def test_down_quiet(self):
+        self.dispatch(['up', '-d'], None)
+        result = self.dispatch(['down', '-q'], None)
+        assert result.stderr == ''
+
     def test_down_timeout(self):
         self.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')
@@ -1095,6 +1101,11 @@ class CLITestCase(DockerClientTestCase):
         assert "%c[2K\r" % 27 not in result.stderr
         assert "%c[1A" % 27 not in result.stderr
         assert "%c[1B" % 27 not in result.stderr
+
+    @v2_only()
+    def test_up_quiet(self):
+        result = self.dispatch(['up', '-d', '-q'], None)
+        assert result.stderr == ''
 
     @v2_only()
     def test_up_with_default_network_config(self):


### PR DESCRIPTION
Added -q, --quiet option to 'up' and 'down' commands to suppress parallel stream messages.

Resolves #6026
