### PR TITLE
Make COMPOSE_DOCKER_CLI_BUILD=1 the default

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -272,8 +272,6 @@ class TopLevelCommand:
             --no-rm                 Do not remove intermediate containers after a successful build.
             --parallel              Build images in parallel.
             --progress string       Set type of progress output (auto, plain, tty).
-                                    EXPERIMENTAL flag for native builder.
-                                    To enable, run with COMPOSE_DOCKER_CLI_BUILD=1)
             --pull                  Always attempt to pull a newer version of the image.
             -q, --quiet             Don't print anything to STDOUT
         """
@@ -287,7 +285,7 @@ class TopLevelCommand:
                 )
             build_args = resolve_build_args(build_args, self.toplevel_environment)
 
-        native_builder = self.toplevel_environment.get_boolean('COMPOSE_DOCKER_CLI_BUILD')
+        native_builder = self.toplevel_environment.get_boolean('COMPOSE_DOCKER_CLI_BUILD', True)
 
         self.project.build(
             service_names=options['SERVICE'],
@@ -1049,7 +1047,7 @@ class TopLevelCommand:
         for excluded in [x for x in opts if options.get(x) and no_start]:
             raise UserError('--no-start and {} cannot be combined.'.format(excluded))
 
-        native_builder = self.toplevel_environment.get_boolean('COMPOSE_DOCKER_CLI_BUILD')
+        native_builder = self.toplevel_environment.get_boolean('COMPOSE_DOCKER_CLI_BUILD', True)
 
         with up_shutdown_context(self.project, service_names, timeout, detached):
             warn_for_swarm_mode(self.project.client)

--- a/compose/config/environment.py
+++ b/compose/config/environment.py
@@ -113,13 +113,13 @@ class Environment(dict):
             )
         return super().get(key, *args, **kwargs)
 
-    def get_boolean(self, key):
+    def get_boolean(self, key, default=False):
         # Convert a value to a boolean using "common sense" rules.
         # Unset, empty, "0" and "false" (i-case) yield False.
         # All other values yield True.
         value = self.get(key)
         if not value:
-            return False
+            return default
         if value.lower() in ['0', 'false']:
             return False
         return True

--- a/compose/project.py
+++ b/compose/project.py
@@ -489,7 +489,8 @@ class Project:
                 log.info('%s uses an image, skipping' % service.name)
 
         if cli:
-            log.warning("Native build is an experimental feature and could change at any time")
+            log.info("Building with native build. Learn about native build in Compose here: "
+                     "https://docs.docker.com/go/compose-native-build/")
             if parallel_build:
                 log.warning("Flag '--parallel' is ignored when building with "
                             "COMPOSE_DOCKER_CLI_BUILD=1")
@@ -649,7 +650,8 @@ class Project:
            ):
 
         if cli:
-            log.warning("Native build is an experimental feature and could change at any time")
+            log.info("Building with native build. Learn about native build in Compose here: "
+                     "https://docs.docker.com/go/compose-native-build/")
 
         self.initialize()
         if not ignore_orphans:

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -783,7 +783,11 @@ services:
         assert BUILD_CACHE_TEXT not in result.stdout
         assert BUILD_PULL_TEXT in result.stdout
 
+    @mock.patch.dict(os.environ)
     def test_build_log_level(self):
+        os.environ['COMPOSE_DOCKER_CLI_BUILD'] = '0'
+        os.environ['DOCKER_BUILDKIT'] = '0'
+        self.test_env_file_relative_to_compose_file()
         self.base_dir = 'tests/fixtures/simple-dockerfile'
         result = self.dispatch(['--log-level', 'warning', 'build', 'simple'])
         assert result.stderr == ''
@@ -845,13 +849,17 @@ services:
         for c in self.project.client.containers(all=True):
             self.addCleanup(self.project.client.remove_container, c, force=True)
 
+    @mock.patch.dict(os.environ)
     def test_build_shm_size_build_option(self):
+        os.environ['COMPOSE_DOCKER_CLI_BUILD'] = '0'
         pull_busybox(self.client)
         self.base_dir = 'tests/fixtures/build-shm-size'
         result = self.dispatch(['build', '--no-cache'], None)
         assert 'shm_size: 96' in result.stdout
 
+    @mock.patch.dict(os.environ)
     def test_build_memory_build_option(self):
+        os.environ['COMPOSE_DOCKER_CLI_BUILD'] = '0'
         pull_busybox(self.client)
         self.base_dir = 'tests/fixtures/build-memory'
         result = self.dispatch(['build', '--no-cache', '--memory', '96m', 'service'], None)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -948,7 +948,12 @@ class ServiceTest(DockerClientTestCase):
         with open(os.path.join(base_dir, 'Dockerfile'), 'w') as f:
             f.write("FROM busybox\n")
 
-        service = self.create_service('web', build={'context': base_dir})
+        service = self.create_service('web',
+                                      build={'context': base_dir},
+                                      environment={
+                                          'COMPOSE_DOCKER_CLI_BUILD': '0',
+                                          'DOCKER_BUILDKIT': '0',
+                                      })
         service.build()
         self.addCleanup(self.client.remove_image, service.image_name)
 
@@ -964,7 +969,6 @@ class ServiceTest(DockerClientTestCase):
         service = self.create_service('web',
                                       build={'context': base_dir},
                                       environment={
-                                          'COMPOSE_DOCKER_CLI_BUILD': '1',
                                           'DOCKER_BUILDKIT': '1',
                                       })
         service.build(cli=True)
@@ -1015,7 +1019,6 @@ class ServiceTest(DockerClientTestCase):
         web = self.create_service('web',
                                   build={'context': base_dir},
                                   environment={
-                                      'COMPOSE_DOCKER_CLI_BUILD': '1',
                                       'DOCKER_BUILDKIT': '1',
                                   })
         project = Project('composetest', [web], self.client)


### PR DESCRIPTION
This changes compose to use "native" build through the CLI by default. With this, docker-compose can take advantage of BuildKit (which is now enabled by default on Docker Desktop 2.5 and up).

Users that want to use the python client for building can opt-out of this feature by setting COMPOSE_DOCKER_CLI_BUILD=0
