### PR TITLE
Update run.sh formatting

### DIFF
--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -69,4 +69,5 @@ if docker info --format '{{json .SecurityOptions}}' 2> /dev/null | grep -q 'name
     DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} --privileged"
 fi
 
-eval exec docker run --rm "${DOCKER_RUN_OPTIONS}" "${DOCKER_ADDR}" "${COMPOSE_OPTIONS}" "${VOLUMES}" -w "${PWD}" "${IMAGE}" "$@"
+# shellcheck disable=SC2086
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${DOCKER_ADDR} ${COMPOSE_OPTIONS} ${VOLUMES} -w "${PWD}" "${IMAGE}" "$@"

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -11,13 +11,11 @@
 # You can add additional volumes (or any docker run options) using
 # the ${COMPOSE_OPTIONS} environment variable.
 #
-# You can set a specific image tag from Docker Hub, such as "1.27.4", or "alpine-1.27.4"
-# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "1.27.4")
+# You can set a specific image and tag, such as "docker/compose:1.27.4", or "docker/compose:alpine-1.27.4"
+# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "docker/compose:1.27.4")
 #
 
 set -e
-
-IMAGE="docker/compose:${DOCKER_COMPOSE_IMAGE_TAG:-1.27.4}"
 
 # Setup options for connecting to docker host
 if [ -z "${DOCKER_HOST}" ]; then
@@ -70,4 +68,4 @@ if docker info --format '{{json .SecurityOptions}}' 2> /dev/null | grep -q 'name
 fi
 
 # shellcheck disable=SC2086
-exec docker run --rm ${DOCKER_RUN_OPTIONS} ${DOCKER_ADDR} ${COMPOSE_OPTIONS} ${VOLUMES} -w "${PWD}" "${IMAGE}" "$@"
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${DOCKER_ADDR} ${COMPOSE_OPTIONS} ${VOLUMES} -w "${PWD}" "${DOCKER_COMPOSE_IMAGE_TAG:-docker/compose:1.27.4}" "$@"

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -64,4 +64,9 @@ if docker info --format '{{json .SecurityOptions}}' 2> /dev/null | grep -q 'name
     DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} --userns=host"
 fi
 
+# Detect SELinux and add --privileged if necessary
+if docker info --format '{{json .SecurityOptions}}' 2> /dev/null | grep -q 'name=selinux'; then
+    DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} --privileged"
+fi
+
 eval exec docker run --rm "${DOCKER_RUN_OPTIONS}" "${DOCKER_ADDR}" "${COMPOSE_OPTIONS}" "${VOLUMES}" -w "${PWD}" "${IMAGE}" "$@"

--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -11,13 +11,13 @@
 # You can add additional volumes (or any docker run options) using
 # the ${COMPOSE_OPTIONS} environment variable.
 #
-# You can set a specific image tag from Docker Hub, such as "1.26.1", or "alpine-1.26.1"
-# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "latest")
+# You can set a specific image tag from Docker Hub, such as "1.27.4", or "alpine-1.27.4"
+# using the $DOCKER_COMPOSE_IMAGE_TAG environment variable (defaults to "1.27.4")
 #
 
 set -e
 
-IMAGE="docker/compose:${DOCKER_COMPOSE_IMAGE_TAG:-latest}"
+IMAGE="docker/compose:${DOCKER_COMPOSE_IMAGE_TAG:-1.27.4}"
 
 # Setup options for connecting to docker host
 if [ -z "${DOCKER_HOST}" ]; then


### PR DESCRIPTION
A few things here.

- Use `${BRACES}` on all variables (good formatting).
- Use `${PWD}` instead of `$(pwd)` to rely on the environment instead of a subshell.
- Allow users to define `DOCKER_COMPOSE_IMAGE_TAG` in their environment to select an image and version to run. Default to `docker/compose:1.27.4` if the user has not set a version. (`latest` seems to be 3 months old as of writing so I've changed this to `docker/compose:1.27.4`). This also allows users to use alternative images or registries such as ghcr.io if their preferred image is available on other registries.
- Uppercase `COMPOSE_DIR` to be in-line with all other variables.
- ~~Fix `shellcheck disable=SC2086` by quoting all variables in https://github.com/docker/compose/compare/master...nemchik:run.sh?expand=1#diff-7123de446b63ba53f37a8e092cafaaaeR67 which then requires adding `eval` to the beginning of the line so that it will be correctly expanded.~~ Reverted this as it caused other issues. It's fixable in bash, but I have not found a posix shell solution.
- Update the script to work with SELinux enforced (mostly RHEL) (from https://github.com/linuxserver/docker-docker-compose/commit/2658740a07816ed118a314c32b12c2a2a1edae25#diff-1b0c2b516b83393edb7200ad5ff12181R65-R69 )

I have tested these changes on Ubuntu 20.04