### PR TITLE
Fix typo: netwok -> network

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -75,7 +75,7 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 		}
 	}
 
-	ops, err := s.ensureNetwoksDown(ctx, projectName)
+	ops, err := s.ensureNetworksDown(ctx, projectName)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (s *composeService) ensureImagesDown(ctx context.Context, projectName strin
 	return ops
 }
 
-func (s *composeService) ensureNetwoksDown(ctx context.Context, projectName string) ([]downOp, error) {
+func (s *composeService) ensureNetworksDown(ctx context.Context, projectName string) ([]downOp, error) {
 	var ops []downOp
 	networks, err := s.apiClient.NetworkList(ctx, moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(projectName))})
 	if err != nil {


### PR DESCRIPTION
Just fixed one simple typo in the method name: netwok -> network

![gargoyle-gecko-shutterstock_130126787](https://user-images.githubusercontent.com/9464285/137068608-9a86d682-3f7d-482a-a33b-f0966ab4b4b5.jpg)


