### PR TITLE
"log" must stop watching on SIGTERM

### DIFF
--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -37,7 +37,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 	if options.Follow {
 		eg.Go(func() error {
 			printer := newLogPrinter(consumer)
-			return s.watchContainers(projectName, options.Services, printer.HandleEvent, containers, func(c types.Container) error {
+			return s.watchContainers(ctx, projectName, options.Services, printer.HandleEvent, containers, func(c types.Container) error {
 				return s.logContainers(ctx, consumer, c, options)
 			})
 		})

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -47,7 +47,7 @@ func (s *composeService) start(ctx context.Context, project *types.Project, opti
 		}
 
 		eg.Go(func() error {
-			return s.watchContainers(project.Name, options.AttachTo, listener, attached, func(container moby.Container) error {
+			return s.watchContainers(context.Background(), project.Name, options.AttachTo, listener, attached, func(container moby.Container) error {
 				return s.attachContainer(ctx, container, listener, project)
 			})
 		})
@@ -69,13 +69,13 @@ func (s *composeService) start(ctx context.Context, project *types.Project, opti
 type containerWatchFn func(container moby.Container) error
 
 // watchContainers uses engine events to capture container start/die and notify ContainerEventListener
-func (s *composeService) watchContainers(projectName string, services []string, listener api.ContainerEventListener, containers Containers, onStart containerWatchFn) error {
+func (s *composeService) watchContainers(ctx context.Context, projectName string, services []string, listener api.ContainerEventListener, containers Containers, onStart containerWatchFn) error {
 	watched := map[string]int{}
 	for _, c := range containers {
 		watched[c.ID] = 0
 	}
 
-	ctx, stop := context.WithCancel(context.Background())
+	ctx, stop := context.WithCancel(ctx)
 	err := s.Events(ctx, projectName, api.EventsOptions{
 		Services: services,
 		Consumer: func(event api.Event) error {


### PR DESCRIPTION
while "start" must not interupt the watch process, so need a background context,
"log" must stop on SIGTERM and as such watch operation must use the top-level cancelable context.
(otherwise `docker compose logs --follow` never stops)


this is a combination of https://github.com/docker/compose/commit/1458beea84fbd8b7aa9757bde025fc210cf545b5 and https://github.com/docker/compose/commit/f7c360b721b1e2a0bb1eb78b60cd60bb1c1c6199