### PR TITLE
Do not error out on lines containg spaces

### DIFF
--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -19,17 +19,11 @@ log = logging.getLogger(__name__)
 def split_env(env):
     if isinstance(env, six.binary_type):
         env = env.decode('utf-8', 'replace')
-    key = value = None
+
     if '=' in env:
         key, value = env.split('=', 1)
     else:
-        key = env
-    if re.search(r'\s', key):
-        raise ConfigurationError(
-            "environment variable name '{}' may not contain whitespace.".format(key)
-        )
-    return key, value
-
+        return env, None
 
 def env_vars_from_file(filename):
     """

--- a/tests/unit/config/environment_test.py
+++ b/tests/unit/config/environment_test.py
@@ -53,12 +53,3 @@ class EnvironmentTest(unittest.TestCase):
         assert env_vars_from_file(str(tmpdir.join('bom.env'))) == {
             'PARK_BOM': '박봄'
         }
-
-    def test_env_vars_from_file_whitespace(self):
-        tmpdir = pytest.ensuretemp('env_file')
-        self.addCleanup(tmpdir.remove)
-        with codecs.open('{}/whitespace.env'.format(str(tmpdir)), 'w', encoding='utf-8') as f:
-            f.write('WHITESPACE =yes\n')
-        with pytest.raises(ConfigurationError) as exc:
-            env_vars_from_file(str(tmpdir.join('whitespace.env')))
-        assert 'environment variable' in exc.exconly()


### PR DESCRIPTION
This is a breaking change, instead of breaking workflows for [existing users](https://github.com/docker/compose/pull/6850#issuecomment-529877214). I believe that at this point the spec needs to be adjusted to explicitly tell users that lines not conforming to the `VAR=VAL` syntax will be *ignored*.

Should this behaviour turn out to be a huge problem then it can be changed again but with a deprecation notice and a spec change.

There is a feature request for a switch that would prevent docker-compose from reading `.env` but it only solves the problem of `I don't want docker-compose to use my .env file at all` (https://github.com/docker/compose/issues/6741). It's implemented in https://github.com/docker/compose/pull/6850.

This merge request should be merged with https://github.com/docker/docker.github.io/pull/9467 so that the spec reflects the actual behaviour.

Resolves #6511, #6838