### PR TITLE
introduce docker compose config --images

### DIFF
--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -47,6 +47,7 @@ type convertOptions struct {
 	services            bool
 	volumes             bool
 	profiles            bool
+	images              bool
 	hash                string
 }
 
@@ -81,6 +82,9 @@ func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
 			if opts.profiles {
 				return runProfiles(opts, args)
 			}
+			if opts.images {
+				return runConfigImages(opts, args)
+			}
 
 			return runConvert(ctx, backend, opts, args)
 		}),
@@ -95,6 +99,7 @@ func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	flags.BoolVar(&opts.services, "services", false, "Print the service names, one per line.")
 	flags.BoolVar(&opts.volumes, "volumes", false, "Print the volume names, one per line.")
 	flags.BoolVar(&opts.profiles, "profiles", false, "Print the profile names, one per line.")
+	flags.BoolVar(&opts.images, "images", false, "Print the image names, one per line.")
 	flags.StringVar(&opts.hash, "hash", "", "Print the service config hash, one per line.")
 	flags.StringVarP(&opts.Output, "output", "o", "", "Save to file (default to stdout)")
 
@@ -204,6 +209,21 @@ func runProfiles(opts convertOptions, services []string) error {
 	sort.Strings(profiles)
 	for _, p := range profiles {
 		fmt.Println(p)
+	}
+	return nil
+}
+
+func runConfigImages(opts convertOptions, services []string) error {
+	project, err := opts.toProject(services)
+	if err != nil {
+		return err
+	}
+	for _, s := range project.Services {
+		if s.Image != "" {
+			fmt.Println(s.Image)
+		} else {
+			fmt.Printf("%s_%s\n", project.Name, s.Name)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What I did**
To align with the few existing `config -xxx` pseudo-commands used to inspect the compose model, I suggest we introduce `compose config --images` to list service images. This is a distinct command vs `compose images` which list the _live_ images from running containers.

_Note:_ we might want to make the default image ID computed from project+service name something canonical by having this declared on compose-go as ServiceConfig#GetImageName()

**Related issue**
close https://github.com/docker/compose/issues/5288

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
