### PR TITLE
use Dockerfile directly when path is absolute otherwise join it with Context path

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/compose-spec/compose-go/types"
@@ -246,7 +247,7 @@ func (s *composeService) toBuildOptions(project *types.Project, service types.Se
 	return build.Options{
 		Inputs: build.Inputs{
 			ContextPath:    service.Build.Context,
-			DockerfilePath: filepath.Join(service.Build.Context, service.Build.Dockerfile),
+			DockerfilePath: dockerFilePath(service.Build.Context, service.Build.Dockerfile),
 		},
 		BuildArgs:   buildArgs,
 		Tags:        tags,
@@ -284,4 +285,11 @@ func mergeArgs(m ...types.Mapping) types.Mapping {
 		}
 	}
 	return merged
+}
+
+func dockerFilePath(context string, dockerfile string) string {
+	if path.IsAbs(dockerfile) {
+		return dockerfile
+	}
+	return filepath.Join(context, dockerfile)
 }


### PR DESCRIPTION

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**Context**
When using a compose file generated by `compose-go` library all the paths are absolute (context, dockerfiles...)
Compose V2 is by default joining the context path to the dockerfile assuming that the last one is defined relatively to the context directory.

So using a `compose-go` generated compose file systematically fail to build. 
To reproduce you can try to start the Dev Environment with the compose sample when the `Use Compose V2` is activated in Docker Desktop.

```
could not find /var/folders/rl/282crpp149x6xf_400p17fj40000gn/T/volume-compose-dev-env-cool_euler/proxy/var/folders/rl/282crpp149x6xf_400p17fj40000gn/T/volume-compose-dev-env-cool_euler/proxy: stat /var/folders/rl/282crpp149x6xf_400p17fj40000gn/T/volume-compose-dev-env-cool_euler/proxy/var/folders/rl/282crpp149x6xf_400p17fj40000gn/T/volume-compose-dev-env-cool_euler/proxy: no such file or directory
exit status 17
```

**What I did**
Add a method to check if the Dockerfile path is absolute and join it with the context path if not

**Related issue**
fix #8928 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/141861094-90e41e96-c318-4de8-be6e-e0ff2c737fa7.png)
