### PR TITLE
acceptance fixtures to conform with compose-spec

### DIFF
--- a/tests/fixtures/UpperCaseDir/docker-compose.yml
+++ b/tests/fixtures/UpperCaseDir/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-another:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+  another:
+    image: busybox:1.31.0-uclibc
+    command: top

--- a/tests/fixtures/abort-on-container-exit-0/docker-compose.yml
+++ b/tests/fixtures/abort-on-container-exit-0/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-another:
-  image: busybox:1.31.0-uclibc
-  command: ls .
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+  another:
+    image: busybox:1.31.0-uclibc
+    command: ls .

--- a/tests/fixtures/abort-on-container-exit-1/docker-compose.yml
+++ b/tests/fixtures/abort-on-container-exit-1/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-another:
-  image: busybox:1.31.0-uclibc
-  command: ls /thecakeisalie
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+  another:
+    image: busybox:1.31.0-uclibc
+    command: ls /thecakeisalie

--- a/tests/fixtures/build-path-override-dir/docker-compose.yml
+++ b/tests/fixtures/build-path-override-dir/docker-compose.yml
@@ -1,2 +1,3 @@
-foo:
-  build: ./build-ctx/
+services:
+  foo:
+    build: ./build-ctx/

--- a/tests/fixtures/build-path/docker-compose.yml
+++ b/tests/fixtures/build-path/docker-compose.yml
@@ -1,2 +1,3 @@
-foo:
-  build: ../build-ctx/
+services:
+  foo:
+    build: ../build-ctx/

--- a/tests/fixtures/commands-composefile/docker-compose.yml
+++ b/tests/fixtures/commands-composefile/docker-compose.yml
@@ -1,5 +1,6 @@
-implicit:
-  image: composetest_test
-explicit:
-  image: composetest_test
-  command: [ "/bin/true" ]
+services:
+  implicit:
+    image: composetest_test
+  explicit:
+    image: composetest_test
+    command: [ "/bin/true" ]

--- a/tests/fixtures/duplicate-override-yaml-files/docker-compose.override.yaml
+++ b/tests/fixtures/duplicate-override-yaml-files/docker-compose.override.yaml
@@ -1,3 +1,3 @@
-
-db:
+services:
+  db:
     command: "top"

--- a/tests/fixtures/duplicate-override-yaml-files/docker-compose.override.yml
+++ b/tests/fixtures/duplicate-override-yaml-files/docker-compose.override.yml
@@ -1,3 +1,3 @@
-
-db:
+services:
+  db:
     command: "sleep 300"

--- a/tests/fixtures/duplicate-override-yaml-files/docker-compose.yml
+++ b/tests/fixtures/duplicate-override-yaml-files/docker-compose.yml
@@ -1,10 +1,10 @@
-
-web:
+services:
+  web:
     image: busybox:1.31.0-uclibc
     command: "sleep 100"
     links:
         - db
 
-db:
+  db:
     image: busybox:1.31.0-uclibc
     command: "sleep 200"

--- a/tests/fixtures/echo-services/docker-compose.yml
+++ b/tests/fixtures/echo-services/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: echo simple
-another:
-  image: busybox:1.31.0-uclibc
-  command: echo another
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: echo simple
+  another:
+    image: busybox:1.31.0-uclibc
+    command: echo another

--- a/tests/fixtures/env-file/docker-compose.yml
+++ b/tests/fixtures/env-file/docker-compose.yml
@@ -1,4 +1,5 @@
-web:
-  image: busybox
-  command: /bin/true
-  env_file: ./test.env
+services:
+  web:
+    image: busybox
+    command: /bin/true
+    env_file: ./test.env

--- a/tests/fixtures/environment-composefile/docker-compose.yml
+++ b/tests/fixtures/environment-composefile/docker-compose.yml
@@ -1,7 +1,7 @@
-service:
-  image: busybox:1.31.0-uclibc
-  command: top
-
-  environment:
-    foo: bar
-    hello: world
+services:
+  service:
+    image: busybox:1.31.0-uclibc
+    command: top
+    environment:
+      foo: bar
+      hello: world

