### PR TITLE
Add support to CLI build

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -266,7 +266,7 @@ class TopLevelCommand(object):
             --build-arg key=val     Set build-time variables for services.
             --compress              Compress the build context using gzip.
             --force-rm              Always remove intermediate containers.
-            -m, --memory MEM        Sets memory limit for the build container.
+            -m, --memory MEM        Set memory limit for the build container.
             --no-cache              Do not use cache when building the image.
             --no-rm                 Do not remove intermediate containers after a successful build.
             --parallel              Build images in parallel.

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -272,7 +272,7 @@ class TopLevelCommand(object):
             --parallel              Build images in parallel.
             --progress string       Set type of progress output (auto, plain, tty).
                                     EXPERIMENTAL flag for native builder.
-                                    To enable, run with COMPOSE_NATIVE_BUILDER=1)
+                                    To enable, run with COMPOSE_DOCKER_CLI_BUILD=1)
             --pull                  Always attempt to pull a newer version of the image.
             -q, --quiet             Don't print anything to STDOUT
         """
@@ -286,7 +286,7 @@ class TopLevelCommand(object):
                 )
             build_args = resolve_build_args(build_args, self.toplevel_environment)
 
-        native_builder = self.toplevel_environment.get_boolean('COMPOSE_NATIVE_BUILDER')
+        native_builder = self.toplevel_environment.get_boolean('COMPOSE_DOCKER_CLI_BUILD')
 
         self.project.build(
             service_names=options['SERVICE'],
@@ -1078,7 +1078,7 @@ class TopLevelCommand(object):
         for excluded in [x for x in opts if options.get(x) and no_start]:
             raise UserError('--no-start and {} cannot be combined.'.format(excluded))
 
-        native_builder = self.toplevel_environment.get_boolean('COMPOSE_NATIVE_BUILDER')
+        native_builder = self.toplevel_environment.get_boolean('COMPOSE_DOCKER_CLI_BUILD')
 
         with up_shutdown_context(self.project, service_names, timeout, detached):
             warn_for_swarm_mode(self.project.client)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -270,6 +270,9 @@ class TopLevelCommand(object):
             --no-cache              Do not use cache when building the image.
             --no-rm                 Do not remove intermediate containers after a successful build.
             --parallel              Build images in parallel.
+            --progress string       Set type of progress output (auto, plain, tty).
+                                    EXPERIMENTAL flag for native builder.
+                                    To enable, run with COMPOSE_NATIVE_BUILDER=1)
             --pull                  Always attempt to pull a newer version of the image.
             -q, --quiet             Don't print anything to STDOUT
         """
@@ -297,6 +300,7 @@ class TopLevelCommand(object):
             parallel_build=options.get('--parallel', False),
             silent=options.get('--quiet', False),
             cli=native_builder,
+            progress=options.get('--progress'),
         )
 
     def bundle(self, options):

--- a/compose/project.py
+++ b/compose/project.py
@@ -355,7 +355,8 @@ class Project(object):
         return containers
 
     def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, memory=None,
-              build_args=None, gzip=False, parallel_build=False, rm=True, silent=False, cli=False):
+              build_args=None, gzip=False, parallel_build=False, rm=True, silent=False, cli=False,
+              progress=None):
 
         services = []
         for service in self.get_services(service_names):
@@ -368,7 +369,7 @@ class Project(object):
             log.warning("Native build is an experimental feature and could change at any time")
 
         def build_service(service):
-            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent, cli)
+            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent, cli, progress)
         if parallel_build:
             _, errors = parallel.parallel_execute(
                 services,

--- a/compose/project.py
+++ b/compose/project.py
@@ -367,6 +367,10 @@ class Project(object):
 
         if cli:
             log.warning("Native build is an experimental feature and could change at any time")
+            if parallel_build:
+                log.warning("unavailable --parallel on COMPOSE_NATIVE_BUILDER=1")
+            if gzip:
+                log.warning("unavailable --compress on COMPOSE_NATIVE_BUILDER=1")
 
         def build_service(service):
             service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent, cli, progress)

