### PR TITLE
Fix bash completion for `build --memory`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -110,11 +110,14 @@ _docker_compose_build() {
 			__docker_compose_nospace
 			return
 			;;
+		--memory|-m)
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--build-arg --compress --force-rm --help --memory --no-cache --pull --parallel" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--build-arg --compress --force-rm --help --memory -m --no-cache --pull --parallel" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_complete_services --filter source=build


### PR DESCRIPTION
- the option requires an argument
- adds missing short form `-m`