### PR TITLE
Improved expanding source paths of volumes

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1281,7 +1281,7 @@ def resolve_volume_paths(working_dir, service_dict):
 
 def resolve_volume_path(working_dir, volume):
     if isinstance(volume, dict):
-        if volume.get('source', '').startswith('.') and volume['type'] == 'bind':
+        if volume.get('source', '').startswith(('.', '~')) and volume['type'] == 'bind':
             volume['source'] = expand_path(working_dir, volume['source'])
         return volume
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1322,6 +1322,29 @@ class ConfigTest(unittest.TestCase):
         assert mount.type == 'bind'
         assert mount.source == expected_source
 
+    def test_load_bind_mount_relative_path_with_tilde(self):
+        base_file = config.ConfigFile(
+            'base.yaml', {
+                'version': '3.4',
+                'services': {
+                    'web': {
+                        'image': 'busybox:latest',
+                        'volumes': [
+                            {'type': 'bind', 'source': '~/web', 'target': '/web'},
+                        ],
+                    },
+                },
+            },
+        )
+
+        details = config.ConfigDetails('.', [base_file])
+        config_data = config.load(details)
+        mount = config_data.services[0].get('volumes')[0]
+        assert mount.target == '/web'
+        assert mount.type == 'bind'
+        assert (not mount.source.startswith('~')
+                and mount.source.endswith('{}web'.format(os.path.sep)))
+
     def test_config_invalid_ipam_config(self):
         with pytest.raises(ConfigurationError) as excinfo:
             config.load(


### PR DESCRIPTION
defined with long syntax when paths starts with '~'
Resolves #6233