### PR TITLE
Fix depends_on serialisation on `docker-compose config`

### DIFF
--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -121,11 +121,6 @@ def denormalize_service_dict(service_dict, version, image_digest=None):
     if version == V1 and 'network_mode' not in service_dict:
         service_dict['network_mode'] = 'bridge'
 
-    if 'depends_on' in service_dict:
-        service_dict['depends_on'] = sorted([
-            svc for svc in service_dict['depends_on'].keys()
-        ])
-
     if 'healthcheck' in service_dict:
         if 'interval' in service_dict['healthcheck']:
             service_dict['healthcheck']['interval'] = serialize_ns_time_value(

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -5269,7 +5269,7 @@ def get_config_filename_for_files(filenames, subdir=None):
 
 
 class SerializeTest(unittest.TestCase):
-    def test_denormalize_depends_on_v3(self):
+    def test_denormalize_depends(self):
         service_dict = {
             'image': 'busybox',
             'command': 'true',
@@ -5279,27 +5279,7 @@ class SerializeTest(unittest.TestCase):
             }
         }
 
-        assert denormalize_service_dict(service_dict, VERSION) == {
-            'image': 'busybox',
-            'command': 'true',
-            'depends_on': ['service2', 'service3']
-        }
-
-    def test_denormalize_depends_on_v2_1(self):
-        service_dict = {
-            'image': 'busybox',
-            'command': 'true',
-            'depends_on': {
-                'service2': {'condition': 'service_started'},
-                'service3': {'condition': 'service_started'},
-            }
-        }
-
-        assert denormalize_service_dict(service_dict, VERSION) == {
-            'image': 'busybox',
-            'command': 'true',
-            'depends_on': ['service2', 'service3']
-        }
+        assert denormalize_service_dict(service_dict, VERSION) == service_dict
 
     def test_serialize_time(self):
         data = {


### PR DESCRIPTION
This fixes the `condition` field being dropped from `depends_on` on `docker-compose config`. 

```
$ docker-compose config
services:
  app1:
    image: nginx
  app2:
    depends_on:
      app1:
        condition: service_started
    image: nginx
  app3:
    depends_on:
      app2:
        condition: service_healthy
    image: nginx
version: '2.4'

```

Resolves https://github.com/docker/compose/issues/7758
