### PR TITLE
add support for COMPOSE_IGNORE_ORPHANS

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -31,6 +31,7 @@ type createOptions struct {
 	Build         bool
 	noBuild       bool
 	removeOrphans bool
+	ignoreOrphans bool
 	forceRecreate bool
 	noRecreate    bool
 	recreateDeps  bool
@@ -57,6 +58,7 @@ func createCommand(p *projectOptions, backend api.Service) *cobra.Command {
 		RunE: p.WithProject(func(ctx context.Context, project *types.Project) error {
 			return backend.Create(ctx, project, api.CreateOptions{
 				RemoveOrphans:        opts.removeOrphans,
+				IgnoreOrphans:        opts.ignoreOrphans,
 				Recreate:             opts.recreateStrategy(),
 				RecreateDependencies: opts.dependenciesRecreateStrategy(),
 				Inherit:              !opts.noInherit,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -100,6 +100,8 @@ type CreateOptions struct {
 	Services []string
 	// Remove legacy containers for services that are not defined in the project
 	RemoveOrphans bool
+	// Ignore legacy containers for services that are not defined in the project
+	IgnoreOrphans bool
 	// Recreate define the strategy to apply on existing containers
 	Recreate string
 	// RecreateDependencies define the strategy to apply on dependencies services

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -86,7 +86,7 @@ func (s *composeService) create(ctx context.Context, project *types.Project, opt
 		allServiceNames = append(allServiceNames, service.Name)
 	}
 	orphans := observedState.filter(isNotService(allServiceNames...))
-	if len(orphans) > 0 {
+	if len(orphans) > 0 && !options.IgnoreOrphans {
 		if options.RemoveOrphans {
 			w := progress.ContextWriter(ctx)
 			err := s.removeContainers(ctx, w, orphans, nil, false)


### PR DESCRIPTION
add support for `COMPOSE_IGNORE_ORPHANS` environment variable to ignore orphaned container

Also manage this variable being set in dotEnv file, as reported on  https://github.com/docker/compose/issues/8203
