### PR TITLE
Add --exclude flag to docker-compose up

### DIFF
--- a/compose/project.py
+++ b/compose/project.py
@@ -244,6 +244,11 @@ class Project:
             service.remove_duplicate_containers()
         return services
 
+    def get_complement_services(self, service_names=None):
+        if service_names is None:
+            service_names = []
+        return [s for s in self.services if s.name not in service_names]
+
     def get_links(self, service_dict):
         links = []
         if 'links' in service_dict:

--- a/contrib/completion/bash/docker-compose
+++ b/contrib/completion/bash/docker-compose
@@ -549,7 +549,7 @@ _docker_compose_up() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --attach-dependencies --build -d --detach --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-log-prefix --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--abort-on-container-exit --always-recreate-deps --attach-dependencies --build -d --detach --exit-code-from --force-recreate --help --no-build --no-color --no-deps --no-log-prefix --no-recreate --no-start --renew-anon-volumes -V --remove-orphans --scale --timeout -t --exclude" -- "$cur" ) )
 			;;
 		*)
 			__docker_compose_complete_services

--- a/contrib/completion/zsh/_docker-compose
+++ b/contrib/completion/zsh/_docker-compose
@@ -296,6 +296,7 @@ __docker-compose_subcommand() {
                 '(-t --timeout)'{-t,--timeout}"[Use this timeout in seconds for container shutdown when attached or when containers are already running. (default: 10)]:seconds: " \
                 '--scale[SERVICE=NUM Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.]:service scale SERVICE=NUM: ' \
                 '--exit-code-from=[Return the exit code of the selected service container. Implies --abort-on-container-exit]:service:__docker-compose_services' \
+                '--exclude[Flag to exclude services]' \
                 $opts_remove_orphans \
                 '*:services:__docker-compose_services' && ret=0
             ;;

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -3147,3 +3147,10 @@ services:
         assert 'another' in result.stdout
         assert 'exited with code 0' in result.stdout
         assert 'exited with code 0' in result.stdout
+
+    def test_up_with_exclude_flag(self):
+        self.base_dir = 'tests/fixtures/v2-simple'
+        self.dispatch(['up', '-d', '--exclude', 'another'], None)
+        services = self.project.get_services()
+        assert services[0].containers()[0].is_running
+        assert len(services[1].containers()) == 0

--- a/tests/unit/project_test.py
+++ b/tests/unit/project_test.py
@@ -175,6 +175,25 @@ class ProjectTest(unittest.TestCase):
         project = Project('test', [web, db], None)
         assert project.get_services(['web', 'db'], include_deps=True) == [db, web]
 
+    def test_get_complement_services(self):
+        db = Service(
+            project='composetest',
+            name='db',
+            image=BUSYBOX_IMAGE_WITH_TAG,
+        )
+        web = Service(
+            project='composetest',
+            name='web',
+            image='foo',
+        )
+        proxy = Service(
+            project='composetest',
+            name='proxy',
+            image='bar',
+        )
+        project = Project('test', [web, db, proxy], None)
+        assert project.get_complement_services(['proxy']) == [web, db]
+
     def test_use_volumes_from_container(self):
         container_id = 'aabbccddee'
         container_dict = dict(Name='aaa', Id=container_id)


### PR DESCRIPTION
see: https://github.com/docker/compose/issues/4133

Adds an option to exclude specific services from docker-compose up.
With the --exclude flag all services, except those specified after the 'up' option, are going to be started.

Signed-off-by: Hans Aschenloher <hansi.aschenloher@gmail.com>