### PR TITLE
Bump python 3.6.8 -> 3.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         command: sudo pip install --upgrade tox==2.1.1 virtualenv==16.2.0
     - run:
         name: unit tests
-        command: tox -e py27,py36,py37 -- tests/unit
+        command: tox -e py27,py37 -- tests/unit
 
   build-osx-binary:
     macos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker:18.06.1 as docker
-FROM python:3.6
+FROM python:3.7.2-stretch
 
 RUN set -ex; \
     apt-get update -qq; \
@@ -33,4 +33,4 @@ RUN tox --notest
 ADD . /code/
 RUN chown -R user /code/
 
-ENTRYPOINT ["/code/.tox/py36/bin/docker-compose"]
+ENTRYPOINT ["/code/.tox/py37/bin/docker-compose"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /code/
 
 # FIXME(chris-crone): virtualenv 16.3.0 breaks build, force 16.2.0 until fixed
 RUN pip install virtualenv==16.2.0
-RUN pip install tox==2.1.1
+RUN pip install tox==2.9.1
 
 ADD requirements.txt /code/
 ADD requirements-dev.txt /code/

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7.2-stretch
 
 RUN set -ex; \
     apt-get update -qq; \
@@ -36,4 +36,4 @@ RUN tox --notest
 ADD . /code/
 RUN chown -R user /code/
 
-ENTRYPOINT ["/code/.tox/py36/bin/docker-compose"]
+ENTRYPOINT ["/code/.tox/py37/bin/docker-compose"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ def runTests = { Map settings ->
   def pythonVersions = settings.get("pythonVersions", null)
 
   if (!pythonVersions) {
-    throw new Exception("Need Python versions to test. e.g.: `runTests(pythonVersions: 'py27,py36')`")
+    throw new Exception("Need Python versions to test. e.g.: `runTests(pythonVersions: 'py27,py37')`")
   }
   if (!dockerVersions) {
     throw new Exception("Need Docker versions to test. e.g.: `runTests(dockerVersions: 'all')`")
@@ -77,7 +77,6 @@ def docker_versions = get_versions(2)
 for (int i = 0; i < docker_versions.length; i++) {
   def dockerVersion = docker_versions[i]
   testMatrix["${dockerVersion}_py27"] = runTests([dockerVersions: dockerVersion, pythonVersions: "py27"])
-  testMatrix["${dockerVersion}_py36"] = runTests([dockerVersions: dockerVersion, pythonVersions: "py36"])
   testMatrix["${dockerVersion}_py37"] = runTests([dockerVersions: dockerVersion, pythonVersions: "py37"])
 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 version: '{branch}-{build}'
 
 install:
-  - "SET PATH=C:\\Python36-x64;C:\\Python36-x64\\Scripts;%PATH%"
+  - "SET PATH=C:\\Python37-x64;C:\\Python37-x64\\Scripts;%PATH%"
   - "python --version"
   - "pip install tox==2.9.1 virtualenv==15.1.0"
 
@@ -10,7 +10,7 @@ install:
 build: false
 
 test_script:
-  - "tox -e py27,py36,py37 -- tests/unit"
+  - "tox -e py27,py37 -- tests/unit"
   - ps: ".\\script\\build\\windows.ps1"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: '{branch}-{build}'
 install:
   - "SET PATH=C:\\Python37-x64;C:\\Python37-x64\\Scripts;%PATH%"
   - "python --version"
-  - "pip install tox==2.9.1 virtualenv==15.1.0"
+  - "pip install tox==2.9.1 virtualenv==16.2.0"
 
 # Build the binary after tests
 build: false

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,1 +1,1 @@
-pyinstaller==3.3.1
+pyinstaller==3.4

--- a/script/build/linux-entrypoint
+++ b/script/build/linux-entrypoint
@@ -3,7 +3,7 @@
 set -ex
 
 TARGET=dist/docker-compose-$(uname -s)-$(uname -m)
-VENV=/code/.tox/py36
+VENV=/code/.tox/py37
 
 mkdir -p `pwd`/dist
 chmod 777 `pwd`/dist

--- a/script/build/windows.ps1
+++ b/script/build/windows.ps1
@@ -6,11 +6,11 @@
 #
 #        http://git-scm.com/download/win
 #
-# 2. Install Python 3.6.4:
+# 2. Install Python 3.7.2:
 #
 #        https://www.python.org/downloads/
 #
-# 3. Append ";C:\Python36;C:\Python36\Scripts" to the "Path" environment variable:
+# 3. Append ";C:\Python37;C:\Python37\Scripts" to the "Path" environment variable:
 #
 #        https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/sysdm_advancd_environmnt_addchange_variable.mspx?mfr=true
 #

--- a/script/build/windows.ps1
+++ b/script/build/windows.ps1
@@ -16,7 +16,7 @@
 #
 # 4. In Powershell, run the following commands:
 #
-#        $ pip install 'virtualenv>=15.1.0'
+#        $ pip install 'virtualenv==16.2.0'
 #        $ Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
 #
 # 5. Clone the repository:

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -36,7 +36,7 @@ if ! [ -x "$(command -v python3)" ]; then
   brew install python3
 fi
 if ! [ -x "$(command -v virtualenv)" ]; then
-  pip install virtualenv
+  pip install virtualenv==16.2.0
 fi
 
 #

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -17,9 +17,9 @@ OPENSSL_VERSION=1.1.1a
 OPENSSL_URL=https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
 OPENSSL_SHA1=8fae27b4f34445a5500c9dc50ae66b4d6472ce29
 
-PYTHON_VERSION=3.6.8
+PYTHON_VERSION=3.7.2
 PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
-PYTHON_SHA1=09fcc4edaef0915b4dedbfb462f1cd15f82d3a6f
+PYTHON_SHA1=0cd8e52d8ed1d0be12ac8e87a623a15df3a3b418
 
 #
 # Install prerequisites.

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -98,6 +98,11 @@ if ! [[ $(${TOOLCHAIN_PATH}/bin/python3 --version) == *"${PYTHON_VERSION}"* ]]; 
   )
 fi
 
+#
+# Smoke test built Python.
+#
+openssl_version ${TOOLCHAIN_PATH}
+
 echo ""
 echo "*** Targeting macOS: ${DEPLOYMENT_TARGET}"
 echo "*** Using SDK ${SDK_PATH}"

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -50,7 +50,7 @@ mkdir -p ${TOOLCHAIN_PATH}
 #
 # Set macOS SDK.
 #
-if [ ${SDK_FETCH} ]; then
+if [[ ${SDK_FETCH} && ! -f ${TOOLCHAIN_PATH}/MacOSX${DEPLOYMENT_TARGET}.sdk/SDKSettings.plist ]]; then
   SDK_PATH=${TOOLCHAIN_PATH}/MacOSX${DEPLOYMENT_TARGET}.sdk
   fetch_tarball ${SDK_URL} ${SDK_PATH} ${SDK_SHA1}
 else
@@ -61,7 +61,7 @@ fi
 # Build OpenSSL.
 #
 OPENSSL_SRC_PATH=${TOOLCHAIN_PATH}/openssl-${OPENSSL_VERSION}
-if ! [ -f ${TOOLCHAIN_PATH}/bin/openssl ]; then
+if ! [[ $(${TOOLCHAIN_PATH}/bin/openssl version) == *"${OPENSSL_VERSION}"* ]]; then
   rm -rf ${OPENSSL_SRC_PATH}
   fetch_tarball ${OPENSSL_URL} ${OPENSSL_SRC_PATH} ${OPENSSL_SHA1}
   (
@@ -77,7 +77,7 @@ fi
 # Build Python.
 #
 PYTHON_SRC_PATH=${TOOLCHAIN_PATH}/Python-${PYTHON_VERSION}
-if ! [ -f ${TOOLCHAIN_PATH}/bin/python3 ]; then
+if ! [[ $(${TOOLCHAIN_PATH}/bin/python3 --version) == *"${PYTHON_VERSION}"* ]]; then
   rm -rf ${PYTHON_SRC_PATH}
   fetch_tarball ${PYTHON_URL} ${PYTHON_SRC_PATH} ${PYTHON_SHA1}
   (
@@ -87,9 +87,10 @@ if ! [ -f ${TOOLCHAIN_PATH}/bin/python3 ]; then
       --datarootdir=${TOOLCHAIN_PATH}/share \
       --datadir=${TOOLCHAIN_PATH}/share \
       --enable-framework=${TOOLCHAIN_PATH}/Frameworks \
+      --with-openssl=${TOOLCHAIN_PATH} \
       MACOSX_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET} \
       CFLAGS="-isysroot ${SDK_PATH} -I${TOOLCHAIN_PATH}/include" \
-      CPPFLAGS="-I${SDK_PATH}/usr/include -I${TOOLCHAIN_PATH}include" \
+      CPPFLAGS="-I${SDK_PATH}/usr/include -I${TOOLCHAIN_PATH}/include" \
       LDFLAGS="-isysroot ${SDK_PATH} -L ${TOOLCHAIN_PATH}/lib"
     make -j 4
     make install PYTHONAPPSDIR=${TOOLCHAIN_PATH}

--- a/script/test/all
+++ b/script/test/all
@@ -24,7 +24,7 @@ fi
 
 
 BUILD_NUMBER=${BUILD_NUMBER-$USER}
-PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py27,py36}
+PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py27,py37}
 
 for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,pre-commit
+envlist = py27,py37,pre-commit
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
Resolves #6502 

Note that this PR tries to enforce the python version in the `Dockerfile` as `3.7.2-stretch` (same as `3.7` by now) to have a more predictable build.

Note also that the versions of `tox` and `virtualenv` get harmonized through the various configurations.