### PR TITLE
WIP - Proposal for allowing envfile to be defined in docker-compose.yml file

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -36,7 +36,15 @@ SILENT_COMMANDS = {
 def project_from_options(project_dir, options, additional_options=None):
     additional_options = additional_options or {}
     override_dir = get_project_dir(options)
+
+    config_details = config.find(project_dir, get_config_path_from_options(options, {}), {}, override_dir)
+
     environment_file = options.get('--env-file')
+    if environment_file is None:
+        for config_file in config_details.config_files:
+            if config_file.config['x-envfile'] is not None:
+                environment_file = config_file.config['x-envfile']
+
     environment = Environment.from_env_file(override_dir or project_dir, environment_file)
     environment.silent = options.get('COMMAND', None) in SILENT_COMMANDS
     set_parallel_limit(environment)


### PR DESCRIPTION
This PR does not meet coding standards. Looking for someone to take this up and add tests and documentation. I'm not familiar enough with python or this project to do this.

This is my proposal for resolving #6741. It allows the `.env` file to be defined from docker-compose.yml file allowing for it to be remapped to `.env.docker` or `/dev/null` to not conflict with applications that utilize the `.env` file.

This implementation evaluates the `docker-compose.yml` file an extra time, looking for `x-env-file`. If this is accepted as a solution, a `env-file` option should be added to the docker-compose schema/spec. I could not find an appropriate section to add a config option like this in the [current spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md).

This solution preserves the ability to utilize `--env-file` command line option to override the `x-env-file` directive in the `docker-compose.yml` file. 

Appreciate any feedback. Thank you.

Resolves #6741