--- a/compose/project.py
+++ b/compose/project.py
@@ -355,7 +355,7 @@ class Project(object):
         return containers
 
     def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, memory=None,
-              build_args=None, gzip=False, parallel_build=False, rm=True, silent=False):
+              build_args=None, gzip=False, parallel_build=False, rm=True, silent=False, cli=False):
 
         services = []
         for service in self.get_services(service_names):
@@ -364,8 +364,11 @@ class Project(object):
             elif not silent:
                 log.info('%s uses an image, skipping' % service.name)
 
+        if cli:
+            log.warning("Native build is an experimental feature and could change at any time")
+
         def build_service(service):
-            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent)
+            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent, cli)
         if parallel_build:
             _, errors = parallel.parallel_execute(
                 services,
@@ -509,7 +512,11 @@ class Project(object):
            reset_container_image=False,
            renew_anonymous_volumes=False,
            silent=False,
+           cli=False,
            ):
+
+        if cli:
+            log.warning("Native build is an experimental feature and could change at any time")
 
         self.initialize()
         if not ignore_orphans:
@@ -523,7 +530,7 @@ class Project(object):
             include_deps=start_deps)
 
         for svc in services:
-            svc.ensure_image_exists(do_build=do_build, silent=silent)
+            svc.ensure_image_exists(do_build=do_build, silent=silent, cli=cli)
         plans = self._get_convergence_plans(
             services, strategy, always_recreate_deps=always_recreate_deps)
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -369,10 +369,10 @@ class Project(object):
             log.warning("Native build is an experimental feature and could change at any time")
             if parallel_build:
                 log.warning("Flag '--parallel' is ignored when building with "
-                            "COMPOSE_NATIVE_BUILDER=1")
+                            "COMPOSE_DOCKER_CLI_BUILD=1")
             if gzip:
                 log.warning("Flag '--compress' is ignored when building with "
-                            "COMPOSE_NATIVE_BUILDER=1")
+                            "COMPOSE_DOCKER_CLI_BUILD=1")
 
         def build_service(service):
             service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent, cli, progress)

--- a/compose/project.py
+++ b/compose/project.py
@@ -368,9 +368,11 @@ class Project(object):
         if cli:
             log.warning("Native build is an experimental feature and could change at any time")
             if parallel_build:
-                log.warning("unavailable --parallel on COMPOSE_NATIVE_BUILDER=1")
+                log.warning("Flag '--parallel' is ignored when building with "
+                            "COMPOSE_NATIVE_BUILDER=1")
             if gzip:
-                log.warning("unavailable --compress on COMPOSE_NATIVE_BUILDER=1")
+                log.warning("Flag '--compress' is ignored when building with "
+                            "COMPOSE_NATIVE_BUILDER=1")
 
         def build_service(service):
             service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent, cli, progress)

--- a/compose/service.py
+++ b/compose/service.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import re
-import subprocess
 import sys
 import tempfile
 from collections import namedtuple
@@ -61,6 +60,11 @@ from .utils import parse_bytes
 from .utils import parse_seconds_float
 from .utils import truncate_id
 from .utils import unique_everseen
