### PR TITLE
Update Jenkins build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Installation and documentation
 Contributing
 ------------
 
-[![Build Status](https://jenkins.dockerproject.org/buildStatus/icon?job=docker/compose/master)](https://jenkins.dockerproject.org/job/docker/job/compose/job/master/)
+[![Build Status](https://ci-next.docker.com/public/buildStatus/icon?job=compose/master)](https://ci-next.docker.com/public/job/compose/job/master/)
 
 Want to help build Compose? Check out our [contributing documentation](https://github.com/docker/compose/blob/master/CONTRIBUTING.md).
 


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

Update the Jenkins build status badge.

Resolves #7245 

![it's-alive](https://user-images.githubusercontent.com/207759/75462976-65b36700-5985-11ea-9548-2fb66ca5c969.jpg)