--- a/tests/fixtures/environment-interpolation/docker-compose.yml
+++ b/tests/fixtures/environment-interpolation/docker-compose.yml
@@ -1,17 +1,18 @@
-web:
-  # unbracketed name
-  image: $IMAGE
+services:
+  web:
+    # unbracketed name
+    image: $IMAGE
 
-  # array element
-  ports:
-    - "${HOST_PORT}:8000"
+    # array element
+    ports:
+      - "${HOST_PORT}:8000"
 
-  # dictionary item value
-  labels:
-    mylabel: "${LABEL_VALUE}"
+    # dictionary item value
+    labels:
+      mylabel: "${LABEL_VALUE}"
 
-  # unset value
-  hostname: "host-${UNSET_VALUE}"
+    # unset value
+    hostname: "host-${UNSET_VALUE}"
 
-  # escaped interpolation
-  command: "$${ESCAPED}"
+    # escaped interpolation
+    command: "$${ESCAPED}"

--- a/tests/fixtures/exit-code-from/docker-compose.yml
+++ b/tests/fixtures/exit-code-from/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: sh -c "echo hello && tail -f /dev/null"
-another:
-  image: busybox:1.31.0-uclibc
-  command: /bin/false
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: sh -c "echo hello && tail -f /dev/null"
+  another:
+    image: busybox:1.31.0-uclibc
+    command: /bin/false

--- a/tests/fixtures/expose-composefile/docker-compose.yml
+++ b/tests/fixtures/expose-composefile/docker-compose.yml
@@ -1,11 +1,11 @@
-
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-  expose:
-    - '3000'
-    - '3001/tcp'
-    - '3001/udp'
-    - '3002-3003'
-    - '3004-3005/tcp'
-    - '3006-3007/udp'
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+    expose:
+      - '3000'
+      - '3001/tcp'
+      - '3001/udp'
+      - '3002-3003'
+      - '3004-3005/tcp'
+      - '3006-3007/udp'

--- a/tests/fixtures/extends/circle-1.yml
+++ b/tests/fixtures/extends/circle-1.yml
@@ -1,12 +1,13 @@
-foo:
-  image: busybox
-bar:
-  image: busybox
-web:
-  extends:
-    file: circle-2.yml
-    service: other
-baz:
-  image: busybox
-quux:
-  image: busybox
+services:
+  foo:
+    image: busybox
+  bar:
+    image: busybox
+  web:
+    extends:
+      file: circle-2.yml
+      service: other
+  baz:
+    image: busybox
+  quux:
+    image: busybox

--- a/tests/fixtures/extends/circle-2.yml
+++ b/tests/fixtures/extends/circle-2.yml
@@ -1,12 +1,13 @@
-foo:
-  image: busybox
-bar:
-  image: busybox
-other:
-  extends:
-    file: circle-1.yml
-    service: web
-baz:
-  image: busybox
-quux:
-  image: busybox
+services:
+  foo:
+    image: busybox
+  bar:
+    image: busybox
+  other:
+    extends:
+      file: circle-1.yml
+      service: web
+  baz:
+    image: busybox
+  quux:
+    image: busybox

--- a/tests/fixtures/extends/common-env-labels-ulimits.yml
+++ b/tests/fixtures/extends/common-env-labels-ulimits.yml
@@ -1,13 +1,14 @@
-web:
-  extends:
-    file: common.yml
-    service: web
-  environment:
-    - FOO=2
-    - BAZ=3
-  labels: ['label=one']
-  ulimits:
-    nproc: 65535
-    memlock:
-        soft: 1024
-        hard: 2048
+services:
+  web:
+    extends:
+      file: common.yml
+      service: web
+    environment:
+      - FOO=2
+      - BAZ=3
+    labels: ['label=one']
+    ulimits:
+      nproc: 65535
+      memlock:
+          soft: 1024
+          hard: 2048

--- a/tests/fixtures/extends/common.yml
+++ b/tests/fixtures/extends/common.yml
@@ -1,7 +1,8 @@
-web:
-  image: busybox
-  command: /bin/true
-  net: host
-  environment:
-    - FOO=1
-    - BAR=1
+services:
+  web:
+    image: busybox
+    command: /bin/true
+    net: host
+    environment:
+      - FOO=1
+      - BAR=1

