### PR TITLE
Rely on returncode to check for errors instead of stderr content.

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -73,13 +73,16 @@ def main():
         log.error(e.msg)
         sys.exit(1)
     except BuildError as e:
-        log.error("Service '{}' failed to build: {}".format(e.service.name, e.reason))
+        reason = ""
+        if e.reason:
+            reason = " : " + e.reason
+        log.error("Service '{}' failed to build{}".format(e.service.name, reason))
         sys.exit(1)
     except StreamOutputError as e:
         log.error(e)
         sys.exit(1)
     except NeedsBuildError as e:
-        log.error("Service '%s' needs to be built, but --no-build was passed." % e.service.name)
+        log.error("Service '{}' needs to be built, but --no-build was passed.".format(e.service.name))
         sys.exit(1)
     except NoSuchCommand as e:
         commands = "\n".join(parse_doc_section("commands:", getdoc(e.supercommand)))

--- a/compose/service.py
+++ b/compose/service.py
@@ -1857,7 +1857,6 @@ class _CLIBuilder:
         magic_word = "Successfully built "
         appear = False
         with subprocess.Popen(args, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE,
                               universal_newlines=True) as p:
             while True:
                 line = p.stdout.readline()
@@ -1867,9 +1866,9 @@ class _CLIBuilder:
                     appear = True
                 yield json.dumps({"stream": line})
 
-            err = p.stderr.readline().strip()
-            if err:
-                raise StreamOutputError(err)
+            p.communicate()
+            if p.returncode != 0:
+                raise StreamOutputError()
 
         with open(iidfile) as f:
             line = f.readline()

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -1002,11 +1002,8 @@ class ServiceTest(DockerClientTestCase):
                                           'context': base_dir,
                                           'labels': {'com.docker.compose.test': 'true'}},
                                       )
-        with pytest.raises(BuildError) as excinfo:
+        with pytest.raises(BuildError):
             service.build(cli=True)
-
-        reason = excinfo.value.reason
-        assert "The command '/bin/sh -c exit 2' returned a non-zero code: 2" == reason
 
     def test_up_build_cli(self):
         base_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Resolves #7712

Rely on `returncode` to check for errors instead of `stderr` content.