### PR TITLE
Only use supported protocols when starting engine CLI subprocess

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1452,7 +1452,9 @@ def call_docker(args, dockeropts):
     if verify:
         tls_options.append('--tlsverify')
     if host:
-        tls_options.extend(['--host', host.lstrip('=')])
+        tls_options.extend(
+            ['--host', re.sub(r'^https?://', 'tcp://', host.lstrip('='))]
+        )
 
     args = [executable_path] + tls_options + args
     log.debug(" ".join(map(pipes.quote, args)))

--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -155,6 +155,14 @@ class TestCallDocker(object):
             'docker', '--host', 'tcp://mydocker.net:2333', 'ps'
         ]
 
+    def test_with_http_host(self):
+        with mock.patch('subprocess.call') as fake_call:
+            call_docker(['ps'], {'--host': 'http://mydocker.net:2333'})
+
+        assert fake_call.call_args[0][0] == [
+            'docker', '--host', 'tcp://mydocker.net:2333', 'ps',
+        ]
+
     def test_with_host_option_shorthand_equal(self):
         with mock.patch('subprocess.call') as fake_call:
             call_docker(['ps'], {'--host': '=tcp://mydocker.net:2333'})


### PR DESCRIPTION
Resolves #6293 
