### PR TITLE
Ignore image tag if both tag and digest available

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1436,12 +1436,15 @@ def parse_repository_tag(repo_path):
     ('user/repo', 'sha256:digest', '@')
     >>> parse_repository_tag('user/repo:v1')
     ('user/repo', 'v1', ':')
+    >>> parse_repository_tag('user/repo:v1@sha256:digest')
+    ('user/repo', 'sha256:digest', '@')
     """
     tag_separator = ":"
     digest_separator = "@"
 
     if digest_separator in repo_path:
         repo, tag = repo_path.rsplit(digest_separator, 1)
+        repo, _, _ = parse_repository_tag(repo)
         return repo, tag, digest_separator
 
     repo, tag = repo_path, ""

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -503,6 +503,13 @@ class ServiceTest(unittest.TestCase):
         assert parse_repository_tag("url:5000/repo@sha256:digest") == (
             "url:5000/repo", "sha256:digest", "@"
         )
+        assert parse_repository_tag("root:tag@sha256:digest") == ("root", "sha256:digest", "@")
+        assert parse_repository_tag("user/repo:tag@sha256:digest") == (
+            "user/repo", "sha256:digest", "@"
+        )
+        assert parse_repository_tag("url:5000/repo:tag@sha256:digest") == (
+            "url:5000/repo", "sha256:digest", "@"
+        )
 
     def test_create_container(self):
         service = Service('foo', client=self.mock_client, build={'context': '.'})


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->

Resolves:
https://github.com/docker/compose/pull/7430#discussion_r420585527

Added support for both `tag` and `digest` in `parse_repository_tag` by ignoring tag