--- a/tests/fixtures/extends/docker-compose.yml
+++ b/tests/fixtures/extends/docker-compose.yml
@@ -1,17 +1,18 @@
-myweb:
-  extends:
-    file: common.yml
-    service: web
-  command: top
-  links:
-    - "mydb:db"
-  environment:
-    # leave FOO alone
-    # override BAR
-    BAR: "2"
-    # add BAZ
-    BAZ: "2"
-  net: bridge
-mydb:
-  image: busybox
-  command: top
+services:
+  myweb:
+    extends:
+      file: common.yml
+      service: web
+    command: top
+    links:
+      - "mydb:db"
+    environment:
+      # leave FOO alone
+      # override BAR
+      BAR: "2"
+      # add BAZ
+      BAZ: "2"
+    net: bridge
+  mydb:
+    image: busybox
+    command: top

--- a/tests/fixtures/extends/invalid-links.yml
+++ b/tests/fixtures/extends/invalid-links.yml
@@ -1,11 +1,12 @@
-mydb:
-  build: '.'
-myweb:
-  build: '.'
-  extends:
-    service: web
-  command: top
-web:
-  build: '.'
-  links:
-    - "mydb:db"
+services:
+  mydb:
+    build: '.'
+  myweb:
+    build: '.'
+    extends:
+      service: web
+    command: top
+  web:
+    build: '.'
+    links:
+      - "mydb:db"

--- a/tests/fixtures/extends/invalid-net.yml
+++ b/tests/fixtures/extends/invalid-net.yml
@@ -1,8 +1,9 @@
-myweb:
-  build: '.'
-  extends:
-    service: web
-  command: top
-web:
-  build: '.'
-  net: "container:db"
+services:
+  myweb:
+    build: '.'
+    extends:
+      service: web
+    command: top
+  web:
+    build: '.'
+    net: "container:db"

--- a/tests/fixtures/extends/invalid-volumes.yml
+++ b/tests/fixtures/extends/invalid-volumes.yml
@@ -1,9 +1,10 @@
-myweb:
-  build: '.'
-  extends:
-    service: web
-  command: top
-web:
-  build: '.'
-  volumes_from:
-    - "db"
+services:
+  myweb:
+    build: '.'
+    extends:
+      service: web
+    command: top
+  web:
+    build: '.'
+    volumes_from:
+      - "db"

--- a/tests/fixtures/extends/nested-intermediate.yml
+++ b/tests/fixtures/extends/nested-intermediate.yml
@@ -1,6 +1,7 @@
-webintermediate:
-  extends:
-    file: common.yml
-    service: web
-  environment:
-    - "FOO=2"
+services:
+  webintermediate:
+    extends:
+      file: common.yml
+      service: web
+    environment:
+      - "FOO=2"

--- a/tests/fixtures/extends/nested.yml
+++ b/tests/fixtures/extends/nested.yml
@@ -1,6 +1,7 @@
-myweb:
-  extends:
-    file: nested-intermediate.yml
-    service: webintermediate
-  environment:
-    - "BAR=2"
+services:
+  myweb:
+    extends:
+      file: nested-intermediate.yml
+      service: webintermediate
+    environment:
+      - "BAR=2"

--- a/tests/fixtures/extends/no-file-specified.yml
+++ b/tests/fixtures/extends/no-file-specified.yml
@@ -1,9 +1,10 @@
-myweb:
-  extends:
-    service: web
-  environment:
-    - "BAR=1"
-web:
-  image: busybox
-  environment:
-    - "BAZ=3"
+services:
+  myweb:
+    extends:
+      service: web
+    environment:
+      - "BAR=1"
+  web:
+    image: busybox
+    environment:
+      - "BAZ=3"

--- a/tests/fixtures/extends/nonexistent-path-base.yml
+++ b/tests/fixtures/extends/nonexistent-path-base.yml
@@ -1,6 +1,7 @@
-dnebase:
-  build: nonexistent.path
-  command: /bin/true
-  environment:
-    - FOO=1
-    - BAR=1
+services:
+  dnebase:
+    build: nonexistent.path
+    command: /bin/true
+    environment:
+      - FOO=1
+      - BAR=1

