### PR TITLE
introduce up --wait condition

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -124,6 +124,8 @@ type StartOptions struct {
 	CascadeStop bool
 	// ExitCodeFrom return exit code from specified service
 	ExitCodeFrom string
+	// Wait won't return until containers reached the running|healthy state
+	Wait bool
 }
 
 // RestartOptions group options of the Restart API

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -493,6 +493,7 @@ func getDeployResources(s types.ServiceConfig) container.Resources {
 		MemorySwap:         int64(s.MemSwapLimit),
 		MemorySwappiness:   swappiness,
 		MemoryReservation:  int64(s.MemReservation),
+		OomKillDisable:     &s.OomKillDisable,
 		CPUCount:           s.CPUCount,
 		CPUPeriod:          s.CPUPeriod,
 		CPUQuota:           s.CPUQuota,
@@ -501,6 +502,10 @@ func getDeployResources(s types.ServiceConfig) container.Resources {
 		CPUShares:          s.CPUShares,
 		CPUPercent:         int64(s.CPUS * 100),
 		CpusetCpus:         s.CPUSet,
+	}
+
+	if s.PidsLimit != 0 {
+		resources.PidsLimit = &s.PidsLimit
 	}
 
 	setBlkio(s.BlkioConfig, &resources)

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -160,7 +160,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 		return "", err
 	}
 	if !opts.NoDeps {
-		if err := s.waitDependencies(ctx, project, service); err != nil {
+		if err := s.waitDependencies(ctx, project, service.DependsOn); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -58,11 +58,26 @@ func (s *composeService) start(ctx context.Context, project *types.Project, opti
 		if err != nil {
 			return err
 		}
+
 		return s.startService(ctx, project, service)
 	})
 	if err != nil {
 		return err
 	}
+
+	if options.Wait {
+		depends := types.DependsOnConfig{}
+		for _, s := range project.Services {
+			depends[s.Name] = types.ServiceDependency{
+				Condition: ServiceConditionRuningOrHealthy,
+			}
+		}
+		err = s.waitDependencies(ctx, project, depends)
+		if err != nil {
+			return err
+		}
+	}
+
 	return eg.Wait()
 }
 


### PR DESCRIPTION
**What I did**
introduced `compose up --wait` to run detached BUT wait for services to reach state `running` or `healthy` (for those with a Healthcheck defined).

Typical usage is to have some backend services (let's say postgres database) ran by compose, and user need to wait for service to be actually up so he can apply database migrations and start an happy coding day. 

```yaml
services:
  db:
    image: postgres:alpine
    ports: ...
    healthcheck:
      test: ['CMD', 'pg_isready']  
```

```console
$ docker compose up -d --wait
(...)
$ rake db:migrate
``` 

**Related issue**
#8351 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/136820001-bf9b4f5c-ccfd-40e7-a873-3ce14efbe37e.png)
