### PR TITLE
[WIP] Sync compose-schemas with upstream (docker/cli)

### DIFF
--- a/compose/config/config_schema_v3.0.json
+++ b/compose/config/config_schema_v3.0.json
@@ -105,7 +105,7 @@
         "hostname": {"type": "string"},
         "image": {"type": "string"},
         "ipc": {"type": "string"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
         "logging": {
@@ -223,7 +223,7 @@
       "properties": {
         "mode": {"type": "string"},
         "replicas": {"type": "integer"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "update_config": {
           "type": "object",
           "properties": {
@@ -294,7 +294,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"}
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -310,7 +310,7 @@
           "additionalProperties": false
         },
         "internal": {"type": "boolean"},
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -333,7 +333,7 @@
           },
           "additionalProperties": false
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -358,21 +358,6 @@
           "patternProperties": {
             ".+": {
               "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
-
-    "labels": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/compose/config/config_schema_v3.1.json
+++ b/compose/config/config_schema_v3.1.json
@@ -116,7 +116,7 @@
         "hostname": {"type": "string"},
         "image": {"type": "string"},
         "ipc": {"type": "string"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
         "logging": {
@@ -252,7 +252,7 @@
       "properties": {
         "mode": {"type": "string"},
         "replicas": {"type": "integer"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "update_config": {
           "type": "object",
           "properties": {
@@ -323,7 +323,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"}
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -339,7 +339,7 @@
           "additionalProperties": false
         },
         "internal": {"type": "boolean"},
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -362,7 +362,7 @@
           },
           "additionalProperties": false
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -378,7 +378,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -403,21 +403,6 @@
           "patternProperties": {
             ".+": {
               "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
-
-    "labels": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -72,7 +72,6 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"$ref": "#/definitions/list_of_strings"}
               },
               "additionalProperties": false
@@ -118,7 +117,7 @@
         "hostname": {"type": "string"},
         "image": {"type": "string"},
         "ipc": {"type": "string"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
         "logging": {
@@ -245,7 +244,6 @@
               {
                 "type": "object",
                 "required": ["type"],
-                "additionalProperties": false,
                 "properties": {
                   "type": {"type": "string"},
                   "source": {"type": "string"},
@@ -264,7 +262,8 @@
                       "nocopy": {"type": "boolean"}
                     }
                   }
-                }
+                },
+                "additionalProperties": false
               }
             ],
             "uniqueItems": true
@@ -299,7 +298,7 @@
         "mode": {"type": "string"},
         "endpoint_mode": {"type": "string"},
         "replicas": {"type": "integer"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "update_config": {
           "type": "object",
           "properties": {
@@ -370,7 +369,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"}
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -387,7 +386,7 @@
         },
         "internal": {"type": "boolean"},
         "attachable": {"type": "boolean"},
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -410,7 +409,7 @@
           },
           "additionalProperties": false
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -426,7 +425,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -451,21 +450,6 @@
           "patternProperties": {
             ".+": {
               "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
-
-    "labels": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/compose/config/config_schema_v3.3.json
+++ b/compose/config/config_schema_v3.3.json
@@ -83,7 +83,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "labels": {"$ref": "#/definitions/labels"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"$ref": "#/definitions/list_of_strings"}
               },
               "additionalProperties": false
@@ -118,10 +118,14 @@
           }
         },
         "container_name": {"type": "string"},
-        "credential_spec": {"type": "object", "properties": {
-          "file": {"type": "string"},
-          "registry": {"type": "string"}
-        }},
+        "credential_spec": {
+          "type": "object",
+          "properties": {
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
         "depends_on": {"$ref": "#/definitions/list_of_strings"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
@@ -151,7 +155,7 @@
         "hostname": {"type": "string"},
         "image": {"type": "string"},
         "ipc": {"type": "string"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
         "logging": {
@@ -278,7 +282,6 @@
               {
                 "type": "object",
                 "required": ["type"],
-                "additionalProperties": false,
                 "properties": {
                   "type": {"type": "string"},
                   "source": {"type": "string"},
@@ -297,7 +300,8 @@
                       "nocopy": {"type": "boolean"}
                     }
                   }
-                }
+                },
+                "additionalProperties": false
               }
             ],
             "uniqueItems": true
@@ -332,7 +336,7 @@
         "mode": {"type": "string"},
         "endpoint_mode": {"type": "string"},
         "replicas": {"type": "integer"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "update_config": {
           "type": "object",
           "properties": {
@@ -413,7 +417,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"}
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -430,7 +434,7 @@
         },
         "internal": {"type": "boolean"},
         "attachable": {"type": "boolean"},
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -453,7 +457,7 @@
           },
           "additionalProperties": false
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -469,7 +473,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -485,7 +489,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -510,21 +514,6 @@
           "patternProperties": {
             ".+": {
               "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
-
-    "labels": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/compose/config/config_schema_v3.4.json
+++ b/compose/config/config_schema_v3.4.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "config_schema_v3.4.json",
@@ -85,7 +84,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "labels": {"$ref": "#/definitions/labels"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"$ref": "#/definitions/list_of_strings"},
                 "network": {"type": "string"},
                 "target": {"type": "string"}
@@ -122,10 +121,14 @@
           }
         },
         "container_name": {"type": "string"},
-        "credential_spec": {"type": "object", "properties": {
-          "file": {"type": "string"},
-          "registry": {"type": "string"}
-        }},
+        "credential_spec": {
+          "type": "object",
+          "properties": {
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
         "depends_on": {"$ref": "#/definitions/list_of_strings"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
@@ -155,7 +158,7 @@
         "hostname": {"type": "string"},
         "image": {"type": "string"},
         "ipc": {"type": "string"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
         "logging": {
@@ -282,7 +285,6 @@
               {
                 "type": "object",
                 "required": ["type"],
-                "additionalProperties": false,
                 "properties": {
                   "type": {"type": "string"},
                   "source": {"type": "string"},
@@ -301,7 +303,8 @@
                       "nocopy": {"type": "boolean"}
                     }
                   }
-                }
+                },
+                "additionalProperties": false
               }
             ],
             "uniqueItems": true
@@ -337,7 +340,7 @@
         "mode": {"type": "string"},
         "endpoint_mode": {"type": "string"},
         "replicas": {"type": "integer"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "update_config": {
           "type": "object",
           "properties": {
@@ -421,7 +424,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"}
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -438,7 +441,7 @@
         },
         "internal": {"type": "boolean"},
         "attachable": {"type": "boolean"},
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -462,7 +465,7 @@
           },
           "additionalProperties": false
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -478,7 +481,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -494,7 +497,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -519,21 +522,6 @@
           "patternProperties": {
             ".+": {
               "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
-
-    "labels": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/compose/config/config_schema_v3.5.json
+++ b/compose/config/config_schema_v3.5.json
@@ -84,7 +84,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "labels": {"$ref": "#/definitions/labels"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"$ref": "#/definitions/list_of_strings"},
                 "network": {"type": "string"},
                 "target": {"type": "string"},
@@ -122,10 +122,14 @@
           }
         },
         "container_name": {"type": "string"},
-        "credential_spec": {"type": "object", "properties": {
-          "file": {"type": "string"},
-          "registry": {"type": "string"}
-        }},
+        "credential_spec": {
+          "type": "object",
+          "properties": {
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
         "depends_on": {"$ref": "#/definitions/list_of_strings"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
@@ -156,7 +160,7 @@
         "image": {"type": "string"},
         "ipc": {"type": "string"},
         "isolation": {"type": "string"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
         "logging": {
@@ -338,7 +342,7 @@
         "mode": {"type": "string"},
         "endpoint_mode": {"type": "string"},
         "replicas": {"type": "integer"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "update_config": {
           "type": "object",
           "properties": {
@@ -447,7 +451,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"}
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -464,7 +468,7 @@
         },
         "internal": {"type": "boolean"},
         "attachable": {"type": "boolean"},
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -488,7 +492,7 @@
           },
           "additionalProperties": false
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -505,7 +509,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -522,7 +526,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -547,21 +551,6 @@
           "patternProperties": {
             ".+": {
               "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
-
-    "labels": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string"
             }
           },
           "additionalProperties": false

--- a/compose/config/config_schema_v3.6.json
+++ b/compose/config/config_schema_v3.6.json
@@ -122,10 +122,14 @@
           }
         },
         "container_name": {"type": "string"},
-        "credential_spec": {"type": "object", "properties": {
-          "file": {"type": "string"},
-          "registry": {"type": "string"}
-        }},
+        "credential_spec": {
+          "type": "object",
+          "properties": {
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
         "depends_on": {"$ref": "#/definitions/list_of_strings"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},

--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -2,13 +2,13 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "config_schema_v3.7.json",
   "type": "object",
-  "required": [
-    "version"
-  ],
+  "required": ["version"],
+
   "properties": {
     "version": {
       "type": "string"
     },
+
     "services": {
       "id": "#/properties/services",
       "type": "object",
@@ -19,6 +19,7 @@
       },
       "additionalProperties": false
     },
+
     "networks": {
       "id": "#/properties/networks",
       "type": "object",
@@ -28,6 +29,7 @@
         }
       }
     },
+
     "volumes": {
       "id": "#/properties/volumes",
       "type": "object",
@@ -38,6 +40,7 @@
       },
       "additionalProperties": false
     },
+
     "secrets": {
       "id": "#/properties/secrets",
       "type": "object",
@@ -48,6 +51,7 @@
       },
       "additionalProperties": false
     },
+
     "configs": {
       "id": "#/properties/configs",
       "type": "object",
@@ -59,251 +63,128 @@
       "additionalProperties": false
     }
   },
-  "patternProperties": {
-    "^x-": {}
-  },
+
+  "patternProperties": {"^x-": {}},
   "additionalProperties": false,
+
   "definitions": {
+
     "service": {
       "id": "#/definitions/service",
       "type": "object",
+
       "properties": {
-        "deploy": {
-          "$ref": "#/definitions/deployment"
-        },
+        "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [
-            {
-              "type": "string"
-            },
+            {"type": "string"},
             {
               "type": "object",
               "properties": {
-                "context": {
-                  "type": "string"
-                },
-                "dockerfile": {
-                  "type": "string"
-                },
-                "args": {
-                  "$ref": "#/definitions/list_or_dict"
-                },
-                "labels": {
-                  "$ref": "#/definitions/list_or_dict"
-                },
-                "cache_from": {
-                  "$ref": "#/definitions/list_of_strings"
-                },
-                "network": {
-                  "type": "string"
-                },
-                "target": {
-                  "type": "string"
-                },
-                "shm_size": {
-                  "type": [
-                    "integer",
-                    "string"
-                  ]
-                }
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "cache_from": {"$ref": "#/definitions/list_of_strings"},
+                "network": {"type": "string"},
+                "target": {"type": "string"},
+                "shm_size": {"type": ["integer", "string"]}
               },
               "additionalProperties": false
             }
           ]
         },
-        "cap_add": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "cap_drop": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "cgroup_parent": {
-          "type": "string"
-        },
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup_parent": {"type": "string"},
         "command": {
           "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
           ]
         },
         "configs": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "string"
-              },
+              {"type": "string"},
               {
                 "type": "object",
                 "properties": {
-                  "source": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "string"
-                  },
-                  "uid": {
-                    "type": "string"
-                  },
-                  "gid": {
-                    "type": "string"
-                  },
-                  "mode": {
-                    "type": "number"
-                  }
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "uid": {"type": "string"},
+                  "gid": {"type": "string"},
+                  "mode": {"type": "number"}
                 }
               }
             ]
           }
         },
-        "container_name": {
-          "type": "string"
-        },
+        "container_name": {"type": "string"},
         "credential_spec": {
           "type": "object",
           "properties": {
-            "file": {
-              "type": "string"
-            },
-            "registry": {
-              "type": "string"
-            }
-          }
-        },
-        "depends_on": {
-          "$ref": "#/definitions/list_of_strings"
-        },
-        "devices": {
-          "type": "array",
-          "items": {
-            "type": "string"
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
           },
-          "uniqueItems": true
+          "additionalProperties": false
         },
-        "dns": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "dns_search": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "domainname": {
-          "type": "string"
-        },
+        "depends_on": {"$ref": "#/definitions/list_of_strings"},
+        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "dns": {"$ref": "#/definitions/string_or_list"},
+        "dns_search": {"$ref": "#/definitions/string_or_list"},
+        "domainname": {"type": "string"},
         "entrypoint": {
           "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
           ]
         },
-        "env_file": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "environment": {
-          "$ref": "#/definitions/list_or_dict"
-        },
+        "env_file": {"$ref": "#/definitions/string_or_list"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
         "expose": {
           "type": "array",
           "items": {
-            "type": [
-              "string",
-              "number"
-            ],
+            "type": ["string", "number"],
             "format": "expose"
           },
           "uniqueItems": true
         },
-        "external_links": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "extra_hosts": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "healthcheck": {
-          "$ref": "#/definitions/healthcheck"
-        },
-        "hostname": {
-          "type": "string"
-        },
-        "image": {
-          "type": "string"
-        },
-        "init": {
-          "type": "boolean"
-        },
-        "ipc": {
-          "type": "string"
-        },
-        "isolation": {
-          "type": "string"
-        },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "links": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
+
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "hostname": {"type": "string"},
+        "image": {"type": "string"},
+        "init": {"type": "boolean"},
+        "ipc": {"type": "string"},
+        "isolation": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+
         "logging": {
-          "type": "object",
-          "properties": {
-            "driver": {
-              "type": "string"
-            },
-            "options": {
-              "type": "object",
-              "patternProperties": {
-                "^.+$": {
-                  "type": [
-                    "string",
-                    "number",
-                    "null"
-                  ]
+            "type": "object",
+
+            "properties": {
+                "driver": {"type": "string"},
+                "options": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {"type": ["string", "number", "null"]}
+                  }
                 }
-              }
-            }
-          },
-          "additionalProperties": false
+            },
+            "additionalProperties": false
         },
-        "mac_address": {
-          "type": "string"
-        },
-        "network_mode": {
-          "type": "string"
-        },
+
+        "mac_address": {"type": "string"},
+        "network_mode": {"type": "string"},
+
         "networks": {
           "oneOf": [
-            {
-              "$ref": "#/definitions/list_of_strings"
-            },
+            {"$ref": "#/definitions/list_of_strings"},
             {
               "type": "object",
               "patternProperties": {
@@ -312,21 +193,13 @@
                     {
                       "type": "object",
                       "properties": {
-                        "aliases": {
-                          "$ref": "#/definitions/list_of_strings"
-                        },
-                        "ipv4_address": {
-                          "type": "string"
-                        },
-                        "ipv6_address": {
-                          "type": "string"
-                        }
+                        "aliases": {"$ref": "#/definitions/list_of_strings"},
+                        "ipv4_address": {"type": "string"},
+                        "ipv6_address": {"type": "string"}
                       },
                       "additionalProperties": false
                     },
-                    {
-                      "type": "null"
-                    }
+                    {"type": "null"}
                   ]
                 }
               },
@@ -334,39 +207,21 @@
             }
           ]
         },
-        "pid": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
+        "pid": {"type": ["string", "null"]},
+
         "ports": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "number",
-                "format": "ports"
-              },
-              {
-                "type": "string",
-                "format": "ports"
-              },
+              {"type": "number", "format": "ports"},
+              {"type": "string", "format": "ports"},
               {
                 "type": "object",
                 "properties": {
-                  "mode": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "integer"
-                  },
-                  "published": {
-                    "type": "integer"
-                  },
-                  "protocol": {
-                    "type": "string"
-                  }
+                  "mode": {"type": "string"},
+                  "target": {"type": "integer"},
+                  "published": {"type": "integer"},
+                  "protocol": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -374,153 +229,81 @@
           },
           "uniqueItems": true
         },
-        "privileged": {
-          "type": "boolean"
-        },
-        "read_only": {
-          "type": "boolean"
-        },
-        "restart": {
-          "type": "string"
-        },
-        "security_opt": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "shm_size": {
-          "type": [
-            "number",
-            "string"
-          ]
-        },
+
+        "privileged": {"type": "boolean"},
+        "read_only": {"type": "boolean"},
+        "restart": {"type": "string"},
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
         "secrets": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "string"
-              },
+              {"type": "string"},
               {
                 "type": "object",
                 "properties": {
-                  "source": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "string"
-                  },
-                  "uid": {
-                    "type": "string"
-                  },
-                  "gid": {
-                    "type": "string"
-                  },
-                  "mode": {
-                    "type": "number"
-                  }
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "uid": {"type": "string"},
+                  "gid": {"type": "string"},
+                  "mode": {"type": "number"}
                 }
               }
             ]
           }
         },
