### PR TITLE
Filter out ansi escape sequences from build output

### DIFF
--- a/compose/service.py
+++ b/compose/service.py
@@ -1888,10 +1888,13 @@ class _CLIBuilder:
         appear = False
         with subprocess.Popen(args, stdout=subprocess.PIPE,
                               universal_newlines=True) as p:
+            # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+            regex = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
             while True:
                 line = p.stdout.readline()
                 if not line:
                     break
+                line = regex.sub('', line)
                 if line.startswith(magic_word):
                     appear = True
                 yield json.dumps({"stream": line})


### PR DESCRIPTION

The colored build output is not visible in windows powershell.

![image](https://user-images.githubusercontent.com/809903/111612932-45e42080-87de-11eb-852a-0bb42c747dac.png)

After removing ansi escape sequences:

![image](https://user-images.githubusercontent.com/809903/111612853-32d15080-87de-11eb-9d13-c77bf6e726ad.png)

