### PR TITLE
Pin `docker-compose config`'s version to `3.9`

### DIFF
--- a/compose/const.py
+++ b/compose/const.py
@@ -24,7 +24,7 @@ SECRETS_PATH = '/run/secrets'
 WINDOWS_LONGPATH_PREFIX = '\\\\?\\'
 
 COMPOSEFILE_V1 = ComposeVersion('1')
-COMPOSE_SPEC = ComposeVersion('3')
+COMPOSE_SPEC = ComposeVersion('3.9')
 
 # minimum DOCKER ENGINE API version needed to support
 # features for each compose schema version


### PR DESCRIPTION
This avoids bugs on using it's output on swarm

Resolves #7730 
