### PR TITLE
don't SetRawTerminal when run is ran with -T

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -62,7 +62,7 @@ func (s *composeService) runInteractive(ctx context.Context, containerID string,
 	}
 
 	in := streams.NewIn(opts.Stdin)
-	if in.IsTerminal() {
+	if in.IsTerminal() && opts.Tty {
 		state, err := term.SetRawTerminal(in.FD())
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
**What I did**
RawTerminal must not be set when container is ran explicitly with -T

**Related issue**
closes https://github.com/docker/compose/issues/8833

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
