### PR TITLE
fix release project to build with GIT_TAG

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Build
-        run: make -f builder.Makefile cross
+        run: make GIT_TAG=${{ github.event.inputs.tag }} -f builder.Makefile cross
 
       - name: License
         run: cp packaging/* bin/


### PR DESCRIPTION
fix release process to generate binaries with GIT_TAG as internal.version