### PR TITLE
Added option to disable log prefix via cli

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -16,18 +16,22 @@ from compose.utils import split_buffer
 
 class LogPresenter:
 
-    def __init__(self, prefix_width, color_func):
+    def __init__(self, prefix_width, color_func, keep_prefix=True):
         self.prefix_width = prefix_width
         self.color_func = color_func
+        self.keep_prefix = keep_prefix
 
     def present(self, container, line):
-        prefix = container.name_without_project.ljust(self.prefix_width)
-        return '{prefix} {line}'.format(
-            prefix=self.color_func(prefix + ' |'),
-            line=line)
+        to_log = '{line}'.format(line=line)
+
+        if self.keep_prefix:
+            prefix = container.name_without_project.ljust(self.prefix_width)
+            to_log = '{prefix} '.format(prefix=self.color_func(prefix + ' |')) + to_log
+
+        return to_log
 
 
-def build_log_presenters(service_names, monochrome):
+def build_log_presenters(service_names, monochrome, keep_prefix=True):
     """Return an iterable of functions.
 
     Each function can be used to format the logs output of a container.
@@ -38,7 +42,7 @@ def build_log_presenters(service_names, monochrome):
         return text
 
     for color_func in cycle([no_color] if monochrome else colors.rainbow()):
-        yield LogPresenter(prefix_width, color_func)
+        yield LogPresenter(prefix_width, color_func, keep_prefix)
 
 
 def max_name_width(service_names, max_index_width=3):

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -3034,3 +3034,12 @@ services:
         another = self.project.get_service('--log-service')
         assert len(service.containers()) == 1
         assert len(another.containers()) == 1
+
+    def test_up_no_log_prefix(self):
+        self.base_dir = 'tests/fixtures/echo-services'
+        result = self.dispatch(['up', '--no-log-prefix'])
+
+        assert 'simple' in result.stdout
+        assert 'another' in result.stdout
+        assert 'exited with code 0' in result.stdout
+        assert 'exited with code 0' in result.stdout


### PR DESCRIPTION
Signed-off-by: Kaushal Rohit <rohit.kg98@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #7416 
Added a `--no-log-prefix` flag to the CLI. Added additional argument to LogPresenter called `keep_prefix`.
