### PR TITLE
Add --no-rm to command build

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -260,6 +260,7 @@ class TopLevelCommand(object):
             --compress              Compress the build context using gzip.
             --force-rm              Always remove intermediate containers.
             --no-cache              Do not use cache when building the image.
+            --no-rm                 Do not remove intermediate containers after a successful build.
             --pull                  Always attempt to pull a newer version of the image.
             -m, --memory MEM        Sets memory limit for the build container.
             --build-arg key=val     Set build-time variables for services.
@@ -282,6 +283,7 @@ class TopLevelCommand(object):
             pull=bool(options.get('--pull', False)),
             force_rm=bool(options.get('--force-rm', False)),
             memory=options.get('--memory'),
+            rm=not bool(options.get('--no-rm', False)),
             build_args=build_args,
             gzip=options.get('--compress', False),
             parallel_build=options.get('--parallel', False),

--- a/compose/project.py
+++ b/compose/project.py
@@ -355,7 +355,7 @@ class Project(object):
         return containers
 
     def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, memory=None,
-              build_args=None, gzip=False, parallel_build=False):
+              build_args=None, gzip=False, parallel_build=False, rm=True):
 
         services = []
         for service in self.get_services(service_names):
@@ -365,7 +365,7 @@ class Project(object):
                 log.info('%s uses an image, skipping' % service.name)
 
         def build_service(service):
-            service.build(no_cache, pull, force_rm, memory, build_args, gzip)
+            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm)
 
         if parallel_build:
             _, errors = parallel.parallel_execute(

--- a/compose/service.py
+++ b/compose/service.py
@@ -1049,7 +1049,7 @@ class Service(object):
         return [build_spec(secret) for secret in self.secrets]
 
     def build(self, no_cache=False, pull=False, force_rm=False, memory=None, build_args_override=None,
-              gzip=False):
+              gzip=False, rm=True):
         log.info('Building %s' % self.name)
 
         build_opts = self.options.get('build', {})
@@ -1070,7 +1070,7 @@ class Service(object):
         build_output = self.client.build(
             path=path,
             tag=self.image_name,
-            rm=True,
+            rm=rm,
             forcerm=force_rm,
             pull=pull,
             nocache=no_cache,

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -117,7 +117,7 @@ _docker_compose_build() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--build-arg --compress --force-rm --help --memory -m --no-cache --pull --parallel" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--build-arg --compress --force-rm --help --memory -m --no-cache --no-rm --pull --parallel" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_complete_services --filter source=build

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -747,6 +747,23 @@ class CLITestCase(DockerClientTestCase):
         ]
         assert not containers
 
+    def test_build_rm(self):
+        containers = [
+            Container.from_ps(self.project.client, c)
+            for c in self.project.client.containers(all=True)
+        ]
+
+        assert not containers
+
+        self.base_dir = 'tests/fixtures/simple-dockerfile'
+        self.dispatch(['build', '--no-rm', 'simple'], returncode=0)
+
+        containers = [
+            Container.from_ps(self.project.client, c)
+            for c in self.project.client.containers(all=True)
+        ]
+        assert containers
+
     def test_build_shm_size_build_option(self):
         pull_busybox(self.client)
         self.base_dir = 'tests/fixtures/build-shm-size'


### PR DESCRIPTION
- When present, build does not remove
intermediate containers after a successful build.

Signed-off-by: Ulysses Souza <ulysses.souza@docker.com>

Resolves #4608