### PR TITLE
Bump dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@
   sha: v1.3.4
   hooks:
     - id: reorder-python-imports
-      language_version: 'python3.7'
+      language_version: 'python3.9'
       args:
          - --py3-plus
 -   repo: https://github.com/asottile/pyupgrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-ARG DOCKER_VERSION=19.03.8
-ARG PYTHON_VERSION=3.7.7
-ARG BUILD_ALPINE_VERSION=3.11
+ARG DOCKER_VERSION=19.03
+ARG PYTHON_VERSION=3.9.0
+
+ARG BUILD_ALPINE_VERSION=3.12
 ARG BUILD_CENTOS_VERSION=7
-ARG BUILD_DEBIAN_VERSION=slim-stretch
-ARG RUNTIME_ALPINE_VERSION=3.11.5
+ARG BUILD_DEBIAN_VERSION=slim-buster
+
+ARG RUNTIME_ALPINE_VERSION=3.12
 ARG RUNTIME_CENTOS_VERSION=7
-ARG RUNTIME_DEBIAN_VERSION=stretch-20200414-slim
+ARG RUNTIME_DEBIAN_VERSION=buster-slim
 
 ARG DISTRO=alpine
 
@@ -36,7 +38,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     git \
     libc-dev \
     libffi-dev \
-    libgcc-6-dev \
+    libgcc-8-dev \
     libssl-dev \
     make \
     openssl \
@@ -57,7 +59,7 @@ RUN curl -L https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_
     && ./configure --enable-optimizations --enable-shared --prefix=/usr LDFLAGS="-Wl,-rpath /usr/lib" \
     && make altinstall
 RUN alternatives --install /usr/bin/python python /usr/bin/python2.7 50
-RUN alternatives --install /usr/bin/python python /usr/bin/python3.7 60
+RUN alternatives --install /usr/bin/python python /usr/bin/python$(echo "${PYTHON_VERSION}" | cut -c1-3) 60
 RUN curl https://bootstrap.pypa.io/get-pip.py | python -
 
 FROM build-${DISTRO} AS build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 #!groovy
 
-def dockerVersions = ['19.03.8']
+def dockerVersions = ['19.03.13']
 def baseImages = ['alpine', 'debian']
-def pythonVersions = ['py37']
+def pythonVersions = ['py39']
 
 pipeline {
     agent none

--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -1,8 +1,8 @@
 #!groovy
 
-def dockerVersions = ['19.03.8', '18.09.9']
+def dockerVersions = ['19.03.13', '18.09.9']
 def baseImages = ['alpine', 'debian']
-def pythonVersions = ['py37']
+def pythonVersions = ['py39']
 
 pipeline {
     agent none
@@ -84,7 +84,7 @@ pipeline {
                     steps {
                         checkout scm
                         sh './script/setup/osx'
-                        sh 'tox -e py37 -- tests/unit'
+                        sh 'tox -e py39 -- tests/unit'
                         sh './script/build/osx'
                         dir ('dist') {
                           checksum('docker-compose-Darwin-x86_64')

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,1 +1,1 @@
-pyinstaller==3.6
+pyinstaller==4.0

--- a/requirements-indirect.txt
+++ b/requirements-indirect.txt
@@ -3,7 +3,7 @@ appdirs==1.4.4
 attrs==20.1.0
 bcrypt==3.1.7
 cffi==1.14.1
-cryptography==3.0
+cryptography==3.2
 distlib==0.3.1
 entrypoints==0.3
 filelock==3.0.12

--- a/script/build/linux-entrypoint
+++ b/script/build/linux-entrypoint
@@ -3,7 +3,7 @@
 set -ex
 
 CODE_PATH=/code
-VENV="${CODE_PATH}"/.tox/py37
+VENV="${CODE_PATH}"/.tox/py39
 
 cd "${CODE_PATH}"
 mkdir -p dist

--- a/script/build/windows.ps1
+++ b/script/build/windows.ps1
@@ -6,7 +6,7 @@
 #
 #        http://git-scm.com/download/win
 #
-# 2. Install Python 3.7.x:
+# 2. Install Python 3.9.x:
 #
 #        https://www.python.org/downloads/
 #

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -13,13 +13,13 @@ if ! [ ${DEPLOYMENT_TARGET} == "$(macos_version)" ]; then
   SDK_SHA1=dd228a335194e3392f1904ce49aff1b1da26ca62
 fi
 
-OPENSSL_VERSION=1.1.1g
+OPENSSL_VERSION=1.1.1h
 OPENSSL_URL=https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-OPENSSL_SHA1=b213a293f2127ec3e323fb3cfc0c9807664fd997
+OPENSSL_SHA1=8d0d099e8973ec851368c8c775e05e1eadca1794
 
-PYTHON_VERSION=3.7.7
+PYTHON_VERSION=3.9.0
 PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
-PYTHON_SHA1=8e9968663a214aea29659ba9dfa959e8a7d82b39
+PYTHON_SHA1=5744a10ba989d2badacbab3c00cdcb83c83106c7
 
 #
 # Install prerequisites.

--- a/script/test/all
+++ b/script/test/all
@@ -11,7 +11,7 @@ docker run --rm \
   "$TAG" tox -e pre-commit
 
 get_versions="docker run --rm
-    --entrypoint=/code/.tox/py37/bin/python
+    --entrypoint=/code/.tox/py39/bin/python
     $TAG
     /code/script/test/versions.py docker/docker-ce,moby/moby"
 
@@ -23,7 +23,7 @@ fi
 
 
 BUILD_NUMBER=${BUILD_NUMBER-$USER}
-PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py37}
+PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py39}
 
 for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"

--- a/setup.py
+++ b/setup.py
@@ -102,5 +102,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,pre-commit
+envlist = py39,pre-commit
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
* Python 3.7 to 3.9
* Linux: bump Debian base image from stretch to buster (required for Python 3.9)
* macOS: OpenSSL 1.1.1g to 1.1.1h, Python 3.7.7 to 3.9.0
* pyinstaller 3.6 to 4.0
* Loosen restriction on base images to latest minor
