### PR TITLE
fix(setup.py): pin docker-py to 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'texttable >= 0.9.0, < 2',
     'websocket-client >= 0.32.0, < 1',
     'distro >= 1.5.0, < 2',
-    'docker[ssh] >= 5',
+    'docker[ssh] == 5.0.0',
     'dockerpty >= 0.4.1, < 1',
     'jsonschema >= 2.5.1, < 4',
     'python-dotenv >= 0.13.0, < 1',


### PR DESCRIPTION
Signed-off-by: Adam Aposhian <aposhian.dev@gmail.com>

<!--
Welcome to the docker-compose issue tracker, and thank you for your interest
in contributing to the project! Please make sure you've read the guidelines
in CONTRIBUTING.md before submitting your pull request. Contributions that
do not comply and contributions with failing tests will not be reviewed!
-->

<!-- Please make sure an issue describing the problem the PR is trying to
    solve exists, or create it before submitting a PR. The maintainers will
    validate if the issue should be addressed or if it is out of scope for the
    project.
-->
Resolves #8499 
While `docker` is pinned in the `requirements.txt`, it is not pinned in `setup.py`, which is used to install dependencies when `docker-compose` is installed with `pip`. `docker-py` 5.0.1 has a breaking change as noted here: https://github.com/docker/docker-py/issues/2885