### PR TITLE
Add dependencies for ARM build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,18 @@ RUN apk add --no-cache \
 ENV BUILD_BOOTLOADER=1
 
 FROM python:${PYTHON_VERSION}-${BUILD_DEBIAN_VERSION} AS build-debian
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     curl \
     gcc \
     git \
     libc-dev \
+    libffi-dev \
     libgcc-6-dev \
+    libssl-dev \
     make \
     openssl \
-    python2.7-dev
+    python2.7-dev \
+    zlib1g-dev
 
 FROM build-${BUILD_PLATFORM} AS build
 COPY docker-compose-entrypoint.sh /usr/local/bin/

--- a/script/build/linux
+++ b/script/build/linux
@@ -12,6 +12,7 @@ docker build -t "${TAG}" . \
        --build-arg GIT_COMMIT="${DOCKER_COMPOSE_GITSHA}"
 TMP_CONTAINER=$(docker create "${TAG}")
 mkdir -p dist
-docker cp "${TMP_CONTAINER}":/usr/local/bin/docker-compose dist/docker-compose-Linux-x86_64
+ARCH=$(uname -m)
+docker cp "${TMP_CONTAINER}":/usr/local/bin/docker-compose "dist/docker-compose-Linux-${ARCH}"
 docker container rm -f "${TMP_CONTAINER}"
 docker image rm -f "${TAG}"


### PR DESCRIPTION
This PR adds missing dependencies if someone tries to build docker-compose on an ARM device like the Raspberry Pi. It seems these dependencies are implicit installed while building on amd64, but need to be installed on arm.

Prerequisites
- a Raspberry Pi
- have Git and Docker installed

How to verify
1. Login to your Raspberry Pi
2. `git clone https://github.com/docker/compose`
3. `cd compose`
4. `scripts/build/linux`
5. `dist/docker-compose-Linux-armv7l --version`

Helps #6831
