### PR TITLE
Use Python3 for macOS build environment

### DIFF
--- a/script/setup/osx
+++ b/script/setup/osx
@@ -36,7 +36,7 @@ if ! [ -x "$(command -v python3)" ]; then
   brew install python3
 fi
 if ! [ -x "$(command -v virtualenv)" ]; then
-  pip install virtualenv==16.2.0
+  pip3 install virtualenv==16.2.0
 fi
 
 #


### PR DESCRIPTION
With the deprecation of Python 2 coming soon, explicitly use
Python 3.