### PR TITLE
Add bash completion for `docker-compose logs|up --no-log-prefix`, fix formatting of help message

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -691,7 +691,7 @@ class TopLevelCommand:
             -t, --timestamps        Show timestamps.
             --tail="all"            Number of lines to show from the end of the logs
                                     for each container.
-            --no-log-prefix    Don't print prefix in logs.
+            --no-log-prefix         Don't print prefix in logs.
         """
         containers = self.project.containers(service_names=options['SERVICE'], stopped=True)
 
@@ -1109,7 +1109,7 @@ class TopLevelCommand:
                                        container. Implies --abort-on-container-exit.
             --scale SERVICE=NUM        Scale SERVICE to NUM instances. Overrides the
                                        `scale` setting in the Compose file if present.
-            --no-log-prefix       Don't print prefix in logs.
+            --no-log-prefix            Don't print prefix in logs.
         """
         start_deps = not options['--no-deps']
         always_recreate_deps = options['--always-recreate-deps']

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -294,7 +294,7 @@ _docker_compose_logs() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--follow -f --help --no-color --tail --timestamps -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--follow -f --help --no-color --no-log-prefix --tail --timestamps -t" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_complete_services
@@ -549,7 +549,7 @@ _docker_compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --attach-dependencies --build -d --detach --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --attach-dependencies --build -d --detach --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-log-prefix --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_complete_services


### PR DESCRIPTION
This adds bash completion for `docker-compose logs|up --no-log-prefix`.
Corresponding feature PR: #7435

Also fixes the tabular alignment of `docker-compose logs|up --no-log-prefix`.