### PR TITLE
Fix KeyError when remote network labels are None.

### DIFF
--- a/compose/network.py
+++ b/compose/network.py
@@ -226,7 +226,7 @@ def check_remote_network_config(remote, local):
         raise NetworkConfigChangedError(local.true_name, 'enable_ipv6')
 
     local_labels = local.labels or {}
-    remote_labels = remote.get('Labels', {})
+    remote_labels = remote.get('Labels') or {}
     for k in set.union(set(remote_labels.keys()), set(local_labels.keys())):
         if k.startswith('com.docker.'):  # We are only interested in user-specified labels
             continue

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -168,3 +168,8 @@ class NetworkTest(unittest.TestCase):
         mock_log.warning.assert_called_once_with(mock.ANY)
         _, args, kwargs = mock_log.warning.mock_calls[0]
         assert 'label "com.project.touhou.character" has changed' in args[0]
+
+    def test_remote_config_labels_none(self):
+        remote = {'Labels': None}
+        local = Network(None, 'test_project', 'test_network')
+        check_remote_network_config(remote, local)


### PR DESCRIPTION
Resolves #6854
