### PR TITLE
find `.env` in parent project directories

### DIFF
--- a/compose/cli/command.py
+++ b/compose/cli/command.py
@@ -35,7 +35,7 @@ SILENT_COMMANDS = {
 
 def project_from_options(project_dir, options, additional_options=None):
     additional_options = additional_options or {}
-    override_dir = get_project_dir(options)
+    override_dir = get_project_dir(options, project_dir)
     environment_file = options.get('--env-file')
     environment = Environment.from_env_file(override_dir or project_dir, environment_file)
     environment.silent = options.get('COMMAND', None) in SILENT_COMMANDS
@@ -87,19 +87,21 @@ def set_parallel_limit(environment):
         parallel.GlobalLimit.set_global_limit(parallel_limit)
 
 
-def get_project_dir(options):
+def get_project_dir(options, base_dir):
     override_dir = None
     files = get_config_path_from_options(options, os.environ)
     if files:
         if files[0] == '-':
             return '.'
         override_dir = os.path.dirname(files[0])
+    else:
+        _, override_dir = config.find_candidates_in_parent_dirs(config.SUPPORTED_FILENAMES, base_dir)
     return options.get('--project-directory') or override_dir
 
 
 def get_config_from_options(base_dir, options, additional_options=None):
     additional_options = additional_options or {}
-    override_dir = get_project_dir(options)
+    override_dir = get_project_dir(options, base_dir)
     environment_file = options.get('--env-file')
     environment = Environment.from_env_file(override_dir or base_dir, environment_file)
     config_path = get_config_path_from_options(options, environment)

--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -323,7 +323,7 @@ class TopLevelCommand:
 
     @property
     def project_dir(self):
-        return get_project_dir(self.toplevel_options)
+        return get_project_dir(self.toplevel_options, '.')
 
     @property
     def toplevel_environment(self):

--- a/compose/config/__init__.py
+++ b/compose/config/__init__.py
@@ -3,6 +3,7 @@ from . import environment
 from .config import ConfigurationError
 from .config import DOCKER_CONFIG_KEYS
 from .config import find
+from .config import find_candidates_in_parent_dirs
 from .config import is_url
 from .config import load
 from .config import merge_environment
@@ -10,3 +11,4 @@ from .config import merge_labels
 from .config import parse_environment
 from .config import parse_labels
 from .config import resolve_build_args
+from .config import SUPPORTED_FILENAMES

--- a/tests/integration/environment_test.py
+++ b/tests/integration/environment_test.py
@@ -90,3 +90,17 @@ class EnvironmentOverrideFileTest(DockerClientTestCase):
         assert len(containers) == 1
         assert "WHEREAMI=default" in containers[0].get('Config.Env')
         dispatch(base_dir, ['down'], None)
+
+    def test_dot_env_file_in_subdir(self):
+        base_dir = 'tests/fixtures/env-file-override'
+        sub_dir = base_dir + '/subdir'
+        env = Environment.from_env_file(base_dir, None)
+        dispatch(sub_dir, ['up'])
+        project = get_project(project_dir=base_dir,
+                              config_path=['docker-compose.yml'],
+                              environment=env,
+                              override_dir=base_dir)
+        containers = project.containers(stopped=True)
+        assert len(containers) == 1
+        assert "WHEREAMI=default" in containers[0].get('Config.Env')
+        dispatch(base_dir, ['down'], None)


### PR DESCRIPTION
Executed in a subdir of a project, `docker-compose` finds`docker-compose.yml` through parent dirs.
On the other hand, it does not search `.env` in parent dirs (see #8347).
This PR fixes this inconsistency.

Resolves  #8347