### PR TITLE
Allow driver property for external networks

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -441,6 +441,8 @@ def load_mapping(config_files, get_func, entity_type, working_dir=None):
 
 def validate_external(entity_type, name, config, version):
     for k in config.keys():
+        if entity_type == 'Network' and k == 'driver':
+            continue
         if k not in ['external', 'name']:
             raise ConfigurationError(
                 "{} {} declared as external but specifies additional attributes "


### PR DESCRIPTION
Regression in 1.27.0. 
When targeting an external overlay network, docker-compose should not verify that the external network exists. We allow the driver property for external network to be able to skip this verification.

```
if self.external:
  if self.driver == 'overlay': 
     # Swarm nodes do not register overlay networks that were 
     # created on a different node unless they're in use. 
     # See docker/compose#4399 
     return 
```
Resolves https://github.com/docker/compose/issues/7734
