### PR TITLE
Do not use context as base dir for Dockerfile when context is a git url

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1855,7 +1855,7 @@ class _CLIBuilder:
         Returns:
             A generator for the build output.
         """
-        if dockerfile:
+        if dockerfile and os.path.isdir(path):
             dockerfile = os.path.join(path, dockerfile)
         iidfile = tempfile.mktemp()
 


### PR DESCRIPTION
Resolves https://github.com/docker/compose/issues/8184
