### PR TITLE
Speed up fish completions for subcommands

### DIFF
--- a/contrib/completion/fish/docker-compose.fish
+++ b/contrib/completion/fish/docker-compose.fish
@@ -3,12 +3,31 @@
 
 complete -e -c docker-compose
 
-for line in (docker-compose --help | \
-             string match -r '^\s+\w+\s+[^\n]+' | \
-             string trim)
-  set -l doc (string split -m 1 ' ' -- $line)
-  complete -c docker-compose -n '__fish_use_subcommand' -xa $doc[1] --description $doc[2]
-end
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'build' --description 'Build or rebuild services'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'config' --description 'Validate and view the Compose file'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'create' --description 'Create services'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'down' --description 'Stop and remove containers, networks, images, and volumes'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'events' --description 'Receive real time events from containers'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'exec' --description 'Execute a command in a running container'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'help' --description 'Get help on a command'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'images' --description 'List images'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'kill' --description 'Kill containers'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'logs' --description 'View output from containers'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'pause' --description 'Pause services'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'port' --description 'Print the public port for a port binding'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'ps' --description 'List containers'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'pull' --description 'Pull service images'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'push' --description 'Push service images'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'restart' --description 'Restart services'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'rm' --description 'Remove stopped containers'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'run' --description 'Run a one-off command'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'scale' --description 'Set number of containers for a service'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'start' --description 'Start services'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'stop' --description 'Stop services'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'top' --description 'Display the running processes'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'unpause' --description 'Unpause services'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'up' --description 'Create and start containers'
+complete -c docker-compose -n '__fish_use_subcommand' -xa 'version' --description 'Show the Docker-Compose version information'
 
 complete -c docker-compose -s f -l file -r                -d 'Specify an alternate compose file'
 complete -c docker-compose -s p -l project-name -x        -d 'Specify an alternate project name'


### PR DESCRIPTION
The current method of generating completions for the fish shell relies
on running `docker-compose --help`. On my system (a 2018 MacBook Pro)
this routinely takes several hundred milliseconds:

```
$ hyperfine --warmup 3 'docker-compose --help'
Benchmark #1: docker-compose --help
  Time (mean ± σ):     351.6 ms ±  16.0 ms    [User: 295.5 ms, System: 44.3 ms]
  Range (min … max):   332.8 ms … 384.0 ms    10 runs
```

If I configure fish to automatically load these completions, it makes
launching a new fish process very sluggish.

In addition, the regular expression used to parse the output of
`docker-compose --help` incorrectly generates completions for `name` and
`in` due to the following lines:

https://github.com/docker/compose/blob/9c5351cf27d10a7b8078496fb21a37929b6687cb/compose/cli/main.py#L208
https://github.com/docker/compose/blob/9c5351cf27d10a7b8078496fb21a37929b6687cb/compose/cli/main.py#L212

This commit fixes these issues by explicitly listing subcommands instead
of generating them dynamically. This means that adding/removing
subcommands won't automatically update the completions but according to
the git blame for `compose/cli/main.py`, no one has touched the list of
subcommands in the help message in 3+ years so I hope that won't be an
issue.

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #7418 

Update: I discovered that fish has a variable `fish_complete_path` which determines which directories it will search for completions in. By adding the vendor completions directory to that variable, I can make fish defer loading the completion until it's actually needed (i.e., only after typing `docker-compose <TAB>`). This speeds up launching new fish processes but there's still the issue that when I _do_ want to load the completions, it hangs for a good while before displaying them (not to mention the incorrect completions bug). So I still think this PR is helpful.