### PR TITLE
Make `--compatibility` flag implicit

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -71,7 +71,6 @@ def project_from_options(project_dir, options, additional_options=None):
         context=context,
         environment=environment,
         override_dir=override_dir,
-        compatibility=compatibility_from_options(project_dir, options, environment),
         interpolate=(not additional_options.get('--no-interpolate')),
         environment_file=environment_file
     )
@@ -103,7 +102,6 @@ def get_config_from_options(base_dir, options, additional_options=None):
     )
     return config.load(
         config.find(base_dir, config_path, environment, override_dir),
-        compatibility_from_options(config_path, options, environment),
         not additional_options.get('--no-interpolate')
     )
 
@@ -125,14 +123,14 @@ def get_config_path_from_options(base_dir, options, environment):
 
 def get_project(project_dir, config_path=None, project_name=None, verbose=False,
                 context=None, environment=None, override_dir=None,
-                compatibility=False, interpolate=True, environment_file=None):
+                interpolate=True, environment_file=None):
     if not environment:
         environment = Environment.from_env_file(project_dir)
     config_details = config.find(project_dir, config_path, environment, override_dir)
     project_name = get_project_name(
         config_details.working_dir, project_name, environment
     )
-    config_data = config.load(config_details, compatibility, interpolate)
+    config_data = config.load(config_details, interpolate)
 
     api_version = environment.get(
         'COMPOSE_API_VERSION',
@@ -193,13 +191,3 @@ def get_project_name(working_dir, project_name=None, environment=None):
         return normalize_name(project)
 
     return 'default'
-
-
-def compatibility_from_options(working_dir, options=None, environment=None):
-    """Get compose v3 compatibility from --compatibility option
-       or from COMPOSE_COMPATIBILITY environment variable."""
-
-    compatibility_option = options.get('--compatibility')
-    compatibility_environment = environment.get_boolean('COMPOSE_COMPATIBILITY')
-
-    return compatibility_option or compatibility_environment

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -210,6 +210,7 @@ class TopLevelCommand(object):
                                   (default: the path of the Compose file)
       --compatibility             If set, Compose will attempt to convert keys
                                   in v3 files to their non-Swarm equivalent
+                                  (WARN: flag ignored due to being made implicit)
       --env-file PATH             Specify an alternate environment file
 
     Commands:

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -920,7 +920,13 @@ def finalize_service(service_config, service_names, version, environment):
     normalize_build(service_dict, service_config.working_dir, environment)
 
     service_dict = translate_credential_spec_to_security_opt(service_dict)
-
+    service_dict, ignored_keys = translate_deploy_keys_to_container_config(
+        service_dict)
+    if ignored_keys:
+        log.warning(
+            'The following deploy sub-keys are not supported and have'
+            ' been ignored: {}'.format(', '.join(ignored_keys))
+        )
     service_dict['name'] = service_config.name
     return normalize_v1_service_format(service_dict)
 
@@ -1004,6 +1010,7 @@ def translate_deploy_keys_to_container_config(service_dict):
             deploy_dict.get('resources', {}), service_dict
         )
     )
+    del service_dict['deploy']
 
     return service_dict, ignored_keys
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -44,9 +44,9 @@ ProcessResult = namedtuple('ProcessResult', 'stdout stderr')
 BUILD_CACHE_TEXT = 'Using cache'
 BUILD_PULL_TEXT = 'Status: Image is up to date for busybox:1.27.2'
 COMPOSE_COMPATIBILITY_DICT = {
-    'version': '2.3',
+    'version': '3.5',
     'volumes': {'foo': {'driver': 'default'}},
-    'networks': {'bar': {}},
+    'networks': {'bar': {'attachable': True}},
     'services': {
         'foo': {
             'command': '/bin/true',
@@ -580,7 +580,7 @@ services:
 
     def test_config_compatibility_mode(self):
         self.base_dir = 'tests/fixtures/compatibility-mode'
-        result = self.dispatch(['--compatibility', 'config'])
+        result = self.dispatch(['config'])
 
         assert yaml.load(result.stdout) == COMPOSE_COMPATIBILITY_DICT
 
@@ -596,7 +596,7 @@ services:
     def test_config_compatibility_mode_from_env_and_option_precedence(self):
         self.base_dir = 'tests/fixtures/compatibility-mode'
         os.environ['COMPOSE_COMPATIBILITY'] = 'false'
-        result = self.dispatch(['--compatibility', 'config'])
+        result = self.dispatch(['config'])
 
         assert yaml.load(result.stdout) == COMPOSE_COMPATIBILITY_DICT
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -3627,12 +3627,12 @@ class InterpolationTest(unittest.TestCase):
         })
 
         with mock.patch('compose.config.config.log') as log:
-            config.load(config_details, compatibility=True)
+            config.load(config_details)
 
         assert log.warning.call_count == 1
         warn_message = log.warning.call_args[0][0]
         assert warn_message.startswith(
-            'The following deploy sub-keys are not supported in compatibility mode'
+            'The following deploy sub-keys are not supported'
         )
         assert 'labels' in warn_message
         assert 'endpoint_mode' in warn_message
@@ -3666,7 +3666,7 @@ class InterpolationTest(unittest.TestCase):
         })
 
         with mock.patch('compose.config.config.log') as log:
-            cfg = config.load(config_details, compatibility=True)
+            cfg = config.load(config_details)
 
         assert log.warning.call_count == 0
 


### PR DESCRIPTION
We don't need to pass the compatibility argument anymore to parse the 'deploy' section of the config.
Using the --compatibility flag will not raise an exception but it will be ignored.

```
$ cat docker-compose.yaml 
version: "3"
services:
  test:
    image: nginx
    deploy:
      mode: replicated
      replicas: 3
```
_BEFORE_
Only one container per service is created.
```
$ docker-compose up -d
WARNING: Some services (test) use the 'deploy' key, which will be ignored. Compose does not support 'deploy' configuration - use `docker stack deploy` to deploy to a swarm.
Creating network "schema_default" with the default driver
Creating schema_test_1 ... done
```
`--compatibility` arg should be passed to get the deploy field parsed
```
$ docker-compose --compatibility up -d
Creating network "schema_default" with the default driver
Creating schema_test_1 ... done
Creating schema_test_2 ... done
Creating schema_test_3 ... done

```

_NOW_
The number of containers to be created is set by the replicas field in the deploy section
```
$ docker-compose up -d
Creating network "schema_default" with the default driver
Creating schema_test_1 ... done
Creating schema_test_2 ... done
Creating schema_test_3 ... done
```

```
$ docker ps 
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
b60359965485        nginx               "nginx -g 'daemon of…"   2 minutes ago       Up 2 minutes        80/tcp              schema_test_1
dfd513b7a273        nginx               "nginx -g 'daemon of…"   2 minutes ago       Up 2 minutes        80/tcp              schema_test_2
62ca6291bc17        nginx               "nginx -g 'daemon of…"   2 minutes ago       Up 2 minutes        80/tcp              schema_test_3
```
```
$ docker-compose down
Stopping schema_test_1 ... done
Stopping schema_test_2 ... done
Stopping schema_test_3 ... done
Removing schema_test_1 ... done
Removing schema_test_2 ... done
Removing schema_test_3 ... done
Removing network schema_default
```

Signed-off-by: Anca Iordache <anca.iordache@docker.com>
Resolves https://github.com/docker/dev-tooling-team/issues/121
