### PR TITLE
Adopts 'unknown' as build revision in case git cannot retrieve it.

### DIFF
--- a/script/build/write-git-sha
+++ b/script/build/write-git-sha
@@ -2,6 +2,11 @@
 #
 # Write the current commit sha to the file GITSHA. This file is included in
 # packaging so that `docker-compose version` can include the git sha.
-#
-set -e
-git rev-parse --short HEAD > compose/GITSHA
+# sets to 'unknown' and echoes a message if the command is not successful
+
+DOCKER_COMPOSE_GITSHA="$(git rev-parse --short HEAD)"
+if [[ "${?}" != "0" ]]; then
+    echo "Couldn't get revision of the git repository. Setting to 'unknown' instead"
+    DOCKER_COMPOSE_GITSHA="unknown"
+fi
+echo "${DOCKER_COMPOSE_GITSHA}" > compose/GITSHA


### PR DESCRIPTION
Try to get the revision with `git rev-parse --short HEAD` and assign `unknown` if the command fails

Resolves #6157 
