### PR TITLE
7391 silence run

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -824,6 +824,7 @@ class TopLevelCommand:
             -d, --detach          Detached mode: Run container in the background, print
                                   new container name.
             --name NAME           Assign a name to the container
+            --quiet-pull          Pull without printing progress information
             --entrypoint CMD      Override the entrypoint of the image.
             -e KEY=VAL            Set an environment variable (can be used multiple times)
             -l, --label KEY=VAL   Add or override a label (can be used multiple times)
@@ -1314,6 +1315,7 @@ def run_one_off_container(container_options, project, service, options, toplevel
         cli=native_builder,
         one_off=True,
         override_options=container_options,
+        silent=options.get('--quiet-pull')
     )
     try:
         container = next(c for c in containers if c.service == service.name)

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -3034,3 +3034,8 @@ services:
         another = self.project.get_service('--log-service')
         assert len(service.containers()) == 1
         assert len(another.containers()) == 1
+
+    def test_run_with_quiet_pull(self):
+        self.base_dir = 'tests/fixtures/run-quiet-pull'
+        result = self.dispatch(['run', '--quiet-pull', 'simple'])
+        assert result.stdout.strip() == "Hello, World!"

--- a/tests/fixtures/run-quiet-pull/docker-compose.yml
+++ b/tests/fixtures/run-quiet-pull/docker-compose.yml
@@ -1,0 +1,3 @@
+simple:
+    image: busybox:1.27.2
+    command: echo "Hello, World!"


### PR DESCRIPTION
`docker-compose up` has a `--quiet-pull` flag to disable pull information from being outputted to `stdout`. Having such a flag allows compose to be more easily incorporated into scripts (e. g `name=$(docker-compose run bash print-name.sh`). This pull request adds an equivalent flag to `docker-compose run`. 

Given the following `docker-compose.yml` file:
```yml
simple:
    image: busybox:1.27.2
    command: echo "Hello, World!"
```

Pre-feature:
```sh
$ docker-compose run simple 2>/dev/null
1.27.2: Pulling from library/busybox
Digest: sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0
Status: Downloaded newer image for busybox:1.27.2
Hello, World!
```

Post-feature:
```sh
Hello, World!
```

Resolves #7391 
