### PR TITLE
Add test and implementation for secret added after container has been…

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -685,6 +685,7 @@ class Service(object):
             'links': self.get_link_names(),
             'net': self.network_mode.id,
             'networks': self.networks,
+            'secrets': self.secrets,
             'volumes_from': [
                 (v.source.name, v.mode)
                 for v in self.volumes_from if isinstance(v.source, Service)

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1534,7 +1534,6 @@ class ProjectTest(DockerClientTestCase):
             config_data=config_data1,
         )
         project.up()
-        project.stop()
 
         # Then up with secret
         project = Project.from_config(

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -333,7 +333,7 @@ class ServiceTest(unittest.TestCase):
         assert service.options['environment'] == environment
 
         assert opts['labels'][LABEL_CONFIG_HASH] == \
-            '2524a06fcb3d781aa2c981fc40bcfa08013bb318e4273bfa388df22023e6f2aa'
+            '689149e6041a85f6fb4945a2146a497ed43c8a5cbd8991753d875b165f1b4de4'
         assert opts['environment'] == ['also=real']
 
     def test_get_container_create_options_sets_affinity_with_binds(self):
@@ -676,6 +676,7 @@ class ServiceTest(unittest.TestCase):
             'options': {'image': 'example.com/foo'},
             'links': [('one', 'one')],
             'net': 'other',
+            'secrets': [],
             'networks': {'default': None},
             'volumes_from': [('two', 'rw')],
         }
@@ -698,6 +699,7 @@ class ServiceTest(unittest.TestCase):
             'options': {'image': 'example.com/foo'},
             'links': [],
             'networks': {},
+            'secrets': [],
             'net': 'aaabbb',
             'volumes_from': [],
         }


### PR DESCRIPTION
… created

The issue is that if a secret is added to the compose file, then it will
not notice that containers have diverged since last run, because secrets
are not part of the config_hash, which determines if the configuration of
a service is the same or not.

Signed-off-by: Henrik Adolfsson <catears13@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6543 

Not sure I got the test to work properly, need some help with that if possible...
