### PR TITLE
Docker compose bug for common parents

### DIFF
--- a/pkg/compose/dependencies_test.go
+++ b/pkg/compose/dependencies_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -27,19 +28,18 @@ import (
 var project = types.Project{
 	Services: []types.ServiceConfig{
 		{
-			Name: "test1",
+			Name: "kochiku_build",
 			DependsOn: map[string]types.ServiceDependency{
-				"test2": {},
+				"kochiku_mysql": {},
+				"kochiku_redis": {},
 			},
+			//Deploy: &types.DeployConfig{ Replicas: },
 		},
 		{
-			Name: "test2",
-			DependsOn: map[string]types.ServiceDependency{
-				"test3": {},
-			},
+			Name: "kochiku_mysql",
 		},
 		{
-			Name: "test3",
+			Name: "kochiku_redis",
 		},
 	},
 }
@@ -51,9 +51,12 @@ func TestInDependencyUpCommandOrder(t *testing.T) {
 		order <- config
 		return nil
 	})
-	assert.Equal(t, <-order, "test3")
-	assert.Equal(t, <-order, "test2")
-	assert.Equal(t, <-order, "test1")
+	for d := range order {
+		fmt.Printf("%s\n", d)
+	}
+	//assert.Equal(t, <-order, "kochiku_redis")
+	//assert.Equal(t, <-order, "kochiku_mysql")
+	//assert.Equal(t, <-order, "kochiku_build")
 }
 
 func TestInDependencyReverseDownCommandOrder(t *testing.T) {


### PR DESCRIPTION
**What I did**

- Put breakpoints on line 93 and 102: https://github.com/docker/compose/blob/8a9c4b52b4c56a2d448a39f544161169cb25c3ae/pkg/compose/dependencies.go#L93-L109
 
**Related issue**

Watch every so often the output vary between GOOD:

```
kochiku_redis
kochiku_mysql
kochiku_build
```

Versus BAD:

```
kochiku_redis
kochiku_mysql
kochiku_build
kochiku_build
```