### PR TITLE
Update compose spec schema to add missing service property `storage_opt`

### DIFF
--- a/compose/config/compose_spec.json
+++ b/compose/config/compose_spec.json
@@ -335,7 +335,6 @@
         "read_only": {"type": "boolean"},
         "restart": {"type": "string"},
         "runtime": {
-          "deprecated": true,
           "type": "string"
         },
         "scale": {
@@ -367,6 +366,7 @@
         "stdin_open": {"type": "boolean"},
         "stop_grace_period": {"type": "string", "format": "duration"},
         "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
         "tmpfs": {"$ref": "#/definitions/string_or_list"},
         "tty": {"type": "boolean"},
         "ulimits": {


### PR DESCRIPTION
Relates to https://github.com/docker/compose/issues/8210