### PR TITLE
Show uptime docker compose

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -742,6 +742,7 @@ class TopLevelCommand(object):
                 'Command',
                 'State',
                 'Ports',
+                'Started At',
             ]
             rows = []
             for container in containers:
@@ -753,6 +754,7 @@ class TopLevelCommand(object):
                     command,
                     container.human_readable_state,
                     container.human_readable_ports,
+                    container.human_readable_start_time,
                 ])
             print(Formatter().table(headers, rows))
 
@@ -883,10 +885,12 @@ class TopLevelCommand(object):
             )
 
         if options['COMMAND'] is not None:
+            print("ASDF - options['COMMAND']: ", options['COMMAND'])
             command = [options['COMMAND']] + options['ARGS']
         elif options['--entrypoint'] is not None:
             command = []
         else:
+            print("ASDF - getting command from service")
             command = service.options.get('command')
 
         options['stdin_open'] = service.options.get('stdin_open', True)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -742,7 +742,7 @@ class TopLevelCommand(object):
                 'Command',
                 'State',
                 'Ports',
-                'Started At',
+                'Uptime',
             ]
             rows = []
             for container in containers:
@@ -754,7 +754,7 @@ class TopLevelCommand(object):
                     command,
                     container.human_readable_state,
                     container.human_readable_ports,
-                    container.human_readable_start_time,
+                    container.human_readable_uptime,
                 ])
             print(Formatter().table(headers, rows))
 
@@ -885,12 +885,10 @@ class TopLevelCommand(object):
             )
 
         if options['COMMAND'] is not None:
-            print("ASDF - options['COMMAND']: ", options['COMMAND'])
             command = [options['COMMAND']] + options['ARGS']
         elif options['--entrypoint'] is not None:
             command = []
         else:
-            print("ASDF - getting command from service")
             command = service.options.get('command')
 
         options['stdin_open'] = service.options.get('stdin_open', True)

--- a/compose/container.py
+++ b/compose/container.py
@@ -5,6 +5,8 @@ from functools import reduce
 
 import six
 from docker.errors import ImageNotFound
+from datetime import date
+from datetime import datetime
 
 from .const import LABEL_CONTAINER_NUMBER
 from .const import LABEL_ONE_OFF
@@ -205,6 +207,17 @@ class Container(object):
             status_string += ' (health: starting)'
         elif container_status is not None:
             status_string += ' (%s)' % container_status
+        return status_string
+    
+    @property
+    def human_readable_start_time(self):
+        """ Generate a start time string
+        """
+        status_string = 'Not yet Started'
+        date_string = self.get('State.StartedAt').split(".")[0].replace('Z', '')
+        container_status = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S')
+        if container_status is not None:
+            status_string = container_status
         return status_string
 
     def attach_log_stream(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ paramiko==2.4.2
 pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
 pypiwin32==223; sys_platform == 'win32' and python_version >= '3.6'
 PySocks==1.6.7
+python-dateutil==2.8.0
+pytz==2019.1
 PyYAML==4.2b1
 requests==2.22.0
 six==1.12.0

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -208,6 +208,27 @@ class ContainerTest(unittest.TestCase):
         expected = "Up (healthy)"
         assert container.human_readable_state == expected
 
+    def test_human_readable_created_uptime(self):
+        container = Container(None, {
+            "State": {
+                "Status": "created",
+                "Running": True,
+                "Paused": False,
+                "Restarting": False,
+                "OOMKilled": False,
+                "Dead": False,
+                "Pid": 7623,
+                "ExitCode": 0,
+                "Error": "",
+                "StartedAt": "2018-01-29T00:34:25.2052414Z",
+                "FinishedAt": "2018-01-30T00:35:10.2052414Z"
+            },
+        }, has_been_inspected=True)
+
+        expected = "1 Days 0 Hours 0 Minutes 45 Seconds"
+        assert container.human_readable_uptime is not None
+        assert container.human_readable_uptime == expected
+
     def test_get(self):
         container = Container(None, {
             "Status": "Up 8 seconds",


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6867 

**Problem Statement:**
In this PR, we are reporting the output when the user executes `docker-compose ps` after launching containers via `docker-compose up`

**Expected Output**
<img width="896" alt="Screen Shot 2019-09-20 at 2 45 21 PM" src="https://user-images.githubusercontent.com/5545603/65360579-526dc580-dbb5-11e9-85da-a285ca5aca82.png">

**Implementation Details**
I currently used the `dateutils` library and retrieved the uptimes from the container properties.  After doing so, parsed them and displayed it in a human readable format.  I added one unit test, but had trouble writing an unit test with the code path using `datetime.now()`.  I didn't see any mocks, but I am open to suggestions and/or okay with reimplementing this without using `pyzar` and/or `dateutils`