### PR TITLE
Enable bootloader_ignore_signals in pyinstaller

### DIFF
--- a/docker-compose.spec
+++ b/docker-compose.spec
@@ -98,4 +98,5 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=True,
-          console=True)
+          console=True,
+          bootloader_ignore_signals=True)


### PR DESCRIPTION
:wave:

This probably fixes Ctrl-C not working, as described in #3347. It seems like I now have to run a pretty invasive script to build an OS X binary, which I am not willing to do on my machine. Somebody might want to test this actually fixes the issue.

Fixes #3347 
