### PR TITLE
Avoids misleading warning concerning env vars when perfoming an `exec` command

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -21,10 +21,26 @@ from .utils import get_version_info
 
 log = logging.getLogger(__name__)
 
+SILENT_COMMANDS = set((
+    'events',
+    'exec',
+    'kill',
+    'logs',
+    'pause',
+    'ps',
+    'restart',
+    'rm',
+    'start',
+    'stop',
+    'top',
+    'unpause',
+))
+
 
 def project_from_options(project_dir, options):
     override_dir = options.get('--project-directory')
     environment = Environment.from_env_file(override_dir or project_dir)
+    environment.silent = options.get('COMMAND', None) in SILENT_COMMANDS
     set_parallel_limit(environment)
 
     host = options.get('--host')

--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -56,6 +56,7 @@ class Environment(dict):
     def __init__(self, *args, **kwargs):
         super(Environment, self).__init__(*args, **kwargs)
         self.missing_keys = []
+        self.silent = False
 
     @classmethod
     def from_env_file(cls, base_dir):
@@ -95,7 +96,7 @@ class Environment(dict):
                     return super(Environment, self).__getitem__(key.upper())
                 except KeyError:
                     pass
-            if key not in self.missing_keys:
+            if not self.silent and key not in self.missing_keys:
                 log.warn(
                     "The {} variable is not set. Defaulting to a blank string."
                     .format(key)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage==4.4.2
+ddt==1.2.0
 flake8==3.5.0
 mock>=1.0.1
 pytest==3.6.3

--- a/tests/integration/environment_test.py
+++ b/tests/integration/environment_test.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import tempfile
+
+from ddt import data
+from ddt import ddt
+
+from .. import mock
+from compose.cli.command import project_from_options
+from tests.integration.testcases import DockerClientTestCase
+
+
+@ddt
+class EnvironmentTest(DockerClientTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(EnvironmentTest, cls).setUpClass()
+        cls.compose_file = tempfile.NamedTemporaryFile(mode='w+b')
+        cls.compose_file.write(bytes("""version: '3.2'
+services:
+  svc:
+    image: busybox:latest
+    environment:
+      TEST_VARIABLE: ${TEST_VARIABLE}""", encoding='utf-8'))
+        cls.compose_file.flush()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(EnvironmentTest, cls).tearDownClass()
+        cls.compose_file.close()
+
+    @data('events',
+          'exec',
+          'kill',
+          'logs',
+          'pause',
+          'ps',
+          'restart',
+          'rm',
+          'start',
+          'stop',
+          'top',
+          'unpause')
+    def _test_no_warning_on_missing_host_environment_var_on_silent_commands(self, cmd):
+        options = {'COMMAND': cmd, '--file': [EnvironmentTest.compose_file.name]}
+        with mock.patch('compose.config.environment.log') as fake_log:
+            # Note that the warning silencing and the env variables check is
+            # done in `project_from_options`
+            # So no need to have a proper options map, the `COMMAND` key is enough
+            project_from_options('.', options)
+            assert fake_log.warn.call_count == 0


### PR DESCRIPTION
Detects the execution on an`exec` command and sets the environment instance to `silent` mode.

Resolves #6350 
