### PR TITLE
Remove universal wheel support used only for Python 2.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
https://github.com/docker/compose/commit/e8424d5ae0de01fae98fa7aaff3c79cbb1dfcf2b dropped Python 2 support.

Universal wheels are only needed if Python 2 support is required. Since this is no longer the case, simplify the project by removing `setup.cfg` as its only entry was to enable universal wheels, which are no longer required.