### PR TITLE
Introduce "cp" command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -774,14 +774,14 @@ class TopLevelCommand(object):
 
         src_service, src_path = splitCpArg(source)
         dest_service, dest_path = splitCpArg(destination)
-        if src_service is not None and dest_service is not None:
+        if src_service and dest_service:
             raise UserError('copying between containers is not supported')
         service = src_service or dest_service
-        if service is None:
+        if not service:
             raise UserError('neither source nor destination path do refer to a service')
         containers = self.project.containers(service_names=[service], stopped=True,
                                              one_off=OneOffFilter.include)
-        if len(containers) == 0:
+        if not containers:
             raise UserError('no container match the service definition')
         if len(containers) > 1:
             raise UserError('multiple containers match the service definition')
@@ -792,8 +792,8 @@ class TopLevelCommand(object):
             args += ["--archive"]
         if options["--follow-link"]:
             args += ["--follow-link"]
-        args += [src_path if src_service is None else container.id+":"+src_path]
-        args += [dest_path if dest_service is None else container.id + ":" + dest_path]
+        args += [src_path if not src_service else container.id+":"+src_path]
+        args += [dest_path if not dest_service else container.id + ":" + dest_path]
 
         sys.exit(call_docker(args))
 

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -160,5 +160,5 @@ def splitCpArg(path):
     if not os.path.isabs(path) and not path.startswith('.'):
         parts = path.split(":", 2)
         if len(parts) == 2:
-            return (parts[0], parts[1])
-    return (None, path)
+            return parts[0], parts[1]
+    return None, path

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -153,3 +153,12 @@ def binarystr_to_unicode(s):
         except UnicodeDecodeError:
             pass
     return s.decode('utf-8', 'replace')
+
+
+# See cli/command/container/cp.go#splitCpArg
+def splitCpArg(path):
+    if not os.path.isabs(path) and not path.startswith('.'):
+        parts = path.split(":", 2)
+        if len(parts) == 2:
+            return (parts[0], parts[1])
+    return (None, path)


### PR DESCRIPTION
to mimic `docker cp` UX but using service abstraction
delegates to the actual docker cp command once target container has been
resolved

Mostly to check interest by maintainers, or maybe we should just reject #5523 and document workaround.
