### PR TITLE
Update service.py

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1785,7 +1785,7 @@ class _CLIBuilder(object):
         """
         if dockerfile:
             dockerfile = os.path.join(path, dockerfile)
-        iidfile = tempfile.mktemp()
+        iidfile = tempfile.NamedTemporaryFile(delete=False)
 
         command_builder = _CommandBuilder()
         command_builder.add_params("--build-arg", buildargs)

--- a/compose/service.py
+++ b/compose/service.py
@@ -1785,6 +1785,7 @@ class _CLIBuilder(object):
         """
         if dockerfile:
             dockerfile = os.path.join(path, dockerfile)
+            
         iidfile = tempfile.NamedTemporaryFile(delete=False)
 
         command_builder = _CommandBuilder()


### PR DESCRIPTION
Removed mktemp which is a deprecated function. This was replaced with NamedTemporaryFile as recommended in the documentation.

Impact:
The creation and open operations don't happen atomically. This provides an opportunity for an attacker to interfere with the file before it is opened. Resulting in another process being able to access this file before it is opened.
This does not present a big impact since an exploit would require a host compromise. Besides, this is the build id file, which is less meaningful than already having host access. Nonetheless, it would be recommended to update the function.

Signed-off-by: Nuno Lopes nunoloeps@gmail.com
Resolves #