-        "sysctls": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "stdin_open": {
-          "type": "boolean"
-        },
-        "stop_grace_period": {
-          "type": "string",
-          "format": "duration"
-        },
-        "stop_signal": {
-          "type": "string"
-        },
-        "tmpfs": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "tty": {
-          "type": "boolean"
-        },
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "stdin_open": {"type": "boolean"},
+        "stop_grace_period": {"type": "string", "format": "duration"},
+        "stop_signal": {"type": "string"},
+        "tmpfs": {"$ref": "#/definitions/string_or_list"},
+        "tty": {"type": "boolean"},
         "ulimits": {
           "type": "object",
           "patternProperties": {
             "^[a-z]+$": {
               "oneOf": [
+                {"type": "integer"},
                 {
-                  "type": "integer"
-                },
-                {
-                  "type": "object",
+                  "type":"object",
                   "properties": {
-                    "hard": {
-                      "type": "integer"
-                    },
-                    "soft": {
-                      "type": "integer"
-                    }
+                    "hard": {"type": "integer"},
+                    "soft": {"type": "integer"}
                   },
-                  "required": [
-                    "soft",
-                    "hard"
-                  ],
+                  "required": ["soft", "hard"],
                   "additionalProperties": false
                 }
               ]
             }
           }
         },
-        "user": {
-          "type": "string"
-        },
-        "userns_mode": {
-          "type": "string"
-        },
+        "user": {"type": "string"},
+        "userns_mode": {"type": "string"},
         "volumes": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "string"
