### PR TITLE
Add --pull arg to "up" command

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -1111,6 +1111,7 @@ class TopLevelCommand:
                                        and image haven't changed.
             --always-recreate-deps     Recreate dependent containers.
                                        Incompatible with --no-recreate.
+            --pull                     Always attempt to pull a newer version of the image.
             --no-recreate              If containers already exist, don't recreate
                                        them. Incompatible with --force-recreate and -V.
             --no-build                 Don't build an image, even if it's missing.
@@ -1134,6 +1135,7 @@ class TopLevelCommand:
         """
         start_deps = not options['--no-deps']
         always_recreate_deps = options['--always-recreate-deps']
+        pull = options['--pull']
         exit_value_from = exitval_from_opts(options, self.project)
         cascade_stop = options['--abort-on-container-exit']
         service_names = options['SERVICE']
@@ -1175,6 +1177,7 @@ class TopLevelCommand:
                     scale_override=parse_scale_args(options['--scale']),
                     start=not no_start,
                     always_recreate_deps=always_recreate_deps,
+                    always_pull=pull,
                     reset_container_image=rebuild,
                     renew_anonymous_volumes=options.get('--renew-anon-volumes'),
                     silent=options.get('--quiet-pull'),

--- a/compose/project.py
+++ b/compose/project.py
@@ -640,6 +640,7 @@ class Project:
            rescale=True,
            start=True,
            always_recreate_deps=False,
+           always_pull=False,
            reset_container_image=False,
            renew_anonymous_volumes=False,
            silent=False,
@@ -661,7 +662,7 @@ class Project:
             include_deps=start_deps)
 
         for svc in services:
-            svc.ensure_image_exists(do_build=do_build, silent=silent, cli=cli)
+            svc.ensure_image_exists(do_build=do_build, always_pull=always_pull, silent=silent, cli=cli)
         plans = self._get_convergence_plans(
             services,
             strategy,

--- a/compose/service.py
+++ b/compose/service.py
@@ -348,13 +348,17 @@ class Service:
             self.build(cli=cli)
             return
 
+        if not self.can_be_built() and always_pull:
+            self.pull(silent=silent)
+            return
+
         try:
             self.image()
             return
         except NoSuchImageError:
             pass
 
-        if not self.can_be_built() or always_pull:
+        if not self.can_be_built():
             self.pull(silent=silent)
             return
 

--- a/compose/service.py
+++ b/compose/service.py
@@ -343,7 +343,7 @@ class Service:
             raise OperationFailedError("Cannot create container for service %s: %s" %
                                        (self.name, binarystr_to_unicode(ex.explanation)))
 
-    def ensure_image_exists(self, do_build=BuildAction.none, silent=False, cli=False):
+    def ensure_image_exists(self, do_build=BuildAction.none, always_pull=False, silent=False, cli=False):
         if self.can_be_built() and do_build == BuildAction.force:
             self.build(cli=cli)
             return
@@ -354,7 +354,7 @@ class Service:
         except NoSuchImageError:
             pass
 
-        if not self.can_be_built():
+        if not self.can_be_built() or always_pull:
             self.pull(silent=silent)
             return
 

--- a/tests/acceptance/cli_test.py
+++ b/tests/acceptance/cli_test.py
@@ -3152,3 +3152,35 @@ services:
         assert 'another' in result.stdout
         assert 'exited with code 0' in result.stdout
         assert 'exited with code 0' in result.stdout
+
+    def test_up_not_pull(self):
+        self.dispatch(['up', '-d'], None)
+        service = self.project.get_service('simple')
+        another = self.project.get_service('another')
+
+        assert len(service.containers()) == 1
+        assert len(another.containers()) == 1
+
+        result = self.dispatch(['up', '-d'], None)
+        assert len(service.containers()) == 1
+        assert len(another.containers()) == 1
+
+        assert 'Pulling simple' not in result.stderr
+        assert 'Pulling another' not in result.stderr
+        assert 'failed' not in result.stderr
+
+    def test_up_pull(self):
+        self.dispatch(['up', '-d'], None)
+        service = self.project.get_service('simple')
+        another = self.project.get_service('another')
+
+        assert len(service.containers()) == 1
+        assert len(another.containers()) == 1
+
+        result = self.dispatch(['up', '-d', '--pull'], None)
+        assert len(service.containers()) == 1
+        assert len(another.containers()) == 1
+
+        assert 'Pulling simple' in result.stderr
+        assert 'Pulling another' in result.stderr
+        assert 'failed' not in result.stderr

--- a/tests/unit/service_test.py
+++ b/tests/unit/service_test.py
@@ -577,6 +577,24 @@ class ServiceTest(unittest.TestCase):
         assert self.mock_client.build.call_count == 1
         self.mock_client.build.call_args[1]['tag'] == 'default_foo'
 
+    def test_ensure_image_exists_not_always_pull(self):
+        service = Service('foo', client=self.mock_client, image='someimage:sometag')
+
+        self.mock_client.inspect_image.side_effect = [NoSuchImageError, {'Id': 'abc123'}]
+        service.ensure_image_exists()
+        service.ensure_image_exists()
+
+        assert self.mock_client.pull.call_count == 1
+
+    def test_ensure_image_exists_always_pull(self):
+        service = Service('foo', client=self.mock_client, image='someimage:sometag')
+
+        self.mock_client.inspect_image.side_effect = [NoSuchImageError, {'Id': 'abc123'}]
+        service.ensure_image_exists()
+        service.ensure_image_exists(always_pull=True)
+
+        assert self.mock_client.pull.call_count == 2
+
     def test_build_does_not_pull(self):
         self.mock_client.build.return_value = [
             b'{"stream": "Successfully built 12345"}',


### PR DESCRIPTION
Ability to do: 

 `docker-compose -f my-docker-compose.yml up --pull` 

Instead of :

`docker-compose -f my-docker-compose.yml pull && docker-compose -f my-docker-compose.test.yml up`. 

Why:

- It's shorter

- Less prone to errors since you don't have to type the yml file name twice (Which means double chance for typos)

- It has better performance because `&&` throws away the asynchrony

- Makes the API more consistent since there is already a `--build` flag and one expect to be a `--pull` one.

One example without this flag that looks weird to me (maybe is just me) is this:

`docker-compose pull && docker-compose up --build`

There it looks like `pull` and `build` are two features with different degrees of importance, when in fact, they don't, the condition to do one thing or another is even in the same function in the code.

This looks a better fit:

`docker-compose up --build --pull`

I added unit tests and acceptance tests