### PR TITLE
docs/README.md: update since `vnext-compose` branch is no longer used.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,9 @@ The documentation for Compose has been merged into
 The docs for Compose are now here:
 https://github.com/docker/docker.github.io/tree/master/compose
 
-Please submit pull requests for unpublished features on the `vnext-compose` branch (https://github.com/docker/docker.github.io/tree/vnext-compose).
+Please submit pull requests for unreleased features/changes on the `master` branch (https://github.com/docker/docker.github.io/tree/master), please prefix the PR title with `[WIP]` to indicate that it relates to an unreleased change.
 
-If you submit a PR to this codebase that has a docs impact, create a second docs PR on `docker.github.io`. Use the docs PR template provided (coming soon - watch this space).
-
-PRs for typos, additional information, etc. for already-published features should be labeled as `okay-to-publish` (we are still settling on a naming convention, will provide a label soon). You can submit these PRs either to `vnext-compose` or directly to `master` on `docker.github.io`
+If you submit a PR to this codebase that has a docs impact, create a second docs PR on `docker.github.io`. Use the docs PR template provided.
 
 As always, the docs remain open-source and we appreciate your feedback and
 pull requests!


### PR DESCRIPTION
All PRs should be made to `master` now. Also:

- Template seems to exist now[0] so remove the "coming soon".
- The labels used seem different now, but labelling seems more like a docs
  maintainer thing than a contributor thing, so just drop that paragraph.

[0] https://raw.githubusercontent.com/docker/docker.github.io/master/.github/PULL_REQUEST_TEMPLATE.md

Signed-off-by: Ian Campbell <ijc@docker.com>
