### PR TITLE
Add bash completion for profiles and a command to list profiles

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -381,6 +381,7 @@ class TopLevelCommand:
             --no-interpolate         Don't interpolate environment variables.
             -q, --quiet              Only validate the configuration, don't print
                                      anything.
+            --profiles               Print the profile names, one per line.
             --services               Print the service names, one per line.
             --volumes                Print the volume names, one per line.
             --hash="*"               Print the service config hash, one per line.
@@ -398,6 +399,15 @@ class TopLevelCommand:
                 image_digests = image_digests_for_project(self.project)
 
         if options['--quiet']:
+            return
+
+        if options['--profiles']:
+            profiles = set()
+            for service in compose_config.services:
+                if 'profiles' in service:
+                    for profile in service['profiles']:
+                        profiles.add(profile)
+            print('\n'.join(sorted(profiles)))
             return
 
         if options['--services']:

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -138,7 +138,7 @@ _docker_compose_config() {
 			;;
 	esac
 
-	COMPREPLY=( $( compgen -W "--hash --help --no-interpolate --quiet -q --resolve-image-digests --services --volumes" -- "$cur" ) )
+	COMPREPLY=( $( compgen -W "--hash --help --no-interpolate --profiles --quiet -q --resolve-image-digests --services --volumes" -- "$cur" ) )
 }
 
 

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -172,6 +172,10 @@ _docker_compose_docker_compose() {
 			COMPREPLY=( $( compgen -W "debug info warning error critical" -- "$cur" ) )
 			return
 			;;
+		--profile)
+			COMPREPLY=( $( compgen -W "$(__docker_compose_q config --profiles)" -- "$cur" ) )
+			return
+			;;
 		--project-directory)
 			_filedir -d
 			return
@@ -618,10 +622,11 @@ _docker_compose() {
 		--tlskey
 	"
 
-	# These options are require special treatment when searching the command.
+	# These options require special treatment when searching the command.
 	local top_level_options_with_args="
 		--ansi
 		--log-level
+		--profile
 	"
 
 	COMPREPLY=()

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -237,6 +237,11 @@ class CLITestCase(DockerClientTestCase):
         result = self.dispatch(['-H=tcp://doesnotexist:8000', 'ps'], returncode=1)
         assert "Couldn't connect to Docker daemon" in result.stderr
 
+    def test_config_list_profiles(self):
+        self.base_dir = 'tests/fixtures/config-profiles'
+        result = self.dispatch(['config', '--profiles'])
+        assert set(result.stdout.rstrip().split('\n')) == {'debug', 'frontend', 'gui'}
+
     def test_config_list_services(self):
         self.base_dir = 'tests/fixtures/v2-full'
         result = self.dispatch(['config', '--services'])

--- a/tests/fixtures/config-profiles/docker-compose.yml
+++ b/tests/fixtures/config-profiles/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  frontend:
+    image: frontend
+    profiles: ["frontend", "gui"]
+  phpmyadmin:
+    image: phpmyadmin
+    depends_on:
+      - db
+    profiles:
+      - debug
+  backend:
+    image: backend
+  db:
+    image: mysql


### PR DESCRIPTION
This adds bash completion for `docker-compose --profile`, which was added in #7930.

In order to complete valid profiles, we need a portable way to get a list of profiles used in the current config.

For that purpose, a new option `docker-compose config --profiles` was added.
It works like the `--services` and `--volumes` options.

I'm new to python development, so I guess there's a more elegant idiom for collecting the profiles.
I appreciate any help here.