### PR TITLE
Use `detach=true` for oneoff containers

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1309,7 +1309,7 @@ def run_one_off_container(container_options, project, service, options, toplevel
         service_names=[service.name],
         start_deps=not options['--no-deps'],
         strategy=ConvergenceStrategy.never,
-        detached=detach,
+        detached=True,
         rescale=False,
         cli=native_builder,
         one_off=True,


### PR DESCRIPTION
Use `detach=true` on `project.up` for a oneoff container. We start it after and attach to it.

Resolves https://github.com/docker/compose/issues/7741
