### PR TITLE
Error out when context target is not a docker engine

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -140,6 +140,11 @@ def docker_client(environment, version=None, context=None, tls_version=None):
         if tls:
             context.set_endpoint("docker", host=host, tls_cfg=tls, skip_tls_verify=not verify)
 
+    if not context.is_docker_host():
+        raise UserError(
+            "The platform targeted with the current context is not supported.\n"
+            "Make sure the context in use targets a Docker Engine.\n")
+
     kwargs['base_url'] = context.Host
     if context.TLSConfig:
         kwargs['tls'] = context.TLSConfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2020.4.5.1
 chardet==3.0.4
 colorama==0.4.3; sys_platform == 'win32'
 distro==1.5.0
-docker==4.2.1
+docker==4.2.2
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2


### PR DESCRIPTION
Check the context in use targets a docker engine before deploying.   

```
$ docker-compose --context mycloudcontext up 
**ERROR**: The platform targeted with the current context is not supported.
Make sure the context in use targets a Docker Engine.
```

```
$ docker context use default
$ docker context inspect
[
    {
        "Name": "default",
        "Metadata": { },
        "Endpoints": {
            "docker": {
                "Host": "unix:///var/run/docker.sock",
                "SkipTLSVerify": false
            },
...
$ docker-compose  up
Creating network "hello_default" with the default driver
Creating hello_hello_1 ... done
Attaching to hello_hello_1
```
Requires https://github.com/docker/docker-py/pull/2602


Signed-off-by: aiordache <anca.iordache@docker.com>

