### PR TITLE
Fix incorrect CLI env variable name for service profiles

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -129,7 +129,7 @@ def get_profiles_from_options(options, environment):
     if profile_option:
         return profile_option
 
-    profiles = environment.get('COMPOSE_PROFILE')
+    profiles = environment.get('COMPOSE_PROFILES')
     if profiles:
         return profiles.split(',')
 


### PR DESCRIPTION
Changed from singular to plural as defined in the docs, i.e. "COMPOSE_PROFILES"

Signed-off-by: Jim Cronqvist <jim.cronqvist@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #8092
