### PR TITLE
Merge and fix Convert function from `docker/compose-switch`

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -212,11 +212,11 @@ func (o *projectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 			cli.WithName(o.ProjectName))...)
 }
 
-const pluginName = "compose"
+const PluginName = "compose"
 
 // RunningAsStandalone detects when running as a standalone program
 func RunningAsStandalone() bool {
-	return len(os.Args) < 2 || os.Args[1] != manager.MetadataSubcommandName && os.Args[1] != pluginName
+	return len(os.Args) < 2 || os.Args[1] != manager.MetadataSubcommandName && os.Args[1] != PluginName
 }
 
 // RootCommand returns the compose command with its child commands
@@ -230,7 +230,7 @@ func RootCommand(backend api.Service) *cobra.Command {
 	)
 	command := &cobra.Command{
 		Short:            "Docker Compose",
-		Use:              pluginName,
+		Use:              PluginName,
 		TraverseChildren: true,
 		// By default (no Run/RunE in parent command) for typos in subcommands, cobra displays the help of parent command but exit(0) !
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,0 +1,96 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/compose/v2/cmd/compose"
+)
+
+func getBoolFlags() []string {
+	return []string{
+		"--debug", "-D",
+		"--verbose",
+		"--tls",
+		"--tlsverify",
+	}
+}
+
+func getStringFlags() []string {
+	return []string{
+		"--tlscacert",
+		"--tlscert",
+		"--tlskey",
+		"--host", "-H",
+		"--context",
+		"--log-level",
+	}
+}
+
+func convert(args []string) []string {
+	var rootFlags []string
+	command := []string{compose.PluginName}
+	l := len(args)
+	for i := 0; i < l; i++ {
+		arg := args[i]
+		if arg[0] != '-' {
+			// not a top-level flag anymore, keep the rest of the command unmodified
+			if arg == compose.PluginName {
+				i++
+			}
+			command = append(command, args[i:]...)
+			break
+		}
+		if arg == "--verbose" {
+			arg = "--debug"
+		}
+		if arg == "-h" {
+			// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
+			arg = "--help"
+		}
+		if arg == "--version" || arg == "-v" {
+			// redirect --version pseudo-command to actual command
+			arg = "version"
+		}
+		if contains(getBoolFlags(), arg) {
+			rootFlags = append(rootFlags, arg)
+			continue
+		}
+		if contains(getStringFlags(), arg) {
+			i++
+			if i >= l {
+				fmt.Fprintf(os.Stderr, "flag needs an argument: '%s'\n", arg)
+				os.Exit(1)
+			}
+			rootFlags = append(rootFlags, arg, args[i])
+			continue
+		}
+		command = append(command, arg)
+	}
+	return append(rootFlags, command...)
+}
+
+func contains(array []string, needle string) bool {
+	for _, val := range array {
+		if val == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -1,0 +1,78 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_convert(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "compose only",
+			args: []string{"up"},
+			want: []string{"compose", "up"},
+		},
+		{
+			name: "with context",
+			args: []string{"--context", "foo", "-f", "compose.yaml", "up"},
+			want: []string{"--context", "foo", "compose", "-f", "compose.yaml", "up"},
+		},
+		{
+			name: "with host",
+			args: []string{"--host", "tcp://1.2.3.4", "up"},
+			want: []string{"--host", "tcp://1.2.3.4", "compose", "up"},
+		},
+		{
+			name: "compose --version",
+			args: []string{"--version"},
+			want: []string{"compose", "version"},
+		},
+		{
+			name: "help",
+			args: []string{"-h"},
+			want: []string{"compose", "--help"},
+		},
+		{
+			name: "issues/1962",
+			args: []string{"psql", "-h", "postgres"},
+			want: []string{"compose", "psql", "-h", "postgres"}, // -h should not be converted to --help
+		},
+		{
+			name: "issues/8648",
+			args: []string{"exec", "mongo", "mongo", "--host", "mongo"},
+			want: []string{"compose", "exec", "mongo", "mongo", "--host", "mongo"}, // --host is passed to exec
+		},
+		{
+			name: "issues/12",
+			args: []string{"--log-level", "INFO", "up"},
+			want: []string{"--log-level", "INFO", "compose", "up"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convert(tt.args)
+			assert.DeepEqual(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose-switch/redirect"
 	"github.com/spf13/cobra"
 
 	commands "github.com/docker/compose/v2/cmd/compose"
@@ -69,7 +68,7 @@ func pluginMain() {
 
 func main() {
 	if commands.RunningAsStandalone() {
-		os.Args = append([]string{"docker"}, redirect.Convert(os.Args[1:])...)
+		os.Args = append([]string{"docker"}, convert(os.Args[1:])...)
 	}
 	pluginMain()
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/docker/buildx v0.5.2-0.20210422185057-908a856079fc
 	github.com/docker/cli v20.10.7+incompatible
 	github.com/docker/cli-docs-tool v0.1.1
-	github.com/docker/compose-switch v1.0.2
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,6 @@ github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHv
 github.com/docker/cli-docs-tool v0.1.1 h1:c6vuTMvogCkSFQCXIr6Mb4gFgUpdZ+28YMbCBfaQLik=
 github.com/docker/cli-docs-tool v0.1.1/go.mod h1:oMzPNt1wC3TcxuY22GMnOODNOxkwGH51gV3AhqAjFQ4=
 github.com/docker/compose-on-kubernetes v0.4.19-0.20190128150448-356b2919c496/go.mod h1:iT2pYfi580XlpaV4KmK0T6+4/9+XoKmk/fhoDod1emE=
-github.com/docker/compose-switch v1.0.2 h1:chXFNNcnRvmtQYzwTaVsv/KSLRt8riSRAiSav89mLfk=
-github.com/docker/compose-switch v1.0.2/go.mod h1:uyPj8S3oH1O9rSZ5QVozw28OIjdNIflSSYElC2P0plQ=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.6.0-rc.1.0.20180327202408-83389a148052+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
@@ -966,7 +964,6 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
-github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=


### PR DESCRIPTION
**What I did**
Note that it fixes the problem of double "compose" on calling the compose plugin with "docker" root flags.
Like in "docker --context default compose version"

This also removes the vendoring of the repo

**Related issue**
Resolves https://github.com/docker/compose/issues/8945