### PR TITLE
define compose container names with a valid hostname

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -91,12 +91,13 @@ func Adapt(fn Command) func(cmd *cobra.Command, args []string) error {
 var Warning string
 
 type projectOptions struct {
-	ProjectName string
-	Profiles    []string
-	ConfigPaths []string
-	WorkDir     string
-	ProjectDir  string
-	EnvFile     string
+	ProjectName   string
+	Profiles      []string
+	ConfigPaths   []string
+	WorkDir       string
+	ProjectDir    string
+	EnvFile       string
+	Compatibility bool
 }
 
 // ProjectFunc does stuff within a types.Project
@@ -149,9 +150,8 @@ func (o *projectOptions) addProjectFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.EnvFile, "env-file", "", "Specify an alternate environment file.")
 	f.StringVar(&o.ProjectDir, "project-directory", "", "Specify an alternate working directory\n(default: the path of the Compose file)")
 	f.StringVar(&o.WorkDir, "workdir", "", "DEPRECATED! USE --project-directory INSTEAD.\nSpecify an alternate working directory\n(default: the path of the Compose file)")
-	f.Bool("compatibility", false, "DEPRECATED")
+	f.BoolVar(&o.Compatibility, "compatibility", false, "Run compose in backward compatibility mode")
 	_ = f.MarkHidden("workdir")
-	_ = f.MarkHidden("compatibility")
 }
 
 func (o *projectOptions) toProjectName() (string, error) {
@@ -258,6 +258,9 @@ func RootCommand(backend api.Service) *cobra.Command {
 				}
 				opts.ProjectDir = opts.WorkDir
 				fmt.Fprint(os.Stderr, aec.Apply("option '--workdir' is DEPRECATED at root level! Please use '--project-directory' instead.\n", aec.RedF))
+			}
+			if opts.Compatibility || os.Getenv("COMPOSE_COMPATIBILITY") == "true" {
+				compose.Separator = "_"
 			}
 			return nil
 		},

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -32,6 +32,8 @@ import (
 	"github.com/sanathkr/go-yaml"
 )
 
+var Separator = "-"
+
 // NewComposeService create a local implementation of the compose.Service API
 func NewComposeService(apiClient client.APIClient, configFile *configfile.ConfigFile) api.Service {
 	return &composeService{

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -245,7 +245,7 @@ func (c *convergence) ensureService(ctx context.Context, project *types.Project,
 }
 
 func getContainerName(projectName string, service types.ServiceConfig, number int) string {
-	name := fmt.Sprintf("%s_%s_%d", projectName, service.Name, number)
+	name := strings.Join([]string{projectName, service.Name, strconv.Itoa(number)}, Separator)
 	if service.ContainerName != "" {
 		name = service.ContainerName
 	}

--- a/pkg/e2e/cascade_stop_test.go
+++ b/pkg/e2e/cascade_stop_test.go
@@ -29,13 +29,13 @@ func TestCascadeStop(t *testing.T) {
 
 	t.Run("abort-on-container-exit", func(t *testing.T) {
 		res := c.RunDockerOrExitError("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
-		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `should_fail_1 exited with code 1`})
+		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `should_fail-1 exited with code 1`})
 		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `Aborting on container exit...`})
 	})
 
 	t.Run("exit-code-from", func(t *testing.T) {
 		res := c.RunDockerOrExitError("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
-		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `should_fail_1 exited with code 1`})
+		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `should_fail-1 exited with code 1`})
 		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `Aborting on container exit...`})
 	})
 