-              },
+              {"type": "string"},
               {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
-                  "type": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "string"
-                  },
-                  "read_only": {
-                    "type": "boolean"
-                  },
-                  "consistency": {
-                    "type": "string"
-                  },
+                  "type": {"type": "string"},
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "read_only": {"type": "boolean"},
+                  "consistency": {"type": "string"},
                   "bind": {
                     "type": "object",
                     "properties": {
-                      "propagation": {
-                        "type": "string"
-                      }
+                      "propagation": {"type": "string"}
                     }
                   },
                   "volume": {
                     "type": "object",
                     "properties": {
-                      "nocopy": {
-                        "type": "boolean"
-                      }
+                      "nocopy": {"type": "boolean"}
                     }
                   },
                   "tmpfs": {
@@ -539,129 +322,63 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {
-          "type": "string"
-        }
+        "working_dir": {"type": "string"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "healthcheck": {
       "id": "#/definitions/healthcheck",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "disable": {
-          "type": "boolean"
-        },
-        "interval": {
-          "type": "string",
-          "format": "duration"
-        },
-        "retries": {
-          "type": "number"
-        },
+        "disable": {"type": "boolean"},
+        "interval": {"type": "string", "format": "duration"},
+        "retries": {"type": "number"},
         "test": {
           "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
           ]
         },
-        "timeout": {
-          "type": "string",
-          "format": "duration"
-        },
-        "start_period": {
-          "type": "string",
-          "format": "duration"
-        }
+        "timeout": {"type": "string", "format": "duration"},
+        "start_period": {"type": "string", "format": "duration"}
       }
     },
     "deployment": {
       "id": "#/definitions/deployment",
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
-        "mode": {
-          "type": "string"
-        },
-        "endpoint_mode": {
-          "type": "string"
-        },
-        "replicas": {
-          "type": "integer"
-        },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        },
+        "mode": {"type": "string"},
+        "endpoint_mode": {"type": "string"},
+        "replicas": {"type": "integer"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "rollback_config": {
           "type": "object",
           "properties": {
-            "parallelism": {
-              "type": "integer"
-            },
-            "delay": {
-              "type": "string",
-              "format": "duration"
-            },
-            "failure_action": {
-              "type": "string"
-            },
-            "monitor": {
-              "type": "string",
-              "format": "duration"
-            },
-            "max_failure_ratio": {
-              "type": "number"
-            },
-            "order": {
-              "type": "string",
-              "enum": [
-                "start-first",
-                "stop-first"
-              ]
-            }
+            "parallelism": {"type": "integer"},
+            "delay": {"type": "string", "format": "duration"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string", "format": "duration"},
+            "max_failure_ratio": {"type": "number"},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
           },
           "additionalProperties": false
         },
         "update_config": {
           "type": "object",
           "properties": {
-            "parallelism": {
-              "type": "integer"
-            },
-            "delay": {
-              "type": "string",
-              "format": "duration"
-            },
-            "failure_action": {
-              "type": "string"
-            },
-            "monitor": {
-              "type": "string",
-              "format": "duration"
-            },
-            "max_failure_ratio": {
-              "type": "number"
-            },
-            "order": {
-              "type": "string",
-              "enum": [
-                "start-first",
-                "stop-first"
-              ]
-            }
+            "parallelism": {"type": "integer"},
+            "delay": {"type": "string", "format": "duration"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string", "format": "duration"},
+            "max_failure_ratio": {"type": "number"},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
           },
           "additionalProperties": false
         },
@@ -671,27 +388,17 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {
-                  "type": "string"
-                },
-                "memory": {
-                  "type": "string"
-                }
+                "cpus": {"type": "string"},
+                "memory": {"type": "string"}
               },
               "additionalProperties": false
             },
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {
-                  "type": "string"
-                },
-                "memory": {
-                  "type": "string"
-                },
-                "generic_resources": {
-                  "$ref": "#/definitions/generic_resources"
-                }
+                "cpus": {"type": "string"},
+                "memory": {"type": "string"},
+                "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },
               "additionalProperties": false
             }
