### PR TITLE
Parse network-mode on CLI build

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1845,6 +1845,7 @@ class _CLIBuilder:
         command_builder.add_flag("--force-rm", forcerm)
         command_builder.add_params("--label", labels)
         command_builder.add_arg("--memory", container_limits.get("memory"))
+        command_builder.add_arg("--network", network_mode)
         command_builder.add_flag("--no-cache", nocache)
         command_builder.add_arg("--progress", self._progress)
         command_builder.add_flag("--pull", pull)


### PR DESCRIPTION
Parse `network-mode` when building with the native `docker` CLI

Resolves https://github.com/moby/buildkit/issues/1642 
Resolves #7682