### PR TITLE
Reffer Docker for Mac and Windows as Docker Desktop

### DIFF
--- a/script/release/release.md.tmpl
+++ b/script/release/release.md.tmpl
@@ -1,6 +1,6 @@
-If you're a Mac or Windows user, the best way to install Compose and keep it up-to-date is **[Docker for Mac and Windows](https://www.docker.com/products/docker)**.
+If you're a Mac or Windows user, the best way to install Compose and keep it up-to-date is **[Docker Desktop for Mac and Windows](https://www.docker.com/products/docker-desktop)**.
 
-Docker for Mac and Windows will automatically install the latest version of Docker Engine for you.
+Docker Desktop will automatically install the latest version of Docker Engine for you.
 
 Alternatively, you can use the usual commands to install or upgrade Compose:
 


### PR DESCRIPTION
Updating release notes template to link Docker Desktop page for Docker for Mac and Windows.