### PR TITLE
Add `device_cgroup_rules` support to 3.7 schema

### DIFF
--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -127,6 +127,7 @@
           "registry": {"type": "string"}
         }},
         "depends_on": {"$ref": "#/definitions/list_of_strings"},
+        "device_cgroup_rules": {"$ref": "#/definitions/list_of_strings"},
         "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
         "dns_search": {"$ref": "#/definitions/string_or_list"},


### PR DESCRIPTION
It was last present in the 2.4 schema. I could not find why it was removed for 3.0, so I am adding it back in.

This option is needed to selectively share devices between host and container. [See here.](https://docs.docker.com/engine/reference/commandline/create/#dealing-with-dynamically-created-devices---device-cgroup-rule)
