### PR TITLE
Format image size as decimal to be align with Docker CLI

### DIFF
--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -133,12 +133,12 @@ def generate_user_agent():
 
 def human_readable_file_size(size):
     suffixes = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', ]
-    order = int(math.log(size, 2) / 10) if size else 0
+    order = int(math.log(size, 1000)) if size else 0
     if order >= len(suffixes):
         order = len(suffixes) - 1
 
     return '{0:.4g} {1}'.format(
-        size / float(1 << (order * 10)),
+        size / pow(10, order * 3),
         suffixes[order]
     )
 

--- a/tests/unit/cli/utils_test.py
+++ b/tests/unit/cli/utils_test.py
@@ -29,16 +29,20 @@ class HumanReadableFileSizeTest(unittest.TestCase):
         assert human_readable_file_size(100) == '100 B'
 
     def test_1kb(self):
-        assert human_readable_file_size(1024) == '1 kB'
+        assert human_readable_file_size(1000) == '1 kB'
+        assert human_readable_file_size(1024) == '1.024 kB'
 
     def test_1023b(self):
-        assert human_readable_file_size(1023) == '1023 B'
+        assert human_readable_file_size(1023) == '1.023 kB'
+
+    def test_999b(self):
+        assert human_readable_file_size(999) == '999 B'
 
     def test_units(self):
-        assert human_readable_file_size((2 ** 10) ** 0) == '1 B'
-        assert human_readable_file_size((2 ** 10) ** 1) == '1 kB'
-        assert human_readable_file_size((2 ** 10) ** 2) == '1 MB'
-        assert human_readable_file_size((2 ** 10) ** 3) == '1 GB'
-        assert human_readable_file_size((2 ** 10) ** 4) == '1 TB'
-        assert human_readable_file_size((2 ** 10) ** 5) == '1 PB'
-        assert human_readable_file_size((2 ** 10) ** 6) == '1 EB'
+        assert human_readable_file_size((10 ** 3) ** 0) == '1 B'
+        assert human_readable_file_size((10 ** 3) ** 1) == '1 kB'
+        assert human_readable_file_size((10 ** 3) ** 2) == '1 MB'
+        assert human_readable_file_size((10 ** 3) ** 3) == '1 GB'
+        assert human_readable_file_size((10 ** 3) ** 4) == '1 TB'
+        assert human_readable_file_size((10 ** 3) ** 5) == '1 PB'
+        assert human_readable_file_size((10 ** 3) ** 6) == '1 EB'


### PR DESCRIPTION
Resolves #6590

Use decimal format instead of binary one to display image size in `docker-compose images` command and be consistant with Docker CLI