--- a/tests/fixtures/extends/nonexistent-path-child.yml
+++ b/tests/fixtures/extends/nonexistent-path-child.yml
@@ -1,8 +1,9 @@
-dnechild:
-  extends:
-    file: nonexistent-path-base.yml
-    service: dnebase
-  image: busybox
-  command: /bin/true
-  environment:
-    - BAR=2
+services:
+  dnechild:
+    extends:
+      file: nonexistent-path-base.yml
+      service: dnebase
+    image: busybox
+    command: /bin/true
+    environment:
+      - BAR=2

--- a/tests/fixtures/extends/nonexistent-service.yml
+++ b/tests/fixtures/extends/nonexistent-service.yml
@@ -1,4 +1,5 @@
-web:
-  image: busybox
-  extends:
-    service: foo
+services:
+  web:
+    image: busybox
+    extends:
+      service: foo

--- a/tests/fixtures/extends/service-with-invalid-schema.yml
+++ b/tests/fixtures/extends/service-with-invalid-schema.yml
@@ -1,4 +1,5 @@
-myweb:
-  extends:
-    file: valid-composite-extends.yml
-    service: web
+services:
+  myweb:
+    extends:
+      file: valid-composite-extends.yml
+      service: web

--- a/tests/fixtures/extends/service-with-valid-composite-extends.yml
+++ b/tests/fixtures/extends/service-with-valid-composite-extends.yml
@@ -1,5 +1,6 @@
-myweb:
-  build: '.'
-  extends:
-    file: 'valid-composite-extends.yml'
-    service: web
+services:
+  myweb:
+    build: '.'
+    extends:
+      file: 'valid-composite-extends.yml'
+      service: web

--- a/tests/fixtures/extends/specify-file-as-self.yml
+++ b/tests/fixtures/extends/specify-file-as-self.yml
@@ -1,17 +1,18 @@
-myweb:
-  extends:
-    file: specify-file-as-self.yml
-    service: web
-  environment:
-    - "BAR=1"
-web:
-  extends:
-    file: specify-file-as-self.yml
-    service: otherweb
-  image: busybox
-  environment:
-    - "BAZ=3"
-otherweb:
-  image: busybox
-  environment:
-    - "YEP=1"
+services:
+  myweb:
+    extends:
+      file: specify-file-as-self.yml
+      service: web
+    environment:
+      - "BAR=1"
+  web:
+    extends:
+      file: specify-file-as-self.yml
+      service: otherweb
+    image: busybox
+    environment:
+      - "BAZ=3"
+  otherweb:
+    image: busybox
+    environment:
+      - "YEP=1"

--- a/tests/fixtures/extends/valid-common-config.yml
+++ b/tests/fixtures/extends/valid-common-config.yml
@@ -1,6 +1,7 @@
-myweb:
-  build: '.'
-  extends:
-    file: valid-common.yml
-    service: common-config
-  command: top
+services:
+  myweb:
+    build: '.'
+    extends:
+      file: valid-common.yml
+      service: common-config
+    command: top

--- a/tests/fixtures/extends/valid-common.yml
+++ b/tests/fixtures/extends/valid-common.yml
@@ -1,3 +1,4 @@
-common-config:
-  environment:
-    - FOO=1
+services:
+  common-config:
+    environment:
+      - FOO=1

--- a/tests/fixtures/extends/valid-composite-extends.yml
+++ b/tests/fixtures/extends/valid-composite-extends.yml
@@ -1,2 +1,3 @@
-web:
-  command: top
+services:
+  web:
+    command: top

--- a/tests/fixtures/extends/valid-interpolation-2.yml
+++ b/tests/fixtures/extends/valid-interpolation-2.yml
@@ -1,3 +1,4 @@
-web:
-  build: '.'
-  hostname: "host-${HOSTNAME_VALUE}"
+services:
+  web:
+    build: '.'
+    hostname: "host-${HOSTNAME_VALUE}"

--- a/tests/fixtures/extends/valid-interpolation.yml
+++ b/tests/fixtures/extends/valid-interpolation.yml
@@ -1,5 +1,6 @@
-myweb:
-  extends:
-    service: web
-    file: valid-interpolation-2.yml
-  command: top
+services:
+  myweb:
+    extends:
+      service: web
+      file: valid-interpolation-2.yml
+    command: top

