### PR TITLE
Fix release notes for 1.27.0 - dropped python2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Change log
 
 ### Miscellaneous
 
+- Drop support for Python 2.7
+
 - Bump `docker-py` to 4.3.1
 
 - Bump `tox` to 3.19.0


### PR DESCRIPTION
Relates to https://github.com/docker/compose/issues/7736
