### PR TITLE
Add cpu_shares to conversion map

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -231,6 +231,7 @@ class ConversionMap:
         service_path('build', 'labels', FULL_JOKER): to_str,
         service_path('cpus'): to_float,
         service_path('cpu_count'): to_int,
+        service_path('cpu_shares'): to_int,
         service_path('cpu_quota'): to_microseconds,
         service_path('cpu_period'): to_microseconds,
         service_path('cpu_rt_period'): to_microseconds,


### PR DESCRIPTION
<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves problem, when I tried to use .env variable in cpu_shares, like that:
```
    cpus: ${CPUS}
    cpu_shares: ${CPU_SHARES}
```
Result was:
`TypeError: Invalid type for cpu_shares param: expected int but found <class 'str'>`
But `${CPUS}` works well.
