### PR TITLE
parallel_pull is default behavior in new versions

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -622,7 +622,7 @@ class Project(object):
 
         return plans
 
-    def pull(self, service_names=None, ignore_pull_failures=False, parallel_pull=False, silent=False,
+    def pull(self, service_names=None, ignore_pull_failures=False, parallel_pull=True, silent=False,
              include_deps=False):
         services = self.get_services(service_names, include_deps)
 


### PR DESCRIPTION
https://github.com/docker/compose/blob/13bacba2b9aecdf1f3d9a4aa9e01fbc1f9e293ce/compose/cli/main.py#L736
`            --parallel              Deprecated, pull multiple images in parallel (enabled by default).
`


parallel_pull should be enabled by default for performance.