### PR TITLE
Fix failure check in parallel_execute_watch

### DIFF
--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -102,7 +102,7 @@ def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None):
     errors = {}
     results = []
     error_to_reraise = parallel_execute_watch(
-        events, writer, errors, results, msg, get_name, func.__name__)
+        events, writer, errors, results, msg, get_name, getattr(func, '__name__', None))
 
     for obj_name, error in errors.items():
         stream.write("\nERROR: for {}  {}\n".format(obj_name, error))

--- a/compose/parallel.py
+++ b/compose/parallel.py
@@ -43,16 +43,14 @@ class GlobalLimit(object):
         cls.global_limiter = Semaphore(value)
 
 
-def parallel_execute_watch(events, writer, errors, results, msg, get_name, func_name):
+def parallel_execute_watch(events, writer, errors, results, msg, get_name, fail_check):
     """ Watch events from a parallel execution, update status and fill errors and results.
         Returns exception to re-raise.
     """
     error_to_reraise = None
     for obj, result, exception in events:
         if exception is None:
-            if func_name == 'start_service' and (
-                    callable(getattr(obj, 'containers', None)) and not obj.containers()):
-                # If service has no containers started
+            if fail_check is not None and fail_check(obj):
                 writer.write(msg, get_name(obj), 'failed', red)
             else:
                 writer.write(msg, get_name(obj), 'done', green)
@@ -77,12 +75,14 @@ def parallel_execute_watch(events, writer, errors, results, msg, get_name, func_
     return error_to_reraise
 
 
-def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None):
+def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None, fail_check=None):
     """Runs func on objects in parallel while ensuring that func is
     ran on object only after it is ran on all its dependencies.
 
     get_deps called on object must return a collection with its dependencies.
     get_name called on object must return its name.
+    fail_check is an additional failure check for cases that should display as a failure
+        in the CLI logs, but don't raise an exception (such as attempting to start 0 containers)
     """
     objects = list(objects)
     stream = get_output_stream(sys.stderr)
@@ -102,7 +102,8 @@ def parallel_execute(objects, func, get_name, msg, get_deps=None, limit=None):
     errors = {}
     results = []
     error_to_reraise = parallel_execute_watch(
-        events, writer, errors, results, msg, get_name, getattr(func, '__name__', None))
+        events, writer, errors, results, msg, get_name, fail_check
+    )
 
     for obj_name, error in errors.items():
         stream.write("\nERROR: for {}  {}\n".format(obj_name, error))

--- a/compose/project.py
+++ b/compose/project.py
@@ -280,6 +280,7 @@ class Project(object):
             operator.attrgetter('name'),
             'Starting',
             get_deps,
+            fail_check=lambda obj: not obj.containers(),
         )
 
         return containers

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -610,11 +610,8 @@ class CLITestCase(DockerClientTestCase):
         result = self.dispatch(['pull'])
         assert 'Pulling simple' in result.stderr
         assert 'Pulling another' in result.stderr
-
-    def test_pull_done(self):
-        result = self.dispatch(['pull'])
-        assert 'Pulling simple' in result.stderr
         assert 'done' in result.stderr
+        assert 'failed' not in result.stderr
 
     def test_pull_with_digest(self):
         result = self.dispatch(['-f', 'digest.yml', 'pull', '--no-parallel'])

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -611,6 +611,11 @@ class CLITestCase(DockerClientTestCase):
         assert 'Pulling simple' in result.stderr
         assert 'Pulling another' in result.stderr
 
+    def test_pull_done(self):
+        result = self.dispatch(['pull'])
+        assert 'Pulling simple' in result.stderr
+        assert 'done' in result.stderr
+
     def test_pull_with_digest(self):
         result = self.dispatch(['-f', 'digest.yml', 'pull', '--no-parallel'])
 


### PR DESCRIPTION
Resolves #6446 

@collin5 Thank you for getting this started! We're in a bit of a time crunch so I took the liberty of updating your PR myself ; the idea is to move the very specific `containers()` check into the calling function rather than have it part of the `parallel` module which is intended to work more generically.