### PR TITLE
Update `reorder_python_imports` version to fix Unicode problems

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
     - id: requirements-txt-fixer
     - id: trailing-whitespace
 - repo: git://github.com/asottile/reorder_python_imports
-  sha: v0.3.5
+  sha: v1.3.4
   hooks:
     - id: reorder-python-imports
       language_version: 'python2.7'

--- a/compose/utils.py
+++ b/compose/utils.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import codecs
 import hashlib
-import json
 import json.decoder
 import logging
 import ntpath

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import datetime
 import json
-import os
 import os.path
 import re
 import signal


### PR DESCRIPTION
Getting the following error when running `tox -e pre-commit`.
```
pre-commit installed: aspy.yaml==1.1.1,cached-property==1.5.1,cfgv==1.1.0,docker-compose==1.24.0.dev0,identify==1.1.7,importlib-metadata==0.7,nodeenv==1.3.3,pre-commit==1.12.0,PyYAML==3.13,six==1.11.0,toml==0.10.0,virtualenv==16.1.0
pre-commit run-test-pre: PYTHONHASHSEED='319209005'
pre-commit runtests: commands[0] | pre-commit install
pre-commit installed at /home/ulysses/gopath/src/github.com/docker/compose/.git/hooks/pre-commit
pre-commit runtests: commands[1] | pre-commit run --all-files
Check for added large files..............................................Passed
Check docstring is first.................................................Passed
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
Check JSON...............................................................Passed
Debug Statements (Python)................................................Passed
Fix End of Files.........................................................Passed
Flake8...................................................................Passed
Tests should end in _test.py.............................................Passed
Fix requirements.txt.....................................................Passed
Trim Trailing Whitespace.................................................Passed
Reorder python imports...................................................Failed
hookid: reorder-python-imports

Traceback (most recent call last):
  File "/tmp/.cache/pre-commit/repo_kg19lnf/py_env-python2.7/bin/reorder-python-imports", line 11, in <module>
    sys.exit(main())
  File "/tmp/.cache/pre-commit/repo_kg19lnf/py_env-python2.7/lib/python2.7/site-packages/reorder_python_imports/main.py", line 400, in main
    contents = io.open(filename).read()
  File "/tmp/.cache/pre-commit/repo_kg19lnf/py_env-python2.7/lib/python2.7/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1617: ordinal not in range(128)

ERROR: InvocationError for command '/home/ulysses/gopath/src/github.com/docker/compose/.tox/pre-commit/bin/pre-commit run --all-files' (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   pre-commit: commands failed
```

Got it working by updating `reorder_python-imports` from `v0.3.5` to `v1.3.4`