### PR TITLE
Use BuildKit and add ability to build CentOS binaries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,9 @@ pipeline {
         timeout(time: 2, unit: 'HOURS')
         timestamps()
     }
+    environment {
+        DOCKER_BUILDKIT="1"
+    }
 
     stages {
         stage('Build test images') {
@@ -69,7 +72,7 @@ def buildImage(baseImage) {
             ansiColor('xterm') {
                 sh """docker build -t ${imageName} \\
                     --target build \\
-                    --build-arg BUILD_PLATFORM="${baseImage}" \\
+                    --build-arg DISTRO="${baseImage}" \\
                     --build-arg GIT_COMMIT="${scmvar.GIT_COMMIT}" \\
                     .\\
                 """

--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -13,6 +13,9 @@ pipeline {
         timeout(time: 2, unit: 'HOURS')
         timestamps()
     }
+    environment {
+        DOCKER_BUILDKIT="1"
+    }
 
     stages {
         stage('Build test images') {
@@ -229,7 +232,7 @@ def buildImage(baseImage) {
             ansiColor('xterm') {
                 sh """docker build -t ${imageName} \\
                     --target build \\
-                    --build-arg BUILD_PLATFORM="${baseImage}" \\
+                    --build-arg DISTRO="${baseImage}" \\
                     --build-arg GIT_COMMIT="${scmvar.GIT_COMMIT}" \\
                     .\\
                 """
@@ -276,7 +279,7 @@ def buildRuntimeImage(baseImage) {
     def imageName = "docker/compose:${baseImage}-${env.BRANCH_NAME}"
     ansiColor('xterm') {
         sh """docker build -t ${imageName} \\
-            --build-arg BUILD_PLATFORM="${baseImage}" \\
+            --build-arg DISTRO="${baseImage}" \\
             --build-arg GIT_COMMIT="${scmvar.GIT_COMMIT.take(7)}" \\
             .
         """

--- a/script/build/linux
+++ b/script/build/linux
@@ -5,14 +5,12 @@ set -ex
 ./script/clean
 
 DOCKER_COMPOSE_GITSHA="$(script/build/write-git-sha)"
-TAG="docker/compose:tmp-glibc-linux-binary-${DOCKER_COMPOSE_GITSHA}"
 
-docker build -t "${TAG}" . \
-       --build-arg BUILD_PLATFORM=debian \
-       --build-arg GIT_COMMIT="${DOCKER_COMPOSE_GITSHA}"
-TMP_CONTAINER=$(docker create "${TAG}")
-mkdir -p dist
+docker build . \
+       --target bin \
+       --build-arg DISTRO=debian \
+       --build-arg GIT_COMMIT="${DOCKER_COMPOSE_GITSHA}" \
+       --output dist/
 ARCH=$(uname -m)
-docker cp "${TMP_CONTAINER}":/usr/local/bin/docker-compose "dist/docker-compose-Linux-${ARCH}"
-docker container rm -f "${TMP_CONTAINER}"
-docker image rm -f "${TAG}"
+# Ensure that we output the binary with the same name as we did before
+mv dist/docker-compose-linux-amd64 "dist/docker-compose-Linux-${ARCH}"

--- a/script/build/test-image
+++ b/script/build/test-image
@@ -13,6 +13,6 @@ IMAGE="docker/compose-tests"
 DOCKER_COMPOSE_GITSHA="$(script/build/write-git-sha)"
 docker build -t "${IMAGE}:${TAG}" . \
        --target build \
-       --build-arg BUILD_PLATFORM="debian" \
+       --build-arg DISTRO="debian" \
        --build-arg GIT_COMMIT="${DOCKER_COMPOSE_GITSHA}"
 docker tag "${IMAGE}":"${TAG}" "${IMAGE}":latest


### PR DESCRIPTION
Had this in my stash because I noticed we're using `docker cp` to get the binaries out of the images. What I did:
* Moved to using BuildKit so that we can use `docker build --output` instead of `docker container create && docker cp`
* Added build for CentOS (just in the Dockerfile)
