### PR TITLE
Install and pin openssl version to 1.1.1j

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,13 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libgcc-6-dev \
     libssl-dev \
     make \
-    openssl \
     zlib1g-dev
+
+# FIXME: to be removed when updating the base image to one with newer version that matches the cryptography's openssl version
+RUN curl --output openssl-OpenSSL_1_1_1j.tar.gz https://codeload.github.com/openssl/openssl/tar.gz/OpenSSL_1_1_1j && \
+    echo -n "327a400b8bb58058604f83c7e839fea11bba095e *openssl-OpenSSL_1_1_1j.tar.gz" | sha1sum -c - && \
+    tar xfz openssl-OpenSSL_1_1_1j.tar.gz && cd openssl-OpenSSL_1_1_1j && \
+    ./config -Wl,-Bsymbolic-functions -fPIC shared && make && make install && ldconfig -v
 
 FROM centos:${BUILD_CENTOS_VERSION} AS build-centos
 RUN yum install -y \

--- a/script/setup/osx
+++ b/script/setup/osx
@@ -13,9 +13,9 @@ if ! [ ${DEPLOYMENT_TARGET} == "$(macos_version)" ]; then
   SDK_SHA1=dd228a335194e3392f1904ce49aff1b1da26ca62
 fi
 
-OPENSSL_VERSION=1.1.1h
+OPENSSL_VERSION=1.1.1j
 OPENSSL_URL=https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-OPENSSL_SHA1=8d0d099e8973ec851368c8c775e05e1eadca1794
+OPENSSL_SHA1=327a400b8bb58058604f83c7e839fea11bba095e
 
 PYTHON_VERSION=3.9.0
 PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz


### PR DESCRIPTION
The Python cryptography package was built against a newer version of OpenSSL while the binary version  was older and this caused the mismatch error.

- updated also the openssl version for the MacOS binary

```
$ docker-compose version
docker-compose version 1.29.0dev, build fe51950d
docker-py version: 4.4.2
CPython version: 3.7.9
OpenSSL version: OpenSSL 1.1.1j  16 Feb 2021
```

Resolves https://github.com/docker/compose/issues/7686
