### PR TITLE
`run` must attach to stdin

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -168,7 +168,8 @@ func normalizeRunFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 }
 
 func notAtTTY() bool {
-	return !isatty.IsTerminal(os.Stdout.Fd())
+	b := isatty.IsTerminal(os.Stdout.Fd()) && isatty.IsTerminal(os.Stdin.Fd())
+	return !b
 }
 
 func runRun(ctx context.Context, backend api.Service, project *types.Project, opts runOptions) error {

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -232,7 +232,7 @@ func (c *convergence) ensureService(ctx context.Context, project *types.Project,
 		name := getContainerName(project.Name, service, number)
 		i := i
 		eg.Go(func() error {
-			container, err := c.service.createContainer(ctx, project, service, name, number, false, true)
+			container, err := c.service.createContainer(ctx, project, service, name, number, false, true, false)
 			updated[actual+i] = container
 			return err
 		})
@@ -327,11 +327,11 @@ func getScale(config types.ServiceConfig) (int, error) {
 }
 
 func (s *composeService) createContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,
-	name string, number int, autoRemove bool, useNetworkAliases bool) (container moby.Container, err error) {
+	name string, number int, autoRemove bool, useNetworkAliases bool, attachStdin bool) (container moby.Container, err error) {
 	w := progress.ContextWriter(ctx)
 	eventName := "Container " + name
 	w.Event(progress.CreatingEvent(eventName))
-	container, err = s.createMobyContainer(ctx, project, service, name, number, nil, autoRemove, useNetworkAliases)
+	container, err = s.createMobyContainer(ctx, project, service, name, number, nil, autoRemove, useNetworkAliases, attachStdin)
 	if err != nil {
 		return
 	}
@@ -364,7 +364,7 @@ func (s *composeService) recreateContainer(ctx context.Context, project *types.P
 		inherited = &replaced
 	}
 	name = getContainerName(project.Name, service, number)
-	created, err = s.createMobyContainer(ctx, project, service, name, number, inherited, false, true)
+	created, err = s.createMobyContainer(ctx, project, service, name, number, inherited, false, true, false)
 	if err != nil {
 		return created, err
 	}
@@ -402,9 +402,9 @@ func (s *composeService) startContainer(ctx context.Context, container moby.Cont
 }
 
 func (s *composeService) createMobyContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,
-	name string, number int, inherit *moby.Container, autoRemove bool, useNetworkAliases bool) (moby.Container, error) {
+	name string, number int, inherit *moby.Container, autoRemove bool, useNetworkAliases bool, attachStdin bool) (moby.Container, error) {
 	var created moby.Container
-	containerConfig, hostConfig, networkingConfig, err := s.getCreateOptions(ctx, project, service, number, inherit, autoRemove)
+	containerConfig, hostConfig, networkingConfig, err := s.getCreateOptions(ctx, project, service, number, inherit, autoRemove, attachStdin)
 	if err != nil {
 		return created, err
 	}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -223,8 +223,8 @@ func getImageName(service types.ServiceConfig, projectName string) string {
 	return imageName
 }
 
-func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project, service types.ServiceConfig, number int, inherit *moby.Container,
-	autoRemove bool) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
+func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project, service types.ServiceConfig,
+	number int, inherit *moby.Container, autoRemove bool, attachStdin bool) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
 
 	labels, err := s.prepareLabels(p, service, number)
 	if err != nil {
@@ -243,9 +243,8 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 	}
 
 	var (
-		tty         = service.Tty
-		stdinOpen   = service.StdinOpen
-		attachStdin = false
+		tty       = service.Tty
+		stdinOpen = service.StdinOpen
 	)
 
 	volumeMounts, binds, mounts, err := s.buildContainerVolumes(ctx, *p, service, inherit)

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -164,7 +164,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 			return "", err
 		}
 	}
-	created, err := s.createContainer(ctx, project, service, service.ContainerName, 1, opts.Detach && opts.AutoRemove, opts.UseNetworkAliases)
+	created, err := s.createContainer(ctx, project, service, service.ContainerName, 1, opts.Detach && opts.AutoRemove, opts.UseNetworkAliases, true)
 	if err != nil {
 		return "", err
 	}
@@ -186,6 +186,7 @@ func (s *composeService) getEscapeKeyProxy(r io.ReadCloser) (io.ReadCloser, erro
 
 func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts api.RunOptions) {
 	service.Tty = opts.Tty
+	service.StdinOpen = true
 	service.ContainerName = opts.Name
 
 	if len(opts.Command) > 0 {


### PR DESCRIPTION
`compose run` must configure created container with `attachStdin: true``
also, when stdin is set by piping from another command, tty must be force-disabled

Resolves #8660
