### PR TITLE
schema 3.7: support the `runtime` key

### DIFF
--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -250,6 +250,7 @@
           }
         },
         "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "runtime": {"type": "string"},
         "stdin_open": {"type": "boolean"},
         "stop_grace_period": {"type": "string", "format": "duration"},
         "stop_signal": {"type": "string"},


### PR DESCRIPTION
This is in 2.3, but is not available in 3.x.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>

Resolves #6239