### PR TITLE
Bump 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Change log
 
 - Fix `CTRL+C` issues by enabling `bootloader_ignore_signals` in `pyinstaller`
 
-- Bump `docker-py` version to `3.7.1` to fix SSH issues
+- Bump `docker-py` version to `3.7.2` to fix SSH and proxy config issues
 
 - Fix release script and some typos on release documentation
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.24.0-rc3'
+__version__ = '1.24.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
 colorama==0.4.0; sys_platform == 'win32'
-docker==3.7.1
+docker==3.7.2
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2

--- a/script/release/release/pypi.py
+++ b/script/release/release/pypi.py
@@ -18,7 +18,7 @@ def pypi_upload(args):
             'dist/docker-compose-{}*.tar.gz'.format(rel)
         ])
     except HTTPError as e:
-        if e.response.status_code == 400 and 'File already exists' in e.message:
+        if e.response.status_code == 400 and 'File already exists' in str(e):
             if not args.finalize_resume:
                 raise ScriptError(
                     'Package already uploaded on PyPi.'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.24.0-rc3"
+VERSION="1.24.0"
 IMAGE="docker/compose:$VERSION"
 
 


### PR DESCRIPTION
Automated release for docker-compose 1.24.0


### Features

- Added support for connecting to the Docker Engine using the `ssh` protocol.

- Added a `--all` flag to `docker-compose ps` to include stopped one-off containers
  in the command's output.

- Add bash completion for `ps --all|-a`

- Support for credential_spec

- Add `--parallel` to `docker build`'s options in `bash` and `zsh` completion

### Bugfixes

- Fixed a bug where some valid credential helpers weren't properly handled by Compose
  when attempting to pull images from private registries.

- Fixed an issue where the output of `docker-compose start` before containers were created
  was misleading

- To match the Docker CLI behavior and to avoid confusing issues, Compose will no longer
  accept whitespace in variable names sourced from environment files.

- Compose will now report a configuration error if a service attempts to declare
  duplicate mount points in the volumes section.

- Fixed an issue with the containerized version of Compose that prevented users from
  writing to stdin during interactive sessions started by `run` or `exec`.

- One-off containers started by `run` no longer adopt the restart policy of the service,
  and are instead set to never restart.

- Fixed an issue that caused some container events to not appear in the output of
  the `docker-compose events` command.

- Missing images will no longer stop the execution of `docker-compose down` commands
  (a warning will be displayed instead).

- Force `virtualenv` version for macOS CI

- Fix merging of compose files when network has `None` config

- Fix `CTRL+C` issues by enabling `bootloader_ignore_signals` in `pyinstaller`

- Bump `docker-py` version to `3.7.2` to fix SSH and proxy config issues

- Fix release script and some typos on release documentation
