### PR TITLE
trim whitespaces arround '=' in env settings

### DIFF
--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -18,9 +18,10 @@ def split_env(env):
     if isinstance(env, six.binary_type):
         env = env.decode('utf-8', 'replace')
     if '=' in env:
-        return env.split('=', 1)
+        key, value = env.split('=', 1)
+        return key.strip(), value.strip()
     else:
-        return env, None
+        return env.strip(), None
 
 
 def env_vars_from_file(filename):

--- a/tests/unit/config/environment_test.py
+++ b/tests/unit/config/environment_test.py
@@ -52,3 +52,12 @@ class EnvironmentTest(unittest.TestCase):
         assert env_vars_from_file(str(tmpdir.join('bom.env'))) == {
             'PARK_BOM': '박봄'
         }
+
+    def test_env_vars_from_file_whitespace(self):
+        tmpdir = pytest.ensuretemp('env_file')
+        self.addCleanup(tmpdir.remove)
+        with codecs.open('{}/whitespace.env'.format(str(tmpdir)), 'w', encoding='utf-8') as f:
+            f.write('WHITESPACE = yes\n')
+        assert env_vars_from_file(str(tmpdir.join('whitespace.env'))) == {
+            'WHITESPACE': 'yes'
+        }


### PR DESCRIPTION
This resolves a common mistake.