@@ -701,40 +408,23 @@
         "restart_policy": {
           "type": "object",
           "properties": {
-            "condition": {
-              "type": "string"
-            },
-            "delay": {
-              "type": "string",
-              "format": "duration"
-            },
-            "max_attempts": {
-              "type": "integer"
-            },
-            "window": {
-              "type": "string",
-              "format": "duration"
-            }
+            "condition": {"type": "string"},
+            "delay": {"type": "string", "format": "duration"},
+            "max_attempts": {"type": "integer"},
+            "window": {"type": "string", "format": "duration"}
           },
           "additionalProperties": false
         },
         "placement": {
           "type": "object",
           "properties": {
-            "constraints": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
+            "constraints": {"type": "array", "items": {"type": "string"}},
             "preferences": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "spread": {
-                    "type": "string"
-                  }
+                  "spread": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -745,6 +435,7 @@
       },
       "additionalProperties": false
     },
+
     "generic_resources": {
       "id": "#/definitions/generic_resources",
       "type": "array",
@@ -754,12 +445,8 @@
           "discrete_resource_spec": {
             "type": "object",
             "properties": {
-              "kind": {
-                "type": "string"
-              },
-              "value": {
-                "type": "number"
-              }
+              "kind": {"type": "string"},
+              "value": {"type": "number"}
             },
             "additionalProperties": false
           }
@@ -767,44 +454,29 @@
         "additionalProperties": false
       }
     },
+
     "network": {
       "id": "#/definitions/network",
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "driver": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {
-              "type": [
-                "string",
-                "number"
-              ]
-            }
+            "^.+$": {"type": ["string", "number"]}
           }
         },
         "ipam": {
           "type": "object",
           "properties": {
-            "driver": {
-              "type": "string"
-            },
+            "driver": {"type": "string"},
             "config": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {
-                    "type": "string"
-                  }
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -813,198 +485,119 @@
           "additionalProperties": false
         },
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           },
           "additionalProperties": false
         },
