### PR TITLE
`log --follow` must stop when container get killed

### DIFF
--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -35,11 +35,15 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 
 	eg, ctx := errgroup.WithContext(ctx)
 	if options.Follow {
+		printer := newLogPrinter(consumer)
 		eg.Go(func() error {
-			printer := newLogPrinter(consumer)
 			return s.watchContainers(ctx, projectName, options.Services, printer.HandleEvent, containers, func(c types.Container) error {
 				return s.logContainers(ctx, consumer, c, options)
 			})
+		})
+		eg.Go(func() error {
+			_, err := printer.Run(false, "", nil)
+			return err
 		})
 	}
 


### PR DESCRIPTION
**What I did**
`compose logs --follow` never complete if container gets killed
code missed running the logPrinter so it actually react on container events

#close https://github.com/docker/compose/issues/8715


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/135618269-4570ab8d-f68c-422f-84bc-8cd57a47b689.png)
