### PR TITLE
Use docker cli on docker-compose run when COMPOSE_DOCKER_CLI_BUILD=1 passed.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1298,6 +1298,7 @@ def build_one_off_container_options(options, detach, command):
 
 def run_one_off_container(container_options, project, service, options, toplevel_options,
                           toplevel_environment):
+    native_builder = toplevel_environment.get_boolean('COMPOSE_DOCKER_CLI_BUILD')
     detach = options.get('--detach')
     use_network_aliases = options.get('--use-aliases')
     containers = project.up(
@@ -1306,6 +1307,7 @@ def run_one_off_container(container_options, project, service, options, toplevel
         strategy=ConvergenceStrategy.never,
         detached=detach,
         rescale=False,
+        cli=native_builder,
         one_off=True,
         override_options=container_options,
     )

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -221,6 +221,55 @@ class CLITestCase(unittest.TestCase):
 
         assert not mock_client.create_host_config.call_args[1].get('restart_policy')
 
+    @mock.patch('compose.project.Project.up')
+    @mock.patch.dict(os.environ)
+    def test_run_up_with_docker_cli_build(self, mock_project_up):
+        os.environ['COMPOSE_DOCKER_CLI_BUILD'] = '1'
+        mock_client = mock.create_autospec(docker.APIClient)
+        mock_client.api_version = DEFAULT_DOCKER_API_VERSION
+        mock_client._general_configs = {}
+        container = Container(mock_client, {
+            'Id': '37b35e0ba80d91009d37e16f249b32b84f72bda269985578ed6c75a0a13fcaa8',
+            'Name': 'composetest_service_37b35',
+            'Config': {
+                'Labels': {
+                    LABEL_SERVICE: 'service',
+                }
+            },
+        }, has_been_inspected=True)
+        mock_project_up.return_value = [container]
+
+        project = Project.from_config(
+            name='composetest',
+            config_data=build_config({
+                'service': {'image': 'busybox'}
+            }),
+            client=mock_client,
+        )
+
+        command = TopLevelCommand(project)
+        command.run({
+            'SERVICE': 'service',
+            'COMMAND': None,
+            '-e': [],
+            '--label': [],
+            '--user': None,
+            '--no-deps': None,
+            '--detach': True,
+            '-T': None,
+            '--entrypoint': None,
+            '--service-ports': None,
+            '--use-aliases': None,
+            '--publish': [],
+            '--volume': [],
+            '--rm': None,
+            '--name': None,
+            '--workdir': None,
+        })
+
+        _, _, call_kwargs = mock_project_up.mock_calls[0]
+        assert call_kwargs.get('cli')
+
     def test_command_manual_and_service_ports_together(self):
         project = Project.from_config(
             name='composetest',


### PR DESCRIPTION
Resolves #7336

Build triggered by `docker-compose run` doesn't consider `COMPOSE_DOCKER_CLI_BUILD=1`.
This pull request make `docker-compose run` pass the the `cli` option to build images by docker cli to the internal `up` process considering the environment variable.

This is an experimental feature, but I think implicit build steps of `docker-compose run` and `docker-compose up` should behave as same as possible. https://github.com/docker/compose/issues/7336#issuecomment-671037219

This is my first contribution to this repository.
I can't see the good place to add the test for this change. If I need a fix, please advice.