### PR TITLE
[WIP] config: Normalize internal volumes path on Windows.

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -827,8 +827,10 @@ def process_healthcheck(service_dict):
 def finalize_service_volumes(service_dict, environment):
     if 'volumes' in service_dict:
         finalized_volumes = []
-        normalize = environment.get_boolean('COMPOSE_CONVERT_WINDOWS_PATHS')
-        win_host = environment.get_boolean('COMPOSE_FORCE_WINDOWS_HOST')
+        win_host = environment.get_boolean(
+            'COMPOSE_FORCE_WINDOWS_HOST') or const.IS_WINDOWS_PLATFORM
+        normalize = environment.get_boolean(
+            'COMPOSE_CONVERT_WINDOWS_PATHS') or win_host
         for v in service_dict['volumes']:
             if isinstance(v, dict):
                 finalized_volumes.append(MountSpec.parse(v, normalize, win_host))


### PR DESCRIPTION
See https://github.com/docker/for-win/issues/1829.

Basically, bind mounts using UNIX paths are not valid when running docker-compose on Windows when running Docker for Windows unless `COMPOSE_CONVERT_WINDOWS_PATH` is set.

This PR solves the problem by forcing the denormalization of the internal paths if the running platform is Windows or if `COMPOSE_FOR_WINDOWS_HOST` is set (not just if `COMPOSE_CONVERT_WINDOWS_PATH` is set).

Given `docker-compose.yml`:
```
version: '3'
services:
    service:
        image: docker
        stdin_open: true
        tty: true
        volumes:
            - /var/run/docker.sock:/var/run/docker.sock 
```

## Previous behavior

```
> docker-compose.exe version
docker-compose version 1.22.0, build f46880fe
docker-py version: 3.4.1
CPython version: 3.6.6
OpenSSL version: OpenSSL 1.0.2o  27 Mar 2018
> docker-compose.exe up
Recreating service_1 ... error
 
ERROR: for service_1  Cannot create container for service docker: b'Mount denied:\nThe source path "\\\\var\\\\run\\\\docker.sock:/var/run/docker.sock"\nis not a valid Windows path'
 
ERROR: for docker  Cannot create container for service docker: b'Mount denied:\nThe source path "\\\\var\\\\run\\\\docker.sock:/var/run/docker.sock"\nis not a valid Windows path'
ERROR: Encountered errors while bringing up the project.
```

Path `/var/run/docker.sock` is converted to `\\var\\run\\docker.sock` and Docker for Windows  cannot find this path.

## New behavior

```
> docker-compose.exe up
Creating service_1 ... done
Attaching to service_1
```

Path `/var/run/docker.sock` is reconverted from `\\var\\run\\docker.sock` back to `/var/run/docker.sock` which is intelligible for Docker for Windows.

## Concerns

Or:
- We should not convert the path in the first place making the user responsible for the targeted host platform.
- What about docker machine?
- We could query the host and convert the paths accordingly.

Resolves https://github.com/docker/for-win/issues/1829
