### PR TITLE
Report which variable fails interpolation when they are mandatory

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -111,12 +111,14 @@ class TemplateWithDefaults(Template):
             var, _, err = braced.partition(':?')
             result = mapping.get(var)
             if not result:
+                err = err or var
                 raise UnsetRequiredSubstitution(err)
             return result
         elif '?' == sep:
             var, _, err = braced.partition('?')
             if var in mapping:
                 return mapping.get(var)
+            err = err or var
             raise UnsetRequiredSubstitution(err)
 
     # Modified from python2.7/string.py

--- a/tests/unit/config/interpolation_test.py
+++ b/tests/unit/config/interpolation_test.py
@@ -416,7 +416,7 @@ def test_interpolate_mandatory_no_err_msg(defaults_interpolator):
     with pytest.raises(UnsetRequiredSubstitution) as e:
         defaults_interpolator("not ok ${BAZ?}")
 
-    assert e.value.err == ''
+    assert e.value.err == 'BAZ'
 
 
 def test_interpolate_mixed_separators(defaults_interpolator):


### PR DESCRIPTION
This PR enhances the error reporting while interpolating  by providing a default error message for mandatory variables when they are not set. The default error message corresponds to the name of the variable itself, so it's easier to point out where the issue is.

I have updated the relevant test accordingly.

This was a quick wordaround to get the variable name in the error message, but if you have other ideas for formatting the error please let me know and I'll see what I can do!

Signed-off-by: Luca Nardelli <luca.nardelli@protonmail.com>

Resolves #7504
