### PR TITLE
Error when Docker not found should be "Docker Desktop"

### DIFF
--- a/compose/cli/errors.py
+++ b/compose/cli/errors.py
@@ -68,7 +68,7 @@ def handle_connection_errors(client):
 
 def log_windows_pipe_error(exc):
     if exc.winerror == 2:
-        log.error("Couldn't connect to Docker daemon. You might need to start Docker for Windows.")
+        log.error("Couldn't connect to Docker daemon. You might need to start Docker Desktop.")
     elif exc.winerror == 232:  # https://github.com/docker/compose/issues/5005
         log.error(
             "The current Compose file version is not compatible with your engine version. "


### PR DESCRIPTION
Fixes a minor issue with an error message. "Docker for Windows" is now called "Docker Desktop".