### PR TITLE
[v2] docs: fix stray backtick and add compose version yaml

### DIFF
--- a/docs/reference/compose_down.md
+++ b/docs/reference/compose_down.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Stops containers and removes containers, networks, volumes, and images created by ``up`.
+Stops containers and removes containers, networks, volumes, and images created by `up`.
 
 By default, the only things removed are:
 

--- a/docs/reference/docker_compose_down.yaml
+++ b/docs/reference/docker_compose_down.yaml
@@ -1,7 +1,7 @@
 command: docker compose down
 short: Stop and remove containers, networks
 long: |-
-  Stops containers and removes containers, networks, volumes, and images created by ``up`.
+  Stops containers and removes containers, networks, volumes, and images created by `up`.
 
   By default, the only things removed are:
 

--- a/docs/reference/docker_compose_version.yaml
+++ b/docs/reference/docker_compose_version.yaml
@@ -1,0 +1,31 @@
+command: docker compose version
+short: Show the Docker Compose version information
+long: Show the Docker Compose version information
+usage: docker compose version
+pname: docker compose
+plink: docker_compose.yaml
+options:
+- option: format
+  shorthand: f
+  value_type: string
+  description: 'Format the output. Values: [pretty | json]. (Default: pretty)'
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+- option: short
+  value_type: bool
+  default_value: "false"
+  description: Shows only Compose's version number.
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
+deprecated: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+


### PR DESCRIPTION
follow-up to https://github.com/docker/compose/pull/8612 (saw Usha's comment on https://github.com/docker/docker.github.io/pull/13520 too late 😂)