### PR TITLE
avoid using realpath in scripts

### DIFF
--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -36,7 +36,10 @@ if [ "$(pwd)" != '/' ]; then
 fi
 if [ -n "$COMPOSE_FILE" ]; then
     COMPOSE_OPTIONS="$COMPOSE_OPTIONS -e COMPOSE_FILE=$COMPOSE_FILE"
-    compose_dir=$(realpath "$(dirname "$COMPOSE_FILE")")
+    compose_dir="$(dirname "$COMPOSE_FILE")"
+    # canonicalize dir, do not use realpath or readlink -f
+    # since they are not available in some systems (e.g. macOS).
+    compose_dir="$(cd "$compose_dir" && pwd)"
 fi
 if [ -n "$COMPOSE_PROJECT_NAME" ]; then
     COMPOSE_OPTIONS="-e COMPOSE_PROJECT_NAME $COMPOSE_OPTIONS"


### PR DESCRIPTION
Resolves #5708

scripts/run uses realpath when COMPOSE_FILE is set.
realpath is not available in some systems (e.g. macOS),
and readlink -f isn't either. Replaced with a more
portable approach.