### PR TITLE
Bump 1.23.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ naming scheme accordingly before upgrading.
 - Fixed a bug causing `external: false` entries in the Compose file to be
   printed as `external: true` in the output of `docker-compose config`
 
+- Fixed a bug where issuing a `docker-compose pull` command on services
+  without a defined image key would cause Compose to crash
+
+- Volumes and binds are now mounted in the order they're declared in the
+  service definition
+
 ### Miscellaneous
 
 - The `zsh` completion script has been updated with new options, and no

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.23.0-rc1'
+__version__ = '1.23.0-rc2'

--- a/compose/service.py
+++ b/compose/service.py
@@ -56,6 +56,7 @@ from .utils import json_hash
 from .utils import parse_bytes
 from .utils import parse_seconds_float
 from .utils import truncate_id
+from .utils import unique_everseen
 
 
 log = logging.getLogger(__name__)
@@ -940,8 +941,9 @@ class Service(object):
                 override_options['mounts'] = override_options.get('mounts') or []
                 override_options['mounts'].extend([build_mount(v) for v in secret_volumes])
 
-        # Remove possible duplicates (see e.g. https://github.com/docker/compose/issues/5885)
-        override_options['binds'] = list(set(binds))
+        # Remove possible duplicates (see e.g. https://github.com/docker/compose/issues/5885).
+        # unique_everseen preserves order. (see https://github.com/docker/compose/issues/6091).
+        override_options['binds'] = list(unique_everseen(binds))
         return container_options, override_options
 
     def _get_container_host_config(self, override_options, one_off=False):