+
+if six.PY2:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 log = logging.getLogger(__name__)
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -1774,11 +1774,14 @@ def cli_build(path, tag=None, quiet=False, fileobj=None,
 
     command_builder = _CommandBuilder()
     command_builder.add_params("--build-arg", buildargs)
+    command_builder.add_list("--cache-from", cache_from)
     command_builder.add_arg("--file", dockerfile)
     command_builder.add_flag("--force-rm", forcerm)
     command_builder.add_arg("--memory", container_limits.get("memory"))
     command_builder.add_flag("--no-cache", nocache)
     command_builder.add_flag("--pull", pull)
+    command_builder.add_arg("--tag", tag)
+    command_builder.add_arg("--target", target)
     command_builder.add_arg("--iidfile", iidfile)
     args = command_builder.build([path])
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -1810,6 +1810,10 @@ class _CLIBuilder(object):
             image_id = line.split(":")[1].strip()
         os.remove(iidfile)
 
+        # In case of `DOCKER_BUILDKIT=1`
+        # there is no success message already present in the output.
+        # Since that's the way `Service::build` gets the `image_id`
+        # it has to be added `manually`
         if not appear:
             yield json.dumps({"stream": "{}{}\n".format(magic_word, image_id)})
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -1052,7 +1052,7 @@ class Service(object):
         return [build_spec(secret) for secret in self.secrets]
 
     def build(self, no_cache=False, pull=False, force_rm=False, memory=None, build_args_override=None,
-              gzip=False, rm=True, silent=False, cli=False):
+              gzip=False, rm=True, silent=False, cli=False, progress=None):
         output_stream = open(os.devnull, 'w')
         if not silent:
             output_stream = sys.stdout
@@ -1073,8 +1073,8 @@ class Service(object):
                 'Impossible to perform platform-targeted builds for API version < 1.35'
             )
 
