### PR TITLE
[Compose Spec] Implement service mode for ipc

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -47,6 +47,7 @@ from .validation import validate_credential_spec
 from .validation import validate_depends_on
 from .validation import validate_extends_file_path
 from .validation import validate_healthcheck
+from .validation import validate_ipc_mode
 from .validation import validate_links
 from .validation import validate_network_mode
 from .validation import validate_pid_mode
@@ -734,6 +735,7 @@ def validate_service(service_config, service_names, config_file):
 
     validate_cpu(service_config)
     validate_ulimits(service_config)
+    validate_ipc_mode(service_config, service_names)
     validate_network_mode(service_config, service_names)
     validate_pid_mode(service_config, service_names)
     validate_depends_on(service_config, service_names)

--- a/compose/config/sort_services.py
+++ b/compose/config/sort_services.py
@@ -36,6 +36,7 @@ def get_service_dependents(service_dict, services):
             name in get_service_names_from_volumes_from(service.get('volumes_from', [])) or
             name == get_service_name_from_network_mode(service.get('network_mode')) or
             name == get_service_name_from_network_mode(service.get('pid')) or
+            name == get_service_name_from_network_mode(service.get('ipc')) or
             name in service.get('depends_on', []))
     ]
 

--- a/compose/config/validation.py
+++ b/compose/config/validation.py
@@ -218,6 +218,21 @@ def validate_pid_mode(service_config, service_names):
         )
 
 
+def validate_ipc_mode(service_config, service_names):
+    ipc_mode = service_config.config.get('ipc')
+    if not ipc_mode:
+        return
+
+    dependency = get_service_name_from_network_mode(ipc_mode)
+    if not dependency:
+        return
+    if dependency not in service_names:
+        raise ConfigurationError(
+            "Service '{s.name}' uses the IPC namespace of service '{dep}' which "
+            "is undefined.".format(s=service_config, dep=dependency)
+        )
+
+
 def validate_links(service_config, service_names):
     for link in service_config.config.get('links', []):
         if link.split(':')[0] not in service_names:

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1681,7 +1681,6 @@ services:
         host_mode_container = self.project.get_service('host').containers()[0]
         assert host_mode_container.get('HostConfig.PidMode') == 'host'
 
-    @v2_only()
     @no_cluster('Container IPC mode does not work across clusters')
     def test_up_with_ipc_mode(self):
         c = self.client.create_container(

--- a/tests/fixtures/ipc-mode/docker-compose.yml
+++ b/tests/fixtures/ipc-mode/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2.4"
+
+services:
+  service:
+    image: busybox
+    command: top
+    ipc: "service:shareable"
+
+  container:
+    image: busybox
+    command: top
+    ipc: "container:composetest_ipc_mode_container"
+
+  shareable:
+    image: busybox
+    command: top
+    ipc: shareable

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -38,6 +38,7 @@ from compose.project import Project
 from compose.service import BuildAction
 from compose.service import ConvergencePlan
 from compose.service import ConvergenceStrategy
+from compose.service import IpcMode
 from compose.service import NetworkMode
 from compose.service import PidMode
 from compose.service import Service
@@ -1479,6 +1480,17 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('web', pid_mode=PidMode('host'))
         container = create_and_start_container(service)
         assert container.get('HostConfig.PidMode') == 'host'
+
+    def test_ipc_mode_none_defined(self):
+        service = self.create_service('web', ipc_mode=None)
+        container = create_and_start_container(service)
+        print(container.get('HostConfig.IpcMode'))
+        assert container.get('HostConfig.IpcMode') == 'shareable'
+
+    def test_ipc_mode_host(self):
+        service = self.create_service('web', ipc_mode=IpcMode('host'))
+        container = create_and_start_container(service)
+        assert container.get('HostConfig.IpcMode') == 'host'
 
     @v2_1_only()
     def test_userns_mode_none_defined(self):


### PR DESCRIPTION
# Overview
This PR updates `docker-compose` to support `ipc: service:` syntax similar to existing functionality with `pid` and `network_mode`. Code changes were closely modeled after #4930. Resolves #7220.

# Pre-commit hooks
According to `script/test/default` pre-commit hooks pass:
```
Check for added large files..............................................Passed
Check docstring is first.................................................Passed
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
Check JSON...............................................................Passed
Debug Statements (Python)................................................Passed
Fix End of Files.........................................................Passed
Flake8...................................................................Passed
Tests should end in _test.py.............................................Passed
Fix requirements.txt.....................................................Passed
Trim Trailing Whitespace.................................................Passed
Reorder python imports...................................................Passed
```

# Testing
- 2 integration tests added; they pass:
```
tests/integration/service_test.py::ServiceTest::test_ipc_mode_none_defined PASSED
tests/integration/service_test.py::ServiceTest::test_ipc_mode_host PASSED
```
- An acceptance test was added; it passes:
```
tests/acceptance/cli_test.py::CLITestCase::test_up_with_ipc_mode PASSED
```
- Tested it manually to verify that `ipc: service:` indeed works as expected
