### PR TITLE
Avoid creating duplicate mount points when recreating a service

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1491,6 +1491,11 @@ def get_container_data_volumes(container, volumes_option, tmpfs_option, mounts_o
         if not mount.get('Name'):
             continue
 
+        # Volume (probably an image volume) is overridden by a mount in the service's config
+        # and would cause a duplicate mountpoint error
+        if volume.internal in [m.target for m in mounts_option]:
+            continue
+
         # Copy existing volume from old container
         volume = volume._replace(external=mount['Name'])
         volumes.append(volume)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -425,6 +425,22 @@ class ServiceTest(DockerClientTestCase):
         new_container = service.recreate_container(old_container)
         assert new_container.get_mount('/data')['Source'] == volume_path
 
+    def test_recreate_volume_to_mount(self):
+        # https://github.com/docker/compose/issues/6280
+        service = Service(
+            project='composetest',
+            name='db',
+            client=self.client,
+            build={'context': 'tests/fixtures/dockerfile-with-volume'},
+            volumes=[MountSpec.parse({
+                'type': 'volume',
+                'target': '/data',
+            })]
+        )
+        old_container = create_and_start_container(service)
+        new_container = service.recreate_container(old_container)
+        assert new_container.get_mount('/data')['Source']
+
     def test_duplicate_volume_trailing_slash(self):
         """
         When an image specifies a volume, and the Compose file specifies a host path


### PR DESCRIPTION
Fixes #6280

When an anonymous volume is created (typically when declared inside the image's Dockerfile), Compose attempts to save the data and create a named volume to persist it across recreates. When a mount with the same target path is declared, this causes a "Duplicate mount point" error at the engine level. 

When a mount already exists at that endpoint, it is unnecessary to attempt to save the anonymous volume data. This patch makes discards anonymous volumes that would be created at a mount point already claimed by a mount declared in the service's configuration.