### PR TITLE
avoid using Stty, rely on Posix compliant os.get_terminal_size

### DIFF
--- a/compose/cli/formatter.py
+++ b/compose/cli/formatter.py
@@ -2,20 +2,25 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
-import os
+import shutil
 
 import six
 import texttable
 
 from compose.cli import colors
 
+if hasattr(shutil, "get_terminal_size"):
+    from shutil import get_terminal_size
+else:
+    from backports.shutil_get_terminal_size import get_terminal_size
+
 
 def get_tty_width():
-    tty_size = os.popen('stty size 2> /dev/null', 'r').read().split()
-    if len(tty_size) != 2:
+    try:
+        width, _ = get_terminal_size()
+        return int(width)
+    except OSError:
         return 0
-    _, width = tty_size
-    return int(width)
 
 
 class Formatter:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backports.shutil_get_terminal_size==1.0.0
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.3.0
 certifi==2017.4.17

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ extras_require = {
     ':python_version < "3.2"': ['subprocess32 >= 3.5.4, < 4'],
     ':python_version < "3.4"': ['enum34 >= 1.0.4, < 2'],
     ':python_version < "3.5"': ['backports.ssl_match_hostname >= 3.5, < 4'],
-    ':python_version < "3.3"': ['ipaddress >= 1.0.16, < 2'],
+    ':python_version < "3.3"': ['backports.shutil_get_terminal_size == 1.0.0',
+                                'ipaddress >= 1.0.16, < 2'],
     ':sys_platform == "win32"': ['colorama >= 0.4, < 1'],
     'socks': ['PySocks >= 1.5.6, != 1.5.7, < 2'],
 }

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -2816,8 +2816,8 @@ class CLITestCase(DockerClientTestCase):
         result = self.dispatch(['images'])
 
         assert 'busybox' in result.stdout
-        assert 'multiple-composefiles_another_1' in result.stdout
-        assert 'multiple-composefiles_simple_1' in result.stdout
+        assert '_another_1' in result.stdout
+        assert '_simple_1' in result.stdout
 
     @mock.patch.dict(os.environ)
     def test_images_tagless_image(self):
@@ -2865,4 +2865,4 @@ class CLITestCase(DockerClientTestCase):
 
         assert re.search(r'foo1.+test[ \t]+dev', result.stdout) is not None
         assert re.search(r'foo2.+test[ \t]+prod', result.stdout) is not None
-        assert re.search(r'foo3.+_foo3[ \t]+latest', result.stdout) is not None
+        assert re.search(r'foo3.+test[ \t]+latest', result.stdout) is not None

--- a/tests/fixtures/images-service-tag/docker-compose.yml
+++ b/tests/fixtures/images-service-tag/docker-compose.yml
@@ -8,3 +8,4 @@ services:
     image: test:prod
   foo3:
     build: .
+    image: test:latest


### PR DESCRIPTION
Resolves #6843

![image](https://user-images.githubusercontent.com/132757/66664499-f09cfa80-ec4c-11e9-8383-9bc6b50c0c1d.png)
