### PR TITLE
Fixed non-ascii error when using COMPOSE_DOCKER_CLI_BUILD=1 for Buildkit

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1806,7 +1806,10 @@ class _CLIBuilder(object):
                 line = p.stdout.readline()
                 if not line:
                     break
-                if line.startswith(str(magic_word)):
+                # Fix non ascii chars on Python2. To remove when #6890 is complete.
+                if six.PY2:
+                    magic_word = str(magic_word)
+                if line.startswith(magic_word):
                     appear = True
                 yield json.dumps({"stream": line})
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -1806,7 +1806,7 @@ class _CLIBuilder(object):
                 line = p.stdout.readline()
                 if not line:
                     break
-                if line.startswith(magic_word):
+                if line.startswith(str(magic_word)):
                     appear = True
                 yield json.dumps({"stream": line})
 


### PR DESCRIPTION
When using 
```
DOCKER_BUILDKIT=1 docker-compose build
```
on compose's master, with docker version 18.09.8
I'm getting 
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 24: ordinal not in range(128)
```
which can be traced back to this line: https://github.com/docker/compose/blob/master/compose/service.py#L1809

The problem seems to be that the line read form `stdin` has non-ascii characters and `.startswith` fails when comparing a raw string with the unicode prefix `magic_word`. 

The culprit input line (which is part of the output of `docker build`) is
```
#1     duration: 26.788µs
```
which contains the utf-8 µ character: `\xc2\xb5`. `startswith` errors out as the prefix `magic_word` is a unicode string.

This fixes the problem by encoding magic_word before making the comparison.