### PR TITLE
compose exec doesn't need project

### DIFF
--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 
-	cgo "github.com/compose-spec/compose-go/cli"
 	"github.com/containerd/console"
 	"github.com/docker/cli/cli"
 	"github.com/spf13/cobra"
@@ -78,7 +77,7 @@ func execCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runExec(ctx context.Context, backend api.Service, opts execOpts) error {
-	project, err := opts.toProject(nil, cgo.WithResolvedPaths(true))
+	project, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -61,7 +61,7 @@ type Service interface {
 	// Remove executes the equivalent to a `compose rm`
 	Remove(ctx context.Context, project *types.Project, options RemoveOptions) error
 	// Exec executes a command in a running service container
-	Exec(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
+	Exec(ctx context.Context, project string, opts RunOptions) (int, error)
 	// Copy copies a file/folder between a service container and the local filesystem
 	Copy(ctx context.Context, project *types.Project, opts CopyOptions) error
 	// Pause executes the equivalent to a `compose pause`

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -40,7 +40,7 @@ type ServiceProxy struct {
 	KillFn               func(ctx context.Context, project *types.Project, options KillOptions) error
 	RunOneOffContainerFn func(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 	RemoveFn             func(ctx context.Context, project *types.Project, options RemoveOptions) error
-	ExecFn               func(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
+	ExecFn               func(ctx context.Context, project string, opts RunOptions) (int, error)
 	CopyFn               func(ctx context.Context, project *types.Project, opts CopyOptions) error
 	PauseFn              func(ctx context.Context, project string, options PauseOptions) error
 	UnPauseFn            func(ctx context.Context, project string, options PauseOptions) error
@@ -261,12 +261,9 @@ func (s *ServiceProxy) Remove(ctx context.Context, project *types.Project, optio
 }
 
 // Exec implements Service interface
-func (s *ServiceProxy) Exec(ctx context.Context, project *types.Project, options RunOptions) (int, error) {
+func (s *ServiceProxy) Exec(ctx context.Context, project string, options RunOptions) (int, error) {
 	if s.ExecFn == nil {
 		return 0, ErrNotImplemented
-	}
-	for _, i := range s.interceptors {
-		i(ctx, project)
 	}
 	return s.ExecFn(ctx, project, options)
 }


### PR DESCRIPTION
Align `compose exec` behavior with Compose v1 to not compose environment based on compose file, but only pass values explicitly set by `--environment`.
Bonus point: this make `compose exec` able to run without the original compose file

Note: a follow-up PR is required to apply signature change in compose.API to compose-cli

Resolves #8508
