### PR TITLE
run watchContainers with a background context

### DIFF
--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -37,7 +37,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 	if options.Follow {
 		eg.Go(func() error {
 			printer := newLogPrinter(consumer)
-			return s.watchContainers(ctx, projectName, options.Services, printer.HandleEvent, containers, func(c types.Container) error {
+			return s.watchContainers(projectName, options.Services, printer.HandleEvent, containers, func(c types.Container) error {
 				return s.logContainers(ctx, consumer, c, options)
 			})
 		})

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -47,7 +47,7 @@ func (s *composeService) start(ctx context.Context, project *types.Project, opti
 		}
 
 		eg.Go(func() error {
-			return s.watchContainers(ctx, project.Name, options.AttachTo, listener, attached, func(container moby.Container) error {
+			return s.watchContainers(project.Name, options.AttachTo, listener, attached, func(container moby.Container) error {
 				return s.attachContainer(ctx, container, listener, project)
 			})
 		})
@@ -69,13 +69,13 @@ func (s *composeService) start(ctx context.Context, project *types.Project, opti
 type containerWatchFn func(container moby.Container) error
 
 // watchContainers uses engine events to capture container start/die and notify ContainerEventListener
-func (s *composeService) watchContainers(ctx context.Context, projectName string, services []string, listener api.ContainerEventListener, containers Containers, onStart containerWatchFn) error {
+func (s *composeService) watchContainers(projectName string, services []string, listener api.ContainerEventListener, containers Containers, onStart containerWatchFn) error {
 	watched := map[string]int{}
 	for _, c := range containers {
 		watched[c.ID] = 0
 	}
 
-	ctx, stop := context.WithCancel(ctx)
+	ctx, stop := context.WithCancel(context.Background())
 	err := s.Events(ctx, projectName, api.EventsOptions{
 		Services: services,
 		Consumer: func(event api.Event) error {


### PR DESCRIPTION
When compose is ran attached by `compose up`, and user interrupt by `Ctrl+C`, the log printer is not notified about container termination and compose is stuck waiting.

This PR run `watchContainers` with a background context so it won't get canceled by the top level signal management (see `cmd/compose.go#AdaptCmd`). Doing so, the `logPrinter` will recieve `ContainerExit` events after stop sequence has started, and detect application is down to terminate with adequate exitcode

# How to test:
1. Run compose app with `docker compose up`
```yaml
services:
  web:
    image: nginx
````

2. Hit [Ctrl+C]
3. See notification for container being "Stopped", but still compose command doesn't exit