### PR TITLE
Advertise `docker compose` for non linux users

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -23,6 +23,7 @@ from ..config import resolve_build_args
 from ..config.environment import Environment
 from ..config.serialize import serialize_config
 from ..config.types import VolumeSpec
+from ..const import IS_LINUX_PLATFORM
 from ..const import IS_WINDOWS_PLATFORM
 from ..errors import StreamParseError
 from ..metrics.decorator import metrics
@@ -78,6 +79,8 @@ def main():  # noqa: C901
     try:
         command_func = dispatch()
         command_func()
+        if not IS_LINUX_PLATFORM and command == 'help':
+            print("\nDocker Compose is now in the Docker CLI, try `docker compose` help")
     except (KeyboardInterrupt, signals.ShutdownException):
         exit_with_metrics(command, "Aborting.", status=Status.FAILURE)
     except (UserError, NoSuchService, ConfigurationError,
@@ -98,6 +101,8 @@ def main():  # noqa: C901
                               e.service.name), status=Status.FAILURE)
     except NoSuchCommand as e:
         commands = "\n".join(parse_doc_section("commands:", getdoc(e.supercommand)))
+        if not IS_LINUX_PLATFORM:
+            commands += "\n\nDocker Compose is now in the Docker CLI, try `docker compose`"
         exit_with_metrics(e.command, "No such command: {}\n\n{}".format(e.command, commands))
     except (errors.ConnectionError, StreamParseError):
         exit_with_metrics(command, status=Status.FAILURE)
@@ -116,6 +121,10 @@ def main():  # noqa: C901
         code = 0
         if isinstance(e.code, int):
             code = e.code
+
+        if not IS_LINUX_PLATFORM and not command:
+            msg += "\n\nDocker Compose is now in the Docker CLI, try `docker compose`"
+
         exit_with_metrics(command, log_msg=msg, status=status,
                           exit_code=code)
 
@@ -1122,6 +1131,9 @@ class TopLevelCommand:
         no_start = options.get('--no-start')
         attach_dependencies = options.get('--attach-dependencies')
         keep_prefix = not options.get('--no-log-prefix')
+
+        if not IS_LINUX_PLATFORM:
+            print('Docker Compose is now in the Docker CLI, try `docker compose up`\n')
 
         if detached and (cascade_stop or exit_value_from or attach_dependencies):
             raise UserError(

--- a/compose/const.py
+++ b/compose/const.py
@@ -5,6 +5,7 @@ from .version import ComposeVersion
 DEFAULT_TIMEOUT = 10
 HTTP_TIMEOUT = 60
 IS_WINDOWS_PLATFORM = (sys.platform == "win32")
+IS_LINUX_PLATFORM = (sys.platform == "linux")
 LABEL_CONTAINER_NUMBER = 'com.docker.compose.container-number'
 LABEL_ONE_OFF = 'com.docker.compose.oneoff'
 LABEL_PROJECT = 'com.docker.compose.project'

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ directory = coverage-html
 [flake8]
 max-line-length = 105
 # Set this high for now
-max-complexity = 11
+max-complexity = 12
 exclude = compose/packages
 
 [pytest]


### PR DESCRIPTION
This adds messages on:
- Root command (only `docker-compose`)
- Command not found
- `help` command

Message:
Docker Compose is now in the Docker CLI, try `docker compose`

Resolves https://github.com/docker/compose-cli/issues/1149
