### PR TITLE
Pass in HOME env-var in container mode.

### DIFF
--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -43,7 +43,7 @@ if [ -n "$compose_dir" ]; then
     VOLUMES="$VOLUMES -v $compose_dir:$compose_dir"
 fi
 if [ -n "$HOME" ]; then
-    VOLUMES="$VOLUMES -v $HOME:$HOME -v $HOME:/root" # mount $HOME in /root to share docker.config
+    VOLUMES="$VOLUMES -v $HOME:$HOME -e HOME" # Pass in HOME to share docker.config and allow ~/-relative paths to work.
 fi
 
 # Only allocate tty if we detect one


### PR DESCRIPTION
To get ~/-paths to work as expected in contaier mode, env-var HOME must
be the same outside the container as inside the docker-compose
container, otherwise HOME inside the container points to /root which
might not be what the user expects.