### PR TITLE
Fix configuring labels when using buildkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Installation and documentation
 Contributing
 ------------
 
-[![Build Status](https://jenkins.dockerproject.org/buildStatus/icon?job=docker/compose/master)](https://jenkins.dockerproject.org/job/docker/job/compose/job/master/)
+[![Build Status](https://ci-next.docker.com/public/buildStatus/icon?job=compose/master)](https://ci-next.docker.com/public/job/compose/job/master/)
 
 Want to help build Compose? Check out our [contributing documentation](https://github.com/docker/compose/blob/master/CONTRIBUTING.md).
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -1792,6 +1792,7 @@ class _CLIBuilder(object):
         command_builder.add_list("--cache-from", cache_from)
         command_builder.add_arg("--file", dockerfile)
         command_builder.add_flag("--force-rm", forcerm)
+        command_builder.add_params("--label", labels)
         command_builder.add_arg("--memory", container_limits.get("memory"))
         command_builder.add_flag("--no-cache", nocache)
         command_builder.add_arg("--progress", self._progress)

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -2248,14 +2248,24 @@ services:
 
     def test_run_label_flag(self):
         self.base_dir = 'tests/fixtures/run-labels'
-        name = 'service'
-        self.dispatch(['run', '-l', 'default', '--label', 'foo=baz', name, '/bin/true'])
-        service = self.project.get_service(name)
+        self.dispatch(['build'])
+        self.dispatch(['run', '-l', 'default', '--label', 'foo=baz', 'from_image', '/bin/true'])
+        service = self.project.get_service('from_image')
         container, = service.containers(stopped=True, one_off=OneOffFilter.only)
         labels = container.labels
+
         assert labels['default'] == ''
         assert labels['foo'] == 'baz'
         assert labels['hello'] == 'world'
+
+        self.dispatch(['run', '-l', 'default', '--label', 'foo=baz', 'from_build', '/bin/true'])
+        service = self.project.get_service('from_build')
+        container, = service.containers(stopped=True, one_off=OneOffFilter.only)
+        labels = container.labels
+
+        assert labels['default'] == ''
+        assert labels['foo'] == 'baz'
+        assert labels['some_label'] == 'I am a label'
 
     def test_rm(self):
         service = self.project.get_service('simple')

--- a/tests/fixtures/run-labels/Dockerfile
+++ b/tests/fixtures/run-labels/Dockerfile
@@ -1,0 +1,1 @@
+FROM busybox:1.31.0-uclibc

--- a/tests/fixtures/run-labels/docker-compose.yml
+++ b/tests/fixtures/run-labels/docker-compose.yml
@@ -1,7 +1,14 @@
-service:
-  image: busybox:1.31.0-uclibc
-  command: top
+version: "3.5"
+services:
+  from_image:
+    image: busybox:1.31.0-uclibc
+    command: top
+    labels:
+      foo: bar
+      hello: world
 
-  labels:
-    foo: bar
-    hello: world
+  from_build:
+    build:
+      context: .
+      labels:
+        some_label: I am a label

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -621,6 +621,26 @@ class ServiceTest(unittest.TestCase):
         call_args = self.mock_client.build.call_args
         assert call_args[1]['platform'] == 'linux'
 
+    def test_build_with_label(self):
+        self.mock_client.api_version = '1.35'
+        self.mock_client.build.return_value = [
+            b'{"stream": "Successfully built 12345"}',
+        ]
+
+        service = Service(
+            'foo', client=self.mock_client,
+            build={'labels': {'some_label': 'I am the label'}}
+        )
+        print('kanyaaaa')
+        print(dir(service.containers))
+        service.build()
+
+        assert self.mock_client.build.call_count == 1
+        print(dir(self.mock_client))
+        call_args = self.mock_client.build.call_args
+        assert call_args[1]['platform'] == 'linux'
+        """todo: Still need to figure out what to assert"""
+
     def test_service_platform_precedence(self):
         self.mock_client.api_version = '1.35'
 


### PR DESCRIPTION
Adding labels to images was not in the CLI Builder function. We fix it by adding labels as params to the command builder. Tested it again and it labels added when using buildkit mode. Resolves #7242 

We did a test according to reproduction and now we have labels.
Signed-off-by: Kanya Paramita <kanyaparamita@yahoo.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->