### PR TITLE
Stop compose on CTRL+C and containers are stopped

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -46,6 +46,7 @@ func NewComposeService(apiClient client.APIClient, configFile *configfile.Config
 type composeService struct {
 	apiClient  client.APIClient
 	configFile *configfile.ConfigFile
+	stopping   bool
 }
 
 func getCanonicalContainerName(c moby.Container) string {

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -115,7 +115,7 @@ func (s *composeService) watchContainers(ctx context.Context, projectName string
 				restarted := watched[container.ID]
 				watched[container.ID] = restarted + 1
 				// Container terminated.
-				willRestart := willContainerRestart(inspected, restarted)
+				willRestart := !s.stopping && willContainerRestart(inspected, restarted)
 
 				listener(api.ContainerEvent{
 					Type:       api.ContainerEventExit,

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -73,6 +73,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	go func() {
 		<-signalChan
 		printer.Cancel()
+		s.stopping = true
 		fmt.Println("Gracefully stopping... (press Ctrl+C again to force)")
 		stopFunc() // nolint:errcheck
 	}()


### PR DESCRIPTION
**What I did**
Stop compose on CTRL+C and containers are stopped

Even containers with "restart: always" should be stopped and leave docker-compose finish it's execution.

**Related issue**
Resolves: https://github.com/docker/compose/issues/8523
