### PR TITLE
fixes warn method is deprecated

### DIFF
--- a/compose/bundle.py
+++ b/compose/bundle.py
@@ -164,10 +164,10 @@ def push_image(service):
 
 def to_bundle(config, image_digests):
     if config.networks:
-        log.warn("Unsupported top level key 'networks' - ignoring")
+        log.warning("Unsupported top level key 'networks' - ignoring")
 
     if config.volumes:
-        log.warn("Unsupported top level key 'volumes' - ignoring")
+        log.warning("Unsupported top level key 'volumes' - ignoring")
 
     config = denormalize_config(config)
 
@@ -192,7 +192,7 @@ def convert_service_to_bundle(name, service_dict, image_digest):
             continue
 
         if key not in SUPPORTED_KEYS:
-            log.warn("Unsupported key '{}' in services.{} - ignoring".format(key, name))
+            log.warning("Unsupported key '{}' in services.{} - ignoring".format(key, name))
             continue
 
         if key == 'environment':
@@ -239,7 +239,7 @@ def make_service_networks(name, service_dict):
 
     for network_name, network_def in get_network_defs_for_service(service_dict).items():
         for key in network_def.keys():
-            log.warn(
+            log.warning(
                 "Unsupported key '{}' in services.{}.networks.{} - ignoring"
                 .format(key, name, network_name))
 

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -31,7 +31,7 @@ def get_tls_version(environment):
 
     tls_attr_name = "PROTOCOL_{}".format(compose_tls_version)
     if not hasattr(ssl, tls_attr_name):
-        log.warn(
+        log.warning(
             'The "{}" protocol is unavailable. You may need to update your '
             'version of Python or OpenSSL. Falling back to TLSv1 (default).'
             .format(compose_tls_version)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -391,7 +391,7 @@ class TopLevelCommand(object):
         """
         service_names = options['SERVICE']
 
-        log.warn(
+        log.warning(
             'The create command is deprecated. '
             'Use the up command with the --no-start flag instead.'
         )
@@ -765,7 +765,7 @@ class TopLevelCommand(object):
             --include-deps          Also pull services declared as dependencies
         """
         if options.get('--parallel'):
-            log.warn('--parallel option is deprecated and will be removed in future versions.')
+            log.warning('--parallel option is deprecated and will be removed in future versions.')
         self.project.pull(
             service_names=options['SERVICE'],
             ignore_pull_failures=options.get('--ignore-pull-failures'),
@@ -806,7 +806,7 @@ class TopLevelCommand(object):
             -a, --all     Deprecated - no effect.
         """
         if options.get('--all'):
-            log.warn(
+            log.warning(
                 '--all flag is obsolete. This is now the default behavior '
                 'of `docker-compose rm`'
             )
@@ -916,7 +916,7 @@ class TopLevelCommand(object):
                 'Use the up command with the --scale flag instead.'
             )
         else:
-            log.warn(
+            log.warning(
                 'The scale command is deprecated. '
                 'Use the up command with the --scale flag instead.'
             )
@@ -1250,7 +1250,7 @@ def exitval_from_opts(options, project):
     exit_value_from = options.get('--exit-code-from')
     if exit_value_from:
         if not options.get('--abort-on-container-exit'):
-            log.warn('using --exit-code-from implies --abort-on-container-exit')
+            log.warning('using --exit-code-from implies --abort-on-container-exit')
             options['--abort-on-container-exit'] = True
         if exit_value_from not in [s.name for s in project.get_services()]:
             log.error('No service named "%s" was found in your compose file.',
@@ -1580,7 +1580,7 @@ def warn_for_swarm_mode(client):
             # UCP does multi-node scheduling with traditional Compose files.
             return
 
-        log.warn(
+        log.warning(
             "The Docker Engine you're using is running in swarm mode.\n\n"
             "Compose does not use swarm mode to deploy services to multiple nodes in a swarm. "
             "All containers will be scheduled on the current node.\n\n"

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -198,9 +198,9 @@ class ConfigFile(namedtuple('_ConfigFile', 'filename config')):
         version = self.config['version']
 
         if isinstance(version, dict):
-            log.warn('Unexpected type for "version" key in "{}". Assuming '
-                     '"version" is the name of a service, and defaulting to '
-                     'Compose file version 1.'.format(self.filename))
+            log.warning('Unexpected type for "version" key in "{}". Assuming '
+                        '"version" is the name of a service, and defaulting to '
+                        'Compose file version 1.'.format(self.filename))
             return V1
 
         if not isinstance(version, six.string_types):
@@ -318,8 +318,8 @@ def get_default_config_files(base_dir):
     winner = candidates[0]
 
     if len(candidates) > 1:
-        log.warn("Found multiple config files with supported names: %s", ", ".join(candidates))
-        log.warn("Using %s\n", winner)
+        log.warning("Found multiple config files with supported names: %s", ", ".join(candidates))
+        log.warning("Using %s\n", winner)
 
     return [os.path.join(path, winner)] + get_default_override_file(path)
 
@@ -362,7 +362,7 @@ def check_swarm_only_config(service_dicts, compatibility=False):
     def check_swarm_only_key(service_dicts, key):
         services = [s for s in service_dicts if s.get(key)]
         if services:
-            log.warn(
+            log.warning(
                 warning_template.format(
                     services=", ".join(sorted(s['name'] for s in services)),
                     key=key
@@ -921,7 +921,7 @@ def finalize_service(service_config, service_names, version, environment, compat
             service_dict
         )
         if ignored_keys:
-            log.warn(
+            log.warning(
                 'The following deploy sub-keys are not supported in compatibility mode and have'
                 ' been ignored: {}'.format(', '.join(ignored_keys))
             )

--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -100,7 +100,7 @@ class Environment(dict):
                 except KeyError:
                     pass
             if not self.silent and key not in self.missing_keys:
-                log.warn(
+                log.warning(
                     "The {} variable is not set. Defaulting to a blank string."
                     .format(key)
                 )

--- a/compose/network.py
+++ b/compose/network.py
@@ -231,7 +231,7 @@ def check_remote_network_config(remote, local):
         if k.startswith('com.docker.'):  # We are only interested in user-specified labels
             continue
         if remote_labels.get(k) != local_labels.get(k):
-            log.warn(
+            log.warning(
                 'Network {}: label "{}" has changed. It may need to be'
                 ' recreated.'.format(local.true_name, k)
             )
@@ -276,7 +276,7 @@ class ProjectNetworks(object):
         }
         unused = set(networks) - set(service_networks) - {'default'}
         if unused:
-            log.warn(
+            log.warning(
                 "Some networks were defined but are not used by any service: "
                 "{}".format(", ".join(unused)))
         return cls(service_networks, use_networking)
@@ -288,7 +288,7 @@ class ProjectNetworks(object):
             try:
                 network.remove()
             except NotFound:
-                log.warn("Network %s not found.", network.true_name)
+                log.warning("Network %s not found.", network.true_name)
 
     def initialize(self):
         if not self.use_networking:

--- a/compose/project.py
+++ b/compose/project.py
@@ -776,13 +776,13 @@ def get_secrets(service, service_secrets, secret_defs):
                 .format(service=service, secret=secret.source))
 
         if secret_def.get('external'):
-            log.warn("Service \"{service}\" uses secret \"{secret}\" which is external. "
-                     "External secrets are not available to containers created by "
-                     "docker-compose.".format(service=service, secret=secret.source))
+            log.warning("Service \"{service}\" uses secret \"{secret}\" which is external. "
+                        "External secrets are not available to containers created by "
+                        "docker-compose.".format(service=service, secret=secret.source))
             continue
 
         if secret.uid or secret.gid or secret.mode:
-            log.warn(
+            log.warning(
                 "Service \"{service}\" uses secret \"{secret}\" with uid, "
                 "gid, or mode. These fields are not supported by this "
                 "implementation of the Compose file".format(

--- a/compose/service.py
+++ b/compose/service.py
@@ -240,15 +240,15 @@ class Service(object):
 
     def show_scale_warnings(self, desired_num):
         if self.custom_container_name and desired_num > 1:
-            log.warn('The "%s" service is using the custom container name "%s". '
-                     'Docker requires each container to have a unique name. '
-                     'Remove the custom name to scale the service.'
-                     % (self.name, self.custom_container_name))
+            log.warning('The "%s" service is using the custom container name "%s". '
+                        'Docker requires each container to have a unique name. '
+                        'Remove the custom name to scale the service.'
+                        % (self.name, self.custom_container_name))
 
         if self.specifies_host_port() and desired_num > 1:
-            log.warn('The "%s" service specifies a port on the host. If multiple containers '
-                     'for this service are created on a single host, the port will clash.'
-                     % self.name)
+            log.warning('The "%s" service specifies a port on the host. If multiple containers '
+                        'for this service are created on a single host, the port will clash.'
+                        % self.name)
 
     def scale(self, desired_num, timeout=None):
         """
@@ -357,7 +357,7 @@ class Service(object):
             raise NeedsBuildError(self)
 
         self.build()
-        log.warn(
+        log.warning(
             "Image for service {} was built because it did not already exist. To "
             "rebuild this image you must use `docker-compose build` or "
             "`docker-compose up --build`.".format(self.name))
@@ -1325,7 +1325,7 @@ class ServicePidMode(PidMode):
         if containers:
             return 'container:' + containers[0].id
 
-        log.warn(
+        log.warning(
             "Service %s is trying to use reuse the PID namespace "
             "of another service that is not running." % (self.service_name)
         )
@@ -1388,8 +1388,8 @@ class ServiceNetworkMode(object):
         if containers:
             return 'container:' + containers[0].id
 
-        log.warn("Service %s is trying to use reuse the network stack "
-                 "of another service that is not running." % (self.id))
+        log.warning("Service %s is trying to use reuse the network stack "
+                    "of another service that is not running." % (self.id))
         return None
 
 
@@ -1540,7 +1540,7 @@ def warn_on_masked_volume(volumes_option, container_volumes, service):
             volume.internal in container_volumes and
             container_volumes.get(volume.internal) != volume.external
         ):
-            log.warn((
+            log.warning((
                 "Service \"{service}\" is using volume \"{volume}\" from the "
                 "previous container. Host mapping \"{host_path}\" has no effect. "
                 "Remove the existing containers (with `docker-compose rm {service}`) "

--- a/compose/volume.py
+++ b/compose/volume.py
@@ -127,7 +127,7 @@ class ProjectVolumes(object):
             try:
                 volume.remove()
             except NotFound:
-                log.warn("Volume %s not found.", volume.true_name)
+                log.warning("Volume %s not found.", volume.true_name)
 
     def initialize(self):
         try:
@@ -209,7 +209,7 @@ def check_remote_volume_config(remote, local):
         if k.startswith('com.docker.'):  # We are only interested in user-specified labels
             continue
         if remote_labels.get(k) != local_labels.get(k):
-            log.warn(
+            log.warning(
                 'Volume {}: label "{}" has changed. It may need to be'
                 ' recreated.'.format(local.name, k)
             )

--- a/contrib/migration/migrate-compose-file-v1-to-v2.py
+++ b/contrib/migration/migrate-compose-file-v1-to-v2.py
@@ -44,7 +44,7 @@ def warn_for_links(name, service):
     links = service.get('links')
     if links:
         example_service = links[0].partition(':')[0]
-        log.warn(
+        log.warning(
             "Service {name} has links, which no longer create environment "
             "variables such as {example_service_upper}_PORT. "
             "If you are using those in your application code, you should "
@@ -57,7 +57,7 @@ def warn_for_links(name, service):
 def warn_for_external_links(name, service):
     external_links = service.get('external_links')
     if external_links:
-        log.warn(
+        log.warning(
             "Service {name} has external_links: {ext}, which now work "
             "slightly differently. In particular, two containers must be "
             "connected to at least one network in common in order to "
@@ -107,7 +107,7 @@ def rewrite_volumes_from(service, service_names):
 def create_volumes_section(data):
     named_volumes = get_named_volumes(data['services'])
     if named_volumes:
-        log.warn(
+        log.warning(
             "Named volumes ({names}) must be explicitly declared. Creating a "
             "'volumes' section with declarations.\n\n"
             "For backwards-compatibility, they've been declared as external. "

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -695,8 +695,8 @@ class ServiceTest(DockerClientTestCase):
             new_container, = service.execute_convergence_plan(
                 ConvergencePlan('recreate', [old_container]))
 
-        mock_log.warn.assert_called_once_with(mock.ANY)
-        _, args, kwargs = mock_log.warn.mock_calls[0]
+        mock_log.warning.assert_called_once_with(mock.ANY)
+        _, args, kwargs = mock_log.warning.mock_calls[0]
         assert "Service \"db\" is using volume \"/data\" from the previous container" in args[0]
 
         assert [mount['Destination'] for mount in new_container.get('Mounts')] == ['/data']
@@ -1382,7 +1382,7 @@ class ServiceTest(DockerClientTestCase):
         with pytest.raises(OperationFailedError):
             service.scale(3)
 
-        captured_output = mock_log.warn.call_args[0][0]
+        captured_output = mock_log.warning.call_args[0][0]
 
         assert len(service.containers()) == 1
         assert "Remove the custom name to scale the service." in captured_output

--- a/tests/unit/bundle_test.py
+++ b/tests/unit/bundle_test.py
@@ -94,7 +94,7 @@ def test_to_bundle():
         configs={}
     )
 
-    with mock.patch('compose.bundle.log.warn', autospec=True) as mock_log:
+    with mock.patch('compose.bundle.log.warning', autospec=True) as mock_log:
         output = bundle.to_bundle(config, image_digests)
 
     assert mock_log.mock_calls == [
@@ -128,7 +128,7 @@ def test_convert_service_to_bundle():
         'privileged': True,
     }
 
-    with mock.patch('compose.bundle.log.warn', autospec=True) as mock_log:
+    with mock.patch('compose.bundle.log.warning', autospec=True) as mock_log:
         config = bundle.convert_service_to_bundle(name, service_dict, image_digest)
 
     mock_log.assert_called_once_with(
@@ -177,7 +177,7 @@ def test_make_service_networks_default():
     name = 'theservice'
     service_dict = {}
 
-    with mock.patch('compose.bundle.log.warn', autospec=True) as mock_log:
+    with mock.patch('compose.bundle.log.warning', autospec=True) as mock_log:
         networks = bundle.make_service_networks(name, service_dict)
 
     assert not mock_log.called
@@ -195,7 +195,7 @@ def test_make_service_networks():
         },
     }
 
-    with mock.patch('compose.bundle.log.warn', autospec=True) as mock_log:
+    with mock.patch('compose.bundle.log.warning', autospec=True) as mock_log:
         networks = bundle.make_service_networks(name, service_dict)
 
     mock_log.assert_called_once_with(

--- a/tests/unit/cli/docker_client_test.py
+++ b/tests/unit/cli/docker_client_test.py
@@ -247,5 +247,5 @@ class TestGetTlsVersion(object):
         environment = {'COMPOSE_TLS_VERSION': 'TLSv5_5'}
         with mock.patch('compose.cli.docker_client.log') as mock_log:
             tls_version = get_tls_version(environment)
-        mock_log.warn.assert_called_once_with(mock.ANY)
+        mock_log.warning.assert_called_once_with(mock.ANY)
         assert tls_version is None

--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -63,7 +63,7 @@ class TestCLIMainTestCase(object):
 
         with mock.patch('compose.cli.main.log') as fake_log:
             warn_for_swarm_mode(mock_client)
-            assert fake_log.warn.call_count == 1
+            assert fake_log.warning.call_count == 1
 
 
 class TestSetupConsoleHandlerTestCase(object):

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -329,7 +329,7 @@ class ConfigTest(unittest.TestCase):
             )
 
         assert 'Unexpected type for "version" key in "filename.yml"' \
-            in mock_logging.warn.call_args[0][0]
+            in mock_logging.warning.call_args[0][0]
 
         service_dicts = config_data.services
         assert service_sort(service_dicts) == service_sort([
@@ -3570,8 +3570,8 @@ class InterpolationTest(unittest.TestCase):
         with mock.patch('compose.config.environment.log') as log:
             config.load(config_details)
 
-            assert 2 == log.warn.call_count
-            warnings = sorted(args[0][0] for args in log.warn.call_args_list)
+            assert 2 == log.warning.call_count
+            warnings = sorted(args[0][0] for args in log.warning.call_args_list)
             assert 'BAR' in warnings[0]
             assert 'FOO' in warnings[1]
 
@@ -3601,8 +3601,8 @@ class InterpolationTest(unittest.TestCase):
         with mock.patch('compose.config.config.log') as log:
             config.load(config_details, compatibility=True)
 
-        assert log.warn.call_count == 1
-        warn_message = log.warn.call_args[0][0]
+        assert log.warning.call_count == 1
+        warn_message = log.warning.call_args[0][0]
         assert warn_message.startswith(
             'The following deploy sub-keys are not supported in compatibility mode'
         )
@@ -3641,7 +3641,7 @@ class InterpolationTest(unittest.TestCase):
         with mock.patch('compose.config.config.log') as log:
             cfg = config.load(config_details, compatibility=True)
 
-        assert log.warn.call_count == 0
+        assert log.warning.call_count == 0
 
         service_dict = cfg.services[0]
         assert service_dict == {

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -165,6 +165,6 @@ class NetworkTest(unittest.TestCase):
         with mock.patch('compose.network.log') as mock_log:
             check_remote_network_config(remote, net)
 
-        mock_log.warn.assert_called_once_with(mock.ANY)
-        _, args, kwargs = mock_log.warn.mock_calls[0]
+        mock_log.warning.assert_called_once_with(mock.ANY)
+        _, args, kwargs = mock_log.warning.mock_calls[0]
         assert 'label "com.project.touhou.character" has changed' in args[0]

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -516,8 +516,8 @@ class ServiceTest(unittest.TestCase):
 
         with mock.patch('compose.service.log', autospec=True) as mock_log:
             service.create_container()
-            assert mock_log.warn.called
-            _, args, _ = mock_log.warn.mock_calls[0]
+            assert mock_log.warning.called
+            _, args, _ = mock_log.warning.mock_calls[0]
             assert 'was built because it did not already exist' in args[0]
 
         assert self.mock_client.build.call_count == 1
@@ -546,7 +546,7 @@ class ServiceTest(unittest.TestCase):
         with mock.patch('compose.service.log', autospec=True) as mock_log:
             service.ensure_image_exists(do_build=BuildAction.force)
 
-        assert not mock_log.warn.called
+        assert not mock_log.warning.called
         assert self.mock_client.build.call_count == 1
         self.mock_client.build.call_args[1]['tag'] == 'default_foo'
 
@@ -847,13 +847,13 @@ class ServiceTest(unittest.TestCase):
             ports=["8080:80"])
 
         service.scale(0)
-        assert not mock_log.warn.called
+        assert not mock_log.warning.called
 
         service.scale(1)
-        assert not mock_log.warn.called
+        assert not mock_log.warning.called
 
         service.scale(2)
-        mock_log.warn.assert_called_once_with(
+        mock_log.warning.assert_called_once_with(
             'The "{}" service specifies a port on the host. If multiple containers '
             'for this service are created on a single host, the port will clash.'.format(name))
 
@@ -1391,7 +1391,7 @@ class ServiceVolumesTest(unittest.TestCase):
         with mock.patch('compose.service.log', autospec=True) as mock_log:
             warn_on_masked_volume(volumes_option, container_volumes, service)
 
-        assert not mock_log.warn.called
+        assert not mock_log.warning.called
 
     def test_warn_on_masked_volume_when_masked(self):
         volumes_option = [VolumeSpec('/home/user', '/path', 'rw')]
@@ -1404,7 +1404,7 @@ class ServiceVolumesTest(unittest.TestCase):
         with mock.patch('compose.service.log', autospec=True) as mock_log:
             warn_on_masked_volume(volumes_option, container_volumes, service)
 
-        mock_log.warn.assert_called_once_with(mock.ANY)
+        mock_log.warning.assert_called_once_with(mock.ANY)
 
     def test_warn_on_masked_no_warning_with_same_path(self):
         volumes_option = [VolumeSpec('/home/user', '/path', 'rw')]
@@ -1414,7 +1414,7 @@ class ServiceVolumesTest(unittest.TestCase):
         with mock.patch('compose.service.log', autospec=True) as mock_log:
             warn_on_masked_volume(volumes_option, container_volumes, service)
 
-        assert not mock_log.warn.called
+        assert not mock_log.warning.called
 
     def test_warn_on_masked_no_warning_with_container_only_option(self):
         volumes_option = [VolumeSpec(None, '/path', 'rw')]
@@ -1426,7 +1426,7 @@ class ServiceVolumesTest(unittest.TestCase):
         with mock.patch('compose.service.log', autospec=True) as mock_log:
             warn_on_masked_volume(volumes_option, container_volumes, service)
 
-        assert not mock_log.warn.called
+        assert not mock_log.warning.called
 
     def test_create_with_special_volume_mode(self):
         self.mock_client.inspect_image.return_value = {'Id': 'imageid'}


### PR DESCRIPTION
Resolves #
- fixes `log.warn` method is deprecated with `log.warning`