--- a/tests/fixtures/extends/verbose-and-shorthand.yml
+++ b/tests/fixtures/extends/verbose-and-shorthand.yml
@@ -1,15 +1,16 @@
-base:
-  image: busybox
-  environment:
-    - "BAR=1"
+services:
+  base:
+    image: busybox
+    environment:
+      - "BAR=1"
 
-verbose:
-  extends:
-    service: base
-  environment:
-    - "FOO=1"
+  verbose:
+    extends:
+      service: base
+    environment:
+      - "FOO=1"
 
-shorthand:
-  extends: base
-  environment:
-    - "FOO=2"
+  shorthand:
+    extends: base
+    environment:
+      - "FOO=2"

--- a/tests/fixtures/links-composefile/docker-compose.yml
+++ b/tests/fixtures/links-composefile/docker-compose.yml
@@ -1,11 +1,12 @@
-db:
-  image: busybox:1.27.2
-  command: top
-web:
-  image: busybox:1.27.2
-  command: top
-  links:
-    - db:db
-console:
-  image: busybox:1.27.2
-  command: top
+services:
+  db:
+    image: busybox:1.27.2
+    command: top
+  web:
+    image: busybox:1.27.2
+    command: top
+    links:
+      - db:db
+  console:
+    image: busybox:1.27.2
+    command: top

--- a/tests/fixtures/logs-composefile/docker-compose.yml
+++ b/tests/fixtures/logs-composefile/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: sh -c "sleep 1 && echo hello && tail -f /dev/null"
-another:
-  image: busybox:1.31.0-uclibc
-  command: sh -c "sleep 1 && echo test"
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: sh -c "sleep 1 && echo hello && tail -f /dev/null"
+  another:
+    image: busybox:1.31.0-uclibc
+    command: sh -c "sleep 1 && echo test"

--- a/tests/fixtures/logs-restart-composefile/docker-compose.yml
+++ b/tests/fixtures/logs-restart-composefile/docker-compose.yml
@@ -1,7 +1,8 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: sh -c "echo hello && tail -f /dev/null"
-another:
-  image: busybox:1.31.0-uclibc
-  command: sh -c "sleep 2 && echo world && /bin/false"
-  restart: "on-failure:2"
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: sh -c "echo hello && tail -f /dev/null"
+  another:
+    image: busybox:1.31.0-uclibc
+    command: sh -c "sleep 2 && echo world && /bin/false"
+    restart: "on-failure:2"

--- a/tests/fixtures/logs-tail-composefile/docker-compose.yml
+++ b/tests/fixtures/logs-tail-composefile/docker-compose.yml
@@ -1,3 +1,4 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: sh -c "echo w && echo x && echo y && echo z"
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: sh -c "echo w && echo x && echo y && echo z"

--- a/tests/fixtures/longer-filename-composefile/docker-compose.yaml
+++ b/tests/fixtures/longer-filename-composefile/docker-compose.yaml
@@ -1,3 +1,4 @@
-definedinyamlnotyml:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  definedinyamlnotyml:
+    image: busybox:1.31.0-uclibc
+    command: top

--- a/tests/fixtures/multiple-composefiles/compose2.yml
+++ b/tests/fixtures/multiple-composefiles/compose2.yml
@@ -1,3 +1,4 @@
-yetanother:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  yetanother:
+    image: busybox:1.31.0-uclibc
+    command: top

--- a/tests/fixtures/multiple-composefiles/docker-compose.yml
+++ b/tests/fixtures/multiple-composefiles/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-another:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+  another:
+    image: busybox:1.31.0-uclibc
+    command: top

--- a/tests/fixtures/net-container/docker-compose.yml
+++ b/tests/fixtures/net-container/docker-compose.yml
@@ -1,7 +1,8 @@
-foo:
-  image: busybox
-  command: top
-  net: "container:bar"
-bar:
-  image: busybox
-  command: top
+services:
+  foo:
+    image: busybox
+    command: top
+    net: "container:bar"
+  bar:
+    image: busybox
+    command: top

