### PR TITLE
compose ps: fix typo "unknow" -> "unknown"

### DIFF
--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -59,7 +59,7 @@ func (p *psOptions) parseFilter() error {
 	case "source":
 		return api.ErrNotImplemented
 	default:
-		return fmt.Errorf("unknow filter %s", parts[0])
+		return fmt.Errorf("unknown filter %s", parts[0])
 	}
 	return nil
 }


### PR DESCRIPTION
**What I did**
Added a single 'n' to change:

```go
return fmt.Errorf("unknow filter %s", parts[0])
```

into:

```go
return fmt.Errorf("unknown filter %s", parts[0])
```

because I'm not sure that "unknow" is the right word to be using.

**Related issue**
Fixes #9016

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/76546/145235150-401284bd-ca42-40fd-861b-67d126b2d447.png)
