### PR TITLE
Force sha256 file to be ASCII encoded

### DIFF
--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -296,6 +296,6 @@ def checksum(filepath) {
     if (isUnix()) {
         sh "openssl sha256 -r -out ${filepath}.sha256 ${filepath}"
     } else {
-        powershell "(Get-FileHash -Path ${filepath} -Algorithm SHA256 | % hash) + ' *${filepath}' > ${filepath}.sha256"
+        powershell "(Get-FileHash -Path ${filepath} -Algorithm SHA256 | % hash).ToLower() + ' *${filepath}' | Out-File -encoding ascii ${filepath}.sha256"
     }
 }


### PR DESCRIPTION
Force powershell to produce plain ASCII file

Resolves #7174

![image](https://user-images.githubusercontent.com/132757/72913664-c7a4ff00-3d3d-11ea-838f-0b2aeacdfed2.png)
