### PR TITLE
Enable relative paths for driver_opts.device

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -433,22 +433,27 @@ def load_mapping(config_files, get_func, entity_type, working_dir=None):
                 config['driver_opts'] = build_string_dict(
                     config['driver_opts']
                 )
-                if entity_type != 'Volume':
-                    continue
-                # default driver is 'local'
-                driver = config.get('driver', 'local')
-                if driver != 'local':
-                    continue
-                o = config['driver_opts'].get('o')
-                device = config['driver_opts'].get('device')
-                if o and o == 'bind' and device:
-                    fullpath = os.path.abspath(os.path.expanduser(device))
-                    if not os.path.exists(fullpath):
-                        raise ConfigurationError(
-                            "Device path {} does not exist.".format(fullpath))
-                    config['driver_opts']['device'] = fullpath
-
+                device = format_device_option(entity_type, config)
+                if device:
+                    config['driver_opts']['device'] = device
     return mapping
+
+
+def format_device_option(entity_type, config):
+    if entity_type != 'Volume':
+        return
+    # default driver is 'local'
+    driver = config.get('driver', 'local')
+    if driver != 'local':
+        return
+    o = config['driver_opts'].get('o')
+    device = config['driver_opts'].get('device')
+    if o and o == 'bind' and device:
+        fullpath = os.path.abspath(os.path.expanduser(device))
+        if not os.path.exists(fullpath):
+            raise ConfigurationError(
+                "Device path {} does not exist.".format(fullpath))
+        return fullpath
 
 
 def validate_external(entity_type, name, config, version):


### PR DESCRIPTION
The driver options for a volume are forwarded to the docker engine unmodified (as specified in the compose file). #6343 requests support for relative paths in the 'device' option of the `local` driver. 
This patch converts the relative paths for `driver_opts.device` to absolute paths (only for a `local` driver and `bind` mount option).

_docker-compose.yml_
```yaml
version: '3.8'
services:
  app:
    image: nginx
    volumes:
      - vol:/test
volumes:
  vol:
    driver_opts:
      type: none
      o: bind
      device: .
```
```
$ pwd
/home/anca/compose/test
$ ls
docker-compose.yml

$ docker-compose up -d

$ docker volume ls
DRIVER              VOLUME NAME
local               test_vol

$ docker volume inspect test_vol
[
    {
        "CreatedAt": "2020-09-03T14:52:50+02:00",
        "Driver": "local",
        "Labels": {
            "com.docker.compose.project": "test",
            "com.docker.compose.version": "1.28.0dev",
            "com.docker.compose.volume": "vol"
        },
        "Mountpoint": "/home/anca/.local/docker/volumes/test_vol/_data",
        "Name": "test_vol",
        "Options": {
            "device": "/home/anca/compose/test",
            "o": "bind",
            "type": "none"
        },
        "Scope": "local"
    }
]

```

```
$ docker exec -t  test_app_1 sh -c "ls /test"
docker-compose.yml
```
Resolves #6343
