### PR TITLE
Add env var for base config file

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -169,6 +169,10 @@ class ConfigDetails(namedtuple('_ConfigDetails', 'working_dir config_files envir
     def __new__(cls, working_dir, config_files, environment=None):
         if environment is None:
             environment = Environment.from_env_file(working_dir)
+        base_filename = environment.get("COMPOSE_BASE_FILE")
+        if base_filename:
+            base = ConfigFile.from_filename(base_filename)
+            config_files = [base] + config_files
         return super().__new__(
             cls, working_dir, config_files, environment
         )


### PR DESCRIPTION
The aim of this simple change is to allow a global base file to be configured. I made this for personal use but maybe there's interest in a proper PR in which case I would need help in adding tests.

Use case:
I personally have many docker-compose files which I would like to keep D.R.Y.
For this, the `COMPOSE_BASE_FILE` env var can be set to the path of a YAML file that contains global Extension fields which will then become available in all other compose files.

Signed-off-by: Laurin Schmidt <laurinschmidt2001@gmail.com>