--- a/tests/fixtures/no-links-composefile/docker-compose.yml
+++ b/tests/fixtures/no-links-composefile/docker-compose.yml
@@ -1,9 +1,10 @@
-db:
-  image: busybox:1.31.0-uclibc
-  command: top
-web:
-  image: busybox:1.31.0-uclibc
-  command: top
-console:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  db:
+    image: busybox:1.31.0-uclibc
+    command: top
+  web:
+    image: busybox:1.31.0-uclibc
+    command: top
+  console:
+    image: busybox:1.31.0-uclibc
+    command: top

--- a/tests/fixtures/override-yaml-files/docker-compose.override.yaml
+++ b/tests/fixtures/override-yaml-files/docker-compose.override.yaml
@@ -1,3 +1,3 @@
-
-db:
+services:
+  db:
     command: "top"

--- a/tests/fixtures/override-yaml-files/docker-compose.yml
+++ b/tests/fixtures/override-yaml-files/docker-compose.yml
@@ -1,10 +1,10 @@
-
-web:
+services:
+  web:
     image: busybox:1.31.0-uclibc
     command: "sleep 100"
     links:
         - db
 
-db:
+  db:
     image: busybox:1.31.0-uclibc
     command: "sleep 200"

--- a/tests/fixtures/ports-composefile-scale/docker-compose.yml
+++ b/tests/fixtures/ports-composefile-scale/docker-compose.yml
@@ -1,6 +1,6 @@
-
-simple:
-  image: busybox:1.31.0-uclibc
-  command: /bin/sleep 300
-  ports:
-    - '3000'
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: /bin/sleep 300
+    ports:
+      - '3000'

--- a/tests/fixtures/ports-composefile/docker-compose.yml
+++ b/tests/fixtures/ports-composefile/docker-compose.yml
@@ -1,8 +1,8 @@
-
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-  ports:
-    - '3000'
-    - '49152:3001'
-    - '49153-49154:3002-3003'
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+    ports:
+      - '3000'
+      - '49152:3001'
+      - '49153-49154:3002-3003'

--- a/tests/fixtures/ps-services-filter/docker-compose.yml
+++ b/tests/fixtures/ps-services-filter/docker-compose.yml
@@ -1,6 +1,7 @@
-with_image:
-  image: busybox:1.31.0-uclibc
-  command: top
-with_build:
-  build: ../build-ctx/
-  command: top
+services:
+  with_image:
+    image: busybox:1.31.0-uclibc
+    command: top
+  with_build:
+    build: ../build-ctx/
+    command: top

--- a/tests/fixtures/run-labels/docker-compose.yml
+++ b/tests/fixtures/run-labels/docker-compose.yml
@@ -1,7 +1,8 @@
-service:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  service:
+    image: busybox:1.31.0-uclibc
+    command: top
 
-  labels:
-    foo: bar
-    hello: world
+    labels:
+      foo: bar
+      hello: world

--- a/tests/fixtures/run-workdir/docker-compose.yml
+++ b/tests/fixtures/run-workdir/docker-compose.yml
@@ -1,4 +1,5 @@
-service:
-  image: busybox:1.31.0-uclibc
-  working_dir: /etc
-  command: /bin/true
+services:
+  service:
+    image: busybox:1.31.0-uclibc
+    working_dir: /etc
+    command: /bin/true

--- a/tests/fixtures/simple-composefile-volume-ready/docker-compose.yml
+++ b/tests/fixtures/simple-composefile-volume-ready/docker-compose.yml
@@ -1,2 +1,3 @@
-simple:
-  image: busybox:1.31.0-uclibc
+services:
+  simple:
+    image: busybox:1.31.0-uclibc

--- a/tests/fixtures/simple-composefile/digest.yml
+++ b/tests/fixtures/simple-composefile/digest.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-digest:
-  image: busybox@sha256:38a203e1986cf79639cfb9b2e1d6e773de84002feea2d4eb006b52004ee8502d
-  command: top
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+  digest:
+    image: busybox@sha256:38a203e1986cf79639cfb9b2e1d6e773de84002feea2d4eb006b52004ee8502d
+    command: top

