### PR TITLE
Change Service.get_container not found error to honor custom container_name.

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -238,7 +238,11 @@ class Service(object):
         for container in self.containers(labels=['{0}={1}'.format(LABEL_CONTAINER_NUMBER, number)]):
             return container
 
-        raise ValueError("No container found for %s_%s" % (self.name, number))
+        container_name = "%s_%s" % (self.name, number)
+        if self.custom_container_name:
+            container_name = self.custom_container_name
+
+        raise ValueError("No container found for %s" % (container_name))
 
     def start(self, **options):
         containers = self.containers(stopped=True)

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -388,8 +388,19 @@ class ServiceTest(unittest.TestCase):
         self.mock_client.containers.return_value = []
         service = Service('foo', client=self.mock_client, image='foo')
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as ex:
             service.get_container()
+        assert str(ex.value) == 'No container found for foo_1'
+
+    def test_get_container_not_found_custom_name(self):
+        self.mock_client.containers.return_value = []
+        service = Service(
+            'foo', client=self.mock_client, image='foo', container_name='custom_foo'
+        )
+
+        with pytest.raises(ValueError) as ex:
+            service.get_container()
+        assert str(ex.value) == 'No container found for custom_foo'
 
     @mock.patch('compose.service.Container', autospec=True)
     def test_get_container(self, mock_container_class):


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #7337

If a service has a `container_name` set, and a user attempts to `exec` into it, but it does not exist, it will throw an error that references the default name instead of the custom name.

This PR changes the error logic to check for a custom name before raising the error.
