### PR TITLE
ignore missing (swarm) overlay networks

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1014,6 +1014,14 @@ func (s *composeService) ensureNetwork(ctx context.Context, n types.NetworkConfi
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			if n.External.External {
+				if n.Driver == "overlay" {
+					// Swarm nodes do not register overlay networks that were
+					// created on a different node unless they're in use.
+					// Here we assume `driver` is relevant for a network we don't manage
+					// which is a non-sense, but this is our legacy ¯\(ツ)/¯
+					// networkAttach will later fail anyway if network actually doesn't exists
+					return nil
+				}
 				return fmt.Errorf("network %s declared as external, but could not be found", n.Name)
 			}
 			var ipam *network.IPAM


### PR DESCRIPTION
**What I did**
Don't consider a missing external overlay network to be an error, as this might be caused by swarm design.
NetworkAttach will fail bit later if the network really doesn't exists

**Related issue**
close https://github.com/docker/compose/issues/8996

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
