### PR TITLE
Log warning for docker-compose port binding not avaliable

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -624,9 +624,7 @@ class Service(object):
             container.start()
         except APIError as ex:
             if "driver failed programming external connectivity" in ex.explanation:
-                log.warn(
-                    "Port is already in use, check the docker-compose file to see if the same" +
-                    " port was allocated to multiple services")
+                log.warn("Host is already in use by another container")
             raise OperationFailedError("Cannot start service %s: %s" % (self.name, ex.explanation))
         return container
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -623,6 +623,10 @@ class Service(object):
         try:
             container.start()
         except APIError as ex:
+            if "driver failed programming external connectivity" in ex.explanation:
+                log.warn(
+                    "Port is already in use, check the docker-compose file to see if the same" +
+                    " port was allocated to multiple services")
             raise OperationFailedError("Cannot start service %s: %s" % (self.name, ex.explanation))
         return container
 


### PR DESCRIPTION
Signed-off-by: Zuhayr Elahi <elahi.zuhayr@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6708 

I added a warning at the bottom to let users know to check the compose file if this error occurs.  It seems to only happen when the user runs `docker-compose up` but I believe this could be potentially how we solve this issue above
