### PR TITLE
run docker-compose with remote's local socket

### DIFF
--- a/script/run/run.sh
+++ b/script/run/run.sh
@@ -87,7 +87,7 @@ done
 
 # Setup environment variables for compose config and context
 # shellcheck disable=SC1117
-ENV_OPTIONS=$(printenv | sed -E "/^PATH=.*/d; /^DOCKER_HOST=.*/d; s/^/-e /g; s/=.*//g; s/\n/ /g")
+ENV_OPTIONS=$(printenv | sed -E "/^PATH=.*/d; /^DOCKER_HOST=.*/d; /[^=]/d; s/^/-e /g; s/=.*//g; s/\n/ /g")
 
 # Only allocate tty if we detect one
 if [ -t 0 ] && [ -t 1 ]; then


### PR DESCRIPTION
This commit will use /var/run/docker.sock if it appears to be a socket within the docker container.
For local runs this would not add benefits but for remote runs of docker, this would allow using a docker host that is only known to the host that is running this shell script.

Also:
ignore some errors,
use long-options,
keep debugging commands as comments.

Resolves #8149 