-        build_image = self.client.build if not cli else cli_build
-        build_output = build_image(
+        builder = self.client if not cli else _CLIBuilder(progress)
+        build_output = builder.build(
             path=path,
             tag=self.image_name,
             rm=rm,
@@ -1707,7 +1707,11 @@ def rewrite_build_path(path):
     return path
 
 
-def cli_build(path, tag=None, quiet=False, fileobj=None,
+class _CLIBuilder(object):
+    def __init__(self, progress):
+        self._progress = progress
+
+    def build(self, path, tag=None, quiet=False, fileobj=None,
               nocache=False, rm=False, timeout=None,
               custom_context=False, encoding=None, pull=False,
               forcerm=False, dockerfile=None, container_limits=None,
@@ -1715,94 +1719,95 @@ def cli_build(path, tag=None, quiet=False, fileobj=None,
               labels=None, cache_from=None, target=None, network_mode=None,
               squash=None, extra_hosts=None, platform=None, isolation=None,
               use_config_proxy=True):
-    """
-    Args:
-        path (str): Path to the directory containing the Dockerfile
-        buildargs (dict): A dictionary of build arguments
-        cache_from (:py:class:`list`): A list of images used for build
-            cache resolution
-        container_limits (dict): A dictionary of limits applied to each
-            container created by the build process. Valid keys:
-            - memory (int): set memory limit for build
-            - memswap (int): Total memory (memory + swap), -1 to disable
-                swap
-            - cpushares (int): CPU shares (relative weight)
-            - cpusetcpus (str): CPUs in which to allow execution, e.g.,
-                ``"0-3"``, ``"0,1"``
-        custom_context (bool): Optional if using ``fileobj``
-        decode (bool): If set to ``True``, the returned stream will be
-            decoded into dicts on the fly. Default ``False``
-        dockerfile (str): path within the build context to the Dockerfile
-        encoding (str): The encoding for a stream. Set to ``gzip`` for
-            compressing
-        extra_hosts (dict): Extra hosts to add to /etc/hosts in building
-            containers, as a mapping of hostname to IP address.
-        fileobj: A file object to use as the Dockerfile. (Or a file-like
-            object)
-        forcerm (bool): Always remove intermediate containers, even after
-            unsuccessful builds
-        isolation (str): Isolation technology used during build.
-            Default: `None`.
-        labels (dict): A dictionary of labels to set on the image
-        network_mode (str): networking mode for the run commands during
-            build
-        nocache (bool): Don't use the cache when set to ``True``
-        platform (str): Platform in the format ``os[/arch[/variant]]``
-        pull (bool): Downloads any updates to the FROM image in Dockerfiles
-        quiet (bool): Whether to return the status
-        rm (bool): Remove intermediate containers. The ``docker build``
-            command now defaults to ``--rm=true``, but we have kept the old
-            default of `False` to preserve backward compatibility
-        shmsize (int): Size of `/dev/shm` in bytes. The size must be
-            greater than 0. If omitted the system uses 64MB
-        squash (bool): Squash the resulting images layers into a
-            single layer.
-        tag (str): A tag to add to the final image
-        target (str): Name of the build-stage to build in a multi-stage
-            Dockerfile
-        timeout (int): HTTP timeout
-        use_config_proxy (bool): If ``True``, and if the docker client
-            configuration file (``~/.docker/config.json`` by default)
-            contains a proxy configuration, the corresponding environment
-            variables will be set in the container being built.
-    Returns:
-        A generator for the build output.
-    """
-    if dockerfile:
-        dockerfile = os.path.join(path, dockerfile)
-    iidfile = tempfile.mktemp()
+        """
+        Args:
+            path (str): Path to the directory containing the Dockerfile
+            buildargs (dict): A dictionary of build arguments
+            cache_from (:py:class:`list`): A list of images used for build
+                cache resolution
+            container_limits (dict): A dictionary of limits applied to each
+                container created by the build process. Valid keys:
+                - memory (int): set memory limit for build
+                - memswap (int): Total memory (memory + swap), -1 to disable
+                    swap
+                - cpushares (int): CPU shares (relative weight)
+                - cpusetcpus (str): CPUs in which to allow execution, e.g.,
+                    ``"0-3"``, ``"0,1"``
+            custom_context (bool): Optional if using ``fileobj``
+            decode (bool): If set to ``True``, the returned stream will be
+                decoded into dicts on the fly. Default ``False``
+            dockerfile (str): path within the build context to the Dockerfile
+            encoding (str): The encoding for a stream. Set to ``gzip`` for
+                compressing
+            extra_hosts (dict): Extra hosts to add to /etc/hosts in building
+                containers, as a mapping of hostname to IP address.
+            fileobj: A file object to use as the Dockerfile. (Or a file-like
+                object)
+            forcerm (bool): Always remove intermediate containers, even after
+                unsuccessful builds
+            isolation (str): Isolation technology used during build.
+                Default: `None`.
+            labels (dict): A dictionary of labels to set on the image
+            network_mode (str): networking mode for the run commands during
+                build
+            nocache (bool): Don't use the cache when set to ``True``
+            platform (str): Platform in the format ``os[/arch[/variant]]``
+            pull (bool): Downloads any updates to the FROM image in Dockerfiles
+            quiet (bool): Whether to return the status
+            rm (bool): Remove intermediate containers. The ``docker build``
+                command now defaults to ``--rm=true``, but we have kept the old
+                default of `False` to preserve backward compatibility
+            shmsize (int): Size of `/dev/shm` in bytes. The size must be
+                greater than 0. If omitted the system uses 64MB
+            squash (bool): Squash the resulting images layers into a
+                single layer.
+            tag (str): A tag to add to the final image
+            target (str): Name of the build-stage to build in a multi-stage
+                Dockerfile
+            timeout (int): HTTP timeout
+            use_config_proxy (bool): If ``True``, and if the docker client
+                configuration file (``~/.docker/config.json`` by default)
+                contains a proxy configuration, the corresponding environment
+                variables will be set in the container being built.
+        Returns:
+            A generator for the build output.
+        """
+        if dockerfile:
+            dockerfile = os.path.join(path, dockerfile)
+        iidfile = tempfile.mktemp()
 
-    command_builder = _CommandBuilder()
-    command_builder.add_params("--build-arg", buildargs)
-    command_builder.add_list("--cache-from", cache_from)
-    command_builder.add_arg("--file", dockerfile)
-    command_builder.add_flag("--force-rm", forcerm)
-    command_builder.add_arg("--memory", container_limits.get("memory"))
-    command_builder.add_flag("--no-cache", nocache)
-    command_builder.add_flag("--pull", pull)
-    command_builder.add_arg("--tag", tag)
-    command_builder.add_arg("--target", target)
-    command_builder.add_arg("--iidfile", iidfile)
-    args = command_builder.build([path])
+        command_builder = _CommandBuilder()
+        command_builder.add_params("--build-arg", buildargs)
+        command_builder.add_list("--cache-from", cache_from)
+        command_builder.add_arg("--file", dockerfile)
+        command_builder.add_flag("--force-rm", forcerm)
+        command_builder.add_arg("--memory", container_limits.get("memory"))
+        command_builder.add_flag("--no-cache", nocache)
+        command_builder.add_flag("--progress", self._progress)
+        command_builder.add_flag("--pull", pull)
+        command_builder.add_arg("--tag", tag)
+        command_builder.add_arg("--target", target)
+        command_builder.add_arg("--iidfile", iidfile)
+        args = command_builder.build([path])
 
-    magic_word = "Successfully built "
-    appear = False
-    with subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True) as p:
-        while True:
-            line = p.stdout.readline()
-            if not line:
-                break
-            if line.startswith(magic_word):
-                appear = True
-            yield json.dumps({"stream": line})
+        magic_word = "Successfully built "
+        appear = False
+        with subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True) as p:
+            while True:
+                line = p.stdout.readline()
+                if not line:
+                    break
+                if line.startswith(magic_word):
+                    appear = True
+                yield json.dumps({"stream": line})
 
-    with open(iidfile) as f:
-        line = f.readline()
-        image_id = line.split(":")[1].strip()
-    os.remove(iidfile)
+        with open(iidfile) as f:
+            line = f.readline()
+            image_id = line.split(":")[1].strip()
+        os.remove(iidfile)
 
-    if not appear:
-        yield json.dumps({"stream": "{}{}\n".format(magic_word, image_id)})
+        if not appear:
+            yield json.dumps({"stream": "{}{}\n".format(magic_word, image_id)})
 
 
 class _CommandBuilder(object):

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ if sys.version_info[:2] < (3, 4):
     tests_require.append('mock >= 1.0.1, < 4')
 
 extras_require = {
+    ':python_version < "3.2"': ['subprocess32 >= 3.5.4, < 4'],
     ':python_version < "3.4"': ['enum34 >= 1.0.4, < 2'],
     ':python_version < "3.5"': ['backports.ssl_match_hostname >= 3.5, < 4'],
     ':python_version < "3.3"': ['ipaddress >= 1.0.16, < 2'],

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -978,7 +978,7 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('web',
                                       build={'context': base_dir},
                                       environment={
-                                          'COMPOSE_NATIVE_BUILDER': '1',
+                                          'COMPOSE_DOCKER_CLI_BUILD': '1',
                                           'DOCKER_BUILDKIT': '1',
                                       })
         service.build(cli=True)
@@ -995,7 +995,7 @@ class ServiceTest(DockerClientTestCase):
         web = self.create_service('web',
                                   build={'context': base_dir},
                                   environment={
-                                      'COMPOSE_NATIVE_BUILDER': '1',
+                                      'COMPOSE_DOCKER_CLI_BUILD': '1',
                                       'DOCKER_BUILDKIT': '1',
                                   })
         project = Project('composetest', [web], self.client)


### PR DESCRIPTION
This add support for building with the CLI by setting the env var `COMPOSE_DOCKER_CLI_BUILD=1`.
This feature can be used both by `docker-compose build` and `docker-compose up --build`.

Note that this feature is EXPERIMENTAL, therefore a warning message is printed on every execution

Signed-off-by: Nao YONASHIRO <yonashiro@r.recruit.co.jp>
Signed-off-by: Ulysses Souza <ulysses.souza@docker.com>

This PR is a squashed and resumed version of https://github.com/docker/compose/pull/6584

As a followup we need to check following points in other PRs
- [x] Add `--progress` flag in `docker-compose build` to control the format of the output
- [x] Add a warning if someone has this feature enabled, and uses the --compress or --parallel flag
- [x] Add integration tests for `build` and `up --build`