-        "internal": {
-          "type": "boolean"
-        },
-        "attachable": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        }
+        "internal": {"type": "boolean"},
+        "attachable": {"type": "boolean"},
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "volume": {
       "id": "#/definitions/volume",
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "driver": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {
-              "type": [
-                "string",
-                "number"
-              ]
-            }
+            "^.+$": {"type": ["string", "number"]}
           }
         },
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           },
           "additionalProperties": false
         },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        }
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "secret": {
       "id": "#/definitions/secret",
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "file": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "file": {"type": "string"},
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           }
         },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        }
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "config": {
       "id": "#/definitions/config",
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "file": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "file": {"type": "string"},
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           }
         },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        }
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "string_or_list": {
       "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "$ref": "#/definitions/list_of_strings"
-        }
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
       ]
     },
+
     "list_of_strings": {
       "type": "array",
-      "items": {
-        "type": "string"
-      },
+      "items": {"type": "string"},
       "uniqueItems": true
     },
+
     "list_or_dict": {
       "oneOf": [
         {
           "type": "object",
           "patternProperties": {
             ".+": {
-              "type": [
-                "string",
-                "number",
-                "null"
-              ]
+              "type": ["string", "number", "null"]
             }
           },
           "additionalProperties": false
         },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        }
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
       ]
     },
+
     "constraints": {
       "service": {
         "id": "#/definitions/constraints/service",
         "anyOf": [
-          {
-            "required": [
-              "build"
-            ]
-          },
-          {
-            "required": [
-              "image"
-            ]
-          }
+          {"required": ["build"]},
+          {"required": ["image"]}
         ],
         "properties": {
           "build": {
-            "required": [
-              "context"
-            ]
+            "required": ["context"]
           }
         }
       }

--- a/compose/config/config_schema_v3.8.json
+++ b/compose/config/config_schema_v3.8.json
@@ -2,13 +2,13 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "config_schema_v3.8.json",
   "type": "object",
-  "required": [
-    "version"
-  ],
+  "required": ["version"],
+
   "properties": {
     "version": {
       "type": "string"
     },
+
     "services": {
       "id": "#/properties/services",
       "type": "object",
@@ -19,6 +19,7 @@
       },
       "additionalProperties": false
     },
+
     "networks": {
       "id": "#/properties/networks",
       "type": "object",
@@ -28,6 +29,7 @@
         }
       }
     },
+
     "volumes": {
       "id": "#/properties/volumes",
       "type": "object",
@@ -38,6 +40,7 @@
       },
       "additionalProperties": false
     },
+
     "secrets": {
       "id": "#/properties/secrets",
       "type": "object",
@@ -48,6 +51,7 @@
       },
       "additionalProperties": false
     },
+
     "configs": {
       "id": "#/properties/configs",
       "type": "object",
@@ -59,255 +63,129 @@
       "additionalProperties": false
     }
   },
-  "patternProperties": {
-    "^x-": {}
-  },
+
+  "patternProperties": {"^x-": {}},
   "additionalProperties": false,
+
   "definitions": {
+
     "service": {
       "id": "#/definitions/service",
       "type": "object",
+
       "properties": {
-        "deploy": {
-          "$ref": "#/definitions/deployment"
-        },
+        "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [
-            {
-              "type": "string"
-            },
+            {"type": "string"},
             {
               "type": "object",
               "properties": {
-                "context": {
-                  "type": "string"
-                },
-                "dockerfile": {
-                  "type": "string"
-                },
-                "args": {
-                  "$ref": "#/definitions/list_or_dict"
-                },
-                "labels": {
-                  "$ref": "#/definitions/list_or_dict"
-                },
-                "cache_from": {
-                  "$ref": "#/definitions/list_of_strings"
-                },
-                "network": {
-                  "type": "string"
-                },
-                "target": {
-                  "type": "string"
-                },
-                "shm_size": {
-                  "type": [
-                    "integer",
-                    "string"
-                  ]
-                }
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "cache_from": {"$ref": "#/definitions/list_of_strings"},
+                "network": {"type": "string"},
+                "target": {"type": "string"},
+                "shm_size": {"type": ["integer", "string"]}
               },
               "additionalProperties": false
             }
           ]
         },
-        "cap_add": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "cap_drop": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "cgroup_parent": {
-          "type": "string"
-        },
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup_parent": {"type": "string"},
         "command": {
           "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
           ]
         },
         "configs": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "string"
-              },
+              {"type": "string"},
               {
                 "type": "object",
                 "properties": {
-                  "source": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "string"
-                  },
-                  "uid": {
-                    "type": "string"
-                  },
-                  "gid": {
-                    "type": "string"
-                  },
-                  "mode": {
-                    "type": "number"
-                  }
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "uid": {"type": "string"},
+                  "gid": {"type": "string"},
+                  "mode": {"type": "number"}
                 }
               }
             ]
           }
         },
-        "container_name": {
-          "type": "string"
-        },
+        "container_name": {"type": "string"},
         "credential_spec": {
           "type": "object",
           "properties": {
-            "config": {
-              "type": "string"
-            },
-            "file": {
-              "type": "string"
-            },
-            "registry": {
-              "type": "string"
-            }
+            "config": {"type": "string"},
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
           },
           "additionalProperties": false
         },
-        "depends_on": {
-          "$ref": "#/definitions/list_of_strings"
-        },
-        "devices": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "dns": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "dns_search": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "domainname": {
-          "type": "string"
-        },
+        "depends_on": {"$ref": "#/definitions/list_of_strings"},
+        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "dns": {"$ref": "#/definitions/string_or_list"},
+        "dns_search": {"$ref": "#/definitions/string_or_list"},
+        "domainname": {"type": "string"},
         "entrypoint": {
           "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
           ]
         },
