### PR TITLE
Revert "only pull images that can't build"

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -619,9 +619,6 @@ class Project(object):
     def pull(self, service_names=None, ignore_pull_failures=False, parallel_pull=False, silent=False,
              include_deps=False):
         services = self.get_services(service_names, include_deps)
-        images_to_build = {service.image_name for service in services if service.can_be_built()}
-        services_to_pull = [service for service in services if service.image_name not in images_to_build]
-
         msg = not silent and 'Pulling' or None
 
         if parallel_pull:
@@ -647,7 +644,7 @@ class Project(object):
                     )
 
             _, errors = parallel.parallel_execute(
-                services_to_pull,
+                services,
                 pull_service,
                 operator.attrgetter('name'),
                 msg,
@@ -660,7 +657,7 @@ class Project(object):
                 raise ProjectError(combined_errors)
 
         else:
-            for service in services_to_pull:
+            for service in services:
                 service.pull(ignore_pull_failures, silent=silent)
 
     def push(self, service_names=None, ignore_push_failures=False):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -661,13 +661,6 @@ class CLITestCase(DockerClientTestCase):
                 'image library/nonexisting-image:latest not found' in result.stderr or
                 'pull access denied for nonexisting-image' in result.stderr)
 
-    def test_pull_with_build(self):
-        result = self.dispatch(['-f', 'pull-with-build.yml', 'pull'])
-
-        assert 'Pulling simple' not in result.stderr
-        assert 'Pulling from_simple' not in result.stderr
-        assert 'Pulling another ...' in result.stderr
-
     def test_pull_with_quiet(self):
         assert self.dispatch(['pull', '--quiet']).stderr == ''
         assert self.dispatch(['pull', '--quiet']).stdout == ''


### PR DESCRIPTION
#6494 fix is incorect 

a service can define *both* `image` and `build`, and documentation gives some indications on how those are handled:

> If you specify image as well as build, then Compose names the built image with the webapp and optional tag specified in image

> If the image does not exist, Compose attempts to pull it, unless you have also specified build, in which case it builds it using the specified options and tags it with the specified tag.

unfortunately those indication are not command-specific and the `pull` command documentation doesn't cover this specific case.

Some use `image` to tag built services and later push images, which will be pulled by others. Some use `image` only as a "build cache" and then don't expect compose to pull those from registry. AFAICT this is the case for #6464 - can you please confirm @justinmchase ?

I also can see lack of clarification on the expectation when both `build` and `image` are set brings many ambiguities, see #3853

I propose we first revert change, so 1.25 will behave like 1.24 did, then work on better documentation on `docker-compose pull` and impacts of `build` and `image` combination for a service.

About #6464, `--ignore-pull-failures` should be enough to offer a reasonable workaround.


This PR reverts commit c6dd7da15eb3d85a1f7634e8ded9fe42c9035669.

Resolves #7038
Resolves #6934
