### PR TITLE
Fix stdin_open when running docker-compose run

### DIFF
--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -9,9 +9,11 @@ import pytest
 from compose import container
 from compose.cli.errors import UserError
 from compose.cli.formatter import ConsoleWarningFormatter
+from compose.cli.main import build_one_off_container_options
 from compose.cli.main import call_docker
 from compose.cli.main import convergence_strategy_from_opts
 from compose.cli.main import filter_containers_to_service_names
+from compose.cli.main import get_docker_start_call
 from compose.cli.main import setup_console_handler
 from compose.cli.main import warn_for_swarm_mode
 from compose.service import ConvergenceStrategy
@@ -64,6 +66,64 @@ class TestCLIMainTestCase(object):
         with mock.patch('compose.cli.main.log') as fake_log:
             warn_for_swarm_mode(mock_client)
             assert fake_log.warning.call_count == 1
+
+    def test_build_one_off_container_options(self):
+        command = 'build myservice'
+        detach = False
+        options = {
+            '-e': ['MYVAR=MYVALUE'],
+            '-T': True,
+            '--label': ['MYLABEL'],
+            '--entrypoint': 'bash',
+            '--user': 'MYUSER',
+            '--service-ports': [],
+            '--publish': '',
+            '--name': 'MYNAME',
+            '--workdir': '.',
+            '--volume': [],
+            'stdin_open': False,
+        }
+
+        expected_container_options = {
+            'command': command,
+            'tty': False,
+            'stdin_open': False,
+            'detach': detach,
+            'entrypoint': 'bash',
+            'environment': {'MYVAR': 'MYVALUE'},
+            'labels': {'MYLABEL': ''},
+            'name': 'MYNAME',
+            'ports': [],
+            'restart': None,
+            'user': 'MYUSER',
+            'working_dir': '.',
+        }
+
+        container_options = build_one_off_container_options(options, detach, command)
+        assert container_options == expected_container_options
+
+    def test_get_docker_start_call(self):
+        container_id = 'my_container_id'
+
+        mock_container_options = {'detach': False, 'stdin_open': True}
+        expected_docker_start_call = ['start', '--attach', '--interactive', container_id]
+        docker_start_call = get_docker_start_call(mock_container_options, container_id)
+        assert expected_docker_start_call == docker_start_call
+
+        mock_container_options = {'detach': False, 'stdin_open': False}
+        expected_docker_start_call = ['start', '--attach', container_id]
+        docker_start_call = get_docker_start_call(mock_container_options, container_id)
+        assert expected_docker_start_call == docker_start_call
+
+        mock_container_options = {'detach': True, 'stdin_open': True}
+        expected_docker_start_call = ['start', '--interactive', container_id]
+        docker_start_call = get_docker_start_call(mock_container_options, container_id)
+        assert expected_docker_start_call == docker_start_call
+
+        mock_container_options = {'detach': True, 'stdin_open': False}
+        expected_docker_start_call = ['start', container_id]
+        docker_start_call = get_docker_start_call(mock_container_options, container_id)
+        assert expected_docker_start_call == docker_start_call
 
 
 class TestSetupConsoleHandlerTestCase(object):


### PR DESCRIPTION
This fix makes sure that stdin_open specified in the service
is considering when shelling out to the CLI

Resolves #6747
