### PR TITLE
Revert to Python 3.7 bump for Linux static builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@
   sha: v1.3.4
   hooks:
     - id: reorder-python-imports
-      language_version: 'python3.9'
+      language_version: 'python3.7'
       args:
          - --py3-plus
 -   repo: https://github.com/asottile/pyupgrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG DOCKER_VERSION=19.03
-ARG PYTHON_VERSION=3.9.0
+ARG PYTHON_VERSION=3.7.9
 
 ARG BUILD_ALPINE_VERSION=3.12
 ARG BUILD_CENTOS_VERSION=7
-ARG BUILD_DEBIAN_VERSION=slim-buster
+ARG BUILD_DEBIAN_VERSION=slim-stretch
 
 ARG RUNTIME_ALPINE_VERSION=3.12
 ARG RUNTIME_CENTOS_VERSION=7
-ARG RUNTIME_DEBIAN_VERSION=buster-slim
+ARG RUNTIME_DEBIAN_VERSION=stretch-slim
 
 ARG DISTRO=alpine
 
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     git \
     libc-dev \
     libffi-dev \
-    libgcc-8-dev \
+    libgcc-6-dev \
     libssl-dev \
     make \
     openssl \
@@ -68,8 +68,8 @@ WORKDIR /code/
 COPY docker-compose-entrypoint.sh /usr/local/bin/
 COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
 RUN pip install \
-    virtualenv==20.2.2 \
-    tox==3.20.1
+    virtualenv==20.4.0 \
+    tox==3.21.2
 COPY requirements-dev.txt .
 COPY requirements-indirect.txt .
 COPY requirements.txt .
@@ -79,7 +79,7 @@ COPY tox.ini .
 COPY setup.py .
 COPY README.md .
 COPY compose compose/
-RUN tox --notest
+RUN tox -e py37 --notest
 COPY . .
 ARG GIT_COMMIT=unknown
 ENV DOCKER_COMPOSE_GITSHA=$GIT_COMMIT

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 def dockerVersions = ['19.03.13']
 def baseImages = ['alpine', 'debian']
-def pythonVersions = ['py39']
+def pythonVersions = ['py37']
 
 pipeline {
     agent none

--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -2,7 +2,7 @@
 
 def dockerVersions = ['19.03.13', '18.09.9']
 def baseImages = ['alpine', 'debian']
-def pythonVersions = ['py39']
+def pythonVersions = ['py37']
 
 pipeline {
     agent none

--- a/requirements-indirect.txt
+++ b/requirements-indirect.txt
@@ -23,6 +23,6 @@ pyrsistent==0.16.0
 smmap==3.0.4
 smmap2==3.0.1
 toml==0.10.1
-tox==3.20.1
-virtualenv==20.2.2
+tox==3.21.2
+virtualenv==20.4.0
 wcwidth==0.2.5

--- a/script/build/linux-entrypoint
+++ b/script/build/linux-entrypoint
@@ -3,7 +3,7 @@
 set -ex
 
 CODE_PATH=/code
-VENV="${CODE_PATH}"/.tox/py39
+VENV="${CODE_PATH}"/.tox/py37
 
 cd "${CODE_PATH}"
 mkdir -p dist

--- a/script/test/all
+++ b/script/test/all
@@ -11,7 +11,7 @@ docker run --rm \
   "$TAG" tox -e pre-commit
 
 get_versions="docker run --rm
-    --entrypoint=/code/.tox/py39/bin/python
+    --entrypoint=/code/.tox/py37/bin/python
     $TAG
     /code/script/test/versions.py docker/docker-ce,moby/moby"
 
@@ -22,7 +22,7 @@ elif [ "$DOCKER_VERSIONS" == "all" ]; then
 fi
 
 BUILD_NUMBER=${BUILD_NUMBER-$USER}
-PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py39}
+PY_TEST_VERSIONS=${PY_TEST_VERSIONS:-py37}
 
 for version in $DOCKER_VERSIONS; do
   >&2 echo "Running tests against Docker $version"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,pre-commit
+envlist = py37,py39,pre-commit
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
Resolves #8048 

This reverts the bump from Python 3.7 to 3.9 which allows us to revert the bump from Debian Stretch to Buster. This implicitly bumped the glibc requirements from 2.24 to 2.28.

**Changelog**
Revert to Python 3.7 for static Linux builds.