### PR TITLE
Change resource.limits.cpus conversion to string

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -241,7 +241,7 @@ class ConversionMap:
         service_path('healthcheck', 'disable'): to_boolean,
         service_path('deploy', 'labels', PATH_JOKER): to_str,
         service_path('deploy', 'replicas'): to_int,
-        service_path('deploy', 'resources', 'limits', "cpus"): to_float,
+        service_path('deploy', 'resources', 'limits', "cpus"): to_str,
         service_path('deploy', 'update_config', 'parallelism'): to_int,
         service_path('deploy', 'update_config', 'max_failure_ratio'): to_float,
         service_path('deploy', 'rollback_config', 'parallelism'): to_int,

--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -242,6 +242,7 @@ class ConversionMap:
         service_path('deploy', 'labels', PATH_JOKER): to_str,
         service_path('deploy', 'replicas'): to_int,
         service_path('deploy', 'resources', 'limits', "cpus"): to_str,
+        service_path('deploy', 'resources', 'reservations', "cpus"): to_str,
         service_path('deploy', 'update_config', 'parallelism'): to_int,
         service_path('deploy', 'update_config', 'max_failure_ratio'): to_float,
         service_path('deploy', 'rollback_config', 'parallelism'): to_int,

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -525,7 +525,7 @@ services:
                         },
                         'resources': {
                             'limits': {
-                                'cpus': 0.05,
+                                'cpus': '0.05',
                                 'memory': '50M',
                             },
                             'reservations': {

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -529,7 +529,7 @@ services:
                                 'memory': '50M',
                             },
                             'reservations': {
-                                'cpus': 0.01,
+                                'cpus': '0.01',
                                 'memory': '20M',
                             },
                         },


### PR DESCRIPTION
Fixed the regression introduced in 1.27.0, by changing the resource.limits.cpus conversion to string in order to be compatible with docker stack deploy.

Steps to reproduce the issue:

Having the following docker-compose.yml file
```
version: '3.7'

services:
    api:
        image: busybox
        command: ['sleep', '10']
        deploy:
            resources:
                limits:
                    cpus: '1'
```

```
>#running the following from versions 1.27.0 to 1.28.0dev gives an error
>docker-compose -f docker-compose.yml config | docker stack deploy
services.api.deploy.resources.limits.cpus must be a string
```
After the fix, the command runs as expected.

Resolves #7774
