### PR TITLE
Add --target option to build command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -275,6 +275,7 @@ class TopLevelCommand(object):
                                     To enable, run with COMPOSE_DOCKER_CLI_BUILD=1)
             --pull                  Always attempt to pull a newer version of the image.
             -q, --quiet             Don't print anything to STDOUT
+            --target string         Set the target build stage to build
         """
         service_names = options['SERVICE']
         build_args = options.get('--build-arg', None)
@@ -301,6 +302,7 @@ class TopLevelCommand(object):
             silent=options.get('--quiet', False),
             cli=native_builder,
             progress=options.get('--progress'),
+            target=options.get('--target'),
         )
 
     def bundle(self, options):

--- a/compose/project.py
+++ b/compose/project.py
@@ -356,7 +356,7 @@ class Project(object):
 
     def build(self, service_names=None, no_cache=False, pull=False, force_rm=False, memory=None,
               build_args=None, gzip=False, parallel_build=False, rm=True, silent=False, cli=False,
-              progress=None):
+              progress=None, target=None):
 
         services = []
         for service in self.get_services(service_names):
@@ -375,7 +375,8 @@ class Project(object):
                             "COMPOSE_DOCKER_CLI_BUILD=1")
 
         def build_service(service):
-            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent, cli, progress)
+            service.build(no_cache, pull, force_rm, memory, build_args, gzip, rm, silent,
+                          cli, progress, target)
         if parallel_build:
             _, errors = parallel.parallel_execute(
                 services,

--- a/compose/service.py
+++ b/compose/service.py
@@ -1056,7 +1056,7 @@ class Service(object):
         return [build_spec(secret) for secret in self.secrets]
 
     def build(self, no_cache=False, pull=False, force_rm=False, memory=None, build_args_override=None,
-              gzip=False, rm=True, silent=False, cli=False, progress=None):
+              gzip=False, rm=True, silent=False, cli=False, progress=None, target=None):
         output_stream = open(os.devnull, 'w')
         if not silent:
             output_stream = sys.stdout
@@ -1090,7 +1090,7 @@ class Service(object):
             labels=build_opts.get('labels', None),
             buildargs=build_args,
             network_mode=build_opts.get('network', None),
-            target=build_opts.get('target', None),
+            target=target or build_opts.get('target', None),
             shmsize=parse_bytes(build_opts.get('shm_size')) if build_opts.get('shm_size') else None,
             extra_hosts=build_opts.get('extra_hosts', None),
             container_limits={

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -892,6 +892,14 @@ class CLITestCase(DockerClientTestCase):
         assert 'Successfully tagged build-multiple-composefile_b:latest' in result.stdout
         assert 'Successfully built' in result.stdout
 
+    def test_build_target(self):
+        self.base_dir = 'tests/fixtures/build-target'
+        result = self.dispatch(['build', '--target', 'testpoint'])
+        assert 'Successfully tagged build-target_simple:latest' in result.stdout
+        assert 'Successfully tagged build-target_multi:latest' in result.stdout
+        assert 'Successfully built' in result.stdout
+        assert "as too_far" not in result.stdout
+
     def test_create(self):
         self.dispatch(['create'])
         service = self.project.get_service('simple')

--- a/tests/fixtures/build-target/docker-compose.yml
+++ b/tests/fixtures/build-target/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.3"
+services:
+  simple:
+    build: simple
+  multi:
+    build: multi

--- a/tests/fixtures/build-target/multi/Dockerfile
+++ b/tests/fixtures/build-target/multi/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox:1.27.2
+RUN true
+
+FROM busybox:1.27.2 as testpoint
+LABEL com.docker.compose.test_image=true
+
+FROM busybox:1.27.2 as too_far
+RUN true
+CMD echo "success"

--- a/tests/fixtures/build-target/simple/Dockerfile
+++ b/tests/fixtures/build-target/simple/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox:1.27.2 as testpoint
+LABEL com.docker.compose.test_image=true
+CMD echo "success"


### PR DESCRIPTION
Allow a target to be passed to the build command for multi-stage builds.

Fixes: #6886

Signed-off-by: Samuel Searles-Bryant <samuel.searles-bryant@unipart.io>

Resolves #6886
