### PR TITLE
Add checksum feature

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -17,6 +17,7 @@ from ..project import Project
 from .docker_client import docker_client
 from .docker_client import get_tls_version
 from .docker_client import tls_config_from_options
+from .docker_client import get_checksums_path
 from .utils import get_version_info
 
 log = logging.getLogger(__name__)
@@ -54,6 +55,7 @@ def project_from_options(project_dir, options, additional_options={}):
         verbose=options.get('--verbose'),
         host=host,
         tls_config=tls_config_from_options(options, environment),
+        checksums_path=get_checksums_path(),
         environment=environment,
         override_dir=override_dir,
         compatibility=options.get('--compatibility'),
@@ -125,7 +127,7 @@ def get_client(environment, verbose=False, version=None, tls_config=None, host=N
 
 def get_project(project_dir, config_path=None, project_name=None, verbose=False,
                 host=None, tls_config=None, environment=None, override_dir=None,
-                compatibility=False, interpolate=True):
+                compatibility=False, interpolate=True, checksums_path=None):
     if not environment:
         environment = Environment.from_env_file(project_dir)
     config_details = config.find(project_dir, config_path, environment, override_dir)
@@ -145,7 +147,8 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
 
     with errors.handle_connection_errors(client):
         return Project.from_config(
-            project_name, config_data, client, environment.get('DOCKER_DEFAULT_PLATFORM')
+            project_name, config_data, client, environment.get('DOCKER_DEFAULT_PLATFORM'),
+            checksums_path=checksums_path
         )
 
 

--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -23,6 +23,8 @@ log = logging.getLogger(__name__)
 def default_cert_path():
     return os.path.join(home_dir(), '.docker')
 
+def get_checksums_path():
+    return os.path.join(home_dir(), '.docker', 'checksums.json')
 
 def get_tls_version(environment):
     compose_tls_version = environment.get('COMPOSE_TLS_VERSION', None)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -236,6 +236,7 @@ class TopLevelCommand(object):
       top                Display the running processes
       unpause            Unpause services
       up                 Create and start containers
+      checksum           Calculate checksum for image
       version            Show the Docker-Compose version information
     """
 
@@ -1158,6 +1159,23 @@ class TopLevelCommand(object):
             print(__version__)
         else:
             print(get_version_info('full'))
+
+    def checksum(self, options):
+        """
+        Calculate service image checksum.
+
+        Usage: checksum SERVICE
+        """
+        # 1. get image or service, probably service as it is where checksum declared
+        # 2. call calculate checksum
+        service = self.project.get_service(options['SERVICE'])
+        
+        exit_if(not service, 'No such service', 1)
+
+        if not service.is_checksum_enabled():
+            print('Checksum is not declared fot this service')
+        else:
+            print(service.calculate_checksum())      
 
 
 def compute_service_exit_code(exit_value_from, attached_containers):

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -781,6 +781,11 @@ def process_build_section(service_dict, working_dir):
             service_dict['build']['context'] = resolve_build_path(working_dir, path)
         if 'labels' in service_dict['build']:
             service_dict['build']['labels'] = parse_labels(service_dict['build']['labels'])
+        if 'checksum' in service_dict['build']:
+            service_dict['build']['checksum'] = [
+                resolve_build_path(working_dir, dependency) for dependency 
+                in service_dict['build']['checksum']
+            ]
 
 
 def process_ports(service_dict):

--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -88,7 +88,8 @@
                 "cache_from": {"$ref": "#/definitions/list_of_strings"},
                 "network": {"type": "string"},
                 "target": {"type": "string"},
-                "shm_size": {"type": ["integer", "string"]}
+                "shm_size": {"type": ["integer", "string"]},
+                "checksum": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
               },
               "additionalProperties": false
             }

--- a/compose/project.py
+++ b/compose/project.py
@@ -83,7 +83,7 @@ class Project(object):
         return labels
 
     @classmethod
-    def from_config(cls, name, config_data, client, default_platform=None):
+    def from_config(cls, name, config_data, client, default_platform=None, checksums_path=None):
         """
         Construct a Project from a config.Config object.
         """
@@ -136,6 +136,7 @@ class Project(object):
                     pid_mode=pid_mode,
                     platform=service_dict.pop('platform', None),
                     default_platform=default_platform,
+                    checksums_path=checksums_path,
                     **service_dict)
             )
 


### PR DESCRIPTION
This PR is intended to add a feature called `checksum` (may be changed).

It is a WIP (test will be written after we make sure the implementation is correct)

This is how it works.

1. add to `checksum` list of files

```
webapp:
    image: webapp-dev
    build:
      dockerfile: ./docker/Dockerfile.webapp-dev
      checksum:
      - ./package.json
      - ./package-lock.json
      - ./docker/Dockerfile.webapp-dev
      context: .
    working_dir: /work
```

2. If any of those files changed, rebuild the image

For now, I create file in `~/.docker/checksums.json`. This place is chosen because I did not found any better place. If you know where is the better place - I will be glad to hear.

I am calculating the checksum for image and write it to `checksums.json`. Then I recalculate checksum on every run, and if something changed, update checksum and rebuild the image.

UPD. also i've added new command called `checksum` which calculates and prints same checksum as it will be used to make the decision to rebuild an image

usage: 
`docker-compose checksum my_service` 
