### PR TITLE
Don't convert slashes for UNIX paths on Windows hosts

### DIFF
--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1291,7 +1291,7 @@ class ConfigTest(unittest.TestCase):
         assert tmpfs_mount.target == '/tmpfs'
         assert not tmpfs_mount.is_named_volume
 
-        assert host_mount.source == os.path.normpath('/abc')
+        assert host_mount.source == '/abc'
         assert host_mount.target == '/xyz'
         assert not host_mount.is_named_volume
 


### PR DESCRIPTION
Fixes #5716 
Fixes docker/for-win#1829