### PR TITLE
update docker-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
 colorama==0.4.0; sys_platform == 'win32'
-docker==4.0.1
+docker==4.1.0
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves https://github.com/docker/compose/issues/6713

The [4.1.0 release of docker-py](https://github.com/docker/docker-py/releases/tag/4.1.0) includes [a fix](https://github.com/docker/docker-py/pull/2401) for docker-compose failing to pull images from private registries, even if the user is already authenticated. This occurs for docker-for-mac users who are _not_ saving their credentials in clear text.
