### PR TITLE
 docker-compose .env file support dynamic values #3849

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -680,10 +680,21 @@ def resolve_environment(service_dict, environment=None, interpolate=True):
     """
     env = {}
     for env_file in service_dict.get('env_file', []):
-        env.update(env_vars_from_file(env_file, interpolate))
+        (path, interpreter) = split_path_and_interpreter(env_file)
+        env.update(env_vars_from_file(path, interpolate, interpreter=interpreter))
 
     env.update(parse_environment(service_dict.get('environment')))
     return dict(resolve_env_var(k, v, environment) for k, v in env.items())
+
+
+def split_path_and_interpreter(env_file_path):
+    drive, envfile_config = splitdrive(env_file_path)
+
+    if ':' in envfile_config:
+        (path, interpreter) = envfile_config.split(':', 1)
+        return (drive + path, interpreter)
+    else:
+        return (env_file_path, 'dotenv')
 
 
 def resolve_build_args(buildargs, environment):

--- a/compose/service.py
+++ b/compose/service.py
@@ -1150,7 +1150,7 @@ class Service(object):
         container_name = build_container_name(
             self.project, service_name, number, slug,
         )
-        ext_links_origins = [link.split(':')[0] for link in self.options.get('external_links', [])]
+        ext_links_origins = [links.split(':')[0] for links in self.options.get('external_links', [])]
         if container_name in ext_links_origins:
             raise DependencyError(
                 'Service {0} has a self-referential external link: {1}'.format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
 enum34==1.1.6; python_version < '3.4'
+envbash==1.2.0
 functools32==3.2.3.post2; python_version < '3.2'
 idna==2.8
 ipaddress==1.0.23

--- a/tests/fixtures/env/bash.env
+++ b/tests/fixtures/env/bash.env
@@ -1,0 +1,3 @@
+VAR=1
+CMD_RESULT="$(echo result)"
+EMPTY=

--- a/tests/fixtures/env/get_uuid.env
+++ b/tests/fixtures/env/get_uuid.env
@@ -1,0 +1,2 @@
+CUSTOM_UUID=$(id -u)
+CUSTOM_GUID=$(id -g)

--- a/tests/fixtures/env/resolve_bash.env
+++ b/tests/fixtures/env/resolve_bash.env
@@ -1,0 +1,3 @@
+FILE_DEF=bär
+FILE_DEF_EMPTY=
+NO_DEF=


### PR DESCRIPTION
Hello,

For implement the issue #3849, i propose this PR.
I add the possibility to import the environment variable with bash interpreter, if you add `:bash` after the env file path.

```yaml
web:
  env_file:
    tests/fixtures/env/get_uuid.env:bash
```
with `tests/fixtures/env/get_uuid.env` env file :
```bash
CUSTOM_UUID=$(id -u)
CUSTOM_GUID=$(id -g)
```
If no interpreter is specify, we use dotenv format for retro compatibility.