### PR TITLE
Change Formatter.table method to staticmethod

### DIFF
--- a/compose/cli/formatter.py
+++ b/compose/cli/formatter.py
@@ -18,9 +18,11 @@ def get_tty_width():
     return int(width)
 
 
-class Formatter(object):
+class Formatter:
     """Format tabular data for printing."""
-    def table(self, headers, rows):
+
+    @staticmethod
+    def table(headers, rows):
         table = texttable.Texttable(max_width=get_tty_width())
         table.set_cols_dtype(['t' for h in headers])
         table.add_rows([headers] + rows)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -613,7 +613,7 @@ class TopLevelCommand(object):
                 image_id,
                 size
             ])
-        print(Formatter().table(headers, rows))
+        print(Formatter.table(headers, rows))
 
     def kill(self, options):
         """
@@ -747,7 +747,7 @@ class TopLevelCommand(object):
                     container.human_readable_state,
                     container.human_readable_ports,
                 ])
-            print(Formatter().table(headers, rows))
+            print(Formatter.table(headers, rows))
 
     def pull(self, options):
         """
@@ -987,7 +987,7 @@ class TopLevelCommand(object):
                 rows.append(process)
 
             print(container.name)
-            print(Formatter().table(headers, rows))
+            print(Formatter.table(headers, rows))
 
     def unpause(self, options):
         """


### PR DESCRIPTION
Make this a staticmethod so it's easier to use without needing to init a
Formatter object first.

Resolves #6863 