### PR TITLE
`compose images` should list images of created containers

### DIFF
--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -33,6 +33,7 @@ import (
 
 func (s *composeService) Images(ctx context.Context, projectName string, options api.ImagesOptions) ([]api.ImageSummary, error) {
 	allContainers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
+		All:     true,
 		Filters: filters.NewArgs(projectFilter(projectName)),
 	})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Kevin Roy <kiniou@gmail.com>

**What I did**

Like in compose v1, the `images` sub-command should list images of **created** services instead of just the **running** ones.

I think this is due to the docker containers api is returning the list of running containers by default without status filters.
Therefore, we need to add `All: true` to get back the v1 behaviour according to the v1 python source code in [cli/main.py](https://github.com/docker/compose/blob/6eb51d3b5b8bcb35474e9ecd45972813c5680096/compose/cli/main.py#L642) where `stopped=True` and ends in `all=True` in [project.py](https://github.com/docker/compose/blob/6eb51d3b5b8bcb35474e9ecd45972813c5680096/compose/project.py#L835).

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
closes #8806 
