### PR TITLE
:zap: Added a handy command to dynamically fetch the latest version of compose and install it on Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Or copy it into one of these folders for installing it system-wide:
 
 (might require to make the downloaded file executable with `chmod +x`)
 
+Or you can use the following command, which has been tested on ubuntu 20.04, to dynamically pull the latest version of `docker compose` and install it on your machine:
+
+```bash
+mkdir -p ~/.docker/cli-plugins && curl -SL https://api.github.com/repos/docker/compose/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep -wo https.*docker-compose-$(uname | awk '{print tolower($0)}')-$(uname -m)$ | wget -i - -O ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose
+```
+
+You can verify that `docker compose` has been installed by executing the following command on your terminal:
+
+```bash
+docker compose version
+> Docker Compose version v2.0.1
+```
 
 Quick Start
 -----------


### PR DESCRIPTION
Signed-off-by: Harmouch101 <mahmoudddharmouchhh@gmail.com>

**What I did**
Consider reading the title which is self-explanatory of what I did.

```bash
# create the docker plugins directory
mkdir -p ~/.docker/cli-plugins

# download the latest version of the CLI into the plugins directory and rename it to docker-compose with wget.
# the regex "https.*docker-compose-$(uname | awk '{print tolower($0)}')-$(uname -m)$" would match
#  the name of the binary that matches the one intended to be downloaded on the currently running distro.
# ex: on Ubuntu x86, the regex matches: docker-compose-linux-x86_64, and so on...
curl -SL https://api.github.com/repos/docker/compose/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep -wo https.*docker-compose-$(uname | awk '{print tolower($0)}')-$(uname -m)$ | wget -i - -O ~/.docker/cli-plugins/docker-compose

# make the CLI executable
chmod +x ~/.docker/cli-plugins/docker-compose
```

Combining the previous commands would result in the following:

```bash
mkdir -p ~/.docker/cli-plugins && curl -SL https://api.github.com/repos/docker/compose/releases/latest | grep browser_download_url | cut -d '"' -f 4 | grep -wo https.*docker-compose-$(uname | awk '{print tolower($0)}')-$(uname -m)$ | wget -i - -O ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose
```

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
An enhancement rather than a bug fix.
**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
:cat2: