### PR TITLE
Add bash completion for `config --no-interpolate`

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -150,7 +150,7 @@ _docker_compose_config() {
 			;;
 	esac
 
-	COMPREPLY=( $( compgen -W "--hash --help --quiet -q --resolve-image-digests --services --volumes" -- "$cur" ) )
+	COMPREPLY=( $( compgen -W "--hash --help --no-interpolate --quiet -q --resolve-image-digests --services --volumes" -- "$cur" ) )
 }
 
 


### PR DESCRIPTION
From the [1.25.0-rc1 release](https://github.com/docker/compose/releases/tag/1.25.0-rc1) notes:
> Added --no-interpolate to docker-compose config

This PR adds the corresponding bash completion.
Please include in 1.25.0 for feature parity.