### PR TITLE
docker-compose-help: add explanation about down

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -216,7 +216,7 @@ class TopLevelCommand(object):
       build              Build or rebuild services
       config             Validate and view the Compose file
       create             Create services
-      down               Stop and remove containers, networks, images, and volumes
+      down               Stop and remove resources
       events             Receive real time events from containers
       exec               Execute a command in a running container
       help               Get help on a command


### PR DESCRIPTION
One could think just using `docker-compose down` already remove volumes

closes #7410 

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #
