### PR TITLE
Replace sets with set literal syntax for efficiency

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -21,7 +21,20 @@ from .utils import get_version_info
 
 log = logging.getLogger(__name__)
 
-SILENT_COMMANDS = {'events', 'exec', 'kill', 'logs', 'pause', 'ps', 'restart', 'rm', 'start', 'stop', 'top', 'unpause'}
+SILENT_COMMANDS = {
+    'events',
+    'exec',
+    'kill',
+    'logs',
+    'pause',
+    'ps',
+    'restart',
+    'rm',
+    'start',
+    'stop',
+    'top',
+    'unpause',
+}
 
 
 def project_from_options(project_dir, options, additional_options={}):

--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -21,20 +21,7 @@ from .utils import get_version_info
 
 log = logging.getLogger(__name__)
 
-SILENT_COMMANDS = set((
-    'events',
-    'exec',
-    'kill',
-    'logs',
-    'pause',
-    'ps',
-    'restart',
-    'rm',
-    'start',
-    'stop',
-    'top',
-    'unpause',
-))
+SILENT_COMMANDS = {'events', 'exec', 'kill', 'logs', 'pause', 'ps', 'restart', 'rm', 'start', 'stop', 'top', 'unpause'}
 
 
 def project_from_options(project_dir, options, additional_options={}):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1446,7 +1446,7 @@ class CLITestCase(DockerClientTestCase):
             if v['Name'].split('/')[-1].startswith('{}_'.format(self.project.name))
         ]
 
-        assert set([v['Name'].split('/')[-1] for v in volumes]) == set([volume_with_label])
+        assert set([v['Name'].split('/')[-1] for v in volumes]) == {volume_with_label}
         assert 'label_key' in volumes[0]['Labels']
         assert volumes[0]['Labels']['label_key'] == 'label_val'
 
@@ -2111,7 +2111,7 @@ class CLITestCase(DockerClientTestCase):
             for _, config in networks.items():
                 # TODO: once we drop support for API <1.24, this can be changed to:
                 # assert config['Aliases'] == [container.short_id]
-                aliases = set(config['Aliases'] or []) - set([container.short_id])
+                aliases = set(config['Aliases'] or []) - {container.short_id}
                 assert not aliases
 
     @v2_only()
@@ -2131,7 +2131,7 @@ class CLITestCase(DockerClientTestCase):
         for _, config in networks.items():
             # TODO: once we drop support for API <1.24, this can be changed to:
             # assert config['Aliases'] == [container.short_id]
-            aliases = set(config['Aliases'] or []) - set([container.short_id])
+            aliases = set(config['Aliases'] or []) - {container.short_id}
             assert not aliases
 
         assert self.lookup(container, 'app')
@@ -2741,7 +2741,7 @@ class CLITestCase(DockerClientTestCase):
         self.base_dir = 'tests/fixtures/extends'
         self.dispatch(['up', '-d'], None)
 
