### PR TITLE
Offer docompo alias for docker-compose command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,10 @@ setup(
     tests_require=tests_require,
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={
-        'console_scripts': ['docker-compose=compose.cli.main:main'],
+        'console_scripts': [
+            'docompo=compose.cli.main:main',
+            'docker-compose=compose.cli.main:main'
+        ],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Just a quick patch to provide a shorter alias without dash that's more friendly in the command line: docompo alias for docker-compose. docompo kind of sounds like docker-compose except it should autocomplete fine after typing docoTAB