### PR TITLE
Update service.py

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1773,7 +1773,7 @@ class _CLIBuilder(object):
         """
         if dockerfile:
             dockerfile = os.path.join(path, dockerfile)
-        iidfile = tempfile.mktemp()
+        iidfile = tempfile.NamedTemporaryFile(delete=False)
 
         command_builder = _CommandBuilder()
         command_builder.add_params("--build-arg", buildargs)


### PR DESCRIPTION
Removed mktemp which is a deprecated function. This was replaced with NamedTemporaryFile as recommended in the documentation.

Impact:
The creation and open operations don't happen atomically. This provides an opportunity for an attacker to interfere with the file before it is opened. Resulting in another process being able to access this file before it is opened.
This does not present a big impact since an exploit would require a host compromise. Besides, this is the build id file, which is less meaningful than already having host access. Nonetheless, it would be recommended to update the function.

Signed-off-by: Nuno Lopes nunoloeps@gmail.com

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #
