### PR TITLE
Compose exec cannot process more than 32KB of data

### DIFF
--- a/pkg/compose/exec.go
+++ b/pkg/compose/exec.go
@@ -90,7 +90,7 @@ func (s *composeService) interactiveExec(ctx context.Context, opts api.RunOption
 
 	stdout := ContainerStdout{HijackedResponse: resp}
 	stdin := ContainerStdin{HijackedResponse: resp}
-	r, err := s.getEscapeKeyProxy(opts.Stdin)
+	r, err := s.getEscapeKeyProxy(opts.Stdin, opts.Tty)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -51,7 +51,7 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 }
 
 func (s *composeService) runInteractive(ctx context.Context, containerID string, opts api.RunOptions) (int, error) {
-	r, err := s.getEscapeKeyProxy(opts.Stdin)
+	r, err := s.getEscapeKeyProxy(opts.Stdin, opts.Tty)
 	if err != nil {
 		return 0, err
 	}
@@ -179,7 +179,10 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	return containerID, nil
 }
 
-func (s *composeService) getEscapeKeyProxy(r io.ReadCloser) (io.ReadCloser, error) {
+func (s *composeService) getEscapeKeyProxy(r io.ReadCloser, isTty bool) (io.ReadCloser, error) {
+	if isTty {
+		return r, nil
+	}
 	var escapeKeys = []byte{16, 17}
 	if s.configFile.DetachKeys != "" {
 		customEscapeKeys, err := term.ToBytes(s.configFile.DetachKeys)


### PR DESCRIPTION
Fixes #8811

**What I did**

Made sure that if input is a TTY then the input stream is passed as is and detach functionality is not enabled.

Ran unit tests to make sure nothing is broken and did some manual testing.  

**Related issue**

fixes #8811
