### PR TITLE
Use container_name as prefix if explicitly defined

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -2382,6 +2382,30 @@ class CLITestCase(DockerClientTestCase):
         assert 'w\n' not in result.stdout
         assert 'x\n' not in result.stdout
 
+    def test_log_prefix_implicit(self):
+        self.base_dir = 'tests/fixtures/logs-composefile/foo'
+        self.dispatch(['up', 'simple'])
+
+        result = self.dispatch(['logs'])
+        assert 'simple_1' in result.stdout
+
+    def test_log_prefix_explicit(self):
+        self.base_dir = 'tests/fixtures/logs-composefile/foo'
+        self.dispatch(['up', 'another'])
+
+        result = self.dispatch(['logs'])
+        assert 'bar' in result.stdout
+        assert 'another' not in result.stdout
+
+    def test_log_prefix_explicit2(self):
+        # with project name prefixing the container_name
+        self.base_dir = 'tests/fixtures/logs-composefile/foo'
+        self.dispatch(['up', 'another2'])
+
+        result = self.dispatch(['logs'])
+        assert 'foo_another' in result.stdout
+        assert 'another2' not in result.stdout
+
     def test_kill(self):
         self.dispatch(['up', '-d'], None)
         service = self.project.get_service('simple')

--- a/tests/fixtures/logs-composefile/foo/docker-compose.yml
+++ b/tests/fixtures/logs-composefile/foo/docker-compose.yml
@@ -1,0 +1,11 @@
+simple:
+  image: busybox:latest
+  command: sh -c "echo test"
+another:
+  container_name: 'bar'
+  image: busybox:latest
+  command: sh -c "echo test"
+another2:
+  container_name: 'foo_another'
+  image: busybox:latest
+  command: sh -c "echo test"


### PR DESCRIPTION
Even when `container_name` is prefixed with the project name i.e `baz_foo` for project `baz`

Resolves #6442
