### PR TITLE
Use built-in functools.cached_property when possible

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -10,7 +10,11 @@ from operator import attrgetter
 from operator import itemgetter
 
 import yaml
-from cached_property import cached_property
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 
 from . import types
 from ..const import COMPOSE_SPEC as VERSION

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backports.shutil_get_terminal_size==1.0.0
-cached-property==1.5.1
+cached-property==1.5.1; python_version < '3.8'
 certifi==2020.6.20
 chardet==3.0.4
 colorama==0.4.3; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'cached-property >= 1.2.0, < 2',
     'docopt >= 0.6.1, < 1',
     'PyYAML >= 3.10, < 6',
     'requests >= 2.20.0, < 3',
@@ -50,6 +49,7 @@ if sys.version_info[:2] < (3, 4):
 
 extras_require = {
     ':python_version < "3.5"': ['backports.ssl_match_hostname >= 3.5, < 4'],
+    ':python_version < "3.8"': ['cached-property >= 1.2.0, < 2'],
     ':sys_platform == "win32"': ['colorama >= 0.4, < 1'],
     'socks': ['PySocks >= 1.5.6, != 1.5.7, < 2'],
     'tests': tests_require,


### PR DESCRIPTION
The cached_property decorator is built-in in functools module since
Python 3.8.  Use the external cached_property package only for older
versions of Python.

Signed-off-by: Michał Górny <mgorny@gentoo.org>

Resolves #8177
