### PR TITLE
Mention `--ansi never` in `--no-ansi` deprecation

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -171,7 +171,8 @@ def dispatch():
     if options.get("--no-ansi"):
         if options.get("--ansi"):
             raise UserError("--no-ansi and --ansi cannot be combined.")
-        log.warning('--no-ansi option is deprecated and will be removed in future versions.')
+        log.warning('--no-ansi option is deprecated and will be removed in future versions. '
+                    'Use `--ansi never` instead.')
         ansi_mode = AnsiMode.NEVER
 
     setup_console_handler(console_handler,


### PR DESCRIPTION
Ideally deprecation messages should point users directly at the non-deprecated alternative so it's a no-brainer for someone to switch to it.

Currently the deprecation warning gives no indication that there's any alternative option, almost as if the feature was removed:
```
 --no-ansi option is deprecated and will be removed in future versions.
 ```

Concrete example of why this is insufficient: two people on a project I'm working on, myself being one of them, independently tried to address this warning by simply removing the `--no-ansi` option from our CI build tooling. The current message makes it look like the feature has simply been removed. This is what I assumed and I only discovered the alternative option when I saw the other PR for the same solution then getting curious and doing a `git blame` to find the original PR that added the deprecation: https://github.com/docker/compose/pull/6858 
 
 This PR makes the deprecation message clear to any user that the `--ansi never` option should be used instead of `--no-ansi`:
 
 ```
 --no-ansi option is deprecated and will be removed in future versions. Use `--ansi never` instead.
 ```
 
On initial glance the CI failure for this PR looks unrelated.