### PR TITLE
use CustomLabels for composeV2 metadata and not impact service hash

### DIFF
--- a/pkg/compose/hash.go
+++ b/pkg/compose/hash.go
@@ -24,7 +24,6 @@ import (
 )
 
 // ServiceHash compute configuration has for a service
-// TODO move this to compose-go
 func ServiceHash(o types.ServiceConfig) (string, error) {
 	// remove the Build config when generating the service hash
 	o.Build = nil

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -153,8 +153,9 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	if service.Deploy != nil {
 		service.Deploy.RestartPolicy = nil
 	}
-	service.Labels = service.Labels.Add(api.SlugLabel, slug)
-	service.Labels = service.Labels.Add(api.OneoffLabel, "True")
+	service.CustomLabels = service.CustomLabels.
+		Add(api.SlugLabel, slug).
+		Add(api.OneoffLabel, "True")
 
 	if err := s.ensureImagesExists(ctx, project, opts.QuietPull); err != nil { // all dependencies already checked, but might miss service img
 		return "", err


### PR DESCRIPTION
**What I did**
proof of concept for https://github.com/compose-spec/compose-go/pull/208

**Related issue**
see docker/compose#8725

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**