### PR TITLE
restore `compose build` to support context set as a git URL

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -61,6 +61,7 @@ func buildCommand(p *projectOptions, backend api.Service) *cobra.Command {
 				fmt.Println("WARNING --memory is ignored as not supported in buildkit.")
 			}
 			if opts.quiet {
+				opts.progress = buildx.PrinterModeQuiet
 				devnull, err := os.Open(os.DevNull)
 				if err != nil {
 					return err

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/buildx/util/buildflags"
 	xprogress "github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/pkg/urlutil"
 	bclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
@@ -288,7 +289,7 @@ func mergeArgs(m ...types.Mapping) types.Mapping {
 }
 
 func dockerFilePath(context string, dockerfile string) string {
-	if path.IsAbs(dockerfile) {
+	if urlutil.IsGitURL(context) || path.IsAbs(dockerfile) {
 		return dockerfile
 	}
 	return filepath.Join(context, dockerfile)


### PR DESCRIPTION
**What I did**
restore `compose build` to support context set as a git URL

**Related issue**
close https://github.com/docker/compose/issues/8894

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
