### PR TITLE
Bump 1.25.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,89 @@
 Change log
 ==========
 
+1.25.0-rc4 (2019-10-28)
+-------------------
+
+### Features
+
+- Add BuildKit support, use `DOCKER_BUILDKIT=1` and `COMPOSE_NATIVE_BUILDER=1`
+
+- Bump paramiko to 2.6.0
+
+- Add working dir, config files and env file in service labels
+
+- Add tag `docker-compose:latest`
+
+- Add `docker-compose:<version>-alpine` image/tag
+
+- Add `docker-compose:<version>-debian` image/tag
+
+- Bumped `docker-py` 4.1.0
+
+- Supports `requests` up to 2.22.0 version
+
+- Drops empty tag on `build:cache_from`
+
+- `Dockerfile` now generates `libmusl` binaries for alpine
+
+- Only pull images that can't be built
+
+- Attribute `scale` can now accept `0` as a value
+
+- Added `--quiet` build flag
+
+- Added `--no-interpolate` to `docker-compose config`
+
+- Bump OpenSSL for macOS build (`1.1.0j` to `1.1.1c`)
+
+- Added `--no-rm` to `build` command
+
+- Added support for `credential_spec`
+
+- Resolve digests without pulling image
+
+- Upgrade `pyyaml` to `4.2b1`
+
+- Lowered severity to `warning` if `down` tries to remove nonexisting image
+
+- Use improved API fields for project events when possible
+
+- Update `setup.py` for modern `pypi/setuptools` and remove `pandoc` dependencies
+
+- Removed `Dockerfile.armhf` which is no longer needed
+
+### Bugfixes
+
+- Fix same file 'extends' optimization
+
+- Use python POSIX support to get tty size
+
+- Format image size as decimal to be align with Docker CLI
+
+- Fixed stdin_open
+
+- Fixed `--remove-orphans` when used with `up --no-start`
+
+- Fixed `docker-compose ps --all`
+
+- Fixed `depends_on` dependency recreation behavior
+
+- Fixed bash completion for `build --memory`
+
+- Fixed misleading warning concerning env vars when performing an `exec` command
+
+- Fixed failure check in parallel_execute_watch
+
+- Fixed race condition after pulling image
+
+- Fixed error on duplicate mount points.
+
+- Fixed merge on networks section
+
+- Always connect Compose container to `stdin`
+
+- Fixed the presentation of failed services on 'docker-compose start' when containers are not available
+
 1.24.0 (2019-03-28)
 -------------------
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.25.0dev'
+__version__ = '1.25.0-rc4'

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.24.0"
+VERSION="1.25.0-rc4"
 IMAGE="docker/compose:$VERSION"
 
 


### PR DESCRIPTION
Automated release for docker-compose 1.25.0-rc4


### Features

- Added support for connecting to the Docker Engine using the `ssh` protocol.

- Added a `--all` flag to `docker-compose ps` to include stopped one-off containers
  in the command's output.

- Add bash completion for `ps --all|-a`

- Support for credential_spec

- Add `--parallel` to `docker build`'s options in `bash` and `zsh` completion

### Bugfixes

- Fixed a bug where some valid credential helpers weren't properly handled by Compose
  when attempting to pull images from private registries.

- Fixed an issue where the output of `docker-compose start` before containers were created
  was misleading

- To match the Docker CLI behavior and to avoid confusing issues, Compose will no longer
  accept whitespace in variable names sourced from environment files.

- Compose will now report a configuration error if a service attempts to declare
  duplicate mount points in the volumes section.

- Fixed an issue with the containerized version of Compose that prevented users from
  writing to stdin during interactive sessions started by `run` or `exec`.

- One-off containers started by `run` no longer adopt the restart policy of the service,
  and are instead set to never restart.

- Fixed an issue that caused some container events to not appear in the output of
  the `docker-compose events` command.

- Missing images will no longer stop the execution of `docker-compose down` commands
  (a warning will be displayed instead).

- Force `virtualenv` version for macOS CI

- Fix merging of compose files when network has `None` config

- Fix `CTRL+C` issues by enabling `bootloader_ignore_signals` in `pyinstaller`

- Bump `docker-py` version to `3.7.2` to fix SSH and proxy config issues

- Fix release script and some typos on release documentation
