### PR TITLE
use filepath instead of path to check if the dockerfile path is abolute or not

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/compose-spec/compose-go/types"
@@ -289,7 +288,7 @@ func mergeArgs(m ...types.Mapping) types.Mapping {
 }
 
 func dockerFilePath(context string, dockerfile string) string {
-	if urlutil.IsGitURL(context) || path.IsAbs(dockerfile) {
+	if urlutil.IsGitURL(context) || filepath.IsAbs(dockerfile) {
 		return dockerfile
 	}
 	return filepath.Join(context, dockerfile)


### PR DESCRIPTION
**What I did**
use `filepath.IsAbs` instead of `path.IsAbs` to fix the Dockerfile path check on windows which doesn't work because `filepath.IsAbs` don't have a windows specific implementation.


![image](https://user-images.githubusercontent.com/705411/144589005-9efcfb02-139e-468e-9f4a-49dea61e0875.png)
