### PR TITLE
[Compose Spec] Make 'run' behave in the same way as 'up'

### DIFF
--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -1780,6 +1780,14 @@ services:
         assert len(db.containers()) == 1
         assert len(console.containers()) == 0
 
+    def test_run_service_with_unhealthy_dependencies(self):
+        self.base_dir = 'tests/fixtures/v2-unhealthy-dependencies'
+        result = self.dispatch(['run', 'web', '/bin/true'], returncode=1)
+        assert re.search(
+            re.compile('for web .*is unhealthy.*', re.MULTILINE),
+            result.stderr
+        )
+
     def test_run_service_with_scaled_dependencies(self):
         self.base_dir = 'tests/fixtures/v2-dependencies'
         self.dispatch(['up', '-d', '--scale', 'db=2', '--scale', 'console=0'])

--- a/tests/fixtures/v2-unhealthy-dependencies/docker-compose.yml
+++ b/tests/fixtures/v2-unhealthy-dependencies/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2.1"
+services:
+    db:
+      image: busybox:1.31.0-uclibc
+      command: top
+      healthcheck:
+        test: exit 1
+        interval: 1s
+        timeout: 1s
+        retries: 1
+    web:
+      image: busybox:1.31.0-uclibc
+      command: top
+      depends_on:
+        db:
+          condition: service_healthy
+    console:
+      image: busybox:1.31.0-uclibc
+      command: top

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -18,6 +18,8 @@ from compose.cli.docopt_command import NoSuchCommand
 from compose.cli.errors import UserError
 from compose.cli.main import TopLevelCommand
 from compose.const import IS_WINDOWS_PLATFORM
+from compose.const import LABEL_SERVICE
+from compose.container import Container
 from compose.project import Project
 
 
@@ -94,12 +96,26 @@ class CLITestCase(unittest.TestCase):
     @pytest.mark.xfail(IS_WINDOWS_PLATFORM, reason="requires dockerpty")
     @mock.patch('compose.cli.main.RunOperation', autospec=True)
     @mock.patch('compose.cli.main.PseudoTerminal', autospec=True)
+    @mock.patch('compose.service.Container.create')
     @mock.patch.dict(os.environ)
-    def test_run_interactive_passes_logs_false(self, mock_pseudo_terminal, mock_run_operation):
+    def test_run_interactive_passes_logs_false(
+            self,
+            mock_container_create,
+            mock_pseudo_terminal,
+            mock_run_operation,
+    ):
         os.environ['COMPOSE_INTERACTIVE_NO_CLI'] = 'true'
         mock_client = mock.create_autospec(docker.APIClient)
         mock_client.api_version = DEFAULT_DOCKER_API_VERSION
         mock_client._general_configs = {}
+        mock_container_create.return_value = Container(mock_client, {
+            'Id': '37b35e0ba80d91009d37e16f249b32b84f72bda269985578ed6c75a0a13fcaa8',
+            'Config': {
+                'Labels': {
+                    LABEL_SERVICE: 'service',
+                }
+            },
+        }, has_been_inspected=True)
         project = Project.from_config(
             name='composetest',
             client=mock_client,
@@ -132,10 +148,20 @@ class CLITestCase(unittest.TestCase):
         _, _, call_kwargs = mock_run_operation.mock_calls[0]
         assert call_kwargs['logs'] is False
 
-    def test_run_service_with_restart_always(self):
+    @mock.patch('compose.service.Container.create')
+    def test_run_service_with_restart_always(self, mock_container_create):
         mock_client = mock.create_autospec(docker.APIClient)
         mock_client.api_version = DEFAULT_DOCKER_API_VERSION
         mock_client._general_configs = {}
+        mock_container_create.return_value = Container(mock_client, {
+            'Id': '37b35e0ba80d91009d37e16f249b32b84f72bda269985578ed6c75a0a13fcaa8',
+            'Name': 'composetest_service_37b35',
+            'Config': {
+                'Labels': {
+                    LABEL_SERVICE: 'service',
+                }
+            },
+        }, has_been_inspected=True)
 
         project = Project.from_config(
             name='composetest',


### PR DESCRIPTION
# Overview
This PR updates `docker-compose run` to wait for `condition: service_healthy` dependencies to become healthy. This effectively reflects the behaviour that `docker-compose up` has.  
Resolves #7453. 

# Implementation Summary
- `Project.up` now takes care of creating the one-off container:
  - This is powered by new `one_off` `ConvergencePlan`
  - One-off containers also accept option overrides
- `Project.up` doesn't start the one-off container, this is still responsibility of `run_one_off_container`

# Pre-commit hooks
According to `script/test/default` pre-commit hooks pass:
```
Check for added large files..............................................Passed
Check docstring is first.................................................Passed
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
Check JSON...............................................................Passed
Debug Statements (Python)................................................Passed
Fix End of Files.........................................................Passed
Flake8...................................................................Passed
Tests should end in _test.py.............................................Passed
Fix requirements.txt.....................................................Passed
Trim Trailing Whitespace.................................................Passed
Reorder python imports...................................................Passed
```

# Other Changes
- ~`service.py` and `main.py` have 2 additional changes I had to apply in order to get pre-commit hooks (namely, `flake8`) to pass~ (rebased to pick this up from main branch)
- Gotten rid of `force` parameter in `remove_container` since it doesn't actually get used

# User Experience
An extra `Creating <project>_<service>_run ... done` will be printed to the terminal in addition to dependency information that's already printed. Examples of happy paths:
```
$ docker-compose run web
Starting docker-compose-example_redis_1 ... done
Creating docker-compose-example_web_run ... done
 * Debugger is active!
 * Debugger PIN: 302-617-874

$ docker-compose run test bash
Starting docker-compose-example_db_1 ... done
Creating docker-compose-example_test_run ... done
root@008cf9d35de0:/# ls
bin   dev                  docker-entrypoint.sh  home  lib64  mnt  proc  run   srv  tmp  var
boot  docker-entrypoint.d  etc                   lib   media  opt  root  sbin  sys  usr
```

We're also now getting `up` checks for free. For example, if a dependency is unhealthy and `condition: service_healthy` was specified, the following will happen:
```
$ docker-compose run web bash
Starting docker-compose-example_redis_1 ... done

ERROR: for web  Container "830730e0db0c" is unhealthy.
ERROR: Encountered errors while bringing up the project.
```

# Testing
- An acceptance test was added; it passes
- Tested it manually to verify that `docker-compose run` indeed works as expected
