### PR TITLE
Add auto_up option to exclude service from `docker-compose up` by default

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -124,6 +124,7 @@ DOCKER_CONFIG_KEYS = [
 ]
 
 ALLOWED_KEYS = DOCKER_CONFIG_KEYS + [
+    'auto_up',
     'blkio_config',
     'build',
     'container_name',

--- a/compose/config/config_schema_v2.0.json
+++ b/compose/config/config_schema_v2.0.json
@@ -51,6 +51,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "blkio_config": {
           "type": "object",
           "properties": {

--- a/compose/config/config_schema_v2.1.json
+++ b/compose/config/config_schema_v2.1.json
@@ -51,6 +51,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "blkio_config": {
           "type": "object",
           "properties": {

--- a/compose/config/config_schema_v2.2.json
+++ b/compose/config/config_schema_v2.2.json
@@ -51,6 +51,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "blkio_config": {
           "type": "object",
           "properties": {

--- a/compose/config/config_schema_v2.3.json
+++ b/compose/config/config_schema_v2.3.json
@@ -51,6 +51,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "blkio_config": {
           "type": "object",
           "properties": {

--- a/compose/config/config_schema_v2.4.json
+++ b/compose/config/config_schema_v2.4.json
@@ -51,6 +51,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "blkio_config": {
           "type": "object",
           "properties": {

--- a/compose/config/config_schema_v3.0.json
+++ b/compose/config/config_schema_v3.0.json
@@ -51,6 +51,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [

--- a/compose/config/config_schema_v3.1.json
+++ b/compose/config/config_schema_v3.1.json
@@ -62,6 +62,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [

--- a/compose/config/config_schema_v3.2.json
+++ b/compose/config/config_schema_v3.2.json
@@ -62,6 +62,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [

--- a/compose/config/config_schema_v3.3.json
+++ b/compose/config/config_schema_v3.3.json
@@ -73,6 +73,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [

--- a/compose/config/config_schema_v3.4.json
+++ b/compose/config/config_schema_v3.4.json
@@ -75,6 +75,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [

--- a/compose/config/config_schema_v3.5.json
+++ b/compose/config/config_schema_v3.5.json
@@ -74,6 +74,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [

--- a/compose/config/config_schema_v3.6.json
+++ b/compose/config/config_schema_v3.6.json
@@ -74,6 +74,7 @@
       "type": "object",
 
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {"$ref": "#/definitions/deployment"},
         "build": {
           "oneOf": [

--- a/compose/config/config_schema_v3.7.json
+++ b/compose/config/config_schema_v3.7.json
@@ -68,6 +68,7 @@
       "id": "#/definitions/service",
       "type": "object",
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {
           "$ref": "#/definitions/deployment"
         },

--- a/compose/config/config_schema_v3.8.json
+++ b/compose/config/config_schema_v3.8.json
@@ -68,6 +68,7 @@
       "id": "#/definitions/service",
       "type": "object",
       "properties": {
+        "auto_up": {"type": "boolean"},
         "deploy": {
           "$ref": "#/definitions/deployment"
         },

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -167,6 +167,107 @@ class ProjectTest(unittest.TestCase):
         project = Project('test', [web, db], None)
         assert project.get_services(['web', 'db'], include_deps=True) == [db, web]
 
+    def test_get_services_includes_non_auto_up_services_without_args(self):
+        db = Service(
+            name='db',
+            image='foo',
+        )
+        web = Service(
+            name='web',
+            image='foo',
+            links=[(db, 'database')]
+        )
+        mock_api = Service(
+            auto_up=False,
+            name='mock_api',
+            image='foo',
+        )
+        project = Project('test', [web, db, mock_api], None)
+        assert project.get_services() == [web, db, mock_api]
+
+    def test_get_services_excludes_non_auto_up_services_without_service_names(self):
+        db = Service(
+            name='db',
+            image='foo',
+        )
+        web = Service(
+            name='web',
+            image='foo',
+            links=[(db, 'database')]
+        )
+        mock_api = Service(
+            auto_up=False,
+            name='mock_api',
+            image='foo',
+        )
+        project = Project('test', [web, db, mock_api], None)
+        assert project.get_services(auto_up_only=True) == [web, db]
+
+    def test_get_services_exludes_auto_up_services_as_dependencies_with_no_deps(self):
+        db = Service(
+            auto_up=False,
+            name='db',
+            image='foo',
+        )
+        web = Service(
+            name='web',
+            image='foo',
+            links=[(db, 'database')]
+        )
+        project = Project('test', [web, db], None)
+        assert project.get_services(include_deps=False, auto_up_only=True) == [web]
+
+    def test_get_services_includes_auto_up_services_as_dependencies_with_include_deps(self):
+        db = Service(
+            auto_up=False,
+            name='db',
+            image='foo',
+        )
+        web = Service(
+            name='web',
+            image='foo',
+            links=[(db, 'database')]
+        )
+        project = Project('test', [web, db], None)
+        assert project.get_services(include_deps=True, auto_up_only=True) == [db, web]
+
+    def test_get_services_returns_listed_non_auto_up_services_with_service_names(self):
+        db = Service(
+            name='db',
+            image='foo',
+        )
+        web = Service(
+            name='web',
+            image='foo',
+            links=[(db, 'database')]
+        )
+        mock_api = Service(
+            auto_up=False,
+            name='mock_api',
+            image='foo',
+        )
+        project = Project('test', [web, db, mock_api], None)
+        assert project.get_services(['mock_api'], auto_up_only=True) == [mock_api]
+
+    def test_get_services_returns_listed_non_auto_up_services_and_dependencies_with_service_names(self):
+        db = Service(
+            name='db',
+            image='foo',
+        )
+        web = Service(
+            name='web',
+            image='foo',
+            links=[(db, 'database')]
+        )
+        mock_api = Service(
+            auto_up=False,
+            name='mock_api',
+            image='foo',
+            links=[(db, 'database')]
+        )
+        project = Project('test', [web, db, mock_api], None)
+        assert project.get_services(['mock_api'], include_deps=True, auto_up_only=True) == [db, mock_api]
+
     def test_use_volumes_from_container(self):
         container_id = 'aabbccddee'
         container_dict = dict(Name='aaa', Id=container_id)


### PR DESCRIPTION
This an updated version of #3047, now complete with added test cases.

This adds the new config option `auto_up` to services. When this is explicitly set to `false` the service will not be started when executing `docker-compose up` without service names (unless it is pulled in as a dependency of another service).

This allows to define _optional_ services in a `docker-compose.yml` which are only started when listed explicitly on the command line.

Resolves #6742, #1896 and many more reports requesting this feature or similar.

## Use case

For one example use case of the many listed in #1896 and linked issues consider the following `docker-compose.yml`:
~~~yml
version: '3.8'
services:
  app:
    image: php
    depends_on:
      - db

  db:
    image: mysql

  phpmyadmin:
    auto_up: false
    image: phpmyadmin/phpmyadmin
    depends_on:
      - db

  mailhog:
    auto_up: false
    image: mailhog/mailhog
~~~

This may be an example of a prototypical web app running on PHP and using a MySQL database. Most of the time one only wants to run the `app` and `db` service but for debugging/development purposes two additional, _optional_ services are defined here:
* `phpmyadmin`: simple web interface to access and manipulate the raw database
* `mailhog`: a mocked mail transfer agent to be able to test and debug e-mails sent by the application

This now allows to start the main services with a simple `docker-compose up` and the _optional_ services by listing them:
~~~sh
# start only app and db
# without the auto_up option this would also start phpmyadmin and mailhog
docker-compose up

docker-compose up phpmyadmin # starts phpmyadmin, as well as db if necessary
docker-compose up mailhog # starts only the mailhog service
~~~

## Implementation details

This feature is realized by slightly changing `get_services` in the `Project` module. If no service names are passed via the command line it falls back to _all_ services in the `docker-compose.yml` - which are [now filtered for services which have `auto_up` explicitly set to `false`](https://github.com/acran/compose/commit/3ef48f1bd3975ef1b1570b56eff3c2a0af7db53d#diff-c8c735e30c07f4c7494904b4570d1541R188-R194).

When `auto_up` is set to `true`or is omitted the services are included in the default set as before. Additionally this change only affects the `docker-compose up` and `docker-compose create` commands. Consider this `docker-compose.yml`:
~~~yml
version: '3.8'
services:
  service1:
    image: alpine
    command: echo "I'm service 1"

  service2:
    auto_up: false
    image: alpine
    command: echo "I'm service 2"

  service3:
    image: alpine
    depends_on:
      - service1
      - service2
    command: echo "I'm service 3"

  service4:
    auto_up: false
    image: alpine
    depends_on:
      - service2
    command: echo "I'm service 4"
~~~

With this `docker-compose` behaves as follows:
~~~sh
docker-compose up service1 # starts only service1
docker-compose up service2 # starts only service2

docker-compose up
# starts service1, service2, service3:
# service4 is skipped because of auto_up: false
# service2 is pulled in as dependency of service3

docker-compose up service4 # starts service4 and service2 as its dependency

docker-compose stop # stops all (4) services

docker-compose down # stops and removes all (4) services
# note that --remove-orphans is not needed here

docker-compose logs # shows logs of all 4 services
~~~

## Alternatives

Currently the only way to achive this is by splitting the services into multiple `docker-compose.yml` files and pass them via the `--file` parameter:
~~~sh
# our example from above...
docker-compose up phpmyadmin

# ..,would be instead
docker-compose -f docker-compose.tools.yml up phpmyadmin

# but since phpmyadmin depends_on db we actually need multiple files
docker-compose -f docker-compose.yml -f docker-compose.tools.yml up phpmyadmin
~~~

As can be seen this is quite cumbersome and especially when using `docker-compose` for local development this a **huge** inconvenience as discussed in #1896 extensively and is confirmed by the amount of feature request for many years.

This PR now adds the simple option `auto_up` to the schema from version 2.0 up.

## Documentation

The documentation for this option can be found - and later merged from - here: https://github.com/acran/docker.github.io/commit/03ce9ed4fe282a346da52b69a9187c6807ef739f

## References

This or a similar feature was requested in: #6742 (most recent discussion), #1896 (main discussion), #3047 (previous PR), #697, #912, #1294, #1439, #1547, #2803, #3027, #3289

also related: #1661, #1988, #2773, #3684, #4096, #4650, #6676