-        "env_file": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "environment": {
-          "$ref": "#/definitions/list_or_dict"
-        },
+        "env_file": {"$ref": "#/definitions/string_or_list"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
         "expose": {
           "type": "array",
           "items": {
-            "type": [
-              "string",
-              "number"
-            ],
+            "type": ["string", "number"],
             "format": "expose"
           },
           "uniqueItems": true
         },
-        "external_links": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "extra_hosts": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "healthcheck": {
-          "$ref": "#/definitions/healthcheck"
-        },
-        "hostname": {
-          "type": "string"
-        },
-        "image": {
-          "type": "string"
-        },
-        "init": {
-          "type": "boolean"
-        },
-        "ipc": {
-          "type": "string"
-        },
-        "isolation": {
-          "type": "string"
-        },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "links": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
+
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "hostname": {"type": "string"},
+        "image": {"type": "string"},
+        "init": {"type": "boolean"},
+        "ipc": {"type": "string"},
+        "isolation": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+
         "logging": {
-          "type": "object",
-          "properties": {
-            "driver": {
-              "type": "string"
-            },
-            "options": {
-              "type": "object",
-              "patternProperties": {
-                "^.+$": {
-                  "type": [
-                    "string",
-                    "number",
-                    "null"
-                  ]
+            "type": "object",
+
+            "properties": {
+                "driver": {"type": "string"},
+                "options": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {"type": ["string", "number", "null"]}
+                  }
                 }
-              }
-            }
-          },
-          "additionalProperties": false
+            },
+            "additionalProperties": false
         },
-        "mac_address": {
-          "type": "string"
-        },
-        "network_mode": {
-          "type": "string"
-        },
+
+        "mac_address": {"type": "string"},
+        "network_mode": {"type": "string"},
+
         "networks": {
           "oneOf": [
-            {
-              "$ref": "#/definitions/list_of_strings"
-            },
+            {"$ref": "#/definitions/list_of_strings"},
             {
               "type": "object",
               "patternProperties": {
@@ -316,21 +194,13 @@
                     {
                       "type": "object",
                       "properties": {
-                        "aliases": {
-                          "$ref": "#/definitions/list_of_strings"
-                        },
-                        "ipv4_address": {
-                          "type": "string"
-                        },
-                        "ipv6_address": {
-                          "type": "string"
-                        }
+                        "aliases": {"$ref": "#/definitions/list_of_strings"},
+                        "ipv4_address": {"type": "string"},
+                        "ipv6_address": {"type": "string"}
                       },
                       "additionalProperties": false
                     },
-                    {
-                      "type": "null"
-                    }
+                    {"type": "null"}
                   ]
                 }
               },
@@ -338,39 +208,21 @@
             }
           ]
         },
-        "pid": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
+        "pid": {"type": ["string", "null"]},
+
         "ports": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "number",
-                "format": "ports"
-              },
-              {
-                "type": "string",
-                "format": "ports"
-              },
+              {"type": "number", "format": "ports"},
+              {"type": "string", "format": "ports"},
               {
                 "type": "object",
                 "properties": {
-                  "mode": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "integer"
-                  },
-                  "published": {
-                    "type": "integer"
-                  },
-                  "protocol": {
-                    "type": "string"
-                  }
+                  "mode": {"type": "string"},
+                  "target": {"type": "integer"},
+                  "published": {"type": "integer"},
+                  "protocol": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -378,153 +230,81 @@
           },
           "uniqueItems": true
         },
-        "privileged": {
-          "type": "boolean"
-        },
-        "read_only": {
-          "type": "boolean"
-        },
-        "restart": {
-          "type": "string"
-        },
-        "security_opt": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "shm_size": {
-          "type": [
-            "number",
-            "string"
-          ]
-        },
+
+        "privileged": {"type": "boolean"},
+        "read_only": {"type": "boolean"},
+        "restart": {"type": "string"},
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
         "secrets": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "string"
-              },
+              {"type": "string"},
               {
                 "type": "object",
                 "properties": {
-                  "source": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "string"
-                  },
-                  "uid": {
-                    "type": "string"
-                  },
-                  "gid": {
-                    "type": "string"
-                  },
-                  "mode": {
-                    "type": "number"
-                  }
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "uid": {"type": "string"},
+                  "gid": {"type": "string"},
+                  "mode": {"type": "number"}
                 }
               }
             ]
           }
         },
-        "sysctls": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "stdin_open": {
-          "type": "boolean"
-        },
-        "stop_grace_period": {
-          "type": "string",
-          "format": "duration"
-        },
-        "stop_signal": {
-          "type": "string"
-        },
-        "tmpfs": {
-          "$ref": "#/definitions/string_or_list"
-        },
-        "tty": {
-          "type": "boolean"
-        },
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "stdin_open": {"type": "boolean"},
+        "stop_grace_period": {"type": "string", "format": "duration"},
+        "stop_signal": {"type": "string"},
+        "tmpfs": {"$ref": "#/definitions/string_or_list"},
+        "tty": {"type": "boolean"},
         "ulimits": {
           "type": "object",
           "patternProperties": {
             "^[a-z]+$": {
               "oneOf": [
+                {"type": "integer"},
                 {
-                  "type": "integer"
-                },
-                {
-                  "type": "object",
+                  "type":"object",
                   "properties": {
-                    "hard": {
-                      "type": "integer"
-                    },
-                    "soft": {
-                      "type": "integer"
-                    }
+                    "hard": {"type": "integer"},
+                    "soft": {"type": "integer"}
                   },
-                  "required": [
-                    "soft",
-                    "hard"
-                  ],
+                  "required": ["soft", "hard"],
                   "additionalProperties": false
                 }
               ]
             }
           }
         },
