### PR TITLE
Update schema and fix scale parsing

### DIFF
--- a/compose/config/config_schema_compose_spec.json
+++ b/compose/config/config_schema_compose_spec.json
@@ -258,7 +258,7 @@
           "patternProperties": {"^x-": {}}
         },
         "mac_address": {"type": "string"},
-        "mem_limit": {"type": ["number", "string"]},
+        "mem_limit": {"type": "string"},
         "mem_reservation": {"type": ["string", "integer"]},
         "mem_swappiness": {"type": "integer"},
         "memswap_limit": {"type": ["number", "string"]},
@@ -503,7 +503,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": "number", "minimum": 0},
                 "memory": {"type": "string"}
               },
               "additionalProperties": false,
@@ -512,7 +512,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": "number", "minimum": 0},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },
@@ -633,6 +633,7 @@
           "patternProperties": {"^x-": {}}
         },
         "internal": {"type": "boolean"},
+        "enable_ipv6": {"type": "boolean"},
         "attachable": {"type": "boolean"},
         "labels": {"$ref": "#/definitions/list_or_dict"}
       },

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -241,6 +241,7 @@ class ConversionMap:
         service_path('healthcheck', 'disable'): to_boolean,
         service_path('deploy', 'labels', PATH_JOKER): to_str,
         service_path('deploy', 'replicas'): to_int,
+        service_path('deploy', 'resources', 'limits', "cpus"): to_float,
         service_path('deploy', 'update_config', 'parallelism'): to_int,
         service_path('deploy', 'update_config', 'max_failure_ratio'): to_float,
         service_path('deploy', 'rollback_config', 'parallelism'): to_int,

--- a/compose/project.py
+++ b/compose/project.py
@@ -318,6 +318,8 @@ class Project:
             )
         if replicas:
             scale = replicas
+        if scale is None:
+            return 1
         # deploy may contain placement constraints introduced in v3.8
         max_replicas = deploy_dict.get('placement', {}).get(
             'max_replicas_per_node',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,11 @@ certifi==2020.6.20
 chardet==3.0.4
 colorama==0.4.3; sys_platform == 'win32'
 distro==1.5.0
-docker==4.3.0
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
+# temporary fix for the mem_limit float parsing
+git+git://github.com/docker/docker-py@2c522fb362247a692c0493f0b47a33988eb2f3e3#egg=docker
 idna==2.10
 ipaddress==1.0.23
 jsonschema==3.2.0

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -525,11 +525,11 @@ services:
                         },
                         'resources': {
                             'limits': {
-                                'cpus': '0.05',
+                                'cpus': 0.05,
                                 'memory': '50M',
                             },
                             'reservations': {
-                                'cpus': '0.01',
+                                'cpus': 0.01,
                                 'memory': '20M',
                             },
                         },

--- a/tests/fixtures/v3-full/docker-compose.yml
+++ b/tests/fixtures/v3-full/docker-compose.yml
@@ -14,10 +14,10 @@ services:
         max_failure_ratio: 0.3
       resources:
         limits:
-          cpus: '0.05'
+          cpus: 0.05
           memory: 50M
         reservations:
-          cpus: '0.01'
+          cpus: 0.01
           memory: 20M
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
Updated schema: 
- fix scale bug (missing default value when processing deploy section)
- add enable_ipv6
- change `deploy.resources.limits.cpus` to number type
- change `deploy.resources.reservations.cpus` to number type

Co-authored-by @ulyssessouza 

Resolves https://github.com/docker/compose/issues/7670 and https://github.com/docker/compose/issues/7671
