### PR TITLE
Remove local check for log-driver read support

### DIFF
--- a/compose/cli/log_printer.py
+++ b/compose/cli/log_printer.py
@@ -158,10 +158,8 @@ class QueueItem(namedtuple('_QueueItem', 'item is_stop exc')):
 
 
 def tail_container_logs(container, presenter, queue, log_args):
-    generator = get_log_generator(container)
-
     try:
-        for item in generator(container, log_args):
+        for item in build_log_generator(container, log_args):
             queue.put(QueueItem.new(presenter.present(container, item)))
     except Exception as e:
         queue.put(QueueItem.exception(e))
@@ -169,20 +167,6 @@ def tail_container_logs(container, presenter, queue, log_args):
     if log_args.get('follow'):
         queue.put(QueueItem.new(presenter.color_func(wait_on_exit(container))))
     queue.put(QueueItem.stop(container.name))
-
-
-def get_log_generator(container):
-    if container.has_api_logs:
-        return build_log_generator
-    return build_no_log_generator
-
-
-def build_no_log_generator(container, log_args):
-    """Return a generator that prints a warning about logs and waits for
-    container to exit.
-    """
-    yield "WARNING: no logs are available with the '{}' log driver\n".format(
-        container.log_driver)
 
 
 def build_log_generator(container, log_args):

--- a/compose/container.py
+++ b/compose/container.py
@@ -187,11 +187,6 @@ class Container:
         return self.get('HostConfig.LogConfig.Type')
 
     @property
-    def has_api_logs(self):
-        log_type = self.log_driver
-        return not log_type or log_type in ('json-file', 'journald', 'local')
-
-    @property
     def human_readable_health_status(self):
         """ Generate UP status string with up time and health
         """
@@ -204,11 +199,7 @@ class Container:
         return status_string
 
     def attach_log_stream(self):
-        """A log stream can only be attached if the container uses a
-        json-file, journald or local log driver.
-        """
-        if self.has_api_logs:
-            self.log_stream = self.attach(stdout=True, stderr=True, stream=True)
+        self.log_stream = self.attach(stdout=True, stderr=True, stream=True)
 
     def get(self, key):
         """Return a value from the container or None if the value is not set.

--- a/tests/unit/cli/log_printer_test.py
+++ b/tests/unit/cli/log_printer_test.py
@@ -8,7 +8,6 @@ from docker.errors import APIError
 
 from compose.cli.log_printer import build_log_generator
 from compose.cli.log_printer import build_log_presenters
-from compose.cli.log_printer import build_no_log_generator
 from compose.cli.log_printer import consume_queue
 from compose.cli.log_printer import QueueItem
 from compose.cli.log_printer import wait_on_exit
@@ -73,14 +72,6 @@ def test_wait_on_exit_raises():
         mock_container.name, status_code,
     )
     assert expected in wait_on_exit(mock_container)
-
-
-def test_build_no_log_generator(mock_container):
-    mock_container.has_api_logs = False
-    mock_container.log_driver = 'none'
-    output, = build_no_log_generator(mock_container, None)
-    assert "WARNING: no logs are available with the 'none' log driver\n" in output
-    assert "exited with code" not in output
 
 
 class TestBuildLogGenerator:

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -221,34 +221,6 @@ class ContainerTest(unittest.TestCase):
         container = Container(None, self.container_dict, has_been_inspected=True)
         assert container.short_id == self.container_id[:12]
 
-    def test_has_api_logs(self):
-        container_dict = {
-            'HostConfig': {
-                'LogConfig': {
-                    'Type': 'json-file'
-                }
-            }
-        }
-
-        container = Container(None, container_dict, has_been_inspected=True)
-        assert container.has_api_logs is True
-
-        container_dict['HostConfig']['LogConfig']['Type'] = 'none'
-        container = Container(None, container_dict, has_been_inspected=True)
-        assert container.has_api_logs is False
-
-        container_dict['HostConfig']['LogConfig']['Type'] = 'syslog'
-        container = Container(None, container_dict, has_been_inspected=True)
-        assert container.has_api_logs is False
-
-        container_dict['HostConfig']['LogConfig']['Type'] = 'journald'
-        container = Container(None, container_dict, has_been_inspected=True)
-        assert container.has_api_logs is True
-
-        container_dict['HostConfig']['LogConfig']['Type'] = 'foobar'
-        container = Container(None, container_dict, has_been_inspected=True)
-        assert container.has_api_logs is False
-
 
 class GetContainerNameTestCase(unittest.TestCase):
 


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/40543
relates to https://github.com/moby/moby/issues/30887
(hopefully) fixes https://github.com/docker/compose/issues/8060


Starting with Docker 20.10, the docker daemon has support for "dual logging", which allows reading back logs, irregardless of the logging-driver that is configured (except for "none" as logging driver).

This patch removes the local check, which used a hard-coded list of logging drivers that are expected to support reading logs.

When using an older version of Docker, the API should return an error that reading logs is not supported, so no local check should be needed.

