### PR TITLE
Fix to use Key instead of Service for graph updates

### DIFF
--- a/pkg/compose/dependencies.go
+++ b/pkg/compose/dependencies.go
@@ -93,7 +93,7 @@ func run(ctx context.Context, graph *Graph, eg *errgroup.Group, nodes []*Vertex,
 	for _, node := range nodes {
 		// Don't start this service yet if all of its children have
 		// not been started yet.
-		if len(traversalConfig.filterAdjacentByStatusFn(graph, node.Service, traversalConfig.adjacentServiceStatusToSkip)) != 0 {
+		if len(traversalConfig.filterAdjacentByStatusFn(graph, node.Key, traversalConfig.adjacentServiceStatusToSkip)) != 0 {
 			continue
 		}
 
@@ -104,7 +104,7 @@ func run(ctx context.Context, graph *Graph, eg *errgroup.Group, nodes []*Vertex,
 				return err
 			}
 
-			graph.UpdateStatus(node.Service, traversalConfig.targetServiceStatus)
+			graph.UpdateStatus(node.Key, traversalConfig.targetServiceStatus)
 
 			return run(ctx, graph, eg, traversalConfig.adjacentNodesFn(node), traversalConfig, fn)
 		})


### PR DESCRIPTION
**What I did**
 Fixed to use `Key` instead of `Service` when dealing with graph update methods. Currently it is not a problem because  `Service` and `Key` uses same string excerpt from `Name`. But IMHO it can be a future problem if we want to use other string other than `Name` for `Service`.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
https://github.com/docker/compose/issues/8842

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
