### PR TITLE
Remove path check for bind mounts

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -450,9 +450,6 @@ def format_device_option(entity_type, config):
     device = config['driver_opts'].get('device')
     if o and o == 'bind' and device:
         fullpath = os.path.abspath(os.path.expanduser(device))
-        if not os.path.exists(fullpath):
-            raise ConfigurationError(
-                "Device path {} does not exist.".format(fullpath))
         return fullpath
 
 


### PR DESCRIPTION
Regression in 1.27.3
Skip the path check for bind mounts for backwards compatibility.
Fixes https://github.com/docker/compose/issues/7786