### PR TITLE
Bump 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,110 @@
 Change log
 ==========
 
+1.25.0 (2019-11-18)
+-------------------
+
+### Features
+
+- Set no-colors to true if CLICOLOR env variable is set to 0 
+
+- Add working dir, config files and env file in service labels
+
+- Add dependencies for ARM build
+
+- Add BuildKit support, use `DOCKER_BUILDKIT=1` and `COMPOSE_DOCKER_CLI_BUILD=1`
+
+- Bump paramiko to 2.6.0
+
+- Add working dir, config files and env file in service labels
+
+- Add tag `docker-compose:latest`
+
+- Add `docker-compose:<version>-alpine` image/tag
+
+- Add `docker-compose:<version>-debian` image/tag
+
+- Bumped `docker-py` 4.1.0
+
+- Supports `requests` up to 2.22.0 version
+
+- Drops empty tag on `build:cache_from`
+
+- `Dockerfile` now generates `libmusl` binaries for alpine
+
+- Only pull images that can't be built
+
+- Attribute `scale` can now accept `0` as a value
+
+- Added `--quiet` build flag
+
+- Added `--no-interpolate` to `docker-compose config`
+
+- Bump OpenSSL for macOS build (`1.1.0j` to `1.1.1c`)
+
+- Added `--no-rm` to `build` command
+
+- Added support for `credential_spec`
+
+- Resolve digests without pulling image
+
+- Upgrade `pyyaml` to `4.2b1`
+
+- Lowered severity to `warning` if `down` tries to remove nonexisting image
+
+- Use improved API fields for project events when possible
+
+- Update `setup.py` for modern `pypi/setuptools` and remove `pandoc` dependencies
+
+- Removed `Dockerfile.armhf` which is no longer needed
+
+### Bugfixes
+
+- Make container service color deterministic, remove red from chosen colors
+
+- Fix non ascii chars error. Python2 only
+
+- Format image size as decimal to be align with Docker CLI 
+
+- Use Python Posix support to get tty size 
+
+- Fix same file 'extends' optimization
+
+- Use python POSIX support to get tty size
+
+- Format image size as decimal to be align with Docker CLI
+
+- Fixed stdin_open
+
+- Fixed `--remove-orphans` when used with `up --no-start`
+
+- Fixed `docker-compose ps --all`
+
+- Fixed `depends_on` dependency recreation behavior
+
+- Fixed bash completion for `build --memory`
+
+- Fixed misleading warning concerning env vars when performing an `exec` command
+
+- Fixed failure check in parallel_execute_watch
+
+- Fixed race condition after pulling image
+
+- Fixed error on duplicate mount points.
+
+- Fixed merge on networks section
+
+- Always connect Compose container to `stdin`
+
+- Fixed the presentation of failed services on 'docker-compose start' when containers are not available
+
+1.24.1 (2019-06-24)
+-------------------
+
+### Bugfixes
+
+- Fixed acceptance tests
+
 1.24.0 (2019-03-28)
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,9 @@ Change log
 
 - Fix non ascii chars error. Python2 only
 
-- Format image size as decimal to be align with Docker CLI 
+- Format image size as decimal to be align with Docker CLI
 
-- Use Python Posix support to get tty size 
+- Use Python Posix support to get tty size
 
 - Fix same file 'extends' optimization
 
@@ -90,7 +90,7 @@ Change log
 
 - Fixed race condition after pulling image
 
-- Fixed error on duplicate mount points.
+- Fixed error on duplicate mount points
 
 - Fixed merge on networks section
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Change log
 
 ### Features
 
-- Set no-colors to true if CLICOLOR env variable is set to 0 
+- Set no-colors to true if CLICOLOR env variable is set to 0
 
 - Add working dir, config files and env file in service labels
 

--- a/compose/__init__.py
+++ b/compose/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-__version__ = '1.25.0dev'
+__version__ = '1.25.0'

--- a/compose/cli/formatter.py
+++ b/compose/cli/formatter.py
@@ -2,20 +2,25 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
-import os
+import shutil
 
 import six
 import texttable
 
 from compose.cli import colors
 
+if hasattr(shutil, "get_terminal_size"):
+    from shutil import get_terminal_size
+else:
+    from backports.shutil_get_terminal_size import get_terminal_size
+
 
 def get_tty_width():
-    tty_size = os.popen('stty size 2> /dev/null', 'r').read().split()
-    if len(tty_size) != 2:
+    try:
+        width, _ = get_terminal_size()
+        return int(width)
+    except OSError:
         return 0
-    _, width = tty_size
-    return int(width)
 
 
 class Formatter:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cached-property==1.3.0
 certifi==2017.4.17
 chardet==3.0.4
 colorama==0.4.0; sys_platform == 'win32'
-docker==4.0.1
+docker==4.1.0
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backports.shutil_get_terminal_size==1.0.0
 backports.ssl-match-hostname==3.5.0.1; python_version < '3'
 cached-property==1.3.0
 certifi==2017.4.17

--- a/script/release/release.py
+++ b/script/release/release.py
@@ -204,7 +204,8 @@ def resume(args):
             gh_release = create_release_draft(repository, args.release, pr_data, files)
         delete_assets(gh_release)
         upload_assets(gh_release, files)
