### PR TITLE
Fix scaling on `docker-compose up` when some containers are not running

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -411,7 +411,7 @@ class Service:
         stopped = [c for c in containers if not c.is_running]
 
         if stopped:
-            return ConvergencePlan('start', stopped)
+            return ConvergencePlan('start', containers)
 
         return ConvergencePlan('noop', containers)
 
@@ -514,8 +514,9 @@ class Service:
             self._downscale(containers[scale:], timeout)
             containers = containers[:scale]
         if start:
+            stopped = [c for c in containers if not c.is_running]
             _, errors = parallel_execute(
-                containers,
+                stopped,
                 lambda c: self.start_container_if_stopped(c, attach_logs=not detached, quiet=True),
                 lambda c: c.name,
                 "Starting",

--- a/tests/integration/project_test.py
+++ b/tests/integration/project_test.py
@@ -1347,6 +1347,36 @@ class ProjectTest(DockerClientTestCase):
         project.up()
         assert len(project.containers()) == 3
 
+    def test_project_up_scale_with_stopped_containers(self):
+        config_data = build_config(
+            services=[{
+                'name': 'web',
+                'image': BUSYBOX_IMAGE_WITH_TAG,
+                'command': 'top',
+                'scale': 2
+            }]
+        )
+        project = Project.from_config(
+            name='composetest', config_data=config_data, client=self.client
+        )
+
+        project.up()
+        containers = project.containers()
+        assert len(containers) == 2
+
+        self.client.stop(containers[0].id)
+        project.up(scale_override={'web': 2})
+        containers = project.containers()
+        assert len(containers) == 2
+
+        self.client.stop(containers[0].id)
+        project.up(scale_override={'web': 3})
+        assert len(project.containers()) == 3
+
+        self.client.stop(containers[0].id)
+        project.up(scale_override={'web': 1})
+        assert len(project.containers()) == 1
+
     def test_initialize_volumes(self):
         vol_name = '{:x}'.format(random.getrandbits(32))
         full_vol_name = 'composetest_{}'.format(vol_name)

--- a/tests/integration/state_test.py
+++ b/tests/integration/state_test.py
@@ -375,7 +375,7 @@ class ServiceStateTest(DockerClientTestCase):
 
         assert [c.is_running for c in containers] == [False, True]
 
-        assert ('start', containers[0:1]) == web.convergence_plan()
+        assert ('start', containers) == web.convergence_plan()
 
     def test_trigger_recreate_with_config_change(self):
         web = self.create_service('web', command=["top"])


### PR DESCRIPTION
The problem was caused by having only stopped containers being passed in the execution of the convergence plan for starting containers.  The re-scaling was triggered due to not having the running containers counted (size of the deployment was considered the number of stopped containers which was smaller that the requested scale).

docker-compose.yml
```
version: "3.7"
services:
  test:
    image: nginx
```
Scale tests
```
$ docker-compose up -d --scale test=4
Starting nginx_test_1 ... done
Starting nginx_test_2 ... done
Starting nginx_test_3 ... done
Starting nginx_test_4 ... done

$ docker stop nginx_test_1
nginx_test_1

$ docker-compose up -d --scale test=4
Starting nginx_test_1 ... done

$ docker stop nginx_test_1
nginx_test_1

$ docker-compose up -d --scale test=5
Starting nginx_test_1 ... done
Creating nginx_test_5 ... done

$ docker-compose up -d --scale test=4
Stopping and removing nginx_test_5 ... done

17:25 $ docker stop nginx_test_1
nginx_test_1

$ docker-compose up -d --scale test=3
Stopping and removing nginx_test_4 ... done
Starting nginx_test_1              ... done

$ docker-compose ps
    Name                  Command               State   Ports 
--------------------------------------------------------------
nginx_test_1   /docker-entrypoint.sh ngin ...   Up      80/tcp
nginx_test_2   /docker-entrypoint.sh ngin ...   Up      80/tcp
nginx_test_3   /docker-entrypoint.sh ngin ...   Up      80/tcp
```




Resolves https://github.com/docker/compose/issues/7749
