### PR TITLE
Include errors when raising ProjectError exception

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -840,6 +840,6 @@ class ProjectError(Exception):
 
     def __str__(self):
         if self.value:
-            return self.msg + "\n" + "\n".join(self.value)
+            return "\n".join([self.msg] + self.value)
         else:
             return self.msg

--- a/compose/project.py
+++ b/compose/project.py
@@ -570,7 +570,8 @@ class Project(object):
         )
         if errors:
             raise ProjectError(
-                'Encountered errors while bringing up the project.'
+                'Encountered errors while bringing up the project.',
+                errors=errors
             )
 
         return [
@@ -833,5 +834,12 @@ class NoSuchService(Exception):
 
 
 class ProjectError(Exception):
-    def __init__(self, msg):
+    def __init__(self, msg, errors=None):
         self.msg = msg
+        self.value = errors
+
+    def __str__(self):
+        if self.value:
+            return self.msg + "\n" + "\n".join(self.value)
+        else:
+            return self.msg


### PR DESCRIPTION
Avoids censoring of errors that cause the project failure by including
them with the raised exception.

Resolves #6899