-        "user": {
-          "type": "string"
-        },
-        "userns_mode": {
-          "type": "string"
-        },
+        "user": {"type": "string"},
+        "userns_mode": {"type": "string"},
         "volumes": {
           "type": "array",
           "items": {
             "oneOf": [
-              {
-                "type": "string"
-              },
+              {"type": "string"},
               {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
-                  "type": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "string"
-                  },
-                  "target": {
-                    "type": "string"
-                  },
-                  "read_only": {
-                    "type": "boolean"
-                  },
-                  "consistency": {
-                    "type": "string"
-                  },
+                  "type": {"type": "string"},
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "read_only": {"type": "boolean"},
+                  "consistency": {"type": "string"},
                   "bind": {
                     "type": "object",
                     "properties": {
-                      "propagation": {
-                        "type": "string"
-                      }
+                      "propagation": {"type": "string"}
                     }
                   },
                   "volume": {
                     "type": "object",
                     "properties": {
-                      "nocopy": {
-                        "type": "boolean"
-                      }
+                      "nocopy": {"type": "boolean"}
                     }
                   },
                   "tmpfs": {
@@ -543,129 +323,63 @@
             "uniqueItems": true
           }
         },
-        "working_dir": {
-          "type": "string"
-        }
+        "working_dir": {"type": "string"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "healthcheck": {
       "id": "#/definitions/healthcheck",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "disable": {
-          "type": "boolean"
-        },
-        "interval": {
-          "type": "string",
-          "format": "duration"
-        },
-        "retries": {
-          "type": "number"
-        },
+        "disable": {"type": "boolean"},
+        "interval": {"type": "string", "format": "duration"},
+        "retries": {"type": "number"},
         "test": {
           "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
           ]
         },
-        "timeout": {
-          "type": "string",
-          "format": "duration"
-        },
-        "start_period": {
-          "type": "string",
-          "format": "duration"
-        }
+        "timeout": {"type": "string", "format": "duration"},
+        "start_period": {"type": "string", "format": "duration"}
       }
     },
     "deployment": {
       "id": "#/definitions/deployment",
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
-        "mode": {
-          "type": "string"
-        },
-        "endpoint_mode": {
-          "type": "string"
-        },
-        "replicas": {
-          "type": "integer"
-        },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        },
+        "mode": {"type": "string"},
+        "endpoint_mode": {"type": "string"},
+        "replicas": {"type": "integer"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "rollback_config": {
           "type": "object",
           "properties": {
-            "parallelism": {
-              "type": "integer"
-            },
-            "delay": {
-              "type": "string",
-              "format": "duration"
-            },
-            "failure_action": {
-              "type": "string"
-            },
-            "monitor": {
-              "type": "string",
-              "format": "duration"
-            },
-            "max_failure_ratio": {
-              "type": "number"
-            },
-            "order": {
-              "type": "string",
-              "enum": [
-                "start-first",
-                "stop-first"
-              ]
-            }
+            "parallelism": {"type": "integer"},
+            "delay": {"type": "string", "format": "duration"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string", "format": "duration"},
+            "max_failure_ratio": {"type": "number"},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
           },
           "additionalProperties": false
         },
         "update_config": {
           "type": "object",
           "properties": {
-            "parallelism": {
-              "type": "integer"
-            },
-            "delay": {
-              "type": "string",
-              "format": "duration"
-            },
-            "failure_action": {
-              "type": "string"
-            },
-            "monitor": {
-              "type": "string",
-              "format": "duration"
-            },
-            "max_failure_ratio": {
-              "type": "number"
-            },
-            "order": {
-              "type": "string",
-              "enum": [
-                "start-first",
-                "stop-first"
-              ]
-            }
+            "parallelism": {"type": "integer"},
+            "delay": {"type": "string", "format": "duration"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string", "format": "duration"},
+            "max_failure_ratio": {"type": "number"},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
           },
           "additionalProperties": false
         },
@@ -675,27 +389,17 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {
-                  "type": "string"
-                },
-                "memory": {
-                  "type": "string"
-                }
+                "cpus": {"type": "string"},
+                "memory": {"type": "string"}
               },
               "additionalProperties": false
             },
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {
-                  "type": "string"
-                },
-                "memory": {
-                  "type": "string"
-                },
-                "generic_resources": {
-                  "$ref": "#/definitions/generic_resources"
-                }
+                "cpus": {"type": "string"},
+                "memory": {"type": "string"},
+                "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },
               "additionalProperties": false
             }
@@ -705,53 +409,35 @@
         "restart_policy": {
           "type": "object",
           "properties": {
-            "condition": {
-              "type": "string"
-            },
-            "delay": {
-              "type": "string",
-              "format": "duration"
-            },
-            "max_attempts": {
-              "type": "integer"
-            },
-            "window": {
-              "type": "string",
-              "format": "duration"
-            }
+            "condition": {"type": "string"},
+            "delay": {"type": "string", "format": "duration"},
+            "max_attempts": {"type": "integer"},
+            "window": {"type": "string", "format": "duration"}
           },
           "additionalProperties": false
         },
         "placement": {
           "type": "object",
           "properties": {
-            "constraints": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
+            "constraints": {"type": "array", "items": {"type": "string"}},
             "preferences": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "spread": {
-                    "type": "string"
-                  }
+                  "spread": {"type": "string"}
                 },
                 "additionalProperties": false
               }
             },
-            "max_replicas_per_node": {
-              "type": "integer"
-            }
+            "max_replicas_per_node": {"type": "integer"}
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
+
     "generic_resources": {
       "id": "#/definitions/generic_resources",
       "type": "array",
@@ -761,12 +447,8 @@
           "discrete_resource_spec": {
             "type": "object",
             "properties": {
-              "kind": {
-                "type": "string"
-              },
-              "value": {
-                "type": "number"
-              }
+              "kind": {"type": "string"},
+              "value": {"type": "number"}
             },
             "additionalProperties": false
           }
@@ -774,44 +456,29 @@
         "additionalProperties": false
       }
     },
+
     "network": {
       "id": "#/definitions/network",
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "driver": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {
-              "type": [
-                "string",
-                "number"
-              ]
-            }
+            "^.+$": {"type": ["string", "number"]}
           }
         },
         "ipam": {
           "type": "object",
           "properties": {
-            "driver": {
-              "type": "string"
-            },
+            "driver": {"type": "string"},
             "config": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {
-                    "type": "string"
-                  }
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -820,218 +487,128 @@
           "additionalProperties": false
         },
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           },
           "additionalProperties": false
         },
