### PR TITLE
Bug fix 7242 docker-compose with buildkit does not insert container labels

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1792,6 +1792,7 @@ class _CLIBuilder(object):
         command_builder.add_list("--cache-from", cache_from)
         command_builder.add_arg("--file", dockerfile)
         command_builder.add_flag("--force-rm", forcerm)
+        command_builder.add_params("--label", labels)
         command_builder.add_arg("--memory", container_limits.get("memory"))
         command_builder.add_flag("--no-cache", nocache)
         command_builder.add_arg("--progress", self._progress)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -985,6 +985,23 @@ class ServiceTest(DockerClientTestCase):
         self.addCleanup(self.client.remove_image, service.image_name)
         assert self.client.inspect_image('composetest_web')
 
+    def test_build_cli_with_build_labels(self):
+        base_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, base_dir)
+
+        with open(os.path.join(base_dir, 'Dockerfile'), 'w') as f:
+            f.write("FROM busybox\n")
+
+        service = self.create_service('web',
+                                      build={
+                                          'context': base_dir,
+                                          'labels': {'com.docker.compose.test': 'true'}},
+                                      )
+        service.build(cli=True)
+        self.addCleanup(self.client.remove_image, service.image_name)
+        image = self.client.inspect_image('composetest_web')
+        assert image['Config']['Labels']['com.docker.compose.test']
+
     def test_up_build_cli(self):
         base_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, base_dir)


### PR DESCRIPTION
Resolves #7242

This issue solves bug reported by issue [7242](https://github.com/docker/compose/issues/7242)
where labels are not present when using _CLIBuilder. 

This merge request contains:
- Fix
- Integration test that checks for labels when the _CLIBuilder is used 


