### PR TITLE
Fix merging of compose files when network has None config

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1214,7 +1214,7 @@ def merge_networks(base, override):
     base = {k: {} for k in base} if isinstance(base, list) else base
     override = {k: {} for k in override} if isinstance(override, list) else override
     for network_name in all_network_names:
-        md = MergeDict(base.get(network_name, {}), override.get(network_name, {}))
+        md = MergeDict(base.get(network_name) or {}, override.get(network_name) or {})
         md.merge_field('aliases', merge_unique_items_lists, [])
         md.merge_field('link_local_ips', merge_unique_items_lists, [])
         md.merge_scalar('priority')

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3970,6 +3970,24 @@ class MergeNetworksTest(unittest.TestCase, MergeListsTest):
             }
         }
 
+    def test_network_has_none_value(self):
+        service_dict = config.merge_service_dicts(
+            {self.config_name: {
+                'default': None
+            }},
+            {self.config_name: {
+                'default': {
+                    'aliases': []
+                }
+            }},
+            DEFAULT_VERSION)
+
+        assert service_dict[self.config_name] == {
+            'default': {
+                'aliases': []
+            }
+        }
+
     def test_all_properties(self):
         service_dict = config.merge_service_dicts(
             {self.config_name: {


### PR DESCRIPTION
Signed-off-by: Michael Irwin <mikesir87@gmail.com>

Resolves #6525 

## Explanation

Sample base config file:
```
services:
  app:
    ...
    networks:
      my-network:
networks:
  my-network:
```

With the example above, `base.get('my-network', {})` will return `None`, as the key is defined, but actually has the value of `None`. I'm not sure if the key _should_ have a value of `None`, or if it should be set to `{}`. But, this PR works with it either way.

I would write a test, but honestly not sure where/how to do so. Feel free to point me in the right direction and I can take a stab at it.