-        "internal": {
-          "type": "boolean"
-        },
-        "attachable": {
-          "type": "boolean"
-        },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        }
+        "internal": {"type": "boolean"},
+        "attachable": {"type": "boolean"},
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "volume": {
       "id": "#/definitions/volume",
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "driver": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {
-              "type": [
-                "string",
-                "number"
-              ]
-            }
+            "^.+$": {"type": ["string", "number"]}
           }
         },
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           },
           "additionalProperties": false
         },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        }
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "secret": {
       "id": "#/definitions/secret",
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "file": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "file": {"type": "string"},
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           }
         },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "driver": {
-          "type": "string"
-        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "driver": {"type": "string"},
         "driver_opts": {
           "type": "object",
           "patternProperties": {
-            "^.+$": {
-              "type": [
-                "string",
-                "number"
-              ]
-            }
+            "^.+$": {"type": ["string", "number"]}
           }
         },
-        "template_driver": {
-          "type": "string"
-        }
+        "template_driver": {"type": "string"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "config": {
       "id": "#/definitions/config",
       "type": "object",
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "file": {
-          "type": "string"
-        },
+        "name": {"type": "string"},
+        "file": {"type": "string"},
         "external": {
-          "type": [
-            "boolean",
-            "object"
-          ],
+          "type": ["boolean", "object"],
           "properties": {
-            "name": {
-              "type": "string"
-            }
+            "name": {"type": "string"}
           }
         },
-        "labels": {
-          "$ref": "#/definitions/list_or_dict"
-        },
-        "template_driver": {
-          "type": "string"
-        }
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "template_driver": {"type": "string"}
       },
-      "patternProperties": {
-        "^x-": {}
-      },
+      "patternProperties": {"^x-": {}},
       "additionalProperties": false
     },
+
     "string_or_list": {
       "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "$ref": "#/definitions/list_of_strings"
-        }
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
       ]
     },
+
     "list_of_strings": {
       "type": "array",
-      "items": {
-        "type": "string"
-      },
+      "items": {"type": "string"},
       "uniqueItems": true
     },
+
     "list_or_dict": {
       "oneOf": [
         {
           "type": "object",
           "patternProperties": {
             ".+": {
-              "type": [
-                "string",
-                "number",
-                "null"
-              ]
+              "type": ["string", "number", "null"]
             }
           },
           "additionalProperties": false
         },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        }
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
       ]
     },
+
     "constraints": {
       "service": {
         "id": "#/definitions/constraints/service",
         "anyOf": [
-          {
-            "required": [
-              "build"
-            ]
-          },
-          {
-            "required": [
-              "image"
-            ]
-          }
+          {"required": ["build"]},
+          {"required": ["image"]}
         ],
         "properties": {
           "build": {
-            "required": [
-              "context"
-            ]
+            "required": ["context"]
           }
         }
       }


### PR DESCRIPTION
I wanted to update the compose-schemas to make sure they're in sync with upstream, but noticed there's changes in the schema in this repository that are not upstream.

Also; some of these patches were applied to older version, but are not in the latest (3.7) and upcoming (3.8) version.

- https://github.com/docker/compose/pull/5364 Implement subnet config validation (fixes #4552) 
- https://github.com/docker/compose/pull/5585 Labels validation and basic type conversion (fixes https://github.com/docker/compose/issues/4904)

We should make sure that both `docker stack deploy` and `docker-compose up` validation is equal, otherwise files may work for one, but won't work for the other.

If there's differences because of the implementation (Python vs Go), we should look if we can still use the same schema (if needed, upstream changes to docker/cli).

I was looking at reproducing the original issue () earlier this week (but not sure where I ended up, as I had to finish some other things 😂); I see I have these files still on my machine, which was what I was testing with;

I think I was testing if the problem presented itself on compose-file schema `3.6` and `3.7` as it doesn't appear to have the fix from  https://github.com/docker/compose/issues/4904, thus "should be failing"; here's the diff between 3.6 and 3.7 (before this patch);

```bash
git diff --no-index config_schema_v3.5.json config_schema_v3.6.json
```

<details>
<summary>output:</summary>

```patch
diff --git a/config_schema_v3.5.json b/config_schema_v3.6.json
index e3bdecbc..95a552b3 100644
--- a/config_schema_v3.5.json
+++ b/config_schema_v3.6.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "config_schema_v3.5.json",
+  "id": "config_schema_v3.6.json",
   "type": "object",
   "required": ["version"],
 
@@ -84,7 +84,7 @@
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
-                "labels": {"$ref": "#/definitions/labels"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
                 "cache_from": {"$ref": "#/definitions/list_of_strings"},
                 "network": {"type": "string"},
                 "target": {"type": "string"},
@@ -156,7 +156,7 @@
         "image": {"type": "string"},
         "ipc": {"type": "string"},
         "isolation": {"type": "string"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
         "logging": {
@@ -300,6 +300,15 @@
                     "properties": {
                       "nocopy": {"type": "boolean"}
                     }
+                  },
+                  "tmpfs": {
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    }
                   }
                 },
                 "additionalProperties": false
@@ -338,7 +347,7 @@
         "mode": {"type": "string"},
         "endpoint_mode": {"type": "string"},
         "replicas": {"type": "integer"},
-        "labels": {"$ref": "#/definitions/labels"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
         "update_config": {
           "type": "object",
           "properties": {
@@ -447,7 +456,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "subnet": {"type": "string", "format": "subnet_ip_address"}
+                  "subnet": {"type": "string"}
                 },
                 "additionalProperties": false
               }
@@ -464,7 +473,7 @@
         },
         "internal": {"type": "boolean"},
         "attachable": {"type": "boolean"},
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -488,7 +497,7 @@
           },
           "additionalProperties": false
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -505,7 +514,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -522,7 +531,7 @@
             "name": {"type": "string"}
           }
         },
-        "labels": {"$ref": "#/definitions/labels"}
+        "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false
     },
@@ -555,21 +564,6 @@
       ]
     },
 
-    "labels": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
-
     "constraints": {
       "service": {
         "id": "#/definitions/constraints/service",
```

</details>

Posting my test files here in case someone has time to verify.

`docker-compose.yml`:

```yaml
version: '3.7'
services:
  web:
    image: nginx:alpine
    labels:
      com.duo.access-gateway.builder.version: 89526235
      com.duo.access-gateway.code.version: v1.4.4-beta0
      com.duo.access-gateway.built: Fri, 02 Jun 2017 14:38:41 -0000
      com.duo.access-gateway.nil:
```

`docker-compose.json`:

```json
{
  "version": "3.7",
  "services": {
    "web": {
      "image": "nginx:alpine",
      "labels": {
        "com.duo.access-gateway.builder.version": 89526235,
        "com.duo.access-gateway.code.version": "v1.4.4-beta0",
        "com.duo.access-gateway.built": "Fri, 02 Jun 2017 14:38:41 -0000",
        "com.duo.access-gateway.nil": null
      }
    }
  }
}
```

 