### PR TITLE
Fix to avoid mutation on options dict in build_container_operation_with_timeout_func

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -725,10 +725,11 @@ class Project(object):
 
     def build_container_operation_with_timeout_func(self, operation, options):
         def container_operation_with_timeout(container):
-            if options.get('timeout') is None:
+            _options = options.copy()
+            if _options.get('timeout') is None:
                 service = self.get_service(container.service)
-                options['timeout'] = service.stop_timeout(None)
-            return getattr(container, operation)(**options)
+                _options['timeout'] = service.stop_timeout(None)
+            return getattr(container, operation)(**_options)
         return container_operation_with_timeout
 
 

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -15,6 +15,8 @@ from compose.config.types import VolumeFromSpec
 from compose.const import COMPOSEFILE_V1 as V1
 from compose.const import COMPOSEFILE_V2_0 as V2_0
 from compose.const import COMPOSEFILE_V2_4 as V2_4
+from compose.const import COMPOSEFILE_V3_7 as V3_7
+from compose.const import DEFAULT_TIMEOUT
 from compose.const import LABEL_SERVICE
 from compose.container import Container
 from compose.errors import OperationFailedError
@@ -764,6 +766,34 @@ class ProjectTest(unittest.TestCase):
             name='test', client=self.mock_client, config_data=config_data, default_platform='windows'
         )
         assert project.get_service('web').platform == 'linux/s390x'
+
+    def test_build_container_operation_with_timeout_func_does_not_mutate_options_with_timeout(self):
+        config_data = Config(
+            version=V3_7,
+            services=[
+                {'name': 'web', 'image': 'busybox:latest'},
+                {'name': 'db', 'image': 'busybox:latest', 'stop_grace_period': '1s'},
+            ],
+            networks={}, volumes={}, secrets=None, configs=None,
+        )
+
+        project = Project.from_config(name='test', client=self.mock_client, config_data=config_data)
+
+        stop_op = project.build_container_operation_with_timeout_func('stop', options={})
+
+        web_container = mock.create_autospec(Container, service='web')
+        db_container = mock.create_autospec(Container, service='db')
+
+        # `stop_grace_period` is not set to 'web' service,
+        # then it is stopped with the default timeout.
+        stop_op(web_container)
+        web_container.stop.assert_called_once_with(timeout=DEFAULT_TIMEOUT)
+
+        # `stop_grace_period` is set to 'db' service,
+        # then it is stopped with the specified timeout and
+        # the value is not overridden by the previous function call.
+        stop_op(db_container)
+        db_container.stop.assert_called_once_with(timeout=1)
 
     @mock.patch('compose.parallel.ParallelStreamWriter._write_noansi')
     def test_error_parallel_pull(self, mock_write):


### PR DESCRIPTION
Resolves #6508

In `build_container_operation_with_timeout_func` of the original code,
a single `options` dict passed as an argument is directly referred from inside `container_operation_with_timeout`,
while `container_operation_with_timeout` can be invoked multiple times, for example, when `stop()` ing multiple services.
Inside `container_operation_with_timeout`, the `options` can be mutated by setting `timeout` field and this mutated `options` will be used in the consequent calls of `container_operation_with_timeout`.
This causes the problem described in #6508 .