### PR TITLE
Support substitution for set variables

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -95,7 +95,7 @@ class TemplateWithDefaults(Template):
         """.format(
         delim=re.escape('$'),
         id=r'[_a-z][_a-z0-9]*',
-        bid=r'[_a-z][_a-z0-9]*(?:(?P<sep>:?[-?])[^}]*)?',
+        bid=r'[_a-z][_a-z0-9]*(?:(?P<sep>:?[-?+])[^}]*)?',
     )
 
     @staticmethod
@@ -118,6 +118,16 @@ class TemplateWithDefaults(Template):
             if var in mapping:
                 return mapping.get(var)
             raise UnsetRequiredSubstitution(err)
+
+        elif ':+' == sep:
+            var, _, alternate = braced.partition(':+')
+            return mapping.get(var) and alternate
+        elif '+' == sep:
+            var, _, alternate = braced.partition('+')
+            if var not in mapping:
+                return None
+            else:
+                return alternate
 
     # Modified from python2.7/string.py
     def substitute(self, mapping):

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -398,6 +398,21 @@ def test_interpolate_with_empty_and_default_value(defaults_interpolator):
     assert defaults_interpolator("ok ${BAR-def}") == "ok "
 
 
+def test_interpolate_with_alternate(defaults_interpolator):
+    assert defaults_interpolator("ok ${FOO:+def}") == "ok def"
+    assert defaults_interpolator("ok ${FOO+def}") == "ok def"
+
+
+def test_interpolate_missing_with_alternate(defaults_interpolator):
+    assert defaults_interpolator("ok ${missing:+def}") == "ok "
+    assert defaults_interpolator("ok ${missing+def}") == "ok "
+
+
+def test_interpolate_with_empty_and_alternate_value(defaults_interpolator):
+    assert defaults_interpolator("ok ${BAR:+def}") == "ok "
+    assert defaults_interpolator("ok ${BAR+def}") == "ok def"
+
+
 def test_interpolate_mandatory_values(defaults_interpolator):
     assert defaults_interpolator("ok ${FOO:?bar}") == "ok first"
     assert defaults_interpolator("ok ${FOO?bar}") == "ok first"


### PR DESCRIPTION
This adds support for ${parameter:+alternate} and ${parameter+alternate}
syntax to allow for substituting with alternate when the parameter is
set.

Signed-off-by: MarilynFranklin <marilyn.j.franklin@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #7102
