### PR TITLE
Lookup compose files in project directory

### DIFF
--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -313,9 +313,12 @@ def find(base_dir, filenames, environment, override_dir=None):
     if filenames:
         filenames = [os.path.join(base_dir, f) for f in filenames]
     else:
-        # search for compose files in the project directory or current working
-        # directory if no project-directory is set
-        filenames = get_default_config_files(override_dir or base_dir)
+        if override_dir:
+            # search for compose files in the project directory and its parents
+            filenames = get_default_config_files(override_dir)
+        if not filenames:
+            # fallback to base directory (current dir) and its parents
+            filenames = get_default_config_files(base_dir)
         if not filenames:
             raise ComposeFileNotFound(SUPPORTED_FILENAMES)
 

--- a/compose/config/config.py
+++ b/compose/config/config.py
@@ -313,16 +313,11 @@ def find(base_dir, filenames, environment, override_dir=None):
     if filenames:
         filenames = [os.path.join(base_dir, f) for f in filenames]
     else:
-        # search for compose files in the base dir and its parents
-        filenames = get_default_config_files(base_dir)
-        if not filenames and not override_dir:
-            # none found in base_dir and no override_dir defined
-            raise ComposeFileNotFound(SUPPORTED_FILENAMES)
+        # search for compose files in the project directory or current working
+        # directory if no project-directory is set
+        filenames = get_default_config_files(override_dir or base_dir)
         if not filenames:
-            # search for compose files in the project directory and its parents
-            filenames = get_default_config_files(override_dir)
-            if not filenames:
-                raise ComposeFileNotFound(SUPPORTED_FILENAMES)
+            raise ComposeFileNotFound(SUPPORTED_FILENAMES)
 
     log.debug("Using configuration files: {}".format(",".join(filenames)))
     return ConfigDetails(

--- a/compose/config/errors.py
+++ b/compose/config/errors.py
@@ -39,8 +39,7 @@ class CircularReference(ConfigurationError):
 class ComposeFileNotFound(ConfigurationError):
     def __init__(self, supported_filenames):
         super().__init__("""
-        Can't find a suitable configuration file in this directory or any
-        parent. Are you in the right directory?
+        Can't find a suitable configuration file in the project directory or its parents.
 
         Supported filenames: %s
         """ % ", ".join(supported_filenames))

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -901,7 +901,6 @@ services:
         self.override_dir = os.path.abspath('tests/fixtures')
         result = self.dispatch([
             '--project-directory', self.override_dir,
-            '-f', 'docker-compose.yml',
             'build'])
 
         assert 'Successfully built' in result.stdout

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -901,6 +901,7 @@ services:
         self.override_dir = os.path.abspath('tests/fixtures')
         result = self.dispatch([
             '--project-directory', self.override_dir,
+            '-f', 'docker-compose.yml',
             'build'])
 
         assert 'Successfully built' in result.stdout


### PR DESCRIPTION
We lookup the Compose files in the project-directory first (if it is set) and fallback to the current working directory if none was found in the project directory.

`$ cat /tmp/test/docker-compose.yml `
```yaml
services:
  test:
    image: nginx
    ports:
      - 8888:80
```
`$ cat ~/myproject/docker-compose.yml `
```yaml
services:
  myproject:
    image: nginx
    ports:
      - 8081:80

```
When no  `--project-directory` is set in the command line, it defaults to current working directory
```
$ cd /tmp/test
[ /tmp/test/ ]$ docker-compose config
services:
  test:
    image: nginx
    ports:
    - published: 8888
      target: 80
version: '3.9'

```

When a `--project-directory` is set, by default, we look for Compose files in it. 

```
[ /tmp/test/ ]$ docker-compose --project-directory ~/myproject config
services:
  myproject:
    image: nginx
    ports:
    - published: 8081
      target: 80
version: '3.9'
```

If no compose file found in the project directory, error out:
```
[ /tmp/test/ ]$ docker-compose --project-directory /tmp/no_compose_file_dir config
ERROR: 
        Can't find a suitable configuration file in the project directory or its parents.

        Supported filenames: docker-compose.yml, docker-compose.yaml, compose.yml, compose.yaml
```

Setting the compose files with `-f` overrides the ones in the project directory.
```
[ /tmp/test/ ]$ docker-compose --project-directory ~/myproject -f ./docker-compose.yml config
services:
  test:
    image: nginx
    ports:
    - published: 8888
      target: 80
version: '3.9'
```
