### PR TITLE
Remove intermediate containers when build succeeded in classic build

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -212,6 +212,7 @@ func (o *projectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 			cli.WithName(o.ProjectName))...)
 }
 
+// PluginName is the name of the plugin
 const PluginName = "compose"
 
 // RunningAsStandalone detects when running as a standalone program

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -231,6 +231,7 @@ func imageBuildOptions(options buildx.Options) dockertypes.ImageBuildOptions {
 	return dockertypes.ImageBuildOptions{
 		Tags:        options.Tags,
 		NoCache:     options.NoCache,
+		Remove:      true,
 		PullParent:  options.Pull,
 		BuildArgs:   toMapStringStringPtr(options.BuildArgs),
 		Labels:      options.Labels,


### PR DESCRIPTION
**What I did**

Remove intermediate containers when build succeeded in classic build like default behavior of docker build.

**Related issue**

Intermediate containers remain even when build succeeded when building with classic way (i.e. not with buildkit).

The docker-compose cli [accepts the option `--no-rm`](https://github.com/docker/compose/blob/v2/cmd/compose/build.go#L92), but it's ignored because it's deprecated option.