### PR TITLE
Force MacOS SDK version to "10.11"

### DIFF
--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -72,6 +72,9 @@ pipeline {
                     agent {
                         label 'mac-python'
                     }
+                    environment {
+                        DEPLOYMENT_TARGET="10.11"
+                    }
                     steps {
                         checkout scm
                         sh './script/setup/osx'


### PR DESCRIPTION
This is due to the fact that the new CI machines are on 10.14, so this fix makes the CI use the same version as the preceding one.

Resolves #7185 
