### PR TITLE
network: add support for EnableIPv6 parameter to moby.NetworkCreate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.3
 	github.com/buger/goterm v1.0.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
-	github.com/compose-spec/compose-go v1.0.3
+	github.com/compose-spec/compose-go v1.0.4
 	github.com/containerd/console v1.0.2
 	github.com/containerd/containerd v1.5.5
 	github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v1.0.3 h1:yvut1x9H4TUMptNA4mZ63VGVtDNX1OKy2TZCi6yFw8Q=
-github.com/compose-spec/compose-go v1.0.3/go.mod h1:gCIA3No0j5nNszz2X0yd/mkigTIWcOgHiPa9guWvoec=
+github.com/compose-spec/compose-go v1.0.4 h1:JQdq1WGJqMh4CIKiPx5N995NdUfzRenFsl6Fbg6HdjY=
+github.com/compose-spec/compose-go v1.0.4/go.mod h1:gCIA3No0j5nNszz2X0yd/mkigTIWcOgHiPa9guWvoec=
 github.com/compose-spec/godotenv v1.0.0 h1:TV24JYhh5GCC1G14npQVhCtxeoiwd0NcT0VdwcCQyXU=
 github.com/compose-spec/godotenv v1.0.0/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1034,6 +1034,7 @@ func (s *composeService) ensureNetwork(ctx context.Context, n types.NetworkConfi
 				Options:    n.DriverOpts,
 				Internal:   n.Internal,
 				Attachable: n.Attachable,
+				EnableIPv6: n.EnableIPv6,
 				IPAM:       ipam,
 			}
 


### PR DESCRIPTION
**What I did**

Build on the functionality added by https://github.com/compose-spec/compose-go/pull/196 and now available in v1.0.4.  This PR passes the newly parsed `EnableIPv6` parameter to the moby.NetworkCreate() call so that it is now possible to create a docker network with `EnableIPv6: true`.

Prior to this change, the `enable_ipv6` property was ignored by the underlying compose-go library and unavailable to the compose cli plugin.  This resulted in all networks having `EnableIPv6: false`.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Fixes #8832
and maybe others?

