### PR TITLE
[TAR-995] ADDED a stage for executing License Scans

### DIFF
--- a/script/Jenkinsfile.fossa
+++ b/script/Jenkinsfile.fossa
@@ -1,0 +1,20 @@
+pipeline {
+    agent any
+    stages {
+        stage("License Scan") {
+            agent {
+                label 'ubuntu-1604-aufs-edge'
+            }
+
+            steps {
+                withCredentials([
+                    string(credentialsId: 'fossa-api-key', variable: 'FOSSA_API_KEY')
+                ]) {
+                    checkout scm
+                    sh "FOSSA_API_KEY='${FOSSA_API_KEY}' BRANCH_NAME='${env.BRANCH_NAME}' make -f script/fossa.mk fossa-analyze"
+                    sh "FOSSA_API_KEY='${FOSSA_API_KEY}' make -f script/fossa.mk fossa-test"
+                }
+            }
+        }
+    }
+}

--- a/script/fossa.mk
+++ b/script/fossa.mk
@@ -1,0 +1,16 @@
+# Variables for Fossa
+BUILD_ANALYZER?=docker/fossa-analyzer
+FOSSA_OPTS?=--option all-tags:true --option allow-unresolved:true
+
+fossa-analyze:
+	docker run --rm -e FOSSA_API_KEY=$(FOSSA_API_KEY) \
+		-v $(CURDIR)/$*:/go/src/github.com/docker/compose \
+		-w /go/src/github.com/docker/compose \
+		$(BUILD_ANALYZER) analyze ${FOSSA_OPTS} --branch ${BRANCH_NAME}
+
+ # This command is used to run the fossa test command
+fossa-test:
+	docker run -i -e FOSSA_API_KEY=$(FOSSA_API_KEY) \
+		-v $(CURDIR)/$*:/go/src/github.com/docker/compose \
+		-w /go/src/github.com/docker/compose \
+		$(BUILD_ANALYZER) test


### PR DESCRIPTION
Signed-off-by: Zuhayr Elahi <elahi.zuhayr@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->

We are in the process of integrating our license scans to occur pre-commit.  In this PR, we are adding a Jenkinsfile and a Makefile which includes `fossa` commands.  This is to execute a license scan on every commit to check for license violations

The job was created here: 
https://ci.docker.com/teams-dsg/blue/organizations/jenkins/fossa-compose/detail/fossa-compose/2/pipeline

The job ran and a report was uploaded here: https://app.fossa.io/projects/custom+11%2Fgit@github.com:docker%2Fcompose/refs/branch/null/0d061d84d5babeb3403cf4c23fe3c0f79c05002f

Currently it won't run on the same pipeline as the Jenkins that is public facing but we could move it there if the compose team would like us to do so. 

The fossa scans could be flaky due to issues on their end which we are unable to fix, as a result separating them is a nice way for us to handle this as the scans won't block people if they fail