### PR TITLE
[master] forward-port "Bump 1.26.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Change log
 ==========
 
+1.26.1 (2020-06-30)
+-------------------
+
+### Features
+
+- Bump `docker-py` from 4.2.1 to 4.2.2
+
+### Bugs
+
+- Enforce `docker-py` 4.2.1 as minimum version when installing with pip
+
+- Fix context load for non-docker endpoints
+
 1.26.0 (2020-06-03)
 -------------------
 

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-VERSION="1.26.0"
+VERSION="1.26.1"
 IMAGE="docker/compose:$VERSION"
 
 


### PR DESCRIPTION
forward-ports the changes from https://github.com/docker/compose/commit/f216ddbf05c131058cb11323023f8b43cd381926, except for the changes in compose/__init__.py (as master is already on v1.27-dev)