### PR TITLE
Fix push command skips service

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -695,9 +695,7 @@ class Project(object):
             repo, tag, sep = parse_repository_tag(service.image_name)
             service_image_name = sep.join((repo, tag)) if tag else sep.join((repo, 'latest'))
 
-            # Add service to unique if it's pushable
-            if (service_image_name not in unique_images and
-                    service.can_be_pushed()):
+            if service.can_be_pushed() and service_image_name not in unique_images:
                 service.push(ignore_push_failures)
                 unique_images.add(service_image_name)
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -695,7 +695,9 @@ class Project(object):
             repo, tag, sep = parse_repository_tag(service.image_name)
             service_image_name = sep.join((repo, tag)) if tag else sep.join((repo, 'latest'))
 
-            if service_image_name not in unique_images:
+            # Add service to unique if it's pushable
+            if (service_image_name not in unique_images and
+                    service.can_be_pushed()):
                 service.push(ignore_push_failures)
                 unique_images.add(service_image_name)
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -1138,6 +1138,12 @@ class Service(object):
     def can_be_built(self):
         return 'build' in self.options
 
+    def can_be_pulled(self):
+        return 'image' in self.options
+
+    def can_be_pushed(self):
+        return 'build' in self.options and 'image' in self.options
+
     def labels(self, one_off=False, legacy=False):
         proj_name = self.project if not legacy else re.sub(r'[_-]', '', self.project)
         return [
@@ -1227,7 +1233,7 @@ class Service(object):
                 log.error(six.text_type(e))
 
     def pull(self, ignore_pull_failures=False, silent=False, stream=False):
-        if 'image' not in self.options:
+        if not self.can_be_pulled():
             return
 
         repo, tag, separator = parse_repository_tag(self.options['image'])
@@ -1250,7 +1256,7 @@ class Service(object):
         return progress_stream.get_digest_from_pull(event_stream)
 
     def push(self, ignore_push_failures=False):
-        if 'image' not in self.options or 'build' not in self.options:
+        if not self.can_be_pushed():
             return
 
         repo, tag, separator = parse_repository_tag(self.options['image'])

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -12,8 +12,8 @@ from docker.errors import NotFound
 
 from .. import mock
 from .. import unittest
-from ..helpers import BUSYBOX_IMAGE_NAME
 from ..helpers import BUSYBOX_DEFAULT_TAG
+from ..helpers import BUSYBOX_IMAGE_NAME
 from ..helpers import BUSYBOX_IMAGE_WITH_TAG
 from compose.config import ConfigurationError
 from compose.config.config import Config


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #7429 

The first service is skipped because it has no build instruction - it's ok.
But his image still was added to `unique_images` set, so the second service (with same image, but with build instruction) was skipped.
I've fixed this by adding check is service is pushable. Only after this i add it to unique_images
