### PR TITLE
Pin all indirect dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ WORKDIR /code/
 RUN pip install virtualenv==16.2.0
 RUN pip install tox==2.9.1
 
+COPY requirements-indirect.txt .
 COPY requirements.txt .
 COPY requirements-dev.txt .
 COPY .pre-commit-config.yaml .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include Dockerfile
 include LICENSE
+include requirements-indirect.txt
 include requirements.txt
 include requirements-dev.txt
 include tox.ini

--- a/requirements-indirect.txt
+++ b/requirements-indirect.txt
@@ -1,0 +1,28 @@
+altgraph==0.17
+appdirs==1.4.4
+attrs==19.3.0
+bcrypt==3.1.7
+cffi==1.14.0
+cryptography==2.9.2
+distlib==0.3.0
+entrypoints==0.3
+filelock==3.0.12
+gitdb2==2.0.6
+mccabe==0.6.1
+more-itertools==8.3.0; python_version >= '3.5'
+more-itertools==5.0.0; python_version < '3.5'
+packaging==20.4
+pluggy==0.13.1
+py==1.8.1
+pycodestyle==2.5.0
+pycparser==2.20
+pyflakes==2.1.1
+PyNaCl==1.3.0
+pyparsing==2.4.7
+pyrsistent==0.16.0
+smmap==3.0.4
+smmap2==3.0.1
+toml==0.10.1
+tox==2.9.1
+virtualenv==16.2.0
+wcwidth==0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,4 @@ six==1.12.0
 subprocess32==3.5.4; python_version < '3.2'
 texttable==1.6.2
 urllib3==1.25.9; python_version == '3.3'
-wcwidth==0.1.9
 websocket-client==0.57.0

--- a/script/build/osx
+++ b/script/build/osx
@@ -6,6 +6,7 @@ TOOLCHAIN_PATH="$(realpath $(dirname $0)/../../build/toolchain)"
 rm -rf venv
 
 virtualenv -p "${TOOLCHAIN_PATH}"/bin/python3 venv
+venv/bin/pip install -r requirements-indirect.txt
 venv/bin/pip install -r requirements.txt
 venv/bin/pip install -r requirements-build.txt
 venv/bin/pip install --no-deps .

--- a/script/build/windows.ps1
+++ b/script/build/windows.ps1
@@ -45,6 +45,7 @@ virtualenv -p C:\Python37\python.exe .\venv
 $ErrorActionPreference = "Continue"
 
 .\venv\Scripts\pip install pypiwin32==223
+.\venv\Scripts\pip install -r requirements-indirect.txt
 .\venv\Scripts\pip install -r requirements.txt
 .\venv\Scripts\pip install --no-deps .
 .\venv\Scripts\pip install -r requirements-build.txt

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ passenv =
 setenv =
     HOME=/tmp
 deps =
+    -rrequirements-indirect.txt
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =


### PR DESCRIPTION
This PR is due to recent problems regarding the version change of `wcwidth` that broke the build on `master`

The intent of the new file `requirements-indirect.txt` is to pin the version of all the indirect dependencies.
That was generated by creating a new virtualenv, installing all the dependencies in `requirements.txt`, `requirements-dev.txt` and `requirements-build.txt`, running `pip freeze` and then removing all the packages in the intersection with the union of the 3 others.