### PR TITLE
Actually fix #8811

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -180,7 +180,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 }
 
 func (s *composeService) getEscapeKeyProxy(r io.ReadCloser, isTty bool) (io.ReadCloser, error) {
-	if isTty {
+	if !isTty {
 		return r, nil
 	}
 	var escapeKeys = []byte{16, 17}


### PR DESCRIPTION
The initial PR had the wrong boolean check. This commit addressed it.

fixes #8811

**What I did**
Made sure that the right boolean condition is enforced. When a TTY is requested, then the input stream should process the escape characters; otherwise the input stream should be processed as is.

**Related issue**


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
