### PR TITLE
Dockerfile: Decrease footprint by using python-slim-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM docker:18.06.1 as docker
-FROM python:3.7.2-stretch
+FROM python:3.7.2-slim-stretch
 
 RUN set -ex; \
     apt-get update -qq; \
     apt-get install -y \
+        gcc \
         locales \
         python-dev \
         git


### PR DESCRIPTION
The Docker image for docker-compose is HUGE. By using the slim version
of the Debian python base image, footprint is still huge, but
significantly decreased as compared to before.

Change-Id: If62e87ee05975cb734aa6b7252c935e37fc8938c
Signed-off-by: Joakim Roubert <joakimr@axis.com>

Resolves #6567
