### PR TITLE
Pin wcwidth==0.1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ six==1.12.0
 subprocess32==3.5.4; python_version < '3.2'
 texttable==1.6.2
 urllib3==1.25.9; python_version == '3.3'
+wcwidth==0.1.9
 websocket-client==0.57.0


### PR DESCRIPTION
wcwidth version 0.2.0 until at least 0.2.3 results in:

```
[745] Failed to execute script pyi_rth_pkgres
Traceback (most recent call last):
	File "site-packages/PyInstaller/loader/rthooks/pyi_rth_pkgres.py", line 13, in <module>
	File "/code/.tox/py37/lib/python3.7/site-packages/PyInstaller/loader/pyimod03_importers.py", line 623, in exec_module
		exec(bytecode, module.__dict__)
	File "site-packages/pkg_resources/__init__.py", line 86, in <module>
ModuleNotFoundError: No module named 'pkg_resources.py2_warn'
```