### PR TITLE
v2: Don't try to start services with 0 replicas

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -559,6 +559,10 @@ func (s *composeService) isServiceCompleted(ctx context.Context, project *types.
 }
 
 func (s *composeService) startService(ctx context.Context, project *types.Project, service types.ServiceConfig) error {
+	if service.Deploy != nil && service.Deploy.Replicas != nil && *service.Deploy.Replicas == 0 {
+		return nil
+	}
+
 	err := s.waitDependencies(ctx, project, service.DependsOn)
 	if err != nil {
 		return err
@@ -579,7 +583,7 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 		if scale, err := getScale(service); err != nil && scale == 0 {
 			return nil
 		}
-		return fmt.Errorf("no containers to start")
+		return fmt.Errorf("service %q has no container to start", service.Name)
 	}
 
 	w := progress.ContextWriter(ctx)


### PR DESCRIPTION
When a service has 0 replicas to start, it don't try to create any
container. However `composeService.startService()` still gets executed.
This method checks if there's been containers created for that service
beforehand. If there's none, it returns the following error: `no
containers to start`.
    
This change checks if replicas == 0 and exits early from
`composeService.startService()` when that's the case. Moreover, it puts
the name of the incriminated service in the error message to help users
know what triggered it.

EDIT: CI is failing but doesn't seem related to this PR.