--- a/tests/fixtures/simple-composefile/docker-compose.yml
+++ b/tests/fixtures/simple-composefile/docker-compose.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.27.2
-  command: top
-another:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  simple:
+    image: busybox:1.27.2
+    command: top
+  another:
+    image: busybox:1.31.0-uclibc
+    command: top

--- a/tests/fixtures/simple-composefile/ignore-pull-failures.yml
+++ b/tests/fixtures/simple-composefile/ignore-pull-failures.yml
@@ -1,6 +1,7 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command: top
-another:
-  image: nonexisting-image:latest
-  command: top
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command: top
+  another:
+    image: nonexisting-image:latest
+    command: top

--- a/tests/fixtures/simple-dockerfile/docker-compose.yml
+++ b/tests/fixtures/simple-dockerfile/docker-compose.yml
@@ -1,2 +1,3 @@
-simple:
-  build: .
+services:
+  simple:
+    build: .

--- a/tests/fixtures/simple-failing-dockerfile/docker-compose.yml
+++ b/tests/fixtures/simple-failing-dockerfile/docker-compose.yml
@@ -1,2 +1,3 @@
-simple:
-  build: .
+services:
+  simple:
+    build: .

--- a/tests/fixtures/stop-signal-composefile/docker-compose.yml
+++ b/tests/fixtures/stop-signal-composefile/docker-compose.yml
@@ -1,10 +1,11 @@
-simple:
-  image: busybox:1.31.0-uclibc
-  command:
-    - sh
-    - '-c'
-    - |
-        trap 'exit 0' SIGINT
-        trap 'exit 1' SIGTERM
-        while true; do :; done
-  stop_signal: SIGINT
+services:
+  simple:
+    image: busybox:1.31.0-uclibc
+    command:
+      - sh
+      - '-c'
+      - |
+          trap 'exit 0' SIGINT
+          trap 'exit 1' SIGTERM
+          while true; do :; done
+    stop_signal: SIGINT

--- a/tests/fixtures/top/docker-compose.yml
+++ b/tests/fixtures/top/docker-compose.yml
@@ -1,6 +1,7 @@
-service_a:
-  image: busybox:1.31.0-uclibc
-  command: top
-service_b:
-  image: busybox:1.31.0-uclibc
-  command: top
+services:
+  service_a:
+    image: busybox:1.31.0-uclibc
+    command: top
+  service_b:
+    image: busybox:1.31.0-uclibc
+    command: top

--- a/tests/fixtures/user-composefile/docker-compose.yml
+++ b/tests/fixtures/user-composefile/docker-compose.yml
@@ -1,4 +1,5 @@
-service:
-  image: busybox:1.31.0-uclibc
-  user: notauser
-  command: id
+services:
+  service:
+    image: busybox:1.31.0-uclibc
+    user: notauser
+    command: id

--- a/tests/fixtures/volume-path-interpolation/docker-compose.yml
+++ b/tests/fixtures/volume-path-interpolation/docker-compose.yml
@@ -1,5 +1,6 @@
-test:
-  image: busybox
-  command: top
-  volumes:
-    - "~/${VOLUME_NAME}:/container-path"
+services:
+  test:
+    image: busybox
+    command: top
+    volumes:
+      - "~/${VOLUME_NAME}:/container-path"

--- a/tests/fixtures/volume-path/common/services.yml
+++ b/tests/fixtures/volume-path/common/services.yml
@@ -1,5 +1,6 @@
-db:
-  image: busybox
-  volumes:
-    - ./foo:/foo
-    - ./bar:/bar
+services:
+  db:
+    image: busybox
+    volumes:
+      - ./foo:/foo
+      - ./bar:/bar

--- a/tests/fixtures/volume-path/docker-compose.yml
+++ b/tests/fixtures/volume-path/docker-compose.yml
@@ -1,6 +1,7 @@
-db:
-  extends:
-    file: common/services.yml
-    service: db
-  volumes:
-    - ./bar:/bar
+services:
+  db:
+    extends:
+      file: common/services.yml
+      service: db
+    volumes:
+      - ./bar:/bar


### PR DESCRIPTION
Adapted most of the relevant acceptance fixtures so they conform to compose-spec, i.e use v2/v3 syntax (without requiring a `version`). This will help make those reusable to double check compatibility with another compose implementation.