### PR TITLE
Add placement.max_replicas_per_node to conversion map

### DIFF
--- a/compose/config/interpolation.py
+++ b/compose/config/interpolation.py
@@ -243,6 +243,7 @@ class ConversionMap:
         service_path('healthcheck', 'disable'): to_boolean,
         service_path('deploy', 'labels', PATH_JOKER): to_str,
         service_path('deploy', 'replicas'): to_int,
+        service_path('deploy', 'placement', 'max_replicas_per_node'): to_int,
         service_path('deploy', 'resources', 'limits', "cpus"): to_float,
         service_path('deploy', 'update_config', 'parallelism'): to_int,
         service_path('deploy', 'update_config', 'max_failure_ratio'): to_float,


### PR DESCRIPTION

```
version: '3.8'

services:
  hello-world:
    image: "docker.io/hello-world"
    deploy:
      replicas: "${REPLICAS}"
      placement:
        max_replicas_per_node: "${MAX_REPLICAS_PER_NODE}"
```

```
[example]$ REPLICAS=2 MAX_REPLICAS_PER_NODE=2 docker-compose config
services:
  hello-world:
    deploy:
      placement:
        max_replicas_per_node: 2
      replicas: 2
    image: docker.io/hello-world
version: '3.8'
```



Relates to https://github.com/docker/compose/issues/8277
