### PR TITLE
[WiP] Enable docker-compose for the latest compose-spec

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -194,6 +194,8 @@ class ConfigFile(namedtuple('_ConfigFile', 'filename config')):
     @cached_property
     def version(self):
         if 'version' not in self.config:
+            if 'services' not in self.config:
+                return V1
             return const.COMPOSEFILE_NO_VERSION
 
         version = self.config['version']

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -194,7 +194,7 @@ class ConfigFile(namedtuple('_ConfigFile', 'filename config')):
     @cached_property
     def version(self):
         if 'version' not in self.config:
-            return V1
+            return const.COMPOSEFILE_NO_VERSION
 
         version = self.config['version']
 

--- a/compose/config/config_schema_v3.9.json
+++ b/compose/config/config_schema_v3.9.json
@@ -4,7 +4,6 @@
   "type": "object",
   "title": "Compose Specification",
   "description": "The Compose file is a YAML file defining a multi-containers based application.",
-  "required": ["version"],
 
   "properties": {
     "version": {

--- a/compose/config/config_schema_v3.9.json
+++ b/compose/config/config_schema_v3.9.json
@@ -391,7 +391,7 @@
         "start_period": {"type": "string", "format": "duration"}
       },
       "additionalProperties": false,
-      "patternProperties": {"^x-": {}}      
+      "patternProperties": {"^x-": {}}
     },
     "deployment": {
       "id": "#/definitions/deployment",
@@ -414,7 +414,7 @@
             ]}
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         },
         "update_config": {
           "type": "object",
@@ -429,7 +429,7 @@
             ]}
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         },
         "resources": {
           "type": "object",
@@ -441,7 +441,7 @@
                 "memory": {"type": "string"}
               },
               "additionalProperties": false,
-              "patternProperties": {"^x-": {}}     
+              "patternProperties": {"^x-": {}}
             },
             "reservations": {
               "type": "object",
@@ -451,11 +451,11 @@
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },
               "additionalProperties": false,
-              "patternProperties": {"^x-": {}}     
+              "patternProperties": {"^x-": {}}
             }
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         },
         "restart_policy": {
           "type": "object",
@@ -466,7 +466,7 @@
             "window": {"type": "string", "format": "duration"}
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         },
         "placement": {
           "type": "object",
@@ -480,17 +480,17 @@
                   "spread": {"type": "string"}
                 },
                 "additionalProperties": false,
-                "patternProperties": {"^x-": {}}     
+                "patternProperties": {"^x-": {}}
               }
             },
             "max_replicas_per_node": {"type": "integer"}
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         }
       },
       "additionalProperties": false,
-      "patternProperties": {"^x-": {}}     
+      "patternProperties": {"^x-": {}}
     },
 
     "generic_resources": {
@@ -506,11 +506,11 @@
               "value": {"type": "number"}
             },
             "additionalProperties": false,
-            "patternProperties": {"^x-": {}}     
+            "patternProperties": {"^x-": {}}
           }
         },
         "additionalProperties": false,
-        "patternProperties": {"^x-": {}}     
+        "patternProperties": {"^x-": {}}
       }
     },
 
@@ -538,12 +538,12 @@
                   "subnet": {"type": "string"}
                 },
                 "additionalProperties": false,
-                "patternProperties": {"^x-": {}}     
+                "patternProperties": {"^x-": {}}
               }
             }
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         },
         "external": {
           "type": ["boolean", "object"],
@@ -554,14 +554,14 @@
             }
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         },
         "internal": {"type": "boolean"},
         "attachable": {"type": "boolean"},
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },
       "additionalProperties": false,
-      "patternProperties": {"^x-": {}}     
+      "patternProperties": {"^x-": {}}
     },
 
     "volume": {
@@ -585,7 +585,7 @@
             }
           },
           "additionalProperties": false,
-          "patternProperties": {"^x-": {}}     
+          "patternProperties": {"^x-": {}}
         },
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },
@@ -616,7 +616,7 @@
         "template_driver": {"type": "string"}
       },
       "additionalProperties": false,
