### PR TITLE
setup.py: allow all recent 2.x requests releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'cached-property >= 1.2.0, < 2',
     'docopt >= 0.6.1, < 0.7',
     'PyYAML >= 3.10, < 4',
-    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.21',
+    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 3.0',
     'texttable >= 0.9.0, < 0.10',
     'websocket-client >= 0.32.0, < 1.0',
     'docker >= 3.6.0, < 4.0',


### PR DESCRIPTION
Instead of having to update this for each new requests release.

It it not quite clear why the restriction was added in the first place in
commit b0480b4d04e (Bump SDK version to latest), but change it to simply
disallow the upcoming 3.0 release to match what is done for the other
modules.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #
