### PR TITLE
Update client version

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -6,7 +6,6 @@ from . import errors
 from .. import config
 from .. import parallel
 from ..config.environment import Environment
-from ..const import API_VERSIONS
 from ..const import LABEL_CONFIG_FILES
 from ..const import LABEL_ENVIRONMENT_FILE
 from ..const import LABEL_WORKING_DIR
@@ -127,9 +126,7 @@ def get_project(project_dir, config_path=None, project_name=None, verbose=False,
     )
     config_data = config.load(config_details, interpolate)
 
-    api_version = environment.get(
-        'COMPOSE_API_VERSION',
-        API_VERSIONS[config_data.version])
+    api_version = environment.get('COMPOSE_API_VERSION')
 
     client = get_client(
         verbose=verbose, version=api_version, context=context, environment=environment

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -367,27 +367,6 @@ def find_candidates_in_parent_dirs(filenames, path):
     return (candidates, path)
 
 
-def check_swarm_only_config(service_dicts):
-    warning_template = (
-        "Some services ({services}) use the '{key}' key, which will be ignored. "
-        "Compose does not support '{key}' configuration - use "
-        "`docker stack deploy` to deploy to a swarm."
-    )
-
-    def check_swarm_only_key(service_dicts, key):
-        services = [s for s in service_dicts if s.get(key)]
-        if services:
-            log.warning(
-                warning_template.format(
-                    services=", ".join(sorted(s['name'] for s in services)),
-                    key=key
-                )
-            )
-
-    check_swarm_only_key(service_dicts, 'deploy')
-    check_swarm_only_key(service_dicts, 'configs')
-
-
 def load(config_details, interpolate=True):
     """Load the configuration from a working directory and a list of
     configuration files.  Files are loaded in order, and merged on top
@@ -423,8 +402,6 @@ def load(config_details, interpolate=True):
     if main_file.version != V1:
         for service_dict in service_dicts:
             match_named_volumes(service_dict, volumes)
-
-    check_swarm_only_config(service_dicts)
 
     version = main_file.version
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,10 @@ certifi==2020.6.20
 chardet==3.0.4
 colorama==0.4.3; sys_platform == 'win32'
 distro==1.5.0
+docker==4.3.1
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
-# temporary fix for the mem_limit float parsing
-git+git://github.com/docker/docker-py@2c522fb362247a692c0493f0b47a33988eb2f3e3#egg=docker
 idna==2.10
 ipaddress==1.0.23
 jsonschema==3.2.0


### PR DESCRIPTION
- Bump docker-py version to 4.3.1
- Cleanup warning messages for deploy and config sections
- Use the default API version from docker-py client
