### PR TITLE
feat: drop empty tag on cache_from

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1078,7 +1078,7 @@ class Service(object):
             pull=pull,
             nocache=no_cache,
             dockerfile=build_opts.get('dockerfile', None),
-            cache_from=build_opts.get('cache_from', None),
+            cache_from=self.get_cache_from(build_opts),
             labels=build_opts.get('labels', None),
             buildargs=build_args,
             network_mode=build_opts.get('network', None),
@@ -1115,6 +1115,12 @@ class Service(object):
             raise BuildError(self, event if all_events else 'Unknown')
 
         return image_id
+
+    def get_cache_from(self, build_opts):
+        cache_from = build_opts.get('cache_from', None)
+        if cache_from is not None:
+            cache_from = [tag for tag in cache_from if tag]
+        return cache_from
 
     def can_be_built(self):
         return 'build' in self.options


### PR DESCRIPTION
I implemented to dropping empty tags on cache_from.
currently, docker-compose's sending value is `[""]` for cache_from in this case.

```yaml
build:
  cache_from:
    -
```

In my usecase on CI.
```yaml
build:
  cache_from:
    - $CACHE_FROM_TAG
```

I haven't set the environment variable 'CACHE_FROM_TAG' in my local development environment to use the local cache.

Now, moby's implementation is here.
https://github.com/moby/moby/blob/master/daemon/images/cache.go#L9-L27
```go
// MakeImageCache creates a stateful image cache.
func (i *ImageService) MakeImageCache(sourceRefs []string) builder.ImageCache {
	if len(sourceRefs) == 0 {
		return cache.NewLocal(i.imageStore)
	}

	cache := cache.New(i.imageStore)

	for _, ref := range sourceRefs {
		img, err := i.GetImage(ref)
		if err != nil {
			logrus.Warnf("Could not look up %s for cache resolution, skipping: %+v", ref, err)
			continue
		}
		cache.Populate(img)
	}

	return cache
}
```
`sourceRefs == cache_from value`
It does not use local cache on cache_from length non zero patterns.

I want to use the same docker-compose.yaml on local and CI.