-      "patternProperties": {"^x-": {}}     
+      "patternProperties": {"^x-": {}}
     },
 
     "config": {
@@ -638,7 +638,7 @@
         "template_driver": {"type": "string"}
       },
       "additionalProperties": false,
-      "patternProperties": {"^x-": {}}     
+      "patternProperties": {"^x-": {}}
     },
 
     "string_or_list": {

--- a/compose/config/config_schema_v3.9.json
+++ b/compose/config/config_schema_v3.9.json
@@ -1,0 +1,687 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema",
+  "id": "config_schema_v3.9.json",
+  "type": "object",
+  "title": "Compose Specification",
+  "description": "The Compose file is a YAML file defining a multi-containers based application.",
+  "required": ["version"],
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Version of the Compose specification used. Tools not implementing required version MUST reject the configuration file."
+    },
+
+    "services": {
+      "id": "#/properties/services",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/service"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "networks": {
+      "id": "#/properties/networks",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/network"
+        }
+      }
+    },
+
+    "volumes": {
+      "id": "#/properties/volumes",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/volume"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "secrets": {
+      "id": "#/properties/secrets",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/secret"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "configs": {
+      "id": "#/properties/configs",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/config"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
+  "patternProperties": {"^x-": {}},
+  "additionalProperties": false,
+
+  "definitions": {
+
+    "service": {
+      "id": "#/definitions/service",
+      "type": "object",
+
+      "properties": {
+        "deploy": {"$ref": "#/definitions/deployment"},
+        "build": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+              "properties": {
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "cache_from": {"$ref": "#/definitions/list_of_strings"},
+                "network": {"type": "string"},
+                "target": {"type": "string"},
+                "shm_size": {"type": ["integer", "string"]}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
+            }
+          ]
+        },
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup_parent": {"type": "string"},
+        "command": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "configs": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "properties": {
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "uid": {"type": "string"},
+                  "gid": {"type": "string"},
+                  "mode": {"type": "number"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          }
+        },
+        "container_name": {"type": "string"},
+        "credential_spec": {
+          "type": "object",
+          "properties": {
+            "config": {"type": "string"},
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "depends_on": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "condition": {
+                      "type": "string",
+                      "enum": ["service_started", "service_healthy"]
+                    }
+                  },
+                  "required": ["condition"]
+                }
+              }
+            }
+          ]
+        },
+        "device_cgroup_rules": {"$ref": "#/definitions/list_of_strings"},
+        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "dns": {"$ref": "#/definitions/string_or_list"},
+        "dns_search": {"$ref": "#/definitions/string_or_list"},
+        "domainname": {"type": "string"},
+        "entrypoint": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "env_file": {"$ref": "#/definitions/string_or_list"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
+        "expose": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"],
+            "format": "expose"
+          },
+          "uniqueItems": true
+        },
+
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "hostname": {"type": "string"},
+        "image": {"type": "string"},
+        "pull_policy": {"type": "string", "enum": [
+          "always", "never", "if_not_present"
+        ]},
+        "init": {"type": "boolean"},
+        "ipc": {"type": "string"},
+        "isolation": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+
+        "logging": {
+            "type": "object",
+
+            "properties": {
+                "driver": {"type": "string"},
+                "options": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {"type": ["string", "number", "null"]}
+                  }
+                }
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+        },
+
+        "mac_address": {"type": "string"},
+        "network_mode": {"type": "string"},
+
+        "networks": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "aliases": {"$ref": "#/definitions/list_of_strings"},
+                        "ipv4_address": {"type": "string"},
+                        "ipv6_address": {"type": "string"}
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {"^x-": {}}
+                    },
+                    {"type": "null"}
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "pid": {"type": ["string", "null"]},
+
+        "ports": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "number", "format": "ports"},
+              {"type": "string", "format": "ports"},
+              {
+                "type": "object",
+                "properties": {
+                  "mode": {"type": "string"},
+                  "target": {"type": "integer"},
+                  "published": {"type": "integer"},
+                  "protocol": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+
+        "privileged": {"type": "boolean"},
+        "read_only": {"type": "boolean"},
+        "restart": {"type": "string"},
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
+        "secrets": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "properties": {
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "uid": {"type": "string"},
+                  "gid": {"type": "string"},
+                  "mode": {"type": "number"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          }
+        },
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "stdin_open": {"type": "boolean"},
+        "stop_grace_period": {"type": "string", "format": "duration"},
+        "stop_signal": {"type": "string"},
+        "tmpfs": {"$ref": "#/definitions/string_or_list"},
+        "tty": {"type": "boolean"},
+        "ulimits": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-z]+$": {
+              "oneOf": [
+                {"type": "integer"},
+                {
+                  "type":"object",
+                  "properties": {
+                    "hard": {"type": "integer"},
+                    "soft": {"type": "integer"}
+                  },
+                  "required": ["soft", "hard"],
+                  "additionalProperties": false,
+                  "patternProperties": {"^x-": {}}
+                }
+              ]
+            }
+          }
+        },
+        "user": {"type": "string"},
+        "userns_mode": {"type": "string"},
+        "volumes": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {"type": "string"},
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "read_only": {"type": "boolean"},
+                  "consistency": {"type": "string"},
+                  "bind": {
+                    "type": "object",
+                    "properties": {
+                      "propagation": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "volume": {
+                    "type": "object",
+                    "properties": {
+                      "nocopy": {"type": "boolean"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "tmpfs": {
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ],
+            "uniqueItems": true
+          }
+        },
+        "working_dir": {"type": "string"}
+      },
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
+    },
+
+    "healthcheck": {
+      "id": "#/definitions/healthcheck",
+      "type": "object",
+      "properties": {
+        "disable": {"type": "boolean"},
+        "interval": {"type": "string", "format": "duration"},
+        "retries": {"type": "number"},
+        "test": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "timeout": {"type": "string", "format": "duration"},
+        "start_period": {"type": "string", "format": "duration"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}      
+    },
+    "deployment": {
+      "id": "#/definitions/deployment",
+      "type": ["object", "null"],
+      "properties": {
+        "mode": {"type": "string"},
+        "endpoint_mode": {"type": "string"},
+        "replicas": {"type": "integer"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "rollback_config": {
+          "type": "object",
+          "properties": {
+            "parallelism": {"type": "integer"},
+            "delay": {"type": "string", "format": "duration"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string", "format": "duration"},
+            "max_failure_ratio": {"type": "number"},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        },
+        "update_config": {
+          "type": "object",
+          "properties": {
+            "parallelism": {"type": "integer"},
+            "delay": {"type": "string", "format": "duration"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string", "format": "duration"},
+            "max_failure_ratio": {"type": "number"},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpus": {"type": "string"},
+                "memory": {"type": "string"}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}     
+            },
+            "reservations": {
+              "type": "object",
+              "properties": {
+                "cpus": {"type": "string"},
+                "memory": {"type": "string"},
+                "generic_resources": {"$ref": "#/definitions/generic_resources"}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}     
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        },
+        "restart_policy": {
+          "type": "object",
+          "properties": {
+            "condition": {"type": "string"},
+            "delay": {"type": "string", "format": "duration"},
+            "max_attempts": {"type": "integer"},
+            "window": {"type": "string", "format": "duration"}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        },
+        "placement": {
+          "type": "object",
+          "properties": {
+            "constraints": {"type": "array", "items": {"type": "string"}},
+            "preferences": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "spread": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}     
+              }
+            },
+            "max_replicas_per_node": {"type": "integer"}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}     
+    },
+
+    "generic_resources": {
+      "id": "#/definitions/generic_resources",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "discrete_resource_spec": {
+            "type": "object",
+            "properties": {
+              "kind": {"type": "string"},
+              "value": {"type": "number"}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}     
+          }
+        },
+        "additionalProperties": false,
+        "patternProperties": {"^x-": {}}     
+      }
+    },
+
+    "network": {
+      "id": "#/definitions/network",
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "ipam": {
+          "type": "object",
+          "properties": {
+            "driver": {"type": "string"},
+            "config": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "subnet": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}     
+              }
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        },
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        },
+        "internal": {"type": "boolean"},
+        "attachable": {"type": "boolean"},
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}     
+    },
+
+    "volume": {
+      "id": "#/definitions/volume",
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}     
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
+    },
+
+    "secret": {
+      "id": "#/definitions/secret",
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "file": {"type": "string"},
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {"type": "string"}
+          }
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "template_driver": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}     
+    },
+
+    "config": {
+      "id": "#/definitions/config",
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "file": {"type": "string"},
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          }
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "template_driver": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}     
+    },
+
+    "string_or_list": {
+      "oneOf": [
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
+      ]
+    },
+
+    "list_of_strings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+
+    "list_or_dict": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": ["string", "number", "null"]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "constraints": {
+      "service": {
+        "id": "#/definitions/constraints/service",
+        "anyOf": [
+          {"required": ["build"]},
+          {"required": ["image"]}
+        ],
+        "properties": {
+          "build": {
+            "required": ["context"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/compose/const.py
+++ b/compose/const.py
@@ -42,6 +42,7 @@ COMPOSEFILE_V3_5 = ComposeVersion('3.5')
 COMPOSEFILE_V3_6 = ComposeVersion('3.6')
 COMPOSEFILE_V3_7 = ComposeVersion('3.7')
 COMPOSEFILE_V3_8 = ComposeVersion('3.8')
+COMPOSEFILE_V3_9 = ComposeVersion('3.9')
 
 # minimum DOCKER ENGINE API version needed to support
 # features for each compose schema version
@@ -61,6 +62,7 @@ API_VERSIONS = {
     COMPOSEFILE_V3_6: '1.36',
     COMPOSEFILE_V3_7: '1.38',
     COMPOSEFILE_V3_8: '1.38',
+    COMPOSEFILE_V3_9: '1.38',
 }
 
 API_VERSION_TO_ENGINE_VERSION = {
@@ -79,4 +81,5 @@ API_VERSION_TO_ENGINE_VERSION = {
     API_VERSIONS[COMPOSEFILE_V3_6]: '18.02.0',
     API_VERSIONS[COMPOSEFILE_V3_7]: '18.06.0',
     API_VERSIONS[COMPOSEFILE_V3_8]: '18.06.0',
+    API_VERSIONS[COMPOSEFILE_V3_9]: '18.06.0',
 }

--- a/compose/const.py
+++ b/compose/const.py
@@ -42,7 +42,8 @@ COMPOSEFILE_V3_5 = ComposeVersion('3.5')
 COMPOSEFILE_V3_6 = ComposeVersion('3.6')
 COMPOSEFILE_V3_7 = ComposeVersion('3.7')
 COMPOSEFILE_V3_8 = ComposeVersion('3.8')
-COMPOSEFILE_V3_9 = ComposeVersion('3.9')
+
+COMPOSEFILE_NO_VERSION = ComposeVersion('3.9')
 
 # minimum DOCKER ENGINE API version needed to support
 # features for each compose schema version
@@ -62,7 +63,7 @@ API_VERSIONS = {
     COMPOSEFILE_V3_6: '1.36',
     COMPOSEFILE_V3_7: '1.38',
     COMPOSEFILE_V3_8: '1.38',
-    COMPOSEFILE_V3_9: '1.38',
+    COMPOSEFILE_NO_VERSION: '1.38',
 }
 
 API_VERSION_TO_ENGINE_VERSION = {
@@ -81,5 +82,5 @@ API_VERSION_TO_ENGINE_VERSION = {
     API_VERSIONS[COMPOSEFILE_V3_6]: '18.02.0',
     API_VERSIONS[COMPOSEFILE_V3_7]: '18.06.0',
     API_VERSIONS[COMPOSEFILE_V3_8]: '18.06.0',
-    API_VERSIONS[COMPOSEFILE_V3_9]: '18.06.0',
+    API_VERSIONS[COMPOSEFILE_NO_VERSION]: '18.06.0',
 }


### PR DESCRIPTION
# Overview
This PR updates `docker-compose` with the latest version of the schema as specified by [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/schema/config_schema_v3.9.json). This (among other things) enables `condition: service_healthy` to be used in v3 format. I've copied the minimum API/Docker versions from the current latest, as I don't think any new features rely on the newer API/daemon. Please feel free to correct me if not 🙈 

# Testing
- Manually verified that I am able to load a `docker-compose.yaml` with `version: '3.9'`
