### PR TITLE
Add override option to service configuration for ports

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1061,7 +1061,12 @@ def merge_service_dicts(base, override, version):
         md.merge_field(field, merge_list_or_string)
 
     md.merge_field('logging', merge_logging, default={})
-    merge_ports(md, base, override)
+
+    if 'ports' in md.override.get('override', []):
+        md.merge_field('ports', merge_override_items_lists, default=[])
+    else:
+        merge_ports(md, base, override)
+
     md.merge_field('blkio_config', merge_blkio_config, default={})
     md.merge_field('healthcheck', merge_healthchecks, default={})
     md.merge_field('deploy', merge_deploy, default={})
@@ -1218,6 +1223,10 @@ def merge_labels(base, override):
     labels = parse_labels(base)
     labels.update(parse_labels(override))
     return labels
+
+
+def merge_override_items_lists(base, override):
+    return sorted(set(override))
 
 
 def split_kv(kvpair):

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -256,7 +256,8 @@
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
 
       "dependencies": {

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -289,7 +289,8 @@
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
 
       "dependencies": {

--- a/compose/config/config_schema_v2.2.json
+++ b/compose/config/config_schema_v2.2.json
@@ -298,7 +298,8 @@
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "volume_driver": {"type": "string"},
         "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
 
       "dependencies": {

--- a/compose/config/config_schema_v2.3.json
+++ b/compose/config/config_schema_v2.3.json
@@ -341,7 +341,8 @@
         },
         "volume_driver": {"type": "string"},
         "volumes_from": {"$ref": "#/definitions/list_of_strings"},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
 
       "dependencies": {

--- a/compose/config/config_schema_v2.4.json
+++ b/compose/config/config_schema_v2.4.json
@@ -340,7 +340,8 @@
         },
         "volume_driver": {"type": "string"},
         "volumes_from": {"$ref": "#/definitions/list_of_strings"},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
 
       "dependencies": {

--- a/compose/config/config_schema_v3.0.json
+++ b/compose/config/config_schema_v3.0.json
@@ -195,7 +195,8 @@
         "user": {"type": "string"},
         "userns_mode": {"type": "string"},
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "additionalProperties": false
     },

--- a/compose/config/config_schema_v3.1.json
+++ b/compose/config/config_schema_v3.1.json
@@ -224,7 +224,8 @@
         "user": {"type": "string"},
         "userns_mode": {"type": "string"},
         "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "additionalProperties": false
     },

--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -270,7 +270,8 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "additionalProperties": false
     },

--- a/compose/config/config_schema_v3.3.json
+++ b/compose/config/config_schema_v3.3.json
@@ -303,7 +303,8 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "additionalProperties": false
     },

--- a/compose/config/config_schema_v3.4.json
+++ b/compose/config/config_schema_v3.4.json
@@ -307,7 +307,8 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "additionalProperties": false
     },

--- a/compose/config/config_schema_v3.5.json
+++ b/compose/config/config_schema_v3.5.json
@@ -308,7 +308,8 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "additionalProperties": false
     },

--- a/compose/config/config_schema_v3.6.json
+++ b/compose/config/config_schema_v3.6.json
@@ -317,7 +317,8 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "additionalProperties": false
     },

--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -318,7 +318,8 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {"type": "string"}
+        "working_dir": {"type": "string"},
+        "override": {"type": "array", "items": {"type": ["string"], "uniqueItems": true, "format": "override"}}
       },
       "patternProperties": {"^x-": {}},
       "additionalProperties": false

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -69,6 +69,8 @@ VALID_REGEX_IPV6_CIDR = "".join("""
 $
 """.format(IPV6_SEG=VALID_IPV6_SEG, IPV4_ADDR=VALID_IPV4_ADDR).split())
 
+VALID_OVERRIDE_FORMAT = r'^(ports)$'
+
 
 @FormatChecker.cls_checks(format="ports", raises=ValidationError)
 def format_ports(instance):
@@ -95,6 +97,15 @@ def format_subnet_ip_address(instance):
         if not re.match(VALID_REGEX_IPV4_CIDR, instance) and \
                 not re.match(VALID_REGEX_IPV6_CIDR, instance):
             raise ValidationError("should use the CIDR format")
+
+    return True
+
+
+@FormatChecker.cls_checks(format="override", raises=ValidationError)
+def format_override(instance):
+    if isinstance(instance, six.string_types):
+        if not re.match(VALID_OVERRIDE_FORMAT, instance):
+            raise ValidationError("should be of the format 'ports'")
 
     return True
 
@@ -426,7 +437,7 @@ def process_config_schema_errors(error):
 
 def validate_against_config_schema(config_file):
     schema = load_jsonschema(config_file)
-    format_checker = FormatChecker(["ports", "expose", "subnet_ip_address"])
+    format_checker = FormatChecker(["ports", "expose", "subnet_ip_address", "override"])
     validator = Draft4Validator(
         schema,
         resolver=RefResolver(get_resolver_path(), schema),


### PR DESCRIPTION
This adds the ability to explicitly override the ports configuration with a given docker-compose.override.yml. This is manly an updated version of this PR: #3939

# Problem
We have a `docker-compose.yml` which we want to modify by using a `docker-compose.override.yml`. According to the docs [[1]](https://docs.docker.com/compose/extends/#adding-and-overriding-configuration) the `ports` section is overridden as follows:

> For the multi-value options ports, expose, external_links, dns, dns_search, and tmpfs, Compose concatenates both sets of values:

This is bad in some cases: What if the base file contains a port binding which we want to change? This is currently not possible.

# Solution
Inspired by @CarstenHoyer, I used his idea to add a new field to the service configuration called `override`. In this field all override-fields can be set (currently only `ports` is supported). This causes `docker-compose` to ignore the port configuration from the base and only uses the override port configuration.

## Example
docker-compose.yml
```
version: '2.1'
services:
  web:
    image: example/web
    ports:
      - "80:80"
```

docker-compose.override.yml
```
version: '2.1'
services:
  web:
    ports:
      - "8080:80"
    override:
      - ports
```

Before this PR the result would be:
```
version: '2.1'
services:
  web:
    image: example/web
    ports:
      - "80:80"
      - "8080:80"
```

with this PR the result will be:
```
version: '2.1'
services:
  web:
    image: example/web
    ports:
      - "8080:80"
```

---
Signed-off-by: Johan M. von Behren <johan@vonbehren.eu>

Resolves #2260 and #3729

---
\[1\]: https://docs.docker.com/compose/extends/#adding-and-overriding-configuration