### PR TITLE
Removes external/host opts from ports merge_field

### DIFF
--- a/compose/config/types.py
+++ b/compose/config/types.py
@@ -423,7 +423,7 @@ class ServicePort(namedtuple('_ServicePort', 'target published protocol mode ext
 
     @property
     def merge_field(self):
-        return (self.target, self.published, self.external_ip, self.protocol)
+        return (self.protocol, self.target)
 
     def repr(self):
         return dict(

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3922,7 +3922,7 @@ class MergePortsTest(unittest.TestCase, MergeListsTest):
     override_config = ['20:8000']
 
     def merged_config(self):
-        return self.convert(self.base_config) | self.convert(self.override_config)
+        return self.convert(['20:8000', '9000'])
 
     def convert(self, port_config):
         return set(config.merge_service_dicts(


### PR DESCRIPTION
This is a proposed fix for https://github.com/docker/compose/issues/2260 which has remained an issue for many users even though it was closed almost immediately after being opened because a partial work-around exists.

My intent for this change is to allow the author of a docker-compose.yml file to specify a default port mapping that can have the external/host-side mappings be overridden.

E.g., the author of a particular file may specify that the container/guest port `tcp/8000` be mapped to the same external/host port: `tcp/8000`. This works well for most users except some users may already have port 8000 in use on their workstations. In those cases, the user should be able to specify something like `ports: ['8001:8000/tcp']` in docker-compose.override.yml to replace the predefined default on their system and avoid a 'port is already allocated' binding error.

From what I can tell, the existing merge_field only allows the port's `mode` attribute to be overridden. This change allows the `published` and `external_ip` attributes to also be overridden. Since the container/guest's `protocol` and `target` are the two attributes that are given/fixed/predefined/immutable based on the image being loaded, they seem like a more natural merge key. After this change, if overriders want only the `mode` attribute to change, they can simply reiterate/restate the `published` port and `external_ip` defined in the base file.

This change is technically backwards-breaking. Although I don't expect it will negatively impact the vast majority of users, a more comprehensive change could be to add another property to the `ports` specification/schema in compose files called e.g., `merge_strategy`. Then ServicePort.merge_field could be redefined as follows:

```
if self.merge_strategy == 'internal_only':
    return (self.protocol, self.target)
elif self.merge_strategy == 'include_published_and_external_ip':
    return (self.target, self.published, self.external_ip, self.protocol)
else:
    return (self.target, self.published, self.external_ip, self.protocol)
```
 
Assuming that's the route we take, I'd add a deprecation warning to the release notes saying that the `include_published_and_external_ip` will stop being the default and that future versions will default to `merge_strategy == 'internal_only'`.

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #2260
