### PR TITLE
fix #6579 cli ps --all

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -721,7 +721,8 @@ class TopLevelCommand(object):
 
         if options['--all']:
             containers = sorted(self.project.containers(service_names=options['SERVICE'],
-                                                        one_off=OneOffFilter.include, stopped=True))
+                                                        one_off=OneOffFilter.include, stopped=True),
+                                key=attrgetter('name'))
         else:
             containers = sorted(
                 self.project.containers(service_names=options['SERVICE'], stopped=True) +


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6579, Container sort key was missed for `ps --all` option
