### PR TITLE
Add "--attach-dependencies" to command "up" for attaching to dependencies

### DIFF
--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -545,7 +545,7 @@ _docker_compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --build -d --detach --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --attach-dependencies --build -d --detach --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_complete_services

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -284,7 +284,7 @@ __docker-compose_subcommand() {
         (up)
             _arguments \
                 $opts_help \
-                '(--abort-on-container-exit)-d[Detached mode: Run containers in the background, print new container names. Incompatible with --abort-on-container-exit.]' \
+                '(--abort-on-container-exit)-d[Detached mode: Run containers in the background, print new container names. Incompatible with --abort-on-container-exit and --attach-dependencies.]' \
                 $opts_no_color \
                 $opts_no_deps \
                 $opts_force_recreate \
@@ -292,6 +292,7 @@ __docker-compose_subcommand() {
                 $opts_no_build \
                 "(--no-build)--build[Build images before starting containers.]" \
                 "(-d)--abort-on-container-exit[Stops all containers if any container was stopped. Incompatible with -d.]" \
+                "(-d)--attach-dependencies[Attach to dependent containers. Incompatible with -d.]" \
                 '(-t --timeout)'{-t,--timeout}"[Use this timeout in seconds for container shutdown when attached or when containers are already running. (default: 10)]:seconds: " \
                 '--scale[SERVICE=NUM Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.]:service scale SERVICE=NUM: ' \
                 '--exit-code-from=[Return the exit code of the selected service container. Implies --abort-on-container-exit]:service:__docker-compose_services' \

--- a/tests/fixtures/abort-on-container-exit-dependencies/docker-compose.yml
+++ b/tests/fixtures/abort-on-container-exit-dependencies/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2.0"
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+    depends_on:
+      - another
+  another:
+    image: busybox:1.31.0-uclibc
+    command: ls /thecakeisalie

--- a/tests/fixtures/echo-services-dependencies/docker-compose.yml
+++ b/tests/fixtures/echo-services-dependencies/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2.0"
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: echo simple
+    depends_on:
+      - another
+  another:
+    image: busybox:1.31.0-uclibc
+    command: echo another

--- a/tests/unit/cli/main_test.py
+++ b/tests/unit/cli/main_test.py
@@ -12,7 +12,7 @@ from compose.cli.formatter import ConsoleWarningFormatter
 from compose.cli.main import build_one_off_container_options
 from compose.cli.main import call_docker
 from compose.cli.main import convergence_strategy_from_opts
-from compose.cli.main import filter_containers_to_service_names
+from compose.cli.main import filter_attached_containers
 from compose.cli.main import get_docker_start_call
 from compose.cli.main import setup_console_handler
 from compose.cli.main import warn_for_swarm_mode
@@ -37,7 +37,7 @@ def logging_handler():
 
 class TestCLIMainTestCase(object):
 
-    def test_filter_containers_to_service_names(self):
+    def test_filter_attached_containers(self):
         containers = [
             mock_container('web', 1),
             mock_container('web', 2),
@@ -46,17 +46,29 @@ class TestCLIMainTestCase(object):
             mock_container('another', 1),
         ]
         service_names = ['web', 'db']
-        actual = filter_containers_to_service_names(containers, service_names)
+        actual = filter_attached_containers(containers, service_names)
         assert actual == containers[:3]
 
-    def test_filter_containers_to_service_names_all(self):
+    def test_filter_attached_containers_with_dependencies(self):
+        containers = [
+            mock_container('web', 1),
+            mock_container('web', 2),
+            mock_container('db', 1),
+            mock_container('other', 1),
+            mock_container('another', 1),
+        ]
+        service_names = ['web', 'db']
+        actual = filter_attached_containers(containers, service_names, attach_dependencies=True)
+        assert actual == containers
+
+    def test_filter_attached_containers_all(self):
         containers = [
             mock_container('web', 1),
             mock_container('db', 1),
             mock_container('other', 1),
         ]
         service_names = []
-        actual = filter_containers_to_service_names(containers, service_names)
+        actual = filter_attached_containers(containers, service_names)
         assert actual == containers
 
     def test_warning_in_swarm_mode(self):


### PR DESCRIPTION
When using the 'up' command, only services listed as arguments are
attached to, which can be very different to the 'no argument' case
if a service has many and deep dependencies:

   - It's not clear when dependencies have failed to start. Have to run
'compose ps' separately to find out.
   - It's not clear when dependencies are erroring. Have to run 'compose
logs' separately to find out.

With a simple setup, it's possible to work around theses issue by
using the 'up' command without arguments. But when there are lots of
'top-level' services, with common dependencies, in a single config,
using 'up' without arguments isn't practical due to resource limits
and the sheer volume of output from other services.

This introduces a new '--attach-dependencies' flag to optionally attach
dependent containers as part of the 'up' command. This makes their logs
visible in the output, alongside the listed services. It also means we
benefit from the '--abort-on-container-exit' behaviour when dependencies
fail to start, giving more visibility of the failure.

Resolves https://github.com/docker/compose/issues/4611

Extends https://github.com/docker/compose/pull/2130 to treat `up <service>`, which implicitly includes dependent 
containers, the same way as `up`, which refers to all services/containers.
