### PR TITLE
Add 'local' to list of logging drivers that support `docker-compose logs`

### DIFF
--- a/compose/container.py
+++ b/compose/container.py
@@ -208,8 +208,8 @@ class Container(object):
         return status_string
 
     def attach_log_stream(self):
-        """A log stream can only be attached if the container uses a json-file
-        log driver.
+        """A log stream can only be attached if the container uses a
+        json-file, journald or local log driver.
         """
         if self.has_api_logs:
             self.log_stream = self.attach(stdout=True, stderr=True, stream=True)

--- a/compose/container.py
+++ b/compose/container.py
@@ -193,7 +193,7 @@ class Container(object):
     @property
     def has_api_logs(self):
         log_type = self.log_driver
-        return not log_type or log_type in ('json-file', 'journald')
+        return not log_type or log_type in ('json-file', 'journald', 'local')
 
     @property
     def human_readable_health_status(self):


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #7420
