### PR TITLE
Add env vars alternative substitution interpolation

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -100,7 +100,7 @@ class TemplateWithDefaults(Template):
         """ % {
         'delim': re.escape('$'),
         'id': r'[_a-z][_a-z0-9]*',
-        'bid': r'[_a-z][_a-z0-9]*(?:(?P<sep>:?[-?])[^}]*)?',
+        'bid': r'[_a-z][_a-z0-9]*(?:(?P<sep>:?[-?+])[^}]*)?',
     }
 
     @staticmethod
@@ -111,6 +111,13 @@ class TemplateWithDefaults(Template):
         elif '-' == sep:
             var, _, default = braced.partition('-')
             return mapping.get(var, default)
+
+        elif ':+' == sep:
+            var, _, alt = braced.partition(':+')
+            return alt if mapping.get(var) else ""
+        elif '+' == sep:
+            var, _, alt = braced.partition('+')
+            return alt if var in mapping else ""
 
         elif ':?' == sep:
             var, _, err = braced.partition(':?')

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -404,6 +404,16 @@ def test_interpolate_with_empty_and_default_value(defaults_interpolator):
     assert defaults_interpolator("ok ${BAR-def}") == "ok "
 
 
+def test_interpolate_missing_with_alternative(defaults_interpolator):
+    assert defaults_interpolator("ok ${missing:+alt}") == "ok "
+    assert defaults_interpolator("ok ${missing+alt}") == "ok "
+
+
+def test_interpolate_with_empty_and_alternative_value(defaults_interpolator):
+    assert defaults_interpolator("ok ${BAR:+alt}") == "ok "
+    assert defaults_interpolator("ok ${BAR+alt}") == "ok alt"
+
+
 def test_interpolate_mandatory_values(defaults_interpolator):
     assert defaults_interpolator("ok ${FOO:?bar}") == "ok first"
     assert defaults_interpolator("ok ${FOO?bar}") == "ok first"


### PR DESCRIPTION
... | VAR is set and not null | VAR is set and null | VAR is unset
--- | ---------------------------- | ------------------------ | ----------------
`${VAR:+word}` | substitute word | substitute null | substitute null
`${VAR+word}` | substitute word | substitute word | substitute null

Maybe it not so much use cases for this but may be useful.

Consider nginx image with following config with ato redirect http to https if connect on 80 port
```nginx
    listen 80;
    listen 443 ssl http2;
    listen 8000;
...
    if ($server_port = 80) {
         return 301 https://$host$request_uri;
    }
```
On some containers you do not need that redirect, but don't want to use something like `HTTP_CONTAINER_PORT=8000` but `NO_HTTPS_REDIRECT=1`
Then you can use following port mapping
```yaml
ports:
  - 80:80${NO_HTTPS_REDIRECT+00}
```