### PR TITLE
Use ssh client by default

### DIFF
--- a/compose/cli/docker_client.py
+++ b/compose/cli/docker_client.py
@@ -166,8 +166,8 @@ def docker_client(environment, version=None, context=None, tls_version=None):
         kwargs['credstore_env'] = {
             'LD_LIBRARY_PATH': environment.get('LD_LIBRARY_PATH_ORIG'),
         }
-
-    client = APIClient(**kwargs)
+    use_paramiko_ssh = int(environment.get('COMPOSE_PARAMIKO_SSH', 0))
+    client = APIClient(use_ssh_client=not use_paramiko_ssh, **kwargs)
     client._original_base_url = kwargs.get('base_url')
 
     return client

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2020.6.20
 chardet==3.0.4
 colorama==0.4.3; sys_platform == 'win32'
 distro==1.5.0
-docker==4.3.1
+docker==4.4.0
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2


### PR DESCRIPTION
By default, shell out to the ssh client for an ssh connection as the paramiko connection is sometimes unreliable.

The `requirements.txt` must be updated once we have a release of docker-py with the ssh client support.

Depends on https://github.com/docker/docker-py/pull/2691