### PR TITLE
Lower severity to "warning" if `down` tries to remove nonexisting image

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1148,6 +1148,9 @@ class Service(object):
         try:
             self.client.remove_image(self.image_name)
             return True
+        except ImageNotFound:
+            log.warning("Image %s not found.", self.image_name)
+            return False
         except APIError as e:
             log.error("Failed to remove image for service %s: %s", self.name, e)
             return False

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -5,6 +5,7 @@ import docker
 import pytest
 from docker.constants import DEFAULT_DOCKER_API_VERSION
 from docker.errors import APIError
+from docker.errors import ImageNotFound
 from docker.errors import NotFound
 
 from .. import mock
@@ -754,6 +755,13 @@ class ServiceTest(unittest.TestCase):
             assert not web.remove_image(ImageType.all)
         mock_log.error.assert_called_once_with(
             "Failed to remove image for service %s: %s", web.name, error)
+
+    def test_remove_non_existing_image(self):
+        self.mock_client.remove_image.side_effect = ImageNotFound('image not found')
+        web = Service('web', image='example', client=self.mock_client)
+        with mock.patch('compose.service.log', autospec=True) as mock_log:
+            assert not web.remove_image(ImageType.all)
+        mock_log.warning.assert_called_once_with("Image %s not found.", web.image_name)
 
     def test_specifies_host_port_with_no_ports(self):
         service = Service(


### PR DESCRIPTION
Picked up and rebased #5612 
