### PR TITLE
docker-compose pass arbitrary build flags

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -83,6 +83,7 @@ DOCKER_CONFIG_KEYS = [
     'env_file',
     'environment',
     'extra_hosts',
+    'flags',
     'group_add',
     'hostname',
     'healthcheck',

--- a/compose/config/config_schema_compose_spec.json
+++ b/compose/config/config_schema_compose_spec.json
@@ -74,6 +74,7 @@
               "type": "object",
               "properties": {
                 "context": {"type": "string"},
+                "flags": {"type": "string"},
                 "dockerfile": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},

--- a/compose/service.py
+++ b/compose/service.py
@@ -82,6 +82,7 @@ HOST_CONFIG_KEYS = [
     'dns_opt',
     'env_file',
     'extra_hosts',
+    'flags',
     'group_add',
     'init',
     'ipc',
@@ -1123,6 +1124,7 @@ class Service:
             gzip=gzip,
             isolation=build_opts.get('isolation', self.options.get('isolation', None)),
             platform=self.platform,
+            flags=build_opts.get('flags'),
         )
 
         try:
@@ -1781,7 +1783,7 @@ class _CLIBuilder:
               decode=False, buildargs=None, gzip=False, shmsize=None,
               labels=None, cache_from=None, target=None, network_mode=None,
               squash=None, extra_hosts=None, platform=None, isolation=None,
-              use_config_proxy=True):
+              use_config_proxy=True, flags=None):
         """
         Args:
             path (str): Path to the directory containing the Dockerfile
@@ -1853,6 +1855,7 @@ class _CLIBuilder:
         command_builder.add_arg("--tag", tag)
         command_builder.add_arg("--target", target)
         command_builder.add_arg("--iidfile", iidfile)
+        command_builder.add_manual_args(flags)
         args = command_builder.build([path])
 
         magic_word = "Successfully built "
@@ -1895,6 +1898,10 @@ class _CommandBuilder:
     def add_flag(self, name, flag):
         if flag:
             self._args.extend([name])
+
+    def add_manual_args(self, flags):
+        if (flags != '') and (flags is not None):
+            self._args.extend([flag for flag in flags.split(' ') if flag != ''])
 
     def add_params(self, name, params):
         if params:


### PR DESCRIPTION
added a flags option to the service.build section to pass arbitrary arguments to the docker build from the docker-compose file

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #6358  (see https://github.com/docker/compose/issues/6358#issuecomment-443661538)

An example of how I pass aws credentials to my docker build (used for codeartifact in my case)

```version: "3.8"
services:
  worker:
    build:
      context: worker
      flags: '--secret id=aws_creds,src=${HOME}/.aws/credentials'```