### PR TITLE
Default ?err to (missing) required VAR name. Fixed #6587.

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -64,12 +64,12 @@ def interpolate_value(name, config_key, value, section, interpolator):
                 string=e.string))
     except UnsetRequiredSubstitution as e:
         raise ConfigurationError(
-            'Missing mandatory value for "{config_key}" option in {section} "{name}": {err}'.format(
-                config_key=config_key,
-                name=name,
-                section=section,
-                err=e.err
-            )
+            'Missing mandatory value for "{config_key}" option interpolating {value} '
+            'in {section} "{name}": {err}'.format(config_key=config_key,
+                                                  value=value,
+                                                  name=name,
+                                                  section=section,
+                                                  err=e.err)
         )
 
 


### PR DESCRIPTION
Changes the default (no custom `?err`) error-message for a missing required variable ${MYVAR:?} to end with `: MYVAR` e.g.

```
ERROR: Missing mandatory value for "environment" option in service "myservice": MYVAR
```

Behaviour with `${MYVAR:?err}` remains unchanged.

Fixed #6587.