### PR TITLE
Add TOML support for Compose files

### DIFF
--- a/compose/config/errors.py
+++ b/compose/config/errors.py
@@ -46,6 +46,14 @@ class ComposeFileNotFound(ConfigurationError):
         """ % ", ".join(supported_filenames))
 
 
+class InvalidComposeFileExtension(ConfigurationError):
+    def __init__(self, supported_extensions):
+        super().__init__(
+            "The configuration file provided uses an unsupported file extension.\n"
+            "Supported file extensions: {}".format(", ".join(supported_extensions))
+        )
+
+
 class DuplicateOverrideFileFound(ConfigurationError):
     def __init__(self, override_filenames):
         self.override_filenames = override_filenames

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pytest==6.0.1; python_version >= '3.5'
 pytest==4.6.5; python_version < '3.5'
 pytest-cov==2.10.1
 PyYAML==5.3.1
+toml==0.10.2

--- a/requirements-indirect.txt
+++ b/requirements-indirect.txt
@@ -22,7 +22,6 @@ pyparsing==2.4.7
 pyrsistent==0.16.0
 smmap==3.0.4
 smmap2==3.0.1
-toml==0.10.1
 tox==3.21.2
 virtualenv==20.4.0
 wcwidth==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,6 @@ pywin32==227; sys_platform == 'win32'
 PyYAML==5.3.1
 requests==2.24.0
 texttable==1.6.2
+toml==0.10.2
 urllib3==1.25.10; python_version == '3.3'
 websocket-client==0.57.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ install_requires = [
     'cached-property >= 1.2.0, < 2',
     'docopt >= 0.6.1, < 1',
     'PyYAML >= 3.10, < 6',
+    'toml >= 0.10.2, < 1',
     'requests >= 2.20.0, < 3',
     'texttable >= 0.9.0, < 2',
     'websocket-client >= 0.32.0, < 1',


### PR DESCRIPTION
Allow users to use a `docker-compose.toml` alongside `.yml` / `.yaml`.

TOML is a popular configuration file type often compared with YAML and JSON. Since you can 
write JSON in YAML, TOML was the only of the three technically missing for Compose files.

Support for TOML will give users greater ability to write their configurations in the format that they are most
comfortable with, and it will give a bit of unity to projects already using TOML for their own config files (e.g. Cargo).

An example of equivalent Compose files:

YAML
```yaml
version: '3.3'
services:
  backend:
    build: backend
    depends_on:
      - db
    environment:
      DB_KEY: db-key-value
  db:
    image: database
    restart: always
    volumes:
      - db-data:/var/lib/database/data
volumes:
  db-data: {}
```
TOML
```toml
version = "3.3"

[services.backend]
build = "backend"
depends_on = [ "db" ]

[services.backend.environment]
DB_KEY = "db-key-value"

[services.db]
image = "database"
restart = "always"
volumes = [ "db-data:/var/lib/database/data" ]

[volumes.db-data]
```

---
Resolves #6920 