### PR TITLE
set EnvironmentFileLabel label after ServiceHash

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -122,19 +122,20 @@ func (o *projectOptions) WithServices(fn ProjectServicesFunc) func(cmd *cobra.Co
 
 		if o.EnvFile != "" {
 			var services types.Services
-			for _, s := range project.Services {
-				ef := o.EnvFile
-				if ef != "" {
-					if !filepath.IsAbs(ef) {
-						ef = filepath.Join(project.WorkingDir, o.EnvFile)
-					}
-					if s.Labels == nil {
-						s.Labels = make(map[string]string)
-					}
-					s.Labels[api.EnvironmentFileLabel] = ef
-					services = append(services, s)
-				}
+
+			ef := o.EnvFile
+			if !filepath.IsAbs(ef) {
+				ef = filepath.Join(project.WorkingDir, o.EnvFile)
 			}
+
+			for _, s := range project.Services {
+				if s.Extensions == nil {
+					s.Extensions = make(map[string]interface{})
+				}
+				s.Extensions[compose.ServiceExtProjectEnvironmentFile] = ef
+				services = append(services, s)
+			}
+
 			project.Services = services
 		}
 

--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -121,22 +121,16 @@ func (o *projectOptions) WithServices(fn ProjectServicesFunc) func(cmd *cobra.Co
 		}
 
 		if o.EnvFile != "" {
-			var services types.Services
-
 			ef := o.EnvFile
 			if !filepath.IsAbs(ef) {
 				ef = filepath.Join(project.WorkingDir, o.EnvFile)
 			}
 
-			for _, s := range project.Services {
-				if s.Extensions == nil {
-					s.Extensions = make(map[string]interface{})
-				}
-				s.Extensions[compose.ServiceExtProjectEnvironmentFile] = ef
-				services = append(services, s)
+			if project.Extensions == nil {
+				project.Extensions = make(map[string]interface{})
 			}
 
-			project.Services = services
+			project.Extensions[compose.ExtProjectEnvironmentFile] = ef
 		}
 
 		return fn(ctx, project, args)

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -46,6 +46,9 @@ import (
 	"github.com/docker/compose/v2/pkg/utils"
 )
 
+// ServiceExtProjectEnvironmentFile is name of service extension that is used to pass down the project environment file
+const ServiceExtProjectEnvironmentFile = "x-dockercompose-projectenvironmentfile"
+
 func (s *composeService) Create(ctx context.Context, project *types.Project, options api.CreateOptions) error {
 	return progress.Run(ctx, func(ctx context.Context) error {
 		return s.create(ctx, project, options)
@@ -430,6 +433,9 @@ func (s *composeService) prepareLabels(p *types.Project, service types.ServiceCo
 		return nil, err
 	}
 
+	if val, ok := service.Extensions[ServiceExtProjectEnvironmentFile].(string); ok {
+		labels[api.EnvironmentFileLabel] = val
+	}
 	labels[api.ConfigHashLabel] = hash
 	labels[api.WorkingDirLabel] = p.WorkingDir
 	labels[api.ConfigFilesLabel] = strings.Join(p.ComposeFiles, ",")

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -46,8 +46,8 @@ import (
 	"github.com/docker/compose/v2/pkg/utils"
 )
 
-// ServiceExtProjectEnvironmentFile is name of service extension that is used to pass down the project environment file
-const ServiceExtProjectEnvironmentFile = "x-dockercompose-projectenvironmentfile"
+// ExtProjectEnvironmentFile defines the name of the extension that is used to pass down the path of the project environment file
+const ExtProjectEnvironmentFile = "x-dockercompose-projectenvironmentfile"
 
 func (s *composeService) Create(ctx context.Context, project *types.Project, options api.CreateOptions) error {
 	return progress.Run(ctx, func(ctx context.Context) error {
@@ -433,7 +433,7 @@ func (s *composeService) prepareLabels(p *types.Project, service types.ServiceCo
 		return nil, err
 	}
 
-	if val, ok := service.Extensions[ServiceExtProjectEnvironmentFile].(string); ok {
+	if val, ok := p.Extensions[ExtProjectEnvironmentFile].(string); ok {
 		labels[api.EnvironmentFileLabel] = val
 	}
 	labels[api.ConfigHashLabel] = hash


### PR DESCRIPTION
**What I did**
In order to fix #8725, we need to not include the EnvironmentFileLabel in the hash computation.
Note that the other file system path labels (WorkingDirLabel and ConfigFilesLabel) are already set after hash computation, so path changes are not an issue there. This patch brings the behaviour of EnvironmentFileLabel inline with other file system paths.

The project environment is usually set directly inside `WithServices` of `cmd/compose/compse.go`. But this needs
to be delayed until `prepareLabels` in `pkg/compose/create.go`. The easiest (but perhaps not cleanest) way
was to pass down the variable inside an extension field. Both project or service extension would work, this patch
uses a service extension field.

**Related issue**
fixes #8725 