### PR TITLE
Add missing --add-host args to the build command

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1875,6 +1875,11 @@ class _CLIBuilder:
         command_builder.add_arg("--iidfile", iidfile)
         command_builder.add_arg("--platform", platform)
         command_builder.add_arg("--isolation", isolation)
+
+        if extra_hosts:
+            for host, ip in extra_hosts.items():
+                command_builder.add_arg("--add-host", "{}:{}".format(host, ip))
+
         args = command_builder.build([path])
 
         magic_word = "Successfully built "


### PR DESCRIPTION
Hello,

Until now when building a container the build `extra_hosts` were ignored.
This commit just adds the `--add-host` option to the build command.

Thanks