### PR TITLE
Pickup and use eventual HTTP proxy

### DIFF
--- a/script/build/image
+++ b/script/build/image
@@ -16,5 +16,7 @@ echo "${DOCKER_COMPOSE_GITSHA}" > compose/GITSHA
 python setup.py sdist bdist_wheel
 
 docker build \
+    --build-arg http_proxy=$http_proxy \
+    --build-arg https_proxy=$https_proxy \
     --build-arg GIT_COMMIT="${DOCKER_COMPOSE_GITSHA}" \
     -t "${TAG}" .

--- a/script/build/linux
+++ b/script/build/linux
@@ -8,6 +8,8 @@ DOCKER_COMPOSE_GITSHA="$(script/build/write-git-sha)"
 TAG="docker/compose:tmp-glibc-linux-binary-${DOCKER_COMPOSE_GITSHA}"
 
 docker build -t "${TAG}" . \
+       --build-arg http_proxy=$http_proxy \
+       --build-arg https_proxy=$https_proxy \
        --build-arg BUILD_PLATFORM=debian \
        --build-arg GIT_COMMIT="${DOCKER_COMPOSE_GITSHA}"
 TMP_CONTAINER=$(docker create "${TAG}")

--- a/script/build/test-image
+++ b/script/build/test-image
@@ -13,6 +13,8 @@ IMAGE="docker/compose-tests"
 DOCKER_COMPOSE_GITSHA="$(script/build/write-git-sha)"
 docker build -t "${IMAGE}:${TAG}" . \
        --target build \
+       --build-arg http_proxy=$http_proxy \
+       --build-arg https_proxy=$https_proxy \
        --build-arg BUILD_PLATFORM="debian" \
        --build-arg GIT_COMMIT="${DOCKER_COMPOSE_GITSHA}"
 docker tag "${IMAGE}":"${TAG}" "${IMAGE}":latest

--- a/script/test/all
+++ b/script/test/all
@@ -56,6 +56,7 @@ for version in $DOCKER_VERSIONS; do
     --link="$daemon_container:docker" \
     --env="DOCKER_HOST=tcp://docker:2375" \
     --env="DOCKER_VERSION=$version" \
+    --env="no_proxy=$no_proxy,docker" \
     --entrypoint="tox" \
     "$TAG" \
     -e "$PY_TEST_VERSIONS" -- "$@"

--- a/script/test/default
+++ b/script/test/default
@@ -14,7 +14,7 @@ rm -rf coverage-html
 # Create the host directory so it's owned by $USER
 mkdir -p coverage-html
 
-docker build -f "${DOCKERFILE}" -t "${TAG}" --target "${DOCKER_BUILD_TARGET}" .
+docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -f "${DOCKERFILE}" -t "${TAG}" --target "${DOCKER_BUILD_TARGET}" .
 
 GIT_VOLUME="--volume=$(pwd)/.git:/code/.git"
 . script/test/all

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ passenv =
     DOCKER_VERSION
     SWARM_SKIP_*
     SWARM_ASSUME_MULTINODE
+    http_proxy
+    https_proxy
+    no_proxy
 setenv =
     HOME=/tmp
 deps =


### PR DESCRIPTION
Without passing proper proxy settings to the docker build command, it
will fail. This patch mitigates that (and works if no proxy is set).

Change-Id: I81e50b173047dd4a92b5a38a4940eff3453c8b80
Signed-off-by: Joakim Roubert <joakimr@axis.com>

Resolves #2590