--- a/compose/service.py
+++ b/compose/service.py
@@ -1429,7 +1429,7 @@ def merge_volume_bindings(volumes, tmpfs, previous_container, mounts):
     """
     affinity = {}
 
-    volume_bindings = dict(
+    volume_bindings = OrderedDict(
         build_volume_binding(volume)
         for volume in volumes
         if volume.external

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -180,3 +180,9 @@ def unique_everseen(iterable, key=lambda x: x):
         if unique_key not in seen:
             seen.add(unique_key)
             yield element
+
+
+def truncate_string(s, max_chars=35):
+    if len(s) > max_chars:
+        return s[:max_chars - 2] + '...'
+    return s

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -176,6 +176,7 @@ def unique_everseen(iterable, key=lambda x: x):
     "List unique elements, preserving order. Remember all elements ever seen."
     seen = set()
     for element in iterable:
-        if key(element) not in seen:
-            seen.add(element)
+        unique_key = key(element)
+        if unique_key not in seen:
+            seen.add(unique_key)
             yield element

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -170,3 +170,12 @@ def truncate_id(value):
     if len(value) > 12:
         return value[:12]
     return value
+
+
+def unique_everseen(iterable, key=lambda x: x):
+    "List unique elements, preserving order. Remember all elements ever seen."
+    seen = set()
+    for element in iterable:
+        if key(element) not in seen:
+            seen.add(element)
+            yield element

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -136,7 +136,18 @@ _docker_compose_bundle() {
 
 
 _docker_compose_config() {
-	COMPREPLY=( $( compgen -W "--help --quiet -q --resolve-image-digests --services --volumes --hash" -- "$cur" ) )
+	case "$prev" in
+		--hash)
+			if [[ $cur == \\* ]] ; then
+				COMPREPLY=( '\*' )
+			else
+				COMPREPLY=( $(compgen -W "$(__docker_compose_services) \\\* " -- "$cur") )
+			fi
+			return
+			;;
+	esac
+
+	COMPREPLY=( $( compgen -W "--hash --help --quiet -q --resolve-image-digests --services --volumes" -- "$cur" ) )
 }
 
 

--- a/script/release/release.py
+++ b/script/release/release.py
@@ -173,9 +173,10 @@ def distclean():
 def pypi_upload(args):
     print('Uploading to PyPi')
     try:
+        rel = args.release.replace('-rc', 'rc')
         twine_upload([
-            'dist/docker_compose-{}*.whl'.format(args.release),
-            'dist/docker-compose-{}*.tar.gz'.format(args.release)
+            'dist/docker_compose-{}*.whl'.format(rel),
+            'dist/docker-compose-{}*.tar.gz'.format(rel)
         ])
     except HTTPError as e:
         if e.response.status_code == 400 and 'File already exists' in e.message:

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.23.0-rc1"
+VERSION="1.23.0-rc2"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -105,6 +105,23 @@ class ProjectTest(DockerClientTestCase):
         project = Project('composetest', [web, db], self.client)
         assert set(project.containers(stopped=True)) == set([web_1, db_1])
 
+    def test_parallel_pull_with_no_image(self):
+        config_data = build_config(
+            version=V2_3,
+            services=[{
+                'name': 'web',
+                'build': {'context': '.'},
+            }],
+        )
+
+        project = Project.from_config(
+            name='composetest',
+            config_data=config_data,
+            client=self.client
+        )
+
+        project.pull(parallel_pull=True)
+
     def test_volumes_from_service(self):
         project = Project.from_config(
             name='composetest',

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import tempfile
 from operator import itemgetter
+from random import shuffle
 
 import py
 import pytest
@@ -3535,6 +3536,13 @@ class VolumeConfigTest(unittest.TestCase):
             )
         ).services[0]
         assert d['volumes'] == [VolumeSpec.parse('/host/path:/container/path')]
+
+    @pytest.mark.skipif(IS_WINDOWS_PLATFORM, reason='posix paths')
+    def test_volumes_order_is_preserved(self):
+        volumes = ['/{0}:/{0}'.format(i) for i in range(0, 6)]
+        shuffle(volumes)
+        cfg = make_service_dict('foo', {'build': '.', 'volumes': volumes})
+        assert cfg['volumes'] == volumes
 
     @pytest.mark.skipif(IS_WINDOWS_PLATFORM, reason='posix paths')
     @mock.patch.dict(os.environ)

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -42,7 +42,7 @@ from tests import unittest
 DEFAULT_VERSION = V2_0
 
 
-def make_service_dict(name, service_dict, working_dir, filename=None):
+def make_service_dict(name, service_dict, working_dir='.', filename=None):
     """Test helper function to construct a ServiceExtendsResolver
     """
     resolver = config.ServiceExtendsResolver(

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -1037,6 +1037,23 @@ class ServiceTest(unittest.TestCase):
         assert len(override_opts['binds']) == 1
         assert override_opts['binds'][0] == 'vol:/data:rw'
 
+    def test_volumes_order_is_preserved(self):
+        service = Service('foo', client=self.mock_client)
+        volumes = [
+            VolumeSpec.parse(cfg) for cfg in [
+                '/v{0}:/v{0}:rw'.format(i) for i in range(6)
+            ]
+        ]
+        ctnr_opts, override_opts = service._build_container_volume_options(
+            previous_container=None,
+            container_options={
+                'volumes': volumes,
+                'environment': {},
+            },
+            override_options={},
+        )
+        assert override_opts['binds'] == [vol.repr() for vol in volumes]
+
 
 class TestServiceNetwork(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -72,5 +72,7 @@ class TestParseBytes(object):
 
 class TestMoreItertools(object):
     def test_unique_everseen(self):
-        assert list(utils.unique_everseen([2, 1, 2, 1])) == [2, 1]
-        assert list(utils.unique_everseen([2, 1, 2, 1], hash)) == [2, 1]
+        unique = utils.unique_everseen
+        assert list(unique([2, 1, 2, 1])) == [2, 1]
+        assert list(unique([2, 1, 2, 1], hash)) == [2, 1]
+        assert list(unique([2, 1, 2, 1], lambda x: 'key_%s' % x)) == [2, 1]

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -68,3 +68,9 @@ class TestParseBytes(object):
         assert utils.parse_bytes(123) == 123
         assert utils.parse_bytes('foobar') is None
         assert utils.parse_bytes('123') == 123
+
+
+class TestMoreItertools(object):
+    def test_unique_everseen(self):
+        assert list(utils.unique_everseen([2, 1, 2, 1])) == [2, 1]
+        assert list(utils.unique_everseen([2, 1, 2, 1], hash)) == [2, 1]


### PR DESCRIPTION
Automated release for docker-compose 1.23.0-rc2


### Important note

The default naming scheme for containers created by Compose in this version
has changed from `<project>_<service>_<index>` to
`<project>_<service>_<index>_<slug>`, where `<slug>` is a randomly-generated
hexadecimal string. Please make sure to update scripts relying on the old
naming scheme accordingly before upgrading.

### Features

- Logs for containers restarting after a crash will now appear in the output
  of the `up` and `logs` commands.

- Added `--hash` option to the `docker-compose config` command, allowing users
  to print a hash string for each service's configuration to facilitate rolling
  updates.

- Output for the `pull` command now reports status / progress even when pulling
  multiple images in parallel.

- For images with multiple names, Compose will now attempt to match the one
  present in the service configuration in the output of the `images` command.

### Bugfixes

- Parallel `run` commands for the same service will no longer fail due to name
  collisions.

- Fixed an issue where paths longer than 260 characters on Windows clients would
  cause `docker-compose build` to fail.

- Fixed a bug where attempting to mount `/var/run/docker.sock` with
  Docker Desktop for Windows would result in failure.

- The `--project-directory` option is now used by Compose to determine where to
  look for the `.env` file.

- `docker-compose build` no longer fails when attempting to pull an image with
  credentials provided by the gcloud credential helper.

- Fixed the `--exit-code-from` option in `docker-compose up` to always report
  the actual exit code even when the watched container isn't the cause of the
  exit.

- Fixed a bug that caused hash configuration with multiple networks to be
  inconsistent, causing some services to be unnecessarily restarted.

- Fixed a pipe handling issue when using the containerized version of Compose.

- Fixed a bug causing `external: false` entries in the Compose file to be
  printed as `external: true` in the output of `docker-compose config`

- Fixed a bug where issuing a `docker-compose pull` command on services
  without a defined image key would cause Compose to crash

- Volumes and binds are now mounted in the order they're declared in the
  service definition

### Miscellaneous

- The `zsh` completion script has been updated with new options, and no
  longer suggests container names where service names are expected.
