### PR TITLE
Make test and build scripts POSIX compatible

### DIFF
--- a/script/build/image
+++ b/script/build/image
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -e
 

--- a/script/build/linux
+++ b/script/build/linux
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -ex
 

--- a/script/build/linux-entrypoint
+++ b/script/build/linux-entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -ex
 

--- a/script/build/osx
+++ b/script/build/osx
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env sh
+
 set -ex
 
 TOOLCHAIN_PATH="$(realpath $(dirname $0)/../../build/toolchain)"

--- a/script/build/test-image
+++ b/script/build/test-image
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -e
 

--- a/script/build/write-git-sha
+++ b/script/build/write-git-sha
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env sh
 #
 # Write the current commit sha to the file GITSHA. This file is included in
 # packaging so that `docker-compose version` can include the git sha.
 # sets to 'unknown' and echoes a message if the command is not successful
 
 DOCKER_COMPOSE_GITSHA="$(git rev-parse --short HEAD)"
-if [[ "${?}" != "0" ]]; then
+if [ $? -ne 0 ] ; then
     echo "Couldn't get revision of the git repository. Setting to 'unknown' instead"
     DOCKER_COMPOSE_GITSHA="unknown"
 fi

--- a/script/test/all
+++ b/script/test/all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # This should be run inside a container built from the Dockerfile
 # at the root of the repo - script/test will do it automatically.
 
@@ -15,9 +15,9 @@ get_versions="docker run --rm
     $TAG
     /code/script/test/versions.py docker/docker-ce,moby/moby"
 
-if [ "$DOCKER_VERSIONS" == "" ]; then
+if [ "$DOCKER_VERSIONS" = "" ]; then
   DOCKER_VERSIONS="$($get_versions default)"
-elif [ "$DOCKER_VERSIONS" == "all" ]; then
+elif [ "$DOCKER_VERSIONS" = "all" ]; then
   DOCKER_VERSIONS=$($get_versions -n 2 recent)
 fi
 
@@ -30,8 +30,8 @@ for version in $DOCKER_VERSIONS; do
 
   daemon_container="compose-dind-$version-$BUILD_NUMBER"
 
-  function on_exit() {
-    if [[ "$?" != "0" ]]; then
+  on_exit() {
+    if [ $? -ne 0 ]; then
         docker logs "$daemon_container" 2>&1 | tail -n 100
     fi
     docker rm -vf "$daemon_container"

--- a/script/test/ci
+++ b/script/test/ci
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # This should be run inside a container built from the Dockerfile
 # at the root of the repo:
 #

--- a/script/test/default
+++ b/script/test/default
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # See CONTRIBUTING.md for usage.
 
 set -ex


### PR DESCRIPTION
There is no need for these scripts to be bash-specific. This patch
contains the bare minimum alterations to make them POSIX compatible.
The benefits of having portable scripts, when possible, are obvious.

Change-Id: I1bb78f77653e948fa301c1e77bee4ff55ca415c6
Signed-off-by: Joakim Roubert <joakimr@axis.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6573 #6575 
