### PR TITLE
Removed upper bounds for python dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,16 +30,16 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'cached-property >= 1.2.0, < 2',
-    'docopt >= 0.6.1, < 0.7',
-    'PyYAML >= 3.10, < 4.3',
-    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0, < 2.23',
-    'texttable >= 0.9.0, < 0.10',
-    'websocket-client >= 0.32.0, < 1.0',
-    'docker[ssh] >= 3.7.0, < 4.0.2',
-    'dockerpty >= 0.4.1, < 0.5',
-    'six >= 1.3.0, < 2',
-    'jsonschema >= 2.5.1, < 3',
+    'cached-property >= 1.2.0',
+    'docopt >= 0.6.1',
+    'PyYAML >= 3.10',
+    'requests >= 2.6.1, != 2.11.0, != 2.12.2, != 2.18.0',
+    'texttable >= 0.9.0',
+    'websocket-client >= 0.32.0',
+    'docker[ssh] >= 3.7.0',
+    'dockerpty >= 0.4.1',
+    'six >= 1.3.0',
+    'jsonschema >= 2.5.1',
 ]
 
 
@@ -52,11 +52,11 @@ if sys.version_info[:2] < (3, 4):
     tests_require.append('mock >= 1.0.1')
 
 extras_require = {
-    ':python_version < "3.4"': ['enum34 >= 1.0.4, < 2'],
+    ':python_version < "3.4"': ['enum34 >= 1.0.4'],
     ':python_version < "3.5"': ['backports.ssl_match_hostname >= 3.5'],
     ':python_version < "3.3"': ['ipaddress >= 1.0.16'],
-    ':sys_platform == "win32"': ['colorama >= 0.4, < 0.5'],
-    'socks': ['PySocks >= 1.5.6, != 1.5.7, < 2'],
+    ':sys_platform == "win32"': ['colorama >= 0.4'],
+    'socks': ['PySocks >= 1.5.6, != 1.5.7'],
 }
 
 


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
This removes the upper bounds on the dependency versions for some of the python libraries used for the project

Resolves #6756 
