### PR TITLE
Add devices to config hash to trigger container recreate on change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(UNAME_S),Darwin)
 	BUILD_SCRIPT = osx
 endif
 
-COMPOSE_SPEC_SCHEMA_PATH = "compose/config/config_schema_compose_spec.json"
+COMPOSE_SPEC_SCHEMA_PATH = "compose/config/compose_spec.json"
 COMPOSE_SPEC_RAW_URL = "https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json"
 
 all: cli

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -1166,6 +1166,7 @@ def merge_reservations(base, override):
     md.merge_scalar('cpus')
     md.merge_scalar('memory')
     md.merge_sequence('generic_resources', types.GenericResource.parse)
+    md.merge_field('devices', merge_unique_objects_lists, default=[])
     return dict(md)
 
 

--- a/compose/project.py
+++ b/compose/project.py
@@ -128,7 +128,7 @@ class Project:
                 config_data.secrets)
 
             service_dict['scale'] = project.get_service_scale(service_dict)
-            device_requests = project.get_device_requests(service_dict)
+            service_dict['device_requests'] = project.get_device_requests(service_dict)
             service_dict = translate_credential_spec_to_security_opt(service_dict)
             service_dict, ignored_keys = translate_deploy_keys_to_container_config(
                 service_dict
@@ -154,7 +154,6 @@ class Project:
                     ipc_mode=ipc_mode,
                     platform=service_dict.pop('platform', None),
                     default_platform=default_platform,
-                    device_requests=device_requests,
                     extra_labels=extra_labels,
                     **service_dict)
             )

--- a/compose/service.py
+++ b/compose/service.py
@@ -181,7 +181,6 @@ class Service:
             pid_mode=None,
             default_platform=None,
             extra_labels=None,
-            device_requests=None,
             **options
     ):
         self.name = name
@@ -197,7 +196,6 @@ class Service:
         self.secrets = secrets or []
         self.scale_num = scale
         self.default_platform = default_platform
-        self.device_requests = device_requests
         self.options = options
         self.extra_labels = extra_labels or []
 
@@ -709,7 +707,7 @@ class Service:
             except NoSuchImageError:
                 return None
 
-        c = {
+        return {
             'options': self.options,
             'image_id': image_id(),
             'links': self.get_link_names(),
@@ -721,10 +719,6 @@ class Service:
                 for v in self.volumes_from if isinstance(v.source, Service)
             ]
         }
-
-        if self.device_requests:
-            c['devices'] = self.device_requests
-        return c
 
     def get_dependency_names(self):
         net_name = self.network_mode.service_name
@@ -1023,7 +1017,7 @@ class Service:
             privileged=options.get('privileged', False),
             network_mode=self.network_mode.mode,
             devices=options.get('devices'),
-            device_requests=self.device_requests,
+            device_requests=options.get('device_requests'),
             dns=options.get('dns'),
             dns_opt=options.get('dns_opt'),
             dns_search=options.get('dns_search'),

--- a/compose/service.py
+++ b/compose/service.py
@@ -709,7 +709,7 @@ class Service:
             except NoSuchImageError:
                 return None
 
-        return {
+        c = {
             'options': self.options,
             'image_id': image_id(),
             'links': self.get_link_names(),
@@ -719,8 +719,12 @@ class Service:
             'volumes_from': [
                 (v.source.name, v.mode)
                 for v in self.volumes_from if isinstance(v.source, Service)
-            ],
+            ]
         }
+
+        if self.device_requests:
+            c['devices'] = self.device_requests
+        return c
 
     def get_dependency_names(self):
         net_name = self.network_mode.service_name

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -732,29 +732,6 @@ class ServiceTest(unittest.TestCase):
         }
         assert config_dict == expected
 
-    def test_config_dict_with_device_requests(self):
-        self.mock_client.inspect_image.return_value = {'Id': 'abcd'}
-        service = Service(
-            'foo',
-            image='example.com/foo',
-            client=self.mock_client,
-            network_mode=ServiceNetworkMode(Service('other')),
-            networks={'default': None},
-            device_requests=[{'driver': 'nvidia', 'device_ids': ['0'], 'capabilities': ['gpu']}])
-
-        config_dict = service.config_dict()
-        expected = {
-            'image_id': 'abcd',
-            'options': {'image': 'example.com/foo'},
-            'links': [],
-            'net': 'other',
-            'secrets': [],
-            'networks': {'default': None},
-            'volumes_from': [],
-            'devices': [{'driver': 'nvidia', 'device_ids': ['0'], 'capabilities': ['gpu']}],
-        }
-        assert config_dict == expected
-
     def test_config_hash_matches_label(self):
         self.mock_client.inspect_image.return_value = {'Id': 'abcd'}
         service = Service(

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -732,6 +732,29 @@ class ServiceTest(unittest.TestCase):
         }
         assert config_dict == expected
 
+    def test_config_dict_with_device_requests(self):
+        self.mock_client.inspect_image.return_value = {'Id': 'abcd'}
+        service = Service(
+            'foo',
+            image='example.com/foo',
+            client=self.mock_client,
+            network_mode=ServiceNetworkMode(Service('other')),
+            networks={'default': None},
+            device_requests=[{'driver': 'nvidia', 'device_ids': ['0'], 'capabilities': ['gpu']}])
+
+        config_dict = service.config_dict()
+        expected = {
+            'image_id': 'abcd',
+            'options': {'image': 'example.com/foo'},
+            'links': [],
+            'net': 'other',
+            'secrets': [],
+            'networks': {'default': None},
+            'volumes_from': [],
+            'devices': [{'driver': 'nvidia', 'device_ids': ['0'], 'capabilities': ['gpu']}],
+        }
+        assert config_dict == expected
+
     def test_config_hash_matches_label(self):
         self.mock_client.inspect_image.return_value = {'Id': 'abcd'}
         service = Service(


### PR DESCRIPTION
Changing device request configuration was not triggering the container recreation.

Compose file:
```yaml
services:
  test:
    image: nvidia/cuda
    command: /usr/bin/nvidia-smi
    deploy:
      resources:
        reservations:
          devices:
          - 'driver': 'nvidia'
            'device_ids': ['0']
            'capabilities': ['gpu']
```

```
$ docker-compose up
Creating network "gpu_default" with the default driver
Creating gpu_test_1 ... done
Attaching to gpu_test_1
...
```
Update devices mapping in the compose file:
```yaml
services:
  test:
    image: nvidia/cuda
    command: /usr/bin/nvidia-smi
    deploy:
      resources:
        reservations:
          devices:
          - 'driver': 'nvidia'
            'capabilities': ['gpu']
```
Run up again to get the container recreated with the new configuration:
```
$ docker-compose up
Recreating gpu_test_1 ... done
Attaching to gpu_test_1...
...
```