### PR TITLE
rebuild compose project from labels

### DIFF
--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -49,6 +49,8 @@ const (
 	SlugLabel = "com.docker.compose.slug"
 	// ImageDigestLabel stores digest of the container image used to run service
 	ImageDigestLabel = "com.docker.compose.image"
+	// DependenciesLabel stores service dependencies
+	DependenciesLabel = "com.docker.compose.depends_on"
 	// VersionLabel stores the compose tool version used to run application
 	VersionLabel = "com.docker.compose.version"
 )

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -38,7 +38,12 @@ func TestDown(t *testing.T) {
 	tested.apiClient = api
 
 	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt()).Return(
-		[]moby.Container{testContainer("service1", "123"), testContainer("service2", "456"), testContainer("service2", "789"), testContainer("service_orphan", "321")}, nil)
+		[]moby.Container{
+			testContainer("service1", "123", false),
+			testContainer("service2", "456", false),
+			testContainer("service2", "789", false),
+			testContainer("service_orphan", "321", true),
+		}, nil)
 
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
 	api.EXPECT().ContainerStop(gomock.Any(), "456", nil).Return(nil)
@@ -64,7 +69,11 @@ func TestDownRemoveOrphans(t *testing.T) {
 	tested.apiClient = api
 
 	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt()).Return(
-		[]moby.Container{testContainer("service1", "123"), testContainer("service2", "789"), testContainer("service_orphan", "321")}, nil)
+		[]moby.Container{
+			testContainer("service1", "123", false),
+			testContainer("service2", "789", false),
+			testContainer("service_orphan", "321", true),
+		}, nil)
 
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
 	api.EXPECT().ContainerStop(gomock.Any(), "789", nil).Return(nil)
@@ -90,7 +99,7 @@ func TestDownRemoveVolumes(t *testing.T) {
 	tested.apiClient = api
 
 	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt()).Return(
-		[]moby.Container{testContainer("service1", "123")}, nil)
+		[]moby.Container{testContainer("service1", "123", false)}, nil)
 
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "123", moby.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)

--- a/pkg/compose/ps_test.go
+++ b/pkg/compose/ps_test.go
@@ -66,7 +66,7 @@ func containerDetails(service string, id string, status string, health string, e
 	container := moby.Container{
 		ID:     id,
 		Names:  []string{"/" + id},
-		Labels: containerLabels(service),
+		Labels: containerLabels(service, false),
 		State:  status,
 	}
 	inspect := moby.ContainerJSON{ContainerJSONBase: &moby.ContainerJSONBase{State: &moby.ContainerState{Status: status, Health: &moby.Health{Status: health}, ExitCode: exitCode}}}

--- a/pkg/compose/stop_test.go
+++ b/pkg/compose/stop_test.go
@@ -40,9 +40,9 @@ func TestStopTimeout(t *testing.T) {
 	ctx := context.Background()
 	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt()).Return(
 		[]moby.Container{
-			testContainer("service1", "123"),
-			testContainer("service1", "456"),
-			testContainer("service2", "789"),
+			testContainer("service1", "123", false),
+			testContainer("service1", "456", false),
+			testContainer("service2", "789", false),
 		}, nil)
 
 	timeout := time.Duration(2) * time.Second


### PR DESCRIPTION
Introduce `com.docker.compose.depends_on` label and use it to rebuild project model from actual containers without the need for the original compose file (which might have been edited/removed) and environment (which is only partially captured by `com.docker.compose.project.environment_file`, we miss os.Env set by user)

=> `docker compose --project-name foo down` is able to stop container in reverse dependencies order without original compose file

To be debated if we still want `docker compose down` to parse the compose file and only stopped declared containers, or just compute project name

Resolves #8552
