### PR TITLE
Turn external volume usage into a warning instead of erroring

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1103,14 +1103,13 @@ func (s *composeService) ensureVolume(ctx context.Context, volume types.VolumeCo
 		return nil
 	}
 
-	// Volume exists with name, but let's double check this is the expected one
-	// (better safe than sorry when it comes to user's data)
+	// Volume exists with name, but let's double-check this is the expected one
 	p, ok := inspected.Labels[api.ProjectLabel]
 	if !ok {
-		return fmt.Errorf("volume %q already exists but was not created by Docker Compose. Use `external: true` to use an existing volume", volume.Name)
+		logrus.Warnf("volume %q already exists but was not created by Docker Compose. Use `external: true` to use an existing volume", volume.Name)
 	}
-	if p != project {
-		return fmt.Errorf("volume %q already exists but was not created for project %q. Use `external: true` to use an existing volume", volume.Name, p)
+	if ok && p != project {
+		logrus.Warnf("volume %q already exists but was not created for project %q. Use `external: true` to use an existing volume", volume.Name, p)
 	}
 	return nil
 }


### PR DESCRIPTION
This avoids a compatibility break since returning an error would avoid the project to be started.

This avoids breaking projects using volumes created by older versions of Docker Compose.

**What I did**
Turn errors into warnings

**Related issue**
Resolves https://github.com/docker/compose/issues/8976