### PR TITLE
Bump 1.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Change log
 ==========
 
+1.23.1 (2018-11-01)
+-------------------
+
+### Bugfixes
+
+- Fixed a bug where working with containers created with a previous (< 1.23.0)
+  version of Compose would cause unexpected crashes
+
+- Fixed an issue where the behavior of the `--project-directory` flag would
+  vary depending on which subcommand was being used.
+
 1.23.0 (2018-10-30)
 -------------------
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.23.0'
+__version__ = '1.23.1'

--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -23,7 +23,8 @@ log = logging.getLogger(__name__)
 
 
 def project_from_options(project_dir, options):
-    environment = Environment.from_env_file(project_dir)
+    override_dir = options.get('--project-directory')
+    environment = Environment.from_env_file(override_dir or project_dir)
     set_parallel_limit(environment)
 
     host = options.get('--host')
@@ -37,7 +38,7 @@ def project_from_options(project_dir, options):
         host=host,
         tls_config=tls_config_from_options(options, environment),
         environment=environment,
-        override_dir=options.get('--project-directory'),
+        override_dir=override_dir,
         compatibility=options.get('--compatibility'),
     )
 
@@ -59,12 +60,13 @@ def set_parallel_limit(environment):
 
 
 def get_config_from_options(base_dir, options):
-    environment = Environment.from_env_file(base_dir)
+    override_dir = options.get('--project-directory')
+    environment = Environment.from_env_file(override_dir or base_dir)
     config_path = get_config_path_from_options(
         base_dir, options, environment
     )
     return config.load(
-        config.find(base_dir, config_path, environment),
+        config.find(base_dir, config_path, environment, override_dir),
         options.get('--compatibility')
     )
 

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -306,7 +306,7 @@ class TopLevelCommand(object):
             -o, --output PATH          Path to write the bundle file to.
                                        Defaults to "<project name>.dab".
         """
-        compose_config = get_config_from_options(self.project_dir, self.toplevel_options)
+        compose_config = get_config_from_options('.', self.toplevel_options)
 
         output = options["--output"]
         if not output:
@@ -336,7 +336,7 @@ class TopLevelCommand(object):
                                      or use the wildcard symbol to display all services
         """
 
-        compose_config = get_config_from_options(self.project_dir, self.toplevel_options)
+        compose_config = get_config_from_options('.', self.toplevel_options)
         image_digests = None
 
         if options['--resolve-image-digests']:

--- a/compose/container.py
+++ b/compose/container.py
@@ -96,6 +96,8 @@ class Container(object):
 
     @property
     def slug(self):
+        if not self.full_slug:
+            return None
         return truncate_id(self.full_slug)
 
     @property

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.23.0"
+VERSION="1.23.1"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -5,6 +5,7 @@ import docker
 
 from .. import mock
 from .. import unittest
+from compose.const import LABEL_SLUG
 from compose.container import Container
 from compose.container import get_container_name
 
@@ -87,7 +88,7 @@ class ContainerTest(unittest.TestCase):
         assert container.name == "composetest_db_1"
 
     def test_name_without_project(self):
-        self.container_dict['Name'] = "/composetest_web_7"
+        self.container_dict['Name'] = "/composetest_web_7_092cd63296fd"
         container = Container(None, self.container_dict, has_been_inspected=True)
         assert container.name_without_project == "web_7_092cd63296fd"
 
@@ -95,6 +96,12 @@ class ContainerTest(unittest.TestCase):
         self.container_dict['Name'] = "/custom_name_of_container"
         container = Container(None, self.container_dict, has_been_inspected=True)
         assert container.name_without_project == "custom_name_of_container"
+
+    def test_name_without_project_noslug(self):
+        self.container_dict['Name'] = "/composetest_web_7"
+        del self.container_dict['Config']['Labels'][LABEL_SLUG]
+        container = Container(None, self.container_dict, has_been_inspected=True)
+        assert container.name_without_project == 'web_7'
 
     def test_inspect_if_not_inspected(self):
         mock_client = mock.create_autospec(docker.APIClient)


### PR DESCRIPTION
Automated release for docker-compose 1.23.1


### Bugfixes

- Fixed a bug where working with containers created with a previous (< 1.23.0)
  version of Compose would cause unexpected crashes

- Fixed an issue where the behavior of the `--project-directory` flag would
  vary depending on which subcommand was being used.
