### PR TITLE
Add `--timestamps` to up command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1090,7 +1090,8 @@ class TopLevelCommand:
                                        container. Implies --abort-on-container-exit.
             --scale SERVICE=NUM        Scale SERVICE to NUM instances. Overrides the
                                        `scale` setting in the Compose file if present.
-            --no-log-prefix       Don't print prefix in logs.
+            --no-log-prefix            Don't print prefix in logs.
+            --timestamps               Show timestamps.
         """
         start_deps = not options['--no-deps']
         always_recreate_deps = options['--always-recreate-deps']
@@ -1164,11 +1165,15 @@ class TopLevelCommand:
                 service_names,
                 attach_dependencies)
 
+            log_args = {
+                'follow': True,
+                'timestamps': options['--timestamps']
+            }
             log_printer = log_printer_from_project(
                 self.project,
                 attached_containers,
                 set_no_color_if_clicolor(options['--no-color']),
-                {'follow': True},
+                log_args,
                 cascade_stop,
                 event_stream=self.project.events(service_names=service_names),
                 keep_prefix=keep_prefix)


### PR DESCRIPTION
Enable `--timestamps` for `docker up` by expanding the log_args dictionary in L1168-1171.

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves https://github.com/docker/compose/issues/5730
