### PR TITLE
Compute changelog by searching previous tag .. even from a tag

### DIFF
--- a/script/release/generate_changelog.sh
+++ b/script/release/generate_changelog.sh
@@ -10,7 +10,7 @@ set -x
 git config --add remote.origin.fetch +refs/pull/*/head:refs/remotes/origin/pull/*
 git fetch origin
 
-RANGE=${1:-"$(git describe --tags  --abbrev=0)..HEAD"}
+RANGE=${1:-"$(git describe --tags  --abbrev=0 HEAD^)..HEAD"}
 echo "Generate changelog for range ${RANGE}"
 echo
 


### PR DESCRIPTION
As we release, the release process run from a tag, so `git describe --tags  --abbrev=0` will resolve the current tag, not previous one, to compute Changelog
