### PR TITLE
Fix typo in --wait option mechanism

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -261,7 +261,7 @@ func getContainerProgressName(container moby.Container) string {
 	return "Container " + getCanonicalContainerName(container)
 }
 
-const ServiceConditionRuningOrHealthy = "running_or_healthy"
+const ServiceConditionRunningOrHealthy = "running_or_healthy"
 
 func (s *composeService) waitDependencies(ctx context.Context, project *types.Project, dependencies types.DependsOnConfig) error {
 	eg, _ := errgroup.WithContext(ctx)
@@ -273,7 +273,7 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 			for {
 				<-ticker.C
 				switch config.Condition {
-				case ServiceConditionRuningOrHealthy:
+				case ServiceConditionRunningOrHealthy:
 					healthy, err := s.isServiceHealthy(ctx, project, dep, true)
 					if err != nil {
 						return err

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -69,7 +69,7 @@ func (s *composeService) start(ctx context.Context, project *types.Project, opti
 		depends := types.DependsOnConfig{}
 		for _, s := range project.Services {
 			depends[s.Name] = types.ServiceDependency{
-				Condition: ServiceConditionRuningOrHealthy,
+				Condition: ServiceConditionRunningOrHealthy,
 			}
 		}
 		err = s.waitDependencies(ctx, project, depends)


### PR DESCRIPTION
**What I did**

I fixed a typo (Runing => Running) in the 3 places the symbol was declared or used.

**Related issue**

Introduced in https://github.com/docker/compose/pull/8777

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/10195761/140536390-442c5d28-5ecc-4623-a943-4633abcdd9ed.png)
