### PR TITLE
Introduce `compose watch` to rebuild/restart service on change to build context

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -305,6 +305,7 @@ func RootCommand(backend api.Service) *cobra.Command {
 		pullCommand(&opts, backend),
 		createCommand(&opts, backend),
 		copyCommand(&opts, backend),
+		watchCommand(&opts, backend),
 	)
 	command.Flags().SetInterspersed(false)
 	opts.addProjectFlags(command.Flags())

--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -1,0 +1,57 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/compose/v2/pkg/api"
+)
+
+type watchOptions struct {
+	*projectOptions
+}
+
+func watchCommand(p *projectOptions, backend api.Service) *cobra.Command {
+	opts := watchOptions{
+		projectOptions: p,
+	}
+	cmd := &cobra.Command{
+		Use:   "watch [SERVICES...]",
+		Short: "Watch build context for service(s) and rebuild/refresh containers when files are updated",
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runWatch(ctx, backend, opts, args)
+		}),
+		ValidArgsFunction: serviceCompletion(p),
+	}
+
+	return cmd
+}
+
+func runWatch(ctx context.Context, backend api.Service, opts watchOptions, services []string) error {
+	project, err := opts.toProject(services)
+	if err != nil {
+		return err
+	}
+
+	return backend.Watch(ctx, project, api.WatchOptions{})
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/mock v1.5.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-version v1.3.0
@@ -107,7 +108,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
-	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.5 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,9 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
@@ -1322,8 +1323,9 @@ golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -76,6 +76,12 @@ type Service interface {
 	Port(ctx context.Context, project string, service string, port int, options PortOptions) (string, int, error)
 	// Images executes the equivalent of a `compose images`
 	Images(ctx context.Context, projectName string, options ImagesOptions) ([]ImageSummary, error)
+	// Watch services' build context and rebuild/restart image on changes
+	Watch(ctx context.Context, project *types.Project, options WatchOptions) error
+}
+
+// WatchOptions group options of the Watch API
+type WatchOptions struct {
 }
 
 // BuildOptions group options of the Build API

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -48,6 +48,7 @@ type ServiceProxy struct {
 	EventsFn             func(ctx context.Context, project string, options EventsOptions) error
 	PortFn               func(ctx context.Context, project string, service string, port int, options PortOptions) (string, int, error)
 	ImagesFn             func(ctx context.Context, projectName string, options ImagesOptions) ([]ImageSummary, error)
+	WatchFn              func(ctx context.Context, project *types.Project, options WatchOptions) error
 	interceptors         []Interceptor
 }
 
@@ -87,6 +88,7 @@ func (s *ServiceProxy) WithService(service Service) *ServiceProxy {
 	s.EventsFn = service.Events
 	s.PortFn = service.Port
 	s.ImagesFn = service.Images
+	s.WatchFn = service.Watch
 	return s
 }
 
@@ -325,4 +327,12 @@ func (s *ServiceProxy) Images(ctx context.Context, project string, options Image
 		return nil, ErrNotImplemented
 	}
 	return s.ImagesFn(ctx, project, options)
+}
+
+// Watch implements Service interface
+func (s *ServiceProxy) Watch(ctx context.Context, project *types.Project, options WatchOptions) error {
+	if s.WatchFn == nil {
+		return ErrNotImplemented
+	}
+	return s.WatchFn(ctx, project, options)
 }

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -82,7 +82,6 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 					Attrs: map[string]string{"ref": image},
 				})
 			}
-
 			opts[imageName] = buildOptions
 		}
 	}

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -1,0 +1,135 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/docker/compose/v2/pkg/api"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/cli/cli/command/image/build"
+	"github.com/docker/docker/pkg/fileutils"
+	"github.com/fsnotify/fsnotify"
+	"golang.org/x/sync/errgroup"
+)
+
+//nolint:gocyclo
+func (s *composeService) Watch(ctx context.Context, project *types.Project, options api.WatchOptions) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, service := range project.Services {
+		service := service
+		if service.Build == nil {
+			// ignored
+			continue
+		}
+		path := service.Build.Context
+		fmt.Printf("watching build context %s for service %s\n", path, service.Name)
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			return err
+		}
+		err = watcher.Add(path)
+		if err != nil {
+			return err
+		}
+		defer watcher.Close() //nolint:errcheck
+
+		excludes, err := build.ReadDockerignore(path)
+		if err != nil {
+			return err
+		}
+		pm, err := fileutils.NewPatternMatcher(excludes)
+		if err != nil {
+			return err
+		}
+
+		eg.Go(func() error {
+			triggered := make(chan bool)
+
+			// use as a guard to enforce we run a single concurrent `refresh`
+			ready := make(chan bool, 1)
+			ready <- true
+			refresh := func() {
+				select {
+				case <-ready:
+					eg.Go(func() error {
+						triggered <- true
+						err := s.refresh(ctx, project, service.Name)
+						if err != nil {
+							return err
+						}
+						ready <- true
+						return nil
+					})
+				default:
+				}
+			}
+
+			for {
+				var changes []string
+
+				select {
+				case event := <-watcher.Events:
+					ignore, err := pm.Matches(event.Name)
+					if err != nil {
+						return err
+					}
+					if ignore {
+						continue
+					}
+					changes = append(changes, event.Name)
+					if len(changes) == 1 {
+						// change detected, trigger a refresh but apply a quiet period waiting for more changes in a row
+						eg.Go(func() error {
+							time.Sleep(500 * time.Millisecond)
+							refresh()
+							return nil
+						})
+					} else {
+						refresh()
+					}
+				case <-triggered:
+					// a refresh has just started, reset the pending changes list
+					changes = nil
+				case err := <-watcher.Errors:
+					return err
+				case <-ctx.Done():
+					return watcher.Close()
+				}
+			}
+		})
+	}
+	return eg.Wait()
+}
+
+func (s *composeService) refresh(ctx context.Context, project *types.Project, service string) error {
+	err := s.build(ctx, project, api.BuildOptions{
+		Services: []string{service},
+	})
+	if err != nil {
+		return err
+	}
+	return s.Up(ctx, project, api.UpOptions{
+		Create: api.CreateOptions{
+			Services: []string{service},
+			Recreate: api.RecreateForce,
+		},
+	})
+}


### PR DESCRIPTION
**What I did**
Introduced `compose watch` command.
This command watch filesystem (using inotify) to rebuild and restart container when build context is updated for a service

**Implementation details** 
uses `inotify` to get filesystem changes as an event stream
on first change detected, applies a quiet period as such events comes in a row (editing a file in vscode results in CHMOD+WRITE+CHMOD events)
refresh (rebuild+recreate) only run once in parallel using a 1-size bool channel (could have used sync.Once but this one can't be reset)

**Related issue**
close https://github.com/docker/compose/issues/184

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/144748404-5594551b-f62a-4415-9e2e-7f93a6a7cdae.png)
