### PR TITLE
get scale from deploy.replicas. Require scale normalization

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -83,7 +83,7 @@ func (opts upOptions) apply(project *types.Project, services []string) error {
 		if err != nil {
 			return err
 		}
-		err = setServiceScale(project, name, replicas)
+		err = setServiceScale(project, name, uint64(replicas))
 		if err != nil {
 			return err
 		}
@@ -198,14 +198,17 @@ func runUp(ctx context.Context, backend api.Service, createOptions createOptions
 	})
 }
 
-func setServiceScale(project *types.Project, name string, replicas int) error {
+func setServiceScale(project *types.Project, name string, replicas uint64) error {
 	for i, s := range project.Services {
 		if s.Name == name {
 			service, err := project.GetService(name)
 			if err != nil {
 				return err
 			}
-			service.Scale = replicas
+			if service.Deploy == nil {
+				service.Deploy = &types.DeployConfig{}
+			}
+			service.Deploy.Replicas = &replicas
 			project.Services[i] = service
 			return nil
 		}

--- a/cmd/compose/up_test.go
+++ b/cmd/compose/up_test.go
@@ -39,5 +39,5 @@ func TestApplyScaleOpt(t *testing.T) {
 	assert.NilError(t, err)
 	foo, err := p.GetService("foo")
 	assert.NilError(t, err)
-	assert.Equal(t, foo.Scale, 2)
+	assert.Equal(t, *foo.Deploy.Replicas, uint64(2))
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.3
 	github.com/buger/goterm v1.0.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
-	github.com/compose-spec/compose-go v0.0.0-20210906143156-938b039f7805
+	github.com/compose-spec/compose-go v0.0.0-20210915092209-278f20859337
 	github.com/containerd/console v1.0.2
 	github.com/containerd/containerd v1.5.4
 	github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20210906143156-938b039f7805 h1:iFShT4oPik+NnXdzksa4yLvJYDDZBPMjHPN3qtJaXPA=
-github.com/compose-spec/compose-go v0.0.0-20210906143156-938b039f7805/go.mod h1:Hnmn5ZCVA3sSBN2urjCZNNIyNqCPayRGH7PmMSaV2Q0=
+github.com/compose-spec/compose-go v0.0.0-20210915092209-278f20859337 h1:/RP9uzPjZYk1Kv5YvcF+3S9E0oaSn5gRLLfWDIhieW8=
+github.com/compose-spec/compose-go v0.0.0-20210915092209-278f20859337/go.mod h1:Hnmn5ZCVA3sSBN2urjCZNNIyNqCPayRGH7PmMSaV2Q0=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -315,20 +315,15 @@ func nextContainerNumber(containers []moby.Container) (int, error) {
 
 func getScale(config types.ServiceConfig) (int, error) {
 	scale := 1
-	var err error
 	if config.Deploy != nil && config.Deploy.Replicas != nil {
 		scale = int(*config.Deploy.Replicas)
 	}
-	if config.Scale != 0 {
-		scale = config.Scale
-	}
 	if scale > 1 && config.ContainerName != "" {
-		scale = -1
-		err = fmt.Errorf(doubledContainerNameWarning,
+		return 0, fmt.Errorf(doubledContainerNameWarning,
 			config.Name,
 			config.ContainerName)
 	}
-	return scale, err
+	return scale, nil
 }
 
 func (s *composeService) createContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestContainerName(t *testing.T) {
-	var replicas uint64 = 1
 	s := types.ServiceConfig{
 		Name:          "testservicename",
 		ContainerName: "testcontainername",
@@ -36,20 +35,14 @@ func TestContainerName(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, ret, s.Scale)
 
-	s.Scale = 0
-	s.Deploy.Replicas = &replicas
+	var zero uint64 // = 0
+	s.Deploy.Replicas = &zero
 	ret, err = getScale(s)
 	assert.NilError(t, err)
 	assert.Equal(t, ret, int(*s.Deploy.Replicas))
 
-	s.Deploy.Replicas = nil
-	s.Scale = 2
-	_, err = getScale(s)
-	assert.Error(t, err, fmt.Sprintf(doubledContainerNameWarning, s.Name, s.ContainerName))
-
-	replicas = 2
-	s.Deploy.Replicas = &replicas
-	s.Scale = 0
+	var two uint64 = 2
+	s.Deploy.Replicas = &two
 	_, err = getScale(s)
 	assert.Error(t, err, fmt.Sprintf(doubledContainerNameWarning, s.Name, s.ContainerName))
 }


### PR DESCRIPTION
get service scale from `config.Deploy.Replicas` as `scale` is deprecated and normalized by compose-go


Resolves #8571
