### PR TITLE
Adds --since and --until to docker-compose logs

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -53,6 +53,7 @@ from .formatter import ConsoleWarningFormatter
 from .formatter import Formatter
 from .log_printer import build_log_presenters
 from .log_printer import LogPrinter
+from .utils import get_datetime_from_timestamp_or_duration
 from .utils import get_version_info
 from .utils import human_readable_file_size
 from .utils import yesno
@@ -615,8 +616,12 @@ class TopLevelCommand(object):
             --no-color          Produce monochrome output.
             -f, --follow        Follow log output.
             -t, --timestamps    Show timestamps.
+            --since time        Show logs since timestamp (e.g. 2013-01-02T13:23:37)
+                                or relative (e.g. 42m for 42 minutes)
             --tail="all"        Number of lines to show from the end of the logs
                                 for each container.
+            --until time        [API 1.35+] Show logs before a timestamp (e.g. 2013-01-02T13:23:37)
+                                or relative (e.g. 42m for 42 minutes)
         """
         containers = self.project.containers(service_names=options['SERVICE'], stopped=True)
 
@@ -626,10 +631,24 @@ class TopLevelCommand(object):
                 tail = int(tail)
             elif tail != 'all':
                 raise UserError("tail flag must be all or a number")
+
+        since = options['--since']
+        if since is not None:
+            since = get_datetime_from_timestamp_or_duration(since)
+
+        until = options['--until']
+        if until is not None:
+            if docker.utils.version_lt(self.project.client.api_version, '1.35'):
+                raise UserError('--until is only available on API 1.35+.')
+            else:
+                until = get_datetime_from_timestamp_or_duration(until)
+
         log_args = {
             'follow': options['--follow'],
             'tail': tail,
-            'timestamps': options['--timestamps']
+            'since': since,
+            'timestamps': options['--timestamps'],
+            'until': until
         }
         print("Attaching to", list_containers(containers))
         log_printer_from_project(

--- a/compose/cli/utils.py
+++ b/compose/cli/utils.py
@@ -8,12 +8,16 @@ import platform
 import ssl
 import subprocess
 import sys
+import time
+from datetime import datetime
 
 import docker
 import six
+from dateutil.parser import parse
 
 import compose
 from ..const import IS_WINDOWS_PLATFORM
+from ..timeparse import timeparse
 
 # WindowsError is not defined on non-win32 platforms. Avoid runtime errors by
 # defining it as OSError (its parent class) if missing.
@@ -78,6 +82,14 @@ def is_ubuntu():
 
 def is_windows():
     return IS_WINDOWS_PLATFORM
+
+
+def get_datetime_from_timestamp_or_duration(input_time):
+    parsed = timeparse(input_time)
+    if parsed is not None:
+        return datetime.fromtimestamp(int(time.time() - parsed))
+    else:
+        return parse(input_time)
 
 
 def get_version_info(scope):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ paramiko==2.7.1
 pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
 pypiwin32==223; sys_platform == 'win32' and python_version >= '3.6'
 PySocks==1.7.1
+python-dateutil==2.8.1
 python-dotenv==0.11.0
 PyYAML==5.3
 requests==2.22.0

--- a/tests/fixtures/logs-since-until-composefile/docker-compose.yml
+++ b/tests/fixtures/logs-since-until-composefile/docker-compose.yml
@@ -1,0 +1,3 @@
+simple:
+  image: busybox:1.31.0-uclibc
+  command: sh -c "date; sleep 1; date; sleep 1; date; sleep 1; date; sleep 1; date; sleep 1; date;"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import contextlib
 import os
+from datetime import datetime
 
 from compose.config.config import ConfigDetails
 from compose.config.config import ConfigFile
@@ -70,3 +71,12 @@ def cd(path):
         yield
     finally:
         os.chdir(prev_cwd)
+
+
+def get_datetime_from_clock_log(logstring):
+    logstring = logstring.splitlines()[1:]
+    date_fmt = '%a %b %d %H:%M:%S %Z %Y'
+    return [
+        datetime.strptime(l.split('\x1b[0m')[-1].strip(), date_fmt)
+        for l in logstring
+    ]

--- a/tests/unit/cli/utils_test.py
+++ b/tests/unit/cli/utils_test.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import unittest
+from datetime import datetime
+from datetime import timedelta
 
+from compose.cli.utils import get_datetime_from_timestamp_or_duration
 from compose.cli.utils import human_readable_file_size
 from compose.utils import unquote_path
 
@@ -46,3 +49,14 @@ class HumanReadableFileSizeTest(unittest.TestCase):
         assert human_readable_file_size((10 ** 3) ** 4) == '1 TB'
         assert human_readable_file_size((10 ** 3) ** 5) == '1 PB'
         assert human_readable_file_size((10 ** 3) ** 6) == '1 EB'
+
+
+class GetDatetimeFromTimestampOrDuration(unittest.TestCase):
+    def test_duration(self):
+        expected = datetime.now() - timedelta(hours=48, minutes=30, seconds=30)
+        value = get_datetime_from_timestamp_or_duration('48h30m30s')
+        assert expected - value < timedelta(seconds=2)
+
+    def test_timestamp(self):
+        assert get_datetime_from_timestamp_or_duration('2020-01-13T17:00:00') == \
+            datetime(year=2020, month=1, day=13, hour=17, minute=0, second=0)


### PR DESCRIPTION
Resolves #6702 

Supports datetime stamps and relative time

Added `python-dateutils` for Python 2.7 support (Otherwise tests would fail). Could remove this if 2.7 support is getting dropped.

Acceptance tests could be fragile (as time isn't being "frozen"), so far they seem fine for me, but its something to be aware of. Ive done my best to make them not, any advice on ways to improve the tests are appreciated.

Will open documentation PR once this gets merged. 

Regards,
Emmet