### PR TITLE
introduce run —quiet-pull to align with up

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -54,6 +54,7 @@ type runOptions struct {
 	servicePorts  bool
 	name          string
 	noDeps        bool
+	quietPull     bool
 }
 
 func (opts runOptions) apply(project *types.Project) error {
@@ -153,6 +154,7 @@ func runCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	flags.StringArrayVarP(&opts.publish, "publish", "p", []string{}, "Publish a container's port(s) to the host.")
 	flags.BoolVar(&opts.useAliases, "use-aliases", false, "Use the service's network useAliases in the network(s) the container connects to.")
 	flags.BoolVar(&opts.servicePorts, "service-ports", false, "Run command with the service's ports enabled and mapped to the host.")
+	flags.BoolVar(&opts.quietPull, "quiet-pull", false, "Pull without printing progress information.")
 
 	flags.SetNormalizeFunc(normalizeRunFlags)
 	flags.SetInterspersed(false)
@@ -215,6 +217,7 @@ func runRun(ctx context.Context, backend api.Service, project *types.Project, op
 		UseNetworkAliases: opts.useAliases,
 		NoDeps:            opts.noDeps,
 		Index:             0,
+		QuietPull:         opts.quietPull,
 	}
 	exitCode, err := backend.RunOneOffContainer(ctx, project, runOpts)
 	if exitCode != 0 {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -227,6 +227,8 @@ type RunOptions struct {
 	Privileged        bool
 	UseNetworkAliases bool
 	NoDeps            bool
+	// QuietPull makes the pulling process quiet
+	QuietPull bool
 	// used by exec
 	Index int
 }

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -156,7 +156,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	service.Labels = service.Labels.Add(api.SlugLabel, slug)
 	service.Labels = service.Labels.Add(api.OneoffLabel, "True")
 
-	if err := s.ensureImagesExists(ctx, project, false); err != nil { // all dependencies already checked, but might miss service img
+	if err := s.ensureImagesExists(ctx, project, opts.QuietPull); err != nil { // all dependencies already checked, but might miss service img
 		return "", err
 	}
 	if !opts.NoDeps {


### PR DESCRIPTION
**What I did**
Introduce `compose run —quiet-pull` to align with same flag on `up` command

**Related issue**
close https://github.com/docker/compose/issues/8942

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
