### PR TITLE
Support for --env-file option for docker-compose

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -39,7 +39,8 @@ SILENT_COMMANDS = set((
 
 def project_from_options(project_dir, options):
     override_dir = options.get('--project-directory')
-    environment = Environment.from_env_file(override_dir or project_dir)
+    environment_file = options.get('--env-file')
+    environment = Environment.from_env_file(override_dir or project_dir, environment_file)
     environment.silent = options.get('COMMAND', None) in SILENT_COMMANDS
     set_parallel_limit(environment)
 
@@ -77,7 +78,8 @@ def set_parallel_limit(environment):
 
 def get_config_from_options(base_dir, options):
     override_dir = options.get('--project-directory')
-    environment = Environment.from_env_file(override_dir or base_dir)
+    environment_file = options.get('--env-file')
+    environment = Environment.from_env_file(override_dir or base_dir, environment_file)
     config_path = get_config_path_from_options(
         base_dir, options, environment
     )

--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -59,12 +59,15 @@ class Environment(dict):
         self.silent = False
 
     @classmethod
-    def from_env_file(cls, base_dir):
+    def from_env_file(cls, base_dir, env_file=None):
         def _initialize():
             result = cls()
             if base_dir is None:
                 return result
-            env_file_path = os.path.join(base_dir, '.env')
+            if env_file:
+                env_file_path = os.path.join(base_dir, env_file)
+            else:
+                env_file_path = os.path.join(base_dir, '.env')
             try:
                 return cls(env_vars_from_file(env_file_path))
             except EnvFileNotFound:

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -324,6 +324,21 @@ class CLITestCase(DockerClientTestCase):
             'version': '2.4'
         }
 
+    def test_config_with_env_file(self):
+        self.base_dir = 'tests/fixtures/default-env-file'
+        result = self.dispatch(['--env-file', '.env2', 'config'])
+        json_result = yaml.load(result.stdout)
+        assert json_result == {
+            'services': {
+                'web': {
+                    'command': 'false',
+                    'image': 'alpine:latest',
+                    'ports': ['5644/tcp', '9998/tcp']
+                }
+            },
+            'version': '2.4'
+        }
+
     def test_config_with_dot_env_and_override_dir(self):
         self.base_dir = 'tests/fixtures/default-env-file'
         result = self.dispatch(['--project-directory', 'alt/', 'config'])

--- a/tests/fixtures/default-env-file/.env2
+++ b/tests/fixtures/default-env-file/.env2
@@ -1,0 +1,4 @@
+IMAGE=alpine:latest
+COMMAND=false
+PORT1=5644
+PORT2=9998

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3466,6 +3466,25 @@ class InterpolationTest(unittest.TestCase):
         }
 
     @mock.patch.dict(os.environ)
+    def test_config_file_with_options_environment_file(self):
+        project_dir = 'tests/fixtures/default-env-file'
+        service_dicts = config.load(
+            config.find(
+                project_dir, None, Environment.from_env_file(project_dir, '.env2')
+            )
+        ).services
+
+        assert service_dicts[0] == {
+            'name': 'web',
+            'image': 'alpine:latest',
+            'ports': [
+                types.ServicePort.parse('5644')[0],
+                types.ServicePort.parse('9998')[0]
+            ],
+            'command': 'false'
+        }
+
+    @mock.patch.dict(os.environ)
     def test_config_file_with_environment_variable(self):
         project_dir = 'tests/fixtures/environment-interpolation'
         os.environ.update(


### PR DESCRIPTION
Added additional argument (--env-file) for docker-compose to import environment variables from a given file.

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6170
