### PR TITLE
Bump OPENSSL to 1.1.1f

### DIFF
--- a/script/setup/osx
+++ b/script/setup/osx
@@ -13,9 +13,9 @@ if ! [ ${DEPLOYMENT_TARGET} == "$(macos_version)" ]; then
   SDK_SHA1=dd228a335194e3392f1904ce49aff1b1da26ca62
 fi
 
-OPENSSL_VERSION=1.1.1d
+OPENSSL_VERSION=1.1.1f
 OPENSSL_URL=https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-OPENSSL_SHA1=056057782325134b76d1931c48f2c7e6595d7ef4
+OPENSSL_SHA1=238e001ea1fbf19ede43e36209c37c1a636bb51f
 
 PYTHON_VERSION=3.7.6
 PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz


### PR DESCRIPTION
Ported from 1.25.5 release version `1.1.1d` results in a `404 Not Found`