### PR TITLE
Bring back warning for configs in non-swarm mode

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -373,6 +373,23 @@ def find_candidates_in_parent_dirs(filenames, path):
     return (candidates, path)
 
 
+def check_swarm_only_config(service_dicts):
+    warning_template = (
+        "Some services ({services}) use the '{key}' key, which will be ignored. "
+        "Compose does not support '{key}' configuration - use "
+        "`docker stack deploy` to deploy to a swarm."
+    )
+    key = 'configs'
+    services = [s for s in service_dicts if s.get(key)]
+    if services:
+        log.warning(
+            warning_template.format(
+                services=", ".join(sorted(s['name'] for s in services)),
+                key=key
+            )
+        )
+
+
 def load(config_details, interpolate=True):
     """Load the configuration from a working directory and a list of
     configuration files.  Files are loaded in order, and merged on top
@@ -408,6 +425,8 @@ def load(config_details, interpolate=True):
     if main_file.version != V1:
         for service_dict in service_dicts:
             match_named_volumes(service_dict, volumes)
+
+    check_swarm_only_config(service_dicts)
 
     return Config(main_file.config_version, main_file.version,
                   service_dicts, volumes, networks, secrets, configs)


### PR DESCRIPTION
Fixes https://github.com/docker/compose/issues/7931
```yaml
services:
  backend:
    image: nginx
    configs:
      - source: bar
configs:
  bar:
    external: true
    name: bar
```

```
$ docker-compose up
WARNING: Some services (backend) use the 'configs' key, which will be ignored. Compose does not support 'configs' configuration - use `docker stack deploy` to deploy to a swarm.
Creating network "test_default" with the default driver
Creating test_backend_1 ... done
....

```