-        assert set([s.name for s in self.project.services]) == set(['mydb', 'myweb'])
+        assert set([s.name for s in self.project.services]) == {'mydb', 'myweb'}
 
         # Sort by name so we get [db, web]
         containers = sorted(
@@ -2753,15 +2753,9 @@ class CLITestCase(DockerClientTestCase):
         web = containers[1]
         db_name = containers[0].name_without_project
 
-        assert set(get_links(web)) == set(
-            ['db', db_name, 'extends_{}'.format(db_name)]
-        )
+        assert set(get_links(web)) == {'db', db_name, 'extends_{}'.format(db_name)}
 
-        expected_env = set([
-            "FOO=1",
-            "BAR=2",
-            "BAZ=2",
-        ])
+        expected_env = {"FOO=1", "BAR=2", "BAZ=2"}
         assert expected_env <= set(web.get('Config.Env'))
 
     def test_top_services_not_running(self):

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -305,20 +305,20 @@ class ProjectTest(DockerClientTestCase):
         db_container = db.create_container()
 
         project.start(service_names=['web'])
-        assert set(c.name for c in project.containers() if c.is_running) == {web_container_1.name, web_container_2.name}
+        assert set(c.name for c in project.containers() if c.is_running) == {
+            web_container_1.name, web_container_2.name}
 
         project.start()
-        assert set(c.name for c in project.containers() if c.is_running) == set(
-            [web_container_1.name, web_container_2.name, db_container.name]
-        )
+        assert set(c.name for c in project.containers() if c.is_running) == {
+            web_container_1.name, web_container_2.name, db_container.name}
 
         project.pause(service_names=['web'])
-        assert set([c.name for c in project.containers() if c.is_paused]) == {web_container_1.name,
-                                                                              web_container_2.name}
+        assert set([c.name for c in project.containers() if c.is_paused]) == {
+            web_container_1.name, web_container_2.name}
 
         project.pause()
-        assert set([c.name for c in project.containers() if c.is_paused]) == {web_container_1.name,
-                                                                              web_container_2.name, db_container.name}
+        assert set([c.name for c in project.containers() if c.is_paused]) == {
+            web_container_1.name, web_container_2.name, db_container.name}
 
         project.unpause(service_names=['db'])
         assert len([c.name for c in project.containers() if c.is_paused]) == 2

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -104,7 +104,7 @@ class ProjectTest(DockerClientTestCase):
         self.create_service('extra').create_container()
 
         project = Project('composetest', [web, db], self.client)
-        assert set(project.containers(stopped=True)) == set([web_1, db_1])
+        assert set(project.containers(stopped=True)) == {web_1, db_1}
 
     def test_parallel_pull_with_no_image(self):
         config_data = build_config(
@@ -305,9 +305,7 @@ class ProjectTest(DockerClientTestCase):
         db_container = db.create_container()
 
         project.start(service_names=['web'])
-        assert set(c.name for c in project.containers() if c.is_running) == set(
-            [web_container_1.name, web_container_2.name]
-        )
+        assert set(c.name for c in project.containers() if c.is_running) == {web_container_1.name, web_container_2.name}
 
         project.start()
         assert set(c.name for c in project.containers() if c.is_running) == set(
@@ -315,14 +313,12 @@ class ProjectTest(DockerClientTestCase):
         )
 
         project.pause(service_names=['web'])
-        assert set([c.name for c in project.containers() if c.is_paused]) == set(
-            [web_container_1.name, web_container_2.name]
-        )
+        assert set([c.name for c in project.containers() if c.is_paused]) == {web_container_1.name,
+                                                                              web_container_2.name}
 
         project.pause()
-        assert set([c.name for c in project.containers() if c.is_paused]) == set(
-            [web_container_1.name, web_container_2.name, db_container.name]
-        )
+        assert set([c.name for c in project.containers() if c.is_paused]) == {web_container_1.name,
+                                                                              web_container_2.name, db_container.name}
 
         project.unpause(service_names=['db'])
         assert len([c.name for c in project.containers() if c.is_paused]) == 2
@@ -331,7 +327,7 @@ class ProjectTest(DockerClientTestCase):
         assert len([c.name for c in project.containers() if c.is_paused]) == 0
 
         project.stop(service_names=['web'], timeout=1)
-        assert set(c.name for c in project.containers() if c.is_running) == set([db_container.name])
+        assert set(c.name for c in project.containers() if c.is_running) == {db_container.name}
 
         project.kill(service_names=['db'])
         assert len([c for c in project.containers() if c.is_running]) == 0

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3821,35 +3821,35 @@ class MergePathMappingTest(object):
             {self.config_name: ['/foo:/code', '/data']},
             {},
             DEFAULT_VERSION)
-        assert set(service_dict[self.config_name]) == set(['/foo:/code', '/data'])
+        assert set(service_dict[self.config_name]) == {'/foo:/code', '/data'}
 
     def test_no_base(self):
         service_dict = config.merge_service_dicts(
             {},
             {self.config_name: ['/bar:/code']},
             DEFAULT_VERSION)
-        assert set(service_dict[self.config_name]) == set(['/bar:/code'])
+        assert set(service_dict[self.config_name]) == {'/bar:/code'}
 
     def test_override_explicit_path(self):
         service_dict = config.merge_service_dicts(
             {self.config_name: ['/foo:/code', '/data']},
             {self.config_name: ['/bar:/code']},
             DEFAULT_VERSION)
-        assert set(service_dict[self.config_name]) == set(['/bar:/code', '/data'])
+        assert set(service_dict[self.config_name]) == {'/bar:/code', '/data'}
 
     def test_add_explicit_path(self):
         service_dict = config.merge_service_dicts(
             {self.config_name: ['/foo:/code', '/data']},
             {self.config_name: ['/bar:/code', '/quux:/data']},
             DEFAULT_VERSION)
-        assert set(service_dict[self.config_name]) == set(['/bar:/code', '/quux:/data'])
+        assert set(service_dict[self.config_name]) == {'/bar:/code', '/quux:/data'}
 
     def test_remove_explicit_path(self):
         service_dict = config.merge_service_dicts(
             {self.config_name: ['/foo:/code', '/quux:/data']},
             {self.config_name: ['/bar:/code', '/data']},
             DEFAULT_VERSION)
-        assert set(service_dict[self.config_name]) == set(['/bar:/code', '/data'])
+        assert set(service_dict[self.config_name]) == {'/bar:/code', '/data'}
 
 
 class MergeVolumesTest(unittest.TestCase, MergePathMappingTest):
@@ -4053,28 +4053,28 @@ class MergeStringsOrListsTest(unittest.TestCase):
             {'dns': '8.8.8.8'},
             {},
             DEFAULT_VERSION)
