### PR TITLE
Fix missing logs when attaching new container

### DIFF
--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -142,7 +142,7 @@ func (s *composeService) getContainerStreams(ctx context.Context, container stri
 		Stdin:  true,
 		Stdout: true,
 		Stderr: true,
-		Logs:   false,
+		Logs:   true,
 	})
 	if err == nil {
 		stdout = ContainerStdout{HijackedResponse: cnx}


### PR DESCRIPTION
**What I did**

When attaching to a container that has just been started, there may have already been some logs emitted.

Setting ContainerAttachOptions.Logs to true in getContainerStreams gives us the log lines that have already been emitted.

The docs for ContainerAttach suggest this is the right approach:

https://docs.docker.com/engine/api/v1.41/#operation/ContainerAttach

> Replay previous logs from the container.
>
> This is useful for attaching to a container that has started and you want to output everything since the container started.
>
> If stream is also enabled, once all the previous output has been returned, it will seamlessly transition into streaming current output.

I don't have any tests for this I'm afraid. Happy to create some, but I'd need a little guidance on the best way to attack it.

**Related issue**

Fixes: #8884 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![image](https://user-images.githubusercontent.com/615293/140467299-446dd23a-9e95-4a45-a91b-a01dcd2fd6f1.png)

Signed-off-by: Stephen Thirlwall <sdt@dr.com>
