### PR TITLE
Use official docker:dind image instead of custom image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-def dockerVersions = ['19.03.13']
+def dockerVersions = ['20.10.0-rc2', '19.03.14']
 def baseImages = ['alpine', 'debian']
 def pythonVersions = ['py39']
 

--- a/script/test/all
+++ b/script/test/all
@@ -39,15 +39,13 @@ for version in $DOCKER_VERSIONS; do
 
   trap "on_exit" EXIT
 
-  repo="dockerswarm/dind"
-
   docker run \
     -d \
     --name "$daemon_container" \
     --privileged \
     --volume="/var/lib/docker" \
-    "$repo:$version" \
-    dockerd -H tcp://0.0.0.0:2375 $DOCKER_DAEMON_ARGS \
+    "docker:${version}-dind" \
+    sh -c "apk add --no-cache git && dockerd -H tcp://0.0.0.0:2375 $DOCKER_DAEMON_ARGS" \
     2>&1 | tail -n 10
 
   docker run \


### PR DESCRIPTION
Similar to https://github.com/docker/docker-py/pull/2515

- replace the dockerswarm/dind image with the official docker image
- update versions of docker to test against (19.03.14 and 20.10.0-rc2)