### PR TITLE
Restore missing version commands

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -222,6 +222,7 @@ func RootCommand(backend api.Service) *cobra.Command {
 		ansi    string
 		noAnsi  bool
 		verbose bool
+		version bool
 	)
 	command := &cobra.Command{
 		Short:            "Docker Compose",
@@ -231,6 +232,9 @@ func RootCommand(backend api.Service) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return cmd.Help()
+			}
+			if version {
+				return versionCommand().Execute()
 			}
 			_ = cmd.Help()
 			return dockercli.StatusError{
@@ -304,6 +308,8 @@ func RootCommand(backend api.Service) *cobra.Command {
 	command.Flags().SetInterspersed(false)
 	opts.addProjectFlags(command.Flags())
 	command.Flags().StringVar(&ansi, "ansi", "auto", `Control when to print ANSI control characters ("never"|"always"|"auto")`)
+	command.Flags().BoolVarP(&version, "version", "v", false, "Show the Docker Compose version information")
+	command.Flags().MarkHidden("version") //nolint:errcheck
 	command.Flags().BoolVar(&noAnsi, "no-ansi", false, `Do not print ANSI control characters (DEPRECATED)`)
 	command.Flags().MarkHidden("no-ansi") //nolint:errcheck
 	command.Flags().BoolVar(&verbose, "verbose", false, "Show more output")

--- a/cmd/compose/version.go
+++ b/cmd/compose/version.go
@@ -34,10 +34,9 @@ type versionOptions struct {
 func versionCommand() *cobra.Command {
 	opts := versionOptions{}
 	cmd := &cobra.Command{
-		Use:    "version",
-		Short:  "Show the Docker Compose version information",
-		Args:   cobra.MaximumNArgs(0),
-		Hidden: true,
+		Use:   "version",
+		Short: "Show the Docker Compose version information",
+		Args:  cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			runVersion(opts)
 			return nil


### PR DESCRIPTION
**What I did**
- Removed the hidden flag from the `version` command, since by default and for historical reasons aswell it shouldn't be hidden.
- Since the documentation for the v2 still constantly reffering to a `--version` flag on the root command, I added it aswell.
_(This is up for a discuisson, since I think this change shouldn't be exist and we have to correct the documentation.)
(~If we are still planning to keep this change, I think it could be done more elegantly.~
I did it aswell, since I forgot that the old python version also handle the `-v` flag next to `--version`)_

**Related issue**
Fix #8729

**A picture of a cute animal, if possible in relation with what you did**
_(A hiding cat, reffering to the hidden version command.)_
![hidden_cat](https://i.redd.it/d2c35qq5on831.jpg)