### PR TITLE
[DO NOT MERGE] PoC macOS Arm build support

### DIFF
--- a/openssl.patch
+++ b/openssl.patch
@@ -1,0 +1,19 @@
+diff --git a/Configurations/10-main.conf b/Configurations/10-main.conf
+index eb92c24..eaf2ab6 100644
+--- a/Configurations/10-main.conf
++++ b/Configurations/10-main.conf
+@@ -1557,6 +1557,14 @@ my %targets = (
+         bn_ops           => "SIXTY_FOUR_BIT_LONG",
+         perlasm_scheme   => "macosx",
+     },
++    "darwin64-arm64-cc" => {
++        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
++        CFLAGS           => add("-Wall"),
++        cflags           => add("-arch arm64"),
++        lib_cppflags     => add("-DL_ENDIAN"),
++        bn_ops           => "SIXTY_FOUR_BIT_LONG",
++        perlasm_scheme   => "macosx",
++    },
+
+ ##### GNU Hurd
+     "hurd-x86" => {

--- a/script/build/osx
+++ b/script/build/osx
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -ex
 
+. $(dirname $0)/../setup/osx_helpers.sh
+
 TOOLCHAIN_PATH="$(realpath $(dirname $0)/../../build/toolchain)"
 
 rm -rf venv
 
-virtualenv -p "${TOOLCHAIN_PATH}"/bin/python3 venv
+python -m virtualenv -p "${TOOLCHAIN_PATH}"/bin/python3 venv
 venv/bin/pip install -r requirements-indirect.txt
 venv/bin/pip install -r requirements.txt
 venv/bin/pip install -r requirements-build.txt

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -13,19 +13,19 @@ if ! [ ${DEPLOYMENT_TARGET} == "$(macos_version)" ]; then
   SDK_SHA1=dd228a335194e3392f1904ce49aff1b1da26ca62
 fi
 
-OPENSSL_VERSION=1.1.1h
+OPENSSL_VERSION=1.1.1i
 OPENSSL_URL=https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-OPENSSL_SHA1=8d0d099e8973ec851368c8c775e05e1eadca1794
+OPENSSL_SHA1=eb684ba4ed31fe2c48062aead75233ecd36882a6
 
-PYTHON_VERSION=3.9.0
-PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
-PYTHON_SHA1=5744a10ba989d2badacbab3c00cdcb83c83106c7
+PYTHON_VERSION=3.9.1
+PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION%r*}/Python-${PYTHON_VERSION}.tgz
+PYTHON_SHA1=7c22b8183188f2b51d9404c4cdfa00e40cb0663b
 
 #
 # Install prerequisites.
 #
 python -m pip --version 2>&1 /dev/null || curl -L https://bootstrap.pypa.io/get-pip.py | python
-python -m virtualenv --version 2>&1 /dev/null || python -m pip install virtualenv==20.0.30
+python -m pip install virtualenv==20.0.30
 
 #
 # Create toolchain directory.
@@ -56,7 +56,8 @@ if ! [[ $(${TOOLCHAIN_PATH}/bin/openssl version) == *"${OPENSSL_VERSION}"* ]]; t
     cd ${OPENSSL_SRC_PATH}
     export MACOSX_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET}
     export SDKROOT=${SDK_PATH}
-    ./Configure darwin64-x86_64-cc --prefix=${TOOLCHAIN_PATH}
+    OPENSSL_CONFIG_FLAGS="darwin64-$(uname -m)-cc --prefix=${TOOLCHAIN_PATH}"
+    ./Configure $OPENSSL_CONFIG_FLAGS
     make install_sw install_dev
   )
 fi
@@ -79,8 +80,8 @@ if ! [[ $(${TOOLCHAIN_PATH}/bin/python3 --version) == *"${PYTHON_VERSION}"* ]]; 
       MACOSX_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET} \
       CFLAGS="-isysroot ${SDK_PATH} -I${TOOLCHAIN_PATH}/include" \
       CPPFLAGS="-I${SDK_PATH}/usr/include -I${TOOLCHAIN_PATH}/include" \
-      LDFLAGS="-isysroot ${SDK_PATH} -L ${TOOLCHAIN_PATH}/lib"
-    make -j 4
+      LDFLAGS="-isysroot ${SDK_PATH} -L${TOOLCHAIN_PATH}/lib"
+    make -j4
     make install PYTHONAPPSDIR=${TOOLCHAIN_PATH}
     make frameworkinstallextras PYTHONAPPSDIR=${TOOLCHAIN_PATH}/share
   )

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -6,7 +6,7 @@ set -ex
 
 DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET:-"$(macos_version)"}
 SDK_FETCH=
-if ! [ ${DEPLOYMENT_TARGET} == "$(macos_version)" ]; then
+if ! [ -d "$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${DEPLOYMENT_TARGET}.sdk" ]; then
   SDK_FETCH=1
   # SDK URL from https://github.com/docker/golang-cross/blob/master/osx-cross.sh
   SDK_URL=https://s3.dockerproject.org/darwin/v2/MacOSX${DEPLOYMENT_TARGET}.sdk.tar.xz

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -24,25 +24,13 @@ PYTHON_SHA1=5744a10ba989d2badacbab3c00cdcb83c83106c7
 #
 # Install prerequisites.
 #
-if ! [ -x "$(command -v brew)" ]; then
-  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-fi
-if ! [ -x "$(command -v grealpath)" ]; then
-  brew update > /dev/null
-  brew install coreutils
-fi
-if ! [ -x "$(command -v python3)" ]; then
-  brew update > /dev/null
-  brew install python3
-fi
-if ! [ -x "$(command -v virtualenv)" ]; then
-  pip3 install virtualenv==20.0.30
-fi
+python -m pip --version 2>&1 /dev/null || curl -L https://bootstrap.pypa.io/get-pip.py | python
+python -m virtualenv --version 2>&1 /dev/null || python -m pip install virtualenv==20.0.30
 
 #
 # Create toolchain directory.
 #
-BUILD_PATH="$(grealpath $(dirname $0)/../../build)"
+BUILD_PATH="$(realpath $(dirname $0)/../../build)"
 mkdir -p ${BUILD_PATH}
 TOOLCHAIN_PATH="${BUILD_PATH}/toolchain"
 mkdir -p ${TOOLCHAIN_PATH}

--- a/script/setup/osx_helpers.sh
+++ b/script/setup/osx_helpers.sh
@@ -39,3 +39,17 @@ openssl_version() {
 macos_version() {
   sw_vers -productVersion | cut -f1,2 -d'.'
 }
+
+# Realpath substitute.
+realpath() {
+  local OURPWD=$PWD
+  cd "$(dirname "$1")"
+  local LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  local REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
+}


### PR DESCRIPTION
* Uses local macOS Python to bootstrap instead of downloading Python from Homebrew
* Replaces GNU `realpath` with a bash script
* Patch OpenSSL to work on macOS Arm
* Do not use OpenSSL assembler optimization
* Bump to Python 3.9.1rc1 (which has Arm support)
* Fix typo in `LDFLAGS` (fixes PyNaCl build issue)

Contributes to #7945 
