### PR TITLE
Allow requests 2.20.x for CVE fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'cached-property >= 1.2.0, < 2',
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.20',
+    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.21',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
     'docker >= 3.5.0, < 4.0',


### PR DESCRIPTION
In ~1 week `requests` will release `2.20.0` https://github.com/requests/requests/pull/4835

It would be excellent if, since we're about to release, `1.23` included support for that, especially since it will address a rather important CVE https://github.com/requests/requests/pull/4836

@shin- I'm quite sorry to bother again, but do you think we can do this? That security fix is rather critical to some of us 🙏 