### PR TITLE
stop time.Ticker after use

### DIFF
--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -38,12 +38,13 @@ type ttyWriter struct {
 	repeated   bool
 	numLines   int
 	done       chan bool
-	mtx        *sync.RWMutex
+	mtx        *sync.Mutex
 	tailEvents []string
 }
 
 func (w *ttyWriter) Start(ctx context.Context) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -188,7 +189,7 @@ func lineText(event Event, pad string, terminalWidth, statusPadding int, color b
 		padding = 0
 	}
 	// calculate the max length for the status text, on errors it
-	// is 2-3 lines long and breaks the line formating
+	// is 2-3 lines long and breaks the line formatting
 	maxStatusLen := terminalWidth - textLen - statusPadding - 15
 	status := event.StatusText
 	// in some cases (debugging under VS Code), terminalWidth is set to zero by goterm.Width() ; ensuring we don't tweak strings with negative char index

--- a/pkg/progress/tty_test.go
+++ b/pkg/progress/tty_test.go
@@ -78,7 +78,7 @@ func TestLineTextSingleEvent(t *testing.T) {
 func TestErrorEvent(t *testing.T) {
 	w := &ttyWriter{
 		events: map[string]Event{},
-		mtx:    &sync.RWMutex{},
+		mtx:    &sync.Mutex{},
 	}
 	e := Event{
 		ID:         "id",

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -105,7 +105,7 @@ func NewWriter(out console.File) (Writer, error) {
 			events:   map[string]Event{},
 			repeated: false,
 			done:     make(chan bool),
-			mtx:      &sync.RWMutex{},
+			mtx:      &sync.Mutex{},
 		}, nil
 	}
 


### PR DESCRIPTION
**What I did**
just saw by accidant that a `time.Ticker` isn't Stopped after use in the progress package.
[According to the documentation](https://pkg.go.dev/time#NewTicker) the Ticker isn't released if it's not stopped.

Also a `sync.Mutex` looks enough here, as there are no read-only access to it.
