### PR TITLE
Fix fish completion

### DIFF
--- a/contrib/completion/fish/docker-compose.fish
+++ b/contrib/completion/fish/docker-compose.fish
@@ -22,6 +22,6 @@ complete -c docker-compose -l tlskey -r                   -d 'Path to TLS key fi
 complete -c docker-compose -l tlsverify                   -d 'Use TLS and verify the remote'
 complete -c docker-compose -l skip-hostname-check         -d "Don't check the daemon's hostname against the name specified in the client certificate (for example if your docker host is an IP address)"
 complete -c docker-compose -l no-ansi                     -d 'Do not print ANSI control characters'
-complete -c docker-compose -l ansi -a never always auto   -d 'Control when to print ANSI control characters'
+complete -c docker-compose -l ansi -a 'never always auto' -d 'Control when to print ANSI control characters'
 complete -c docker-compose -s h -l help                   -d 'Print usage'
 complete -c docker-compose -s v -l version                -d 'Print version and exit'


### PR DESCRIPTION
As one of the changes in #6858, the fish completion has been added for `no-ansi` and `ansi` options. However, the arguments need to be quoted to be recognized properly.
# Current behavior
```fish
~ ➜ docker-compose complete: Too many arguments

/usr/share/fish/vendor_completions.d/docker-compose.fish (line 25): 
complete -c docker-compose -l ansi -a never always auto -d 'Control when to print ANSI control characters'
^
from sourcing file /usr/share/fish/vendor_completions.d/docker-compose.fish
in command substitution

(Type 'help complete' for related documentation)
```

# Behavior after this change
```fish
~ ➜ docker-compose 
build                         (Build or rebuild services)  kill                           (Kill containers)  rm                  (Remove stopped containers)
config               (Validate and view the Compose file)  logs               (View output from containers)  run                     (Run a one-off command)
create                                  (Create services)  name       (specified in the client certificate)  scale  (Set number of containers for a service)
down                          (Stop and remove resources)  pause                           (Pause services)  start                          (Start services)
```