### PR TITLE
Fix Typos

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -29,7 +29,7 @@
 			# in 2015 with solid bugfixes and improved error handling
 			# among them
 			"mnowster",
-			# Daniel Nephin is one of the longest-running maitainers on
+			# Daniel Nephin is one of the longest-running maintainers on
 			# the Compose project, and has contributed several major features
 			# including muti-file support, variable interpolation, secrets
 			# emulation and many more

--- a/tests/fixtures/simple-failing-dockerfile/Dockerfile
+++ b/tests/fixtures/simple-failing-dockerfile/Dockerfile
@@ -1,7 +1,7 @@
 FROM busybox:1.31.0-uclibc
 LABEL com.docker.compose.test_image=true
 LABEL com.docker.compose.test_failing_image=true
-# With the following label the container wil be cleaned up automatically
+# With the following label the container will be cleaned up automatically
 # Must be kept in sync with LABEL_PROJECT from compose/const.py
 LABEL com.docker.compose.project=composetest
 RUN exit 1


### PR DESCRIPTION
./MAINTAINERS:32: maitainers  ==> maintainers
./tests/fixtures/simple-failing-dockerfile/Dockerfile:4: wil  ==> will

Signed-off-by: Kevin Kirsche <kevin.kirsche@one.verizon.com>