### PR TITLE
Fix bash completion for `config --hash`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -136,7 +136,18 @@ _docker_compose_bundle() {
 
 
 _docker_compose_config() {
-	COMPREPLY=( $( compgen -W "--help --quiet -q --resolve-image-digests --services --volumes --hash" -- "$cur" ) )
+	case "$prev" in
+		--hash)
+			if [[ $cur == \\* ]] ; then
+				COMPREPLY=( '\*' )
+			else
+				COMPREPLY=( $(compgen -W "$(__docker_compose_services) \\\* " -- "$cur") )
+			fi
+			return
+			;;
+	esac
+
+	COMPREPLY=( $( compgen -W "--hash --help --quiet -q --resolve-image-digests --services --volumes" -- "$cur" ) )
 }
 
 


### PR DESCRIPTION
As `--hash` requires an argument, its bash completion is more complex.

I added completion for service names and the literal `\*`. As `*` is unually subject to file globbing, special treatment is required for it.

This completion does not support comma-delimited lists of services. This is because completion relies on the shell for word splitting, which does not split on `,` by default. As a result, with the services `service1` and `service2` being available, the completion for `service1,s` would be `service1,service1 service1,service2`. The whole word is exchanged, not just the part after the comma.