### PR TITLE
Add --quiet build flag

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -266,6 +266,7 @@ class TopLevelCommand(object):
             -m, --memory MEM        Sets memory limit for the build container.
             --build-arg key=val     Set build-time variables for services.
             --parallel              Build images in parallel.
+            -q, --quiet             Don't print anything to STDOUT
         """
         service_names = options['SERVICE']
         build_args = options.get('--build-arg', None)
@@ -289,6 +290,7 @@ class TopLevelCommand(object):
             build_args=build_args,
             gzip=options.get('--compress', False),
             parallel_build=options.get('--parallel', False),
+            silent=options.get('--quiet', False)
         )
 
     def bundle(self, options):

--- a/compose/project.py
+++ b/compose/project.py
@@ -355,18 +355,17 @@ class Project(object):
         return containers
 
     def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, memory=None,
-              build_args=None, gzip=False, parallel_build=False, rm=True):
+              build_args=None, gzip=False, parallel_build=False, rm=True, silent=False):
 
         services = []
         for service in self.get_services(service_names):
             if service.can_be_built():
                 services.append(service)
-            else:
+            elif not silent:
                 log.info('%s uses an image, skipping' % service.name)
 
         def build_service(service):
-            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm)
-
+            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent)
         if parallel_build:
             _, errors = parallel.parallel_execute(
                 services,

--- a/compose/service.py
+++ b/compose/service.py
@@ -59,7 +59,6 @@ from .utils import parse_seconds_float
 from .utils import truncate_id
 from .utils import unique_everseen
 
-
 log = logging.getLogger(__name__)
 
 
@@ -1049,8 +1048,11 @@ class Service(object):
         return [build_spec(secret) for secret in self.secrets]
 
     def build(self, no_cache=False, pull=False, force_rm=False, memory=None, build_args_override=None,
-              gzip=False, rm=True):
-        log.info('Building %s' % self.name)
+              gzip=False, rm=True, silent=False):
+        output_stream = open(os.devnull, 'w')
+        if not silent:
+            output_stream = sys.stdout
+            log.info('Building %s' % self.name)
 
         build_opts = self.options.get('build', {})
 
@@ -1091,7 +1093,7 @@ class Service(object):
         )
 
         try:
-            all_events = list(stream_output(build_output, sys.stdout))
+            all_events = list(stream_output(build_output, output_stream))
         except StreamOutputError as e:
             raise BuildError(self, six.text_type(e))
 

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -117,7 +117,7 @@ _docker_compose_build() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--build-arg --compress --force-rm --help --memory -m --no-cache --no-rm --pull --parallel" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--build-arg --compress --force-rm --help --memory -m --no-cache --no-rm --pull --parallel -q --quiet" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_complete_services --filter source=build

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -113,6 +113,7 @@ __docker-compose_subcommand() {
                 $opts_help \
                 "*--build-arg=[Set build-time variables for one service.]:<varname>=<value>: " \
                 '--force-rm[Always remove intermediate containers.]' \
+                '(--quiet -q)'{--quiet,-q}'[Curb build output]' \
                 '(--memory -m)'{--memory,-m}'[Memory limit for the build container.]' \
                 '--no-cache[Do not use cache when building the image.]' \
                 '--pull[Always attempt to pull a newer version of the image.]' \

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -170,6 +170,13 @@ class CLITestCase(DockerClientTestCase):
         # Prevent tearDown from trying to create a project
         self.base_dir = None
 
+    def test_quiet_build(self):
+        self.base_dir = 'tests/fixtures/build-args'
+        result = self.dispatch(['build'], None)
+        quietResult = self.dispatch(['build', '-q'], None)
+        assert result.stdout != ""
+        assert quietResult.stdout == ""
+
     def test_help_nonexistent(self):
         self.base_dir = 'tests/fixtures/no-composefile'
         result = self.dispatch(['help', 'foobar'], returncode=1)


### PR DESCRIPTION
Resolves #6028 
Changes made in this PR adds -q, --quiet flags for `build` command. Flags -q, --quiets curbs any output to STDOUT but allows any error consoled to STDERR.

@chris-crone  
I created a new PR deleting the old one as it required changes of last 6 months to be rebased. Creating a new PR was a quick option according to me.
Please look for any changes.

P.S. Command completion is added.

Thank you