### PR TITLE
Added support for quoted env vars

### DIFF
--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -22,6 +22,12 @@ def split_env(env):
     key = value = None
     if '=' in env:
         key, value = env.split('=', 1)
+        # If the value is quoted, remove the quotes
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ['"', "'"]:
+            value = value[1:-1]
+            # unescape quoted values
+            quote = value[0]
+            value.replace("\\"+quote, quote)
     else:
         key = env
     if re.search(r'\s', key):

--- a/tests/unit/config/environment_test.py
+++ b/tests/unit/config/environment_test.py
@@ -62,3 +62,14 @@ class EnvironmentTest(unittest.TestCase):
         with pytest.raises(ConfigurationError) as exc:
             env_vars_from_file(str(tmpdir.join('whitespace.env')))
         assert 'environment variable' in exc.exconly()
+
+    def test_env_vars_from_file_quoted(self):
+        tmpdir = pytest.ensuretemp('env_file')
+        self.addCleanup(tmpdir.remove)
+        with codecs.open('{}/quoted.env'.format(str(tmpdir)), 'w', encoding='utf-8') as f:
+            f.write('DOUBLE_QUOTES="testing \"double\" quotes"\n')
+            f.write("SINGLE_QUOTES='testing \'single\' quotes'\n")
+        assert env_vars_from_file(str(tmpdir.join('quoted.env'))) == {
+            'DOUBLE_QUOTES': 'testing "double" quotes',
+            'SINGLE_QUOTES': "testing 'single' quotes",
+        }


### PR DESCRIPTION
Signed-off-by: Steve Kamerman <stevekamerman@gmail.com>

Resolves #2854

This PR adds support for environment variables in `.env` files with quoted values.  The quotes can be single `'` or double `"`, but must be the same on both ends of the value, and must immediately follow the `=`.

Example:
```
MYVAR="this is a test"
```

It also unescapes escaped quotes, like `\"`:
```
MYVAR="this is a \"quoted\" test"
```
Value: `this is a "quoted" test`

All functionality is tested.

This problem has been thoroughly discussed in issue #2854 and there are many reasons for why docker-compose should support this.