### PR TITLE
Fix docker-compose config depends_on to be compliant to v3 and v2

### DIFF
--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -4,8 +4,8 @@ from compose.config import types
 from compose.const import COMPOSE_SPEC as VERSION
 from compose.const import COMPOSEFILE_V1 as V1
 from compose.version import ComposeVersion
-VERSION30 = '3.0'
-VERSION21 = '2.1'
+VERSION30 = ComposeVersion('3.0')
+VERSION21 = ComposeVersion('2.1')
 
 
 def serialize_config_type(dumper, data):
@@ -115,7 +115,7 @@ def validate_depends_on(service_dict, version):
     Validates depends_on based on the config version
     """
     if 'depends_on' in service_dict:
-        if version >= ComposeVersion(VERSION30) or version < ComposeVersion(VERSION21):
+        if version >= VERSION30 or version < VERSION21:
             service_dict['depends_on'] = sorted([
                 svc for svc in service_dict['depends_on'].keys()
             ])

--- a/compose/config/serialize.py
+++ b/compose/config/serialize.py
@@ -110,6 +110,18 @@ def serialize_ns_time_value(value):
     return '{}{}'.format(*result)
 
 
+def validate_depends_on(service_dict, version):
+    """
+    Validates depends_on based on the config version
+    """
+    if 'depends_on' in service_dict:
+        if version >= ComposeVersion(VERSION30) or version < ComposeVersion(VERSION21):
+            service_dict['depends_on'] = sorted([
+                svc for svc in service_dict['depends_on'].keys()
+            ])
+    return service_dict
+
+
 def denormalize_service_dict(service_dict, version, image_digest=None):
     service_dict = service_dict.copy()
 
@@ -124,11 +136,7 @@ def denormalize_service_dict(service_dict, version, image_digest=None):
     if version == V1 and 'network_mode' not in service_dict:
         service_dict['network_mode'] = 'bridge'
 
-    if 'depends_on' in service_dict:
-        if version >= ComposeVersion(VERSION30) or version < ComposeVersion(VERSION21):
-            service_dict['depends_on'] = sorted([
-                svc for svc in service_dict['depends_on'].keys()
-            ])
+    service_dict = validate_depends_on(service_dict, version)
 
     if 'healthcheck' in service_dict:
         if 'interval' in service_dict['healthcheck']:

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -353,12 +353,57 @@ services:
             }
         }
 
-    def test_config_with_dot_env(self):
+    def test_config_with_dot_env_2_4(self):
         self.base_dir = 'tests/fixtures/default-env-file'
         result = self.dispatch(['config'])
         json_result = yaml.safe_load(result.stdout)
         assert json_result == {
             'version': '2.4',
+            'services': {
+                'web': {
+                    'command': 'true',
+                    'image': 'alpine:latest',
+                    'ports': ['5643/tcp', '9999/tcp']
+                }
+            }
+        }
+
+    def test_config_with_env_file_2_4(self):
+        self.base_dir = 'tests/fixtures/default-env-file'
+        result = self.dispatch(['--env-file', '.env2', 'config'])
+        json_result = yaml.safe_load(result.stdout)
+        assert json_result == {
+            'version': '2.4',
+            'services': {
+                'web': {
+                    'command': 'false',
+                    'image': 'alpine:latest',
+                    'ports': ['5644/tcp', '9998/tcp']
+                }
+            }
+        }
+
+    def test_config_with_dot_env_and_override_dir_2_4(self):
+        self.base_dir = 'tests/fixtures/default-env-file'
+        result = self.dispatch(['--project-directory', 'alt/', 'config'])
+        json_result = yaml.safe_load(result.stdout)
+        assert json_result == {
+            'version': '2.4',
+            'services': {
+                'web': {
+                    'command': 'echo uwu',
+                    'image': 'alpine:3.10.1',
+                    'ports': ['3341/tcp', '4449/tcp']
+                }
+            }
+        }
+
+    def test_config_with_dot_env(self):
+        self.base_dir = 'tests/fixtures/default-env-file-v3'
+        result = self.dispatch(['config'])
+        json_result = yaml.safe_load(result.stdout)
+        assert json_result == {
+            'version': '3.9',
             'services': {
                 'web': {
                     'command': 'true',
@@ -369,11 +414,11 @@ services:
         }
 
     def test_config_with_env_file(self):
-        self.base_dir = 'tests/fixtures/default-env-file'
+        self.base_dir = 'tests/fixtures/default-env-file-v3'
         result = self.dispatch(['--env-file', '.env2', 'config'])
         json_result = yaml.safe_load(result.stdout)
         assert json_result == {
-            'version': '2.4',
+            'version': '3.9',
             'services': {
                 'web': {
                     'command': 'false',
@@ -384,11 +429,11 @@ services:
         }
 
     def test_config_with_dot_env_and_override_dir(self):
-        self.base_dir = 'tests/fixtures/default-env-file'
+        self.base_dir = 'tests/fixtures/default-env-file-v3'
         result = self.dispatch(['--project-directory', 'alt/', 'config'])
         json_result = yaml.safe_load(result.stdout)
         assert json_result == {
-            'version': '2.4',
+            'version': '3.9',
             'services': {
                 'web': {
                     'command': 'echo uwu',

--- a/tests/fixtures/default-env-file-v3/.env
+++ b/tests/fixtures/default-env-file-v3/.env
@@ -1,0 +1,4 @@
+IMAGE=alpine:latest
+COMMAND=true
+PORT1=5643
+PORT2=9999

--- a/tests/fixtures/default-env-file-v3/.env2
+++ b/tests/fixtures/default-env-file-v3/.env2
@@ -1,0 +1,4 @@
+IMAGE=alpine:latest
+COMMAND=false
+PORT1=5644
+PORT2=9998

--- a/tests/fixtures/default-env-file-v3/alt/.env
+++ b/tests/fixtures/default-env-file-v3/alt/.env
@@ -1,0 +1,4 @@
+IMAGE=alpine:3.10.1
+COMMAND=echo uwu
+PORT1=3341
+PORT2=4449

--- a/tests/fixtures/default-env-file-v3/docker-compose.yml
+++ b/tests/fixtures/default-env-file-v3/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  web:
+    image: ${IMAGE}
+    command: ${COMMAND}
+    ports:
+        - $PORT1
+        - $PORT2

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -5273,7 +5273,7 @@ def get_config_filename_for_files(filenames, subdir=None):
 
 
 class SerializeTest(unittest.TestCase):
-    def test_denormalize_depends(self):
+    def test_denormalize_depends_on_v3(self):
         service_dict = {
             'image': 'busybox',
             'command': 'true',
@@ -5282,8 +5282,37 @@ class SerializeTest(unittest.TestCase):
                 'service3': {'condition': 'service_started'},
             }
         }
+        assert denormalize_service_dict(service_dict, VERSION) == {
+            'image': 'busybox',
+            'command': 'true',
+            'depends_on': ['service2', 'service3']
+        }
 
-        assert denormalize_service_dict(service_dict, VERSION) == service_dict
+    def test_denormalize_depends_on_v2_1(self):
+        service_dict = {
+            'image': 'busybox',
+            'command': 'true',
+            'depends_on': {
+                'service2': {'condition': 'service_started'},
+                'service3': {'condition': 'service_started'},
+            }
+        }
+        assert denormalize_service_dict(service_dict, '2.1') == service_dict
+
+    def test_denormalize_depends_on_v2_0(self):
+        service_dict = {
+            'image': 'busybox',
+            'command': 'true',
+            'depends_on': {
+                'service2': {'condition': 'service_started'},
+                'service3': {'condition': 'service_started'},
+            }
+        }
+        assert denormalize_service_dict(service_dict, '2.0') == {
+            'image': 'busybox',
+            'command': 'true',
+            'depends_on': ['service2', 'service3']
+        }
 
     def test_serialize_time(self):
         data = {


### PR DESCRIPTION
This change is based on docker-compose documentation https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on, which points out that version 3 no longer supports the condition form of **depends_on**, which was introduced on version 2.1 https://docs.docker.com/compose/compose-file/compose-file-v2/#depends_on

Resolves https://github.com/docker/compose/issues/7773


