### PR TITLE
support --entrypoint="" as override

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -251,10 +251,10 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		runCmd     strslice.StrSlice
 		entrypoint strslice.StrSlice
 	)
-	if len(service.Command) > 0 {
+	if service.Command != nil {
 		runCmd = strslice.StrSlice(service.Command)
 	}
-	if len(service.Entrypoint) > 0 {
+	if service.Entrypoint != nil {
 		entrypoint = strslice.StrSlice(service.Entrypoint)
 	}
 

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -196,7 +196,7 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 	if len(opts.WorkingDir) > 0 {
 		service.WorkingDir = opts.WorkingDir
 	}
-	if len(opts.Entrypoint) > 0 {
+	if opts.Entrypoint != nil {
 		service.Entrypoint = opts.Entrypoint
 	}
 	if len(opts.Environment) > 0 {


### PR DESCRIPTION
Add support for `--entrypoint` flag set to empty string and override service entrypoint on `compose run`

Resolves #8529
Resolved #8581