### PR TITLE
Build OSX binary as a directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
          name: build script
          command: ./script/build/osx
       - store_artifacts:
-          path: dist/docker-compose-Darwin-x86_64
-          destination: docker-compose-Darwin-x86_64
+          path: dist/docker-compose-Darwin-x86_64.tgz
+          destination: docker-compose-Darwin-x86_64.tgz
       - deploy:
           name: Deploy binary to bintray
           command: |

--- a/docker-compose_darwin.spec
+++ b/docker-compose_darwin.spec
@@ -1,0 +1,108 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(['bin/docker-compose'],
+             pathex=['.'],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             cipher=block_cipher)
+
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+
+exe = EXE(pyz,
+          a.scripts,
+          exclude_binaries=True,
+          name='docker-compose',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True,
+          bootloader_ignore_signals=True)
+coll = COLLECT(exe,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [
+            (
+                'compose/config/config_schema_v1.json',
+                'compose/config/config_schema_v1.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v2.0.json',
+                'compose/config/config_schema_v2.0.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v2.1.json',
+                'compose/config/config_schema_v2.1.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v2.2.json',
+                'compose/config/config_schema_v2.2.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v2.3.json',
+                'compose/config/config_schema_v2.3.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v2.4.json',
+                'compose/config/config_schema_v2.4.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.0.json',
+                'compose/config/config_schema_v3.0.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.1.json',
+                'compose/config/config_schema_v3.1.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.2.json',
+                'compose/config/config_schema_v3.2.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.3.json',
+                'compose/config/config_schema_v3.3.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.4.json',
+                'compose/config/config_schema_v3.4.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.5.json',
+                'compose/config/config_schema_v3.5.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.6.json',
+                'compose/config/config_schema_v3.6.json',
+                'DATA'
+            ),
+            (
+                'compose/config/config_schema_v3.7.json',
+                'compose/config/config_schema_v3.7.json',
+                'DATA'
+            ),
+            (
+                'compose/GITSHA',
+                'compose/GITSHA',
+                'DATA'
+            )
+          ],
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          name='docker-compose-Darwin-x86_64')

--- a/script/build/osx
+++ b/script/build/osx
@@ -11,6 +11,12 @@ venv/bin/pip install -r requirements-build.txt
 venv/bin/pip install --no-deps .
 DOCKER_COMPOSE_GITSHA="$(script/build/write-git-sha)"
 echo "${DOCKER_COMPOSE_GITSHA}" > compose/GITSHA
+
 venv/bin/pyinstaller docker-compose.spec
 mv dist/docker-compose dist/docker-compose-Darwin-x86_64
 dist/docker-compose-Darwin-x86_64 version
+
+# Also build as a folder, required on osx Catalina
+venv/bin/pyinstaller docker-compose_darwin.spec
+dist/docker-compose-Darwin-x86_64/docker-compose version
+cd dist/docker-compose-Darwin-x86_64/ && tar zcvf ../docker-compose-Darwin-x86_64.tgz .

--- a/script/release/release/downloader.py
+++ b/script/release/release/downloader.py
@@ -55,6 +55,7 @@ class BinaryDownloader(requests.Session):
 
     def download_all(self, version):
         files = {
+            'docker-compose-Darwin-x86_64.tgz': None,
             'docker-compose-Darwin-x86_64': None,
             'docker-compose-Linux-x86_64': None,
             'docker-compose-Windows-x86_64.exe': None,


### PR DESCRIPTION
OSX Catalina do scan executables, and the singlefile distribution has side-effect that the bundled Pythin runtime, unpacked into a temporary folder, is scanned on each and every run.

With directory packaging, `docker-compose` executable will refer to side files in the distribution folder, only scanned once first time it is ran.

attempt to fix #6956