### PR TITLE
Fix fish completion

### DIFF
--- a/contrib/completion/fish/docker-compose.fish
+++ b/contrib/completion/fish/docker-compose.fish
@@ -1,11 +1,10 @@
 # Tab completion for docker-compose (https://github.com/docker/compose).
-# Version: 1.9.0
+# Version: 1.9.1
 
 complete -e -c docker-compose
 
 for line in (docker-compose --help | \
-             string match -r '^\s+\w+\s+[^\n]+' | \
-             string trim)
+             string replace -f -r '^\s{2}(\w+)\s{2,}([^\n]+)' '$1 $2')
   set -l doc (string split -m 1 ' ' -- $line)
   complete -c docker-compose -n '__fish_use_subcommand' -xa $doc[1] --description $doc[2]
 end


### PR DESCRIPTION
The fish completion shows subcommands improperly.

## Before change

```
akira@home ~> docker-compose 
build                         (Build or rebuild services)  kill                           (Kill containers)  rm                  (Remove stopped containers)
config               (Validate and view the Compose file)  logs               (View output from containers)  run                     (Run a one-off command)
create                                  (Create services)  name       (specified in the client certificate)  scale  (Set number of containers for a service)
down                          (Stop and remove resources)  pause                           (Pause services)  start                          (Start services)
events         (Receive real time events from containers)  port  (Print the public port for a port binding)  stop                            (Stop services)
exec           (Execute a command in a running container)  ps                             (List containers)  top             (Display the running processes)
help                              (Get help on a command)  pull                       (Pull service images)  unpause                      (Unpause services)
images                                      (List images)  push                       (Push service images)  up                (Create and start containers)
in  (v3 files to their non-Swarm equivalent (DEPRECATED))  restart                       (Restart services)  version     (Show version information and quit)
```

`in  (v3 files to their non-Swarm equivalent (DEPRECATED))` at the last line is unexpected. 

## After change

```
akira@home ~> docker-compose 
build                  (Build or rebuild services)  logs               (View output from containers)  scale  (Set number of containers for a service)
config        (Validate and view the Compose file)  pause                           (Pause services)  start                          (Start services)
create                           (Create services)  port  (Print the public port for a port binding)  stop                            (Stop services)
down                   (Stop and remove resources)  ps                             (List containers)  top             (Display the running processes)
events  (Receive real time events from containers)  pull                       (Pull service images)  unpause                      (Unpause services)
exec    (Execute a command in a running container)  push                       (Push service images)  up                (Create and start containers)
help                       (Get help on a command)  restart                       (Restart services)  version     (Show version information and quit)
images                               (List images)  rm                   (Remove stopped containers)  
kill                             (Kill containers)  run                      (Run a one-off command)  
```
