### PR TITLE
Don't exit on container destroy events

### DIFF
--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -79,7 +79,7 @@ func (s *composeService) watchContainers(ctx context.Context, projectName string
 	err := s.Events(ctx, projectName, api.EventsOptions{
 		Services: services,
 		Consumer: func(event api.Event) error {
-			if (event.Status == "destroy") {
+			if event.Status == "destroy" {
 				// This container can't be inspected, because it's gone.
 				// Its already been removed from the watched map.
 				return nil

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -81,7 +81,7 @@ func (s *composeService) watchContainers(ctx context.Context, projectName string
 		Consumer: func(event api.Event) error {
 			if event.Status == "destroy" {
 				// This container can't be inspected, because it's gone.
-				// Its already been removed from the watched map.
+				// It's already been removed from the watched map.
 				return nil
 			}
 

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -79,6 +79,12 @@ func (s *composeService) watchContainers(ctx context.Context, projectName string
 	err := s.Events(ctx, projectName, api.EventsOptions{
 		Services: services,
 		Consumer: func(event api.Event) error {
+			if (event.Status == "destroy") {
+				// This container can't be inspected, because it's gone.
+				// Its already been removed from the watched map.
+				return nil
+			}
+
 			inspected, err := s.apiClient.ContainerInspect(ctx, event.Container)
 			if err != nil {
 				return err


### PR DESCRIPTION
When watchContainers receives a container destroy event, calling ContainerInspect returns an error, because the container no longer exists. This causes both `docker-compose up` and `docker-compose logs -f` to exit with `Error: No such container: <id>` when removing a stopped container.

This patch checks for the destroy event, and just does an early-out. The die event will have already been processed, so the internal cleanup for the destroyed container will have already happened.

Fixes #8747

Signed-off-by: Stephen Thirlwall <sdt@dr.com>
