### PR TITLE
Fixing imprecise timing in timeparse module.

### DIFF
--- a/compose/utils.py
+++ b/compose/utils.py
@@ -8,7 +8,7 @@ from docker.errors import DockerException
 from docker.utils import parse_bytes as sdk_parse_bytes
 
 from .errors import StreamParseError
-from .timeparse import MULTIPLIERS
+from .timeparse import time_from_seconds
 from .timeparse import timeparse
 
 
@@ -101,7 +101,7 @@ def microseconds_from_time_nano(time_nano):
 
 
 def nanoseconds_from_time_seconds(time_seconds):
-    return int(time_seconds / MULTIPLIERS['nano'])
+    return int(time_from_seconds(time_seconds, unit='nano'))
 
 
 def parse_seconds_float(value):
@@ -109,9 +109,9 @@ def parse_seconds_float(value):
 
 
 def parse_nanoseconds_int(value):
-    parsed = timeparse(value or '')
-    if parsed is None:
+    if not value:
         return None
+    parsed = timeparse(value, exact=True)
     return nanoseconds_from_time_seconds(parsed)
 
 

--- a/tests/unit/timeparse_test.py
+++ b/tests/unit/timeparse_test.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from compose import timeparse
 
 
@@ -37,6 +39,25 @@ def test_minute_as_float():
     assert timeparse.timeparse('1.5m') == 90
 
 
+def test_float_ending_in_dot():
+    assert timeparse.timeparse('1.m') == 60
+
+
+def test_float_starting_in_dot():
+    assert timeparse.timeparse('.5m') == 30
+
+
+def test_dot_alone_isnt_number():
+    assert timeparse.timeparse('.m') is None
+
+
+def test_multiple_dots_isnt_number():
+    assert timeparse.timeparse('.0.m') is None
+    assert timeparse.timeparse('0.0.m') is None
+    assert timeparse.timeparse('00..m') is None
+    assert timeparse.timeparse('..00m') is None
+
+
 def test_hour_minute_second():
     assert timeparse.timeparse('5h34m56s') == 20096
 
@@ -51,3 +72,41 @@ def test_invalid_with_comma():
 
 def test_invalid_with_empty_string():
     assert timeparse.timeparse('') is None
+
+
+def test_precise_timing():
+    assert timeparse.timeparse('0.9999999999999999s0.0000001ns') == 1.0
+    assert timeparse.timeparse('0.9999999999999999s0.0000000ns') == 0.9999999999999999
+
+
+def test_exact_timing():
+    h = '10000'
+    m = '0.00000001'
+    s = '0.999999999'
+    ms = '0.00000001'
+    us = '0.999999999'
+    ns = '0.00000001'
+
+    below = Decimal(ns)
+    below = below / 1000 + Decimal(us)
+    below = below / 1000 + Decimal(ms)
+    below /= 1000
+
+    above = (Decimal(h) * 60 + Decimal(m)) * 60
+
+    seconds = above + Decimal(s) + below
+
+    timestamp = '{h}h{m}m{s}s{ms}ms{us}us{ns}ns'.format(h=h, m=m, s=s, ms=ms, us=us, ns=ns)
+
+    assert timeparse.timeparse(timestamp) == float(seconds)
+    assert timeparse.timeparse(timestamp, exact=True) == seconds
+
+
+def test_helper_functions():
+    n = Decimal('1234.567891234')
+
+    units = ['hours', 'mins', 'secs', 'milli', 'micro', 'nano']
+
+    for unit in units:
+        assert n == timeparse.time_to_seconds(timeparse.time_from_seconds(n, unit=unit), unit=unit)
+        assert n == timeparse.time_from_seconds(timeparse.time_to_seconds(n, unit=unit), unit=unit)


### PR DESCRIPTION
When testing `tests/unit/config/config_test.py`, the result of the test
are very reliant on the exact floating point value inaccuracies
cancelling each other out.

The main issue is that

```python
MULTIPLIER['nano'] == 1.0 / 1000.0 / 1000.0 / 1000.0 == 9.999999999999999e-10
```

Therefore, on some serialization tests, when it goes through `parse_nanoseconds_int`,
it was calculating `int(1 / 9.99...)`, that is slightly above 1, and it
was succeeding because it was creating a number slightly above 1 and int
behaves similarly to floor, truncating the number. That doesn't mean that it works correctly serializing all possible configurations

This can be fixed, and by doing that allow more precise and more stable timing.

- We make `timeparse.timeparse` use Decimal internally.
- We also add an `INVERSE_MULTIPLIER` instead to provide better arithmetic
  precision. I want to ask if it is possible to remove the MULTIPLIER
  that are floating point, I am not sure if anything else from another
  codebase is using it
- To allow an easier access, we replace the use of those dictionaries
  with two helper function to and from seconds (They attempt to use the
  more precise floatinig poinnt arithmetic possible, but for exact
  measuring, they can be passed `Decimal` numbers)
- We provide on `timeparse.timeparse` a flag called `exact` to allow
  returning the Decimal result. However, for backwards compatibility, we
  set it to `False` by default
- We modified `parse_nanoseconds_int` to use the exact measuring
- We changed the regex to factor out `FLOAT_NUMBER`.
- We removed the very outdated doctest that wasn't working, and added
  tests for the new code.

Signed-off-by: alexrecuenco <alejandrogonzalezrecuenco@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->