### PR TITLE
Propagate GroupAdd from ServiceConfig to HostConfig

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -380,6 +380,7 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		Isolation:      container.Isolation(service.Isolation),
 		Runtime:        service.Runtime,
 		LogConfig:      logConfig,
+		GroupAdd:       service.GroupAdd,
 	}
 
 	return &containerConfig, &hostConfig, networkConfig, nil


### PR DESCRIPTION
**What I did**
The `group_add` key is parsed correctly from a compose file, but it is not
passed into the `ContainerCreate` API call, thus the configuration does
not take effect. This commit fixes the issue by propagating the
configuration from Docker compose's ServiceConfig to Docker container's
HostConfig.

**Related issue**
I think #8810 was not completely fixed when it was closed. The PR https://github.com/compose-spec/compose-go/pull/201 that was considered the fix to #8810 only solved the first half part of the issue, which is parsing `group_add` correctly, this PR solves the other half.