### PR TITLE
Filter LABEL_CONFIG_FILES if filename is None

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -170,7 +170,8 @@ def execution_context_labels(config_details, environment_file):
 
 def config_files_label(config_details):
     return ",".join(
-        map(str, (os.path.normpath(c.filename) for c in config_details.config_files)))
+        map(str, (os.path.normpath(c.filename)
+            for c in config_details.config_files if c.filename is not None)))
 
 
 def get_project_name(working_dir, project_name=None, environment=None):


### PR DESCRIPTION
This PR fixes a bug where `docker-compose` invocations without an actual `docker-compose.yaml` file (e.g. when a compose file was piped into `docker-compose`) would fail.

Resolves #7032 
