### PR TITLE
Bump Python version for release

### DIFF
--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                         label 'windows-python'
                     }
                     environment {
-                        PATH = "$PATH;C:\\Python37;C:\\Python37\\Scripts"
+                        PATH = "C:\\Python39;C:\\Python39\\Scripts;$PATH"
                     }
                     steps {
                         checkout scm


### PR DESCRIPTION
* Bumped Windows Python version in Jenkins file
* Reversed PATH order so that Jenkinsfile can be used to set Python version

Should've been included in #7944 but was missed.
