### PR TITLE
Don't check compose labels on external volumes

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1092,8 +1092,15 @@ func (s *composeService) ensureVolume(ctx context.Context, volume types.VolumeCo
 		if !errdefs.IsNotFound(err) {
 			return err
 		}
+		if volume.External.External {
+			return fmt.Errorf("external volume %q not found", volume.External.Name)
+		}
 		err := s.createVolume(ctx, volume)
 		return err
+	}
+
+	if volume.External.External {
+		return nil
 	}
 
 	// Volume exists with name, but let's double check this is the expected one


### PR DESCRIPTION
**What I did**
- Removed volume label check for external volumes
- Don't create volume if marked external:true, but report error

**Related issue**
close https://github.com/docker/compose/issues/8969

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
