### PR TITLE
update `Common Use Cases` link on the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ see [the list of features](https://github.com/docker/docker.github.io/blob/maste
 
 Compose is great for development, testing, and staging environments, as well as
 CI workflows. You can learn more about each case in
-[Common Use Cases](https://docs.docker.com/compose/).
+[Common Use Cases](https://docs.docker.com/compose/#common-use-cases).
 
 Using Compose is basically a three-step process.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ see [the list of features](https://github.com/docker/docker.github.io/blob/maste
 
 Compose is great for development, testing, and staging environments, as well as
 CI workflows. You can learn more about each case in
-[Common Use Cases](https://github.com/docker/docker.github.io/blob/master/compose/overview.md#common-use-cases).
+[Common Use Cases](https://docs.docker.com/compose/).
 
 Using Compose is basically a three-step process.
 


### PR DESCRIPTION


<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves `Common Use Cases` link on README.md file, the old link was pointing to 404 page
