### PR TITLE
Show diff on pre-commit failure

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pre-commit
 commands =
     pre-commit install
-    pre-commit run --all-files
+    pre-commit run --all-files --show-diff-on-failure
 
 # Coverage configuration
 [run]


### PR DESCRIPTION
This would provide a better CI experience, since `./scripts/tests/default` is executed within a docker and the `pre-commit` doesn't display the changes you need to make to your code if it fails inside the docker.

Signed-off-by: Alejandro G. Recuenco <alejandrogonzalezrecuenco@gmail.com>
