### PR TITLE
Add 'loki' to list of logging drivers that support `docker-compose logs`

### DIFF
--- a/compose/container.py
+++ b/compose/container.py
@@ -189,7 +189,7 @@ class Container:
     @property
     def has_api_logs(self):
         log_type = self.log_driver
-        return not log_type or log_type in ('json-file', 'journald', 'local')
+        return not log_type or log_type in ('json-file', 'journald', 'local', 'loki')
 
     @property
     def human_readable_health_status(self):
@@ -204,8 +204,8 @@ class Container:
         return status_string
 
     def attach_log_stream(self):
-        """A log stream can only be attached if the container uses a
-        json-file, journald or local log driver.
+        """A log stream can only be attached if the container uses log driver
+        json-file, journald, local or loki.
         """
         if self.has_api_logs:
             self.log_stream = self.attach(stdout=True, stderr=True, stream=True)


### PR DESCRIPTION
The Loki logging driver still uses the json-log driver in combination with sending logs to Loki
https://github.com/grafana/loki/blob/v1.6.0/docs/sources/clients/docker-driver/configuration.md

`docker logs` already works with loki. But docker-compose has its own check whether logs are supported. With this change `docker-compose logs` works when the loki logging driver is configured

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->


Resolves #7408

Follow-up of #7425