-        img_manager = ImageManager(args.release)
+        tag_as_latest = is_tag_latest(args.release)
+        img_manager = ImageManager(args.release, tag_as_latest)
         img_manager.build_images(repository)
     except ScriptError as e:
         print(e)
@@ -244,7 +245,8 @@ def start(args):
         files = downloader.download_all(args.release)
         gh_release = create_release_draft(repository, args.release, pr_data, files)
         upload_assets(gh_release, files)
-        img_manager = ImageManager(args.release)
+        tag_as_latest = is_tag_latest(args.release)
+        img_manager = ImageManager(args.release, tag_as_latest)
         img_manager.build_images(repository)
     except ScriptError as e:
         print(e)

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.24.0"
+VERSION="1.25.0"
 IMAGE="docker/compose:$VERSION"
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ extras_require = {
     ':python_version < "3.2"': ['subprocess32 >= 3.5.4, < 4'],
     ':python_version < "3.4"': ['enum34 >= 1.0.4, < 2'],
     ':python_version < "3.5"': ['backports.ssl_match_hostname >= 3.5, < 4'],
-    ':python_version < "3.3"': ['ipaddress >= 1.0.16, < 2'],
+    ':python_version < "3.3"': ['backports.shutil_get_terminal_size == 1.0.0',
+                                'ipaddress >= 1.0.16, < 2'],
     ':sys_platform == "win32"': ['colorama >= 0.4, < 1'],
     'socks': ['PySocks >= 1.5.6, != 1.5.7, < 2'],
 }

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -2816,8 +2816,8 @@ class CLITestCase(DockerClientTestCase):
         result = self.dispatch(['images'])
 
         assert 'busybox' in result.stdout
-        assert 'multiple-composefiles_another_1' in result.stdout
-        assert 'multiple-composefiles_simple_1' in result.stdout
+        assert '_another_1' in result.stdout
+        assert '_simple_1' in result.stdout
 
     @mock.patch.dict(os.environ)
     def test_images_tagless_image(self):
@@ -2865,4 +2865,4 @@ class CLITestCase(DockerClientTestCase):
 
         assert re.search(r'foo1.+test[ \t]+dev', result.stdout) is not None
         assert re.search(r'foo2.+test[ \t]+prod', result.stdout) is not None
-        assert re.search(r'foo3.+_foo3[ \t]+latest', result.stdout) is not None
+        assert re.search(r'foo3.+test[ \t]+latest', result.stdout) is not None

--- a/tests/fixtures/images-service-tag/docker-compose.yml
+++ b/tests/fixtures/images-service-tag/docker-compose.yml
@@ -8,3 +8,4 @@ services:
     image: test:prod
   foo3:
     build: .
+    image: test:latest


### PR DESCRIPTION
Automated release for docker-compose 1.25.0


### Features

- Set no-colors to true if CLICOLOR env variable is set to 0 

- Add working dir, config files and env file in service labels

- Add dependencies for ARM build

- Add BuildKit support, use `DOCKER_BUILDKIT=1` and `COMPOSE_DOCKER_CLI_BUILD=1`

- Bump paramiko to 2.6.0

- Add working dir, config files and env file in service labels

- Add tag `docker-compose:latest`

- Add `docker-compose:<version>-alpine` image/tag

- Add `docker-compose:<version>-debian` image/tag

- Bumped `docker-py` 4.1.0

- Supports `requests` up to 2.22.0 version

- Drops empty tag on `build:cache_from`

- `Dockerfile` now generates `libmusl` binaries for alpine

- Only pull images that can't be built

- Attribute `scale` can now accept `0` as a value

- Added `--quiet` build flag

- Added `--no-interpolate` to `docker-compose config`

- Bump OpenSSL for macOS build (`1.1.0j` to `1.1.1c`)

- Added `--no-rm` to `build` command

- Added support for `credential_spec`

- Resolve digests without pulling image

- Upgrade `pyyaml` to `4.2b1`

- Lowered severity to `warning` if `down` tries to remove nonexisting image

- Use improved API fields for project events when possible

- Update `setup.py` for modern `pypi/setuptools` and remove `pandoc` dependencies

- Removed `Dockerfile.armhf` which is no longer needed

### Bugfixes

- Make container service color deterministic, remove red from chosen colors

- Fix non ascii chars error. Python2 only

- Format image size as decimal to be align with Docker CLI 

- Use Python Posix support to get tty size 

- Fix same file 'extends' optimization

- Use python POSIX support to get tty size

- Format image size as decimal to be align with Docker CLI

- Fixed stdin_open

- Fixed `--remove-orphans` when used with `up --no-start`

- Fixed `docker-compose ps --all`

- Fixed `depends_on` dependency recreation behavior

- Fixed bash completion for `build --memory`

- Fixed misleading warning concerning env vars when performing an `exec` command

- Fixed failure check in parallel_execute_watch

- Fixed race condition after pulling image

- Fixed error on duplicate mount points.

- Fixed merge on networks section

- Always connect Compose container to `stdin`

- Fixed the presentation of failed services on 'docker-compose start' when containers are not available