-        assert set(service_dict['dns']) == set(['8.8.8.8'])
+        assert set(service_dict['dns']) == {'8.8.8.8'}
 
     def test_no_base(self):
         service_dict = config.merge_service_dicts(
             {},
             {'dns': '8.8.8.8'},
             DEFAULT_VERSION)
-        assert set(service_dict['dns']) == set(['8.8.8.8'])
+        assert set(service_dict['dns']) == {'8.8.8.8'}
 
     def test_add_string(self):
         service_dict = config.merge_service_dicts(
             {'dns': ['8.8.8.8']},
             {'dns': '9.9.9.9'},
             DEFAULT_VERSION)
-        assert set(service_dict['dns']) == set(['8.8.8.8', '9.9.9.9'])
+        assert set(service_dict['dns']) == {'8.8.8.8', '9.9.9.9'}
 
     def test_add_list(self):
         service_dict = config.merge_service_dicts(
             {'dns': '8.8.8.8'},
             {'dns': ['9.9.9.9']},
             DEFAULT_VERSION)
-        assert set(service_dict['dns']) == set(['8.8.8.8', '9.9.9.9'])
+        assert set(service_dict['dns']) == {'8.8.8.8', '9.9.9.9'}
 
 
 class MergeLabelsTest(unittest.TestCase):
@@ -4146,7 +4146,7 @@ class MergeBuildTest(unittest.TestCase):
         assert result['context'] == override['context']
         assert result['dockerfile'] == override['dockerfile']
         assert result['args'] == {'x': '12', 'y': '2'}
-        assert set(result['cache_from']) == set(['ubuntu', 'debian'])
+        assert set(result['cache_from']) == {'ubuntu', 'debian'}
         assert result['labels'] == override['labels']
 
     def test_empty_override(self):
@@ -4350,7 +4350,7 @@ class EnvTest(unittest.TestCase):
                 "tests/fixtures/env",
             )
         ).services[0]
-        assert set(service_dict['volumes']) == set([VolumeSpec.parse('/tmp:/host/tmp')])
+        assert set(service_dict['volumes']) == {VolumeSpec.parse('/tmp:/host/tmp')}
 
         service_dict = config.load(
             build_config_details(
@@ -4358,7 +4358,7 @@ class EnvTest(unittest.TestCase):
                 "tests/fixtures/env",
             )
         ).services[0]
-        assert set(service_dict['volumes']) == set([VolumeSpec.parse('/opt/tmp:/opt/host/tmp')])
+        assert set(service_dict['volumes']) == {VolumeSpec.parse('/opt/tmp:/opt/host/tmp')}
 
 
 def load_from_filename(filename, override_dir=None):

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -1334,10 +1334,8 @@ class ServiceVolumesTest(unittest.TestCase):
             number=1,
         )
 
-        assert set(self.mock_client.create_host_config.call_args[1]['binds']) == set([
-            '/host/path:/data1:rw',
-            '/host/path:/data2:rw',
-        ])
+        assert set(self.mock_client.create_host_config.call_args[1]['binds']) == {'/host/path:/data1:rw',
+                                                                                  '/host/path:/data2:rw'}
 
     def test_get_container_create_options_with_different_host_path_in_container_json(self):
         service = Service(


### PR DESCRIPTION
This PR replaces `set()` functions with *set syntax literals* wherever fit as literal constructions require lesser work from the Python interpreter and are faster. 

Signed-off-by: Taufiq Rahman <taufiqrx8@gmail.com>