--- a/pkg/e2e/compose_exec_test.go
+++ b/pkg/e2e/compose_exec_test.go
@@ -32,17 +32,17 @@ func TestLocalComposeExec(t *testing.T) {
 	c.RunDockerCmd("compose", "--project-directory", "fixtures/simple-composefile", "--project-name", projectName, "up", "-d")
 
 	t.Run("exec true", func(t *testing.T) {
-		res := c.RunDockerOrExitError("exec", "compose-e2e-exec_simple_1", "/bin/true")
+		res := c.RunDockerOrExitError("exec", "compose-e2e-exec-simple-1", "/bin/true")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 	})
 
 	t.Run("exec false", func(t *testing.T) {
-		res := c.RunDockerOrExitError("exec", "compose-e2e-exec_simple_1", "/bin/false")
+		res := c.RunDockerOrExitError("exec", "compose-e2e-exec-simple-1", "/bin/false")
 		res.Assert(t, icmd.Expected{ExitCode: 1})
 	})
 
 	t.Run("exec with env set", func(t *testing.T) {
-		res := icmd.RunCmd(c.NewDockerCmd("exec", "-e", "FOO", "compose-e2e-exec_simple_1", "/usr/bin/env"),
+		res := icmd.RunCmd(c.NewDockerCmd("exec", "-e", "FOO", "compose-e2e-exec-simple-1", "/usr/bin/env"),
 			func(cmd *icmd.Cmd) {
 				cmd.Env = append(cmd.Env, "FOO=BAR")
 			})
@@ -50,7 +50,7 @@ func TestLocalComposeExec(t *testing.T) {
 	})
 
 	t.Run("exec without env set", func(t *testing.T) {
-		res := c.RunDockerOrExitError("exec", "-e", "FOO", "compose-e2e-exec_simple_1", "/usr/bin/env")
+		res := c.RunDockerOrExitError("exec", "-e", "FOO", "compose-e2e-exec-simple-1", "/usr/bin/env")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		assert.Check(t, !strings.Contains(res.Stdout(), "FOO="))
 	})

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -54,7 +54,7 @@ func TestLocalComposeRun(t *testing.T) {
 				truncatedSlug = strings.Replace(containerID, "run-test_back_run_", "", 1)
 				runContainerID = containerID
 			}
-			if strings.HasPrefix(containerID, "run-test_db_1") {
+			if strings.HasPrefix(containerID, "run-test-db-1") {
 				assert.Assert(t, strings.Contains(line, "Up"), line)
 			}
 		}

--- a/pkg/e2e/cp_test.go
+++ b/pkg/e2e/cp_test.go
@@ -51,7 +51,7 @@ func TestCopy(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "./fixtures/cp-test/cp-me.txt", "nginx:/tmp/default.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
-		output := c.RunDockerCmd("exec", projectName+"_nginx_1", "cat", "/tmp/default.txt").Stdout()
+		output := c.RunDockerCmd("exec", projectName+"-nginx-1", "cat", "/tmp/default.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
 		res = c.RunDockerOrExitError("exec", projectName+"_nginx_2", "cat", "/tmp/default.txt")
@@ -62,10 +62,10 @@ func TestCopy(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "--index=3", "./fixtures/cp-test/cp-me.txt", "nginx:/tmp/indexed.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
-		output := c.RunDockerCmd("exec", projectName+"_nginx_3", "cat", "/tmp/indexed.txt").Stdout()
+		output := c.RunDockerCmd("exec", projectName+"-nginx-3", "cat", "/tmp/indexed.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
-		res = c.RunDockerOrExitError("exec", projectName+"_nginx_2", "cat", "/tmp/indexed.txt")
+		res = c.RunDockerOrExitError("exec", projectName+"-nginx-2", "cat", "/tmp/indexed.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 1})
 	})
 
@@ -73,13 +73,13 @@ func TestCopy(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "--all", "./fixtures/cp-test/cp-me.txt", "nginx:/tmp/all.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
-		output := c.RunDockerCmd("exec", projectName+"_nginx_1", "cat", "/tmp/all.txt").Stdout()
+		output := c.RunDockerCmd("exec", projectName+"-nginx-1", "cat", "/tmp/all.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
-		output = c.RunDockerCmd("exec", projectName+"_nginx_2", "cat", "/tmp/all.txt").Stdout()
+		output = c.RunDockerCmd("exec", projectName+"-nginx-2", "cat", "/tmp/all.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
-		output = c.RunDockerCmd("exec", projectName+"_nginx_3", "cat", "/tmp/all.txt").Stdout()
+		output = c.RunDockerCmd("exec", projectName+"-nginx-3", "cat", "/tmp/all.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 	})
 
@@ -105,7 +105,7 @@ func TestCopy(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "./fixtures/cp-test/cp-folder", "nginx:/tmp")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
-		output := c.RunDockerCmd("exec", projectName+"_nginx_1", "cat", "/tmp/cp-folder/cp-me.txt").Stdout()
+		output := c.RunDockerCmd("exec", projectName+"-nginx-1", "cat", "/tmp/cp-folder/cp-me.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world from folder`), output)
 
 		res = c.RunDockerCmd("compose", "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "nginx:/tmp/cp-folder", "./fixtures/cp-test/cp-folder2")

--- a/pkg/e2e/ipc_test.go
+++ b/pkg/e2e/ipc_test.go
@@ -44,13 +44,13 @@ func TestIPC(t *testing.T) {
 	})
 
 	t.Run("check ipcmode in container inspect", func(t *testing.T) {
-		res := c.RunDockerCmd("inspect", projectName+"_shareable_1")
+		res := c.RunDockerCmd("inspect", projectName+"-shareable-1")
 		res.Assert(t, icmd.Expected{Out: `"IpcMode": "shareable",`})
 
-		res = c.RunDockerCmd("inspect", projectName+"_service_1")
+		res = c.RunDockerCmd("inspect", projectName+"-service-1")
 		res.Assert(t, icmd.Expected{Out: `"IpcMode": "container:`})
 
-		res = c.RunDockerCmd("inspect", projectName+"_container_1")
+		res = c.RunDockerCmd("inspect", projectName+"-container-1")
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`"IpcMode": "container:%s",`, cid)})
 	})
 

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -107,7 +107,7 @@ func TestIPAMConfig(t *testing.T) {
 	})
 
 	t.Run("ensure service get fixed IP assigned", func(t *testing.T) {
-		res := c.RunDockerCmd("inspect", projectName+"_foo_1", "-f", "{{ .NetworkSettings.Networks."+projectName+"_default.IPAddress }}")
+		res := c.RunDockerCmd("inspect", projectName+"-foo-1", "-f", "{{ .NetworkSettings.Networks."+projectName+"_default.IPAddress }}")
 		res.Assert(t, icmd.Expected{Out: "10.1.0.100"})
 	})
 

--- a/pkg/e2e/restart_test.go
+++ b/pkg/e2e/restart_test.go
@@ -32,8 +32,8 @@ func TestRestart(t *testing.T) {
 
 	getServiceRegx := func(service string, status string) string {
 		// match output with random spaces like:
-		// e2e-start-stop_db_1      "echo hello"     db      running
-		return fmt.Sprintf("%s_%s_1.+%s\\s+%s", projectName, service, service, status)
+		// e2e-start-stop-db-1      "echo hello"     db      running
+		return fmt.Sprintf("%s-%s-1.+%s\\s+%s", projectName, service, service, status)
 	}
 
 	t.Run("Up a project", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestRestart(t *testing.T) {
 		c.RunDockerOrExitError("compose", "--project-name", projectName, "down")
 
 		res := c.RunDockerOrExitError("compose", "-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "up", "-d")
-		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-restart_restart_1  Started"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-restart-restart-1  Started"), res.Combined())
 
 		c.WaitForCmdResult(c.NewDockerCmd("compose", "--project-name", projectName, "ps", "-a", "--format", "json"),
 			StdoutContains(`"State":"exited"`),

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -37,13 +37,13 @@ func TestStartStop(t *testing.T) {
 
 	getServiceRegx := func(service string, status string) string {
 		// match output with random spaces like:
-		// e2e-start-stop_db_1      "echo hello"       db          running
-		return fmt.Sprintf("%s_%s_1.+%s\\s+%s", projectName, service, service, status)
+		// e2e-start-stop-db-1      "echo hello"       db          running
+		return fmt.Sprintf("%s-%s-1.+%s\\s+%s", projectName, service, service, status)
 	}
 
 	t.Run("Up a project", func(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-f", "./fixtures/start-stop/compose.yaml", "--project-name", projectName, "up", "-d")
-		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop_simple_1  Started"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-simple-1  Started"), res.Combined())
 
 		res = c.RunDockerCmd("compose", "ls", "--all")
 		testify.Regexp(t, getProjectRegx("running"), res.Stdout())
@@ -63,7 +63,7 @@ func TestStartStop(t *testing.T) {
 		testify.Regexp(t, getProjectRegx("exited"), res.Stdout())
 
 		res = c.RunDockerCmd("compose", "--project-name", projectName, "ps")
-		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop_words_1"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-words-1"), res.Combined())
 
 		res = c.RunDockerCmd("compose", "--project-name", projectName, "ps", "--all")
 		testify.Regexp(t, getServiceRegx("simple", "exited"), res.Stdout())

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -44,7 +44,7 @@ func TestLocalComposeVolume(t *testing.T) {
 	})
 
 	t.Run("check container volume specs", func(t *testing.T) {
-		res := c.RunDockerCmd("inspect", "compose-e2e-volume_nginx2_1", "--format", "{{ json .Mounts }}")
+		res := c.RunDockerCmd("inspect", "compose-e2e-volume-nginx2-1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
 		// nolint
 		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/src/app/node_modules","Driver":"local","Mode":"z","RW":true,"Propagation":""`), output)
@@ -52,17 +52,17 @@ func TestLocalComposeVolume(t *testing.T) {
 	})
 
 	t.Run("check config content", func(t *testing.T) {
-		output := c.RunDockerCmd("exec", "compose-e2e-volume_nginx2_1", "cat", "/myconfig").Stdout()
+		output := c.RunDockerCmd("exec", "compose-e2e-volume-nginx2-1", "cat", "/myconfig").Stdout()
 		assert.Assert(t, strings.Contains(output, `Hello from Nginx container`), output)
 	})
 
 	t.Run("check secrets content", func(t *testing.T) {
-		output := c.RunDockerCmd("exec", "compose-e2e-volume_nginx2_1", "cat", "/run/secrets/mysecret").Stdout()
+		output := c.RunDockerCmd("exec", "compose-e2e-volume-nginx2-1", "cat", "/run/secrets/mysecret").Stdout()
 		assert.Assert(t, strings.Contains(output, `Hello from Nginx container`), output)
 	})
 
 	t.Run("check container bind-mounts specs", func(t *testing.T) {
-		res := c.RunDockerCmd("inspect", "compose-e2e-volume_nginx_1", "--format", "{{ json .Mounts }}")
+		res := c.RunDockerCmd("inspect", "compose-e2e-volume-nginx-1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
 		// nolint
 		assert.Assert(t, strings.Contains(output, `"Type":"bind"`))
@@ -70,15 +70,15 @@ func TestLocalComposeVolume(t *testing.T) {
 	})
 
 	t.Run("should inherit anonymous volumes", func(t *testing.T) {
-		c.RunDockerOrExitError("exec", "compose-e2e-volume_nginx2_1", "touch", "/usr/src/app/node_modules/test")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
 		c.RunDockerOrExitError("compose", "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "-d")
-		c.RunDockerOrExitError("exec", "compose-e2e-volume_nginx2_1", "ls", "/usr/src/app/node_modules/test")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
 	})
 
 	t.Run("should renew anonymous volumes", func(t *testing.T) {
-		c.RunDockerOrExitError("exec", "compose-e2e-volume_nginx2_1", "touch", "/usr/src/app/node_modules/test")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
 		c.RunDockerOrExitError("compose", "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "--renew-anon-volumes", "-d")
-		c.RunDockerOrExitError("exec", "compose-e2e-volume_nginx2_1", "ls", "/usr/src/app/node_modules/test")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
 	})
 
 	t.Run("cleanup volume project", func(t *testing.T) {


### PR DESCRIPTION
This is a proposal to fix long running issue https://github.com/docker/compose/issues/229

tl;dr:
docker-compose creates containers as `project_service_number` which make them invalid hostnames. Most tools support this mistakes, but some don't.

As we move to Compose V2, we have a unique opportunity to fix this with a minor backward compatibility break. Maybe we could have this controlled by some COMPOSE_COMPATIBILITY env variable, and/or resurrect the --compatibility flag

Resolves #229
