### PR TITLE
Push latest tag for docker/compose

### DIFF
--- a/script/build/image
+++ b/script/build/image
@@ -15,3 +15,4 @@ VERSION="$(python setup.py --version)"
 python setup.py sdist bdist_wheel
 ./script/build/linux
 docker build -t docker/compose:$TAG -f Dockerfile.run .
+docker tag docker/compose:$TAG docker/compose:latest

--- a/script/release/push-release
+++ b/script/release/push-release
@@ -47,6 +47,7 @@ git push $GITHUB_REPO $VERSION
 
 echo "Uploading the docker image"
 docker push docker/compose:$VERSION
+docker push docker/compose:latest
 
 echo "Uploading the compose-tests image"
 docker push docker/compose-tests:latest


### PR DESCRIPTION
Tag and push the `latest` tag when building and releasing `docker/compose` images.

Resolves https://github.com/docker/compose/issues/6106
Resolves https://github.com/docker/compose/issues/6006
Partly resolves https://github.com/docker/compose/issues/4287