### PR TITLE
Fix v3.8 schema support for binaries

### DIFF
--- a/docker-compose.spec
+++ b/docker-compose.spec
@@ -88,6 +88,11 @@ exe = EXE(pyz,
                 'DATA'
             ),
             (
+                'compose/config/config_schema_v3.8.json',
+                'compose/config/config_schema_v3.8.json',
+                'DATA'
+            ),
+            (
                 'compose/GITSHA',
                 'compose/GITSHA',
                 'DATA'

--- a/docker-compose_darwin.spec
+++ b/docker-compose_darwin.spec
@@ -97,6 +97,11 @@ coll = COLLECT(exe,
                 'DATA'
             ),
             (
+                'compose/config/config_schema_v3.8.json',
+                'compose/config/config_schema_v3.8.json',
+                'DATA'
+            ),
+            (
                 'compose/GITSHA',
                 'compose/GITSHA',
                 'DATA'


### PR DESCRIPTION
Deploying a v3.8 docker-compose.yaml with the docker-compose binary returns an error.
```
$ docker-compose up -d
ERROR: Version in "./docker-compose.yaml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```
With the current changes we get the expected behaviour.
```
$ docker-compose up -d
Creating network "nginx-golang-mysql_default" with the default driver
Creating nginx-golang-mysql_db_1 ... done
Creating nginx-golang-mysql_backend_1 ... done
Creating nginx-golang-mysql_proxy_1   ... done
```

Signed-off-by: Anca Iordache <anca.iordache@docker.com>



