### PR TITLE
handle "stop" event

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package main
+package compatibility
 
 import (
 	"fmt"
@@ -43,7 +43,7 @@ func getStringFlags() []string {
 	}
 }
 
-func convert(args []string) []string {
+func Convert(args []string) []string {
 	var rootFlags []string
 	command := []string{compose.PluginName}
 	l := len(args)

--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package main
+package compatibility
 
 import (
 	"testing"
@@ -71,7 +71,7 @@ func Test_convert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := convert(tt.args)
+			got := Convert(tt.args)
 			assert.DeepEqual(t, tt.want, got)
 		})
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/compose/v2/cmd/compatibility"
 	commands "github.com/docker/compose/v2/cmd/compose"
 	"github.com/docker/compose/v2/internal"
 	"github.com/docker/compose/v2/pkg/api"
@@ -68,7 +69,7 @@ func pluginMain() {
 
 func main() {
 	if commands.RunningAsStandalone() {
-		os.Args = append([]string{"docker"}, convert(os.Args[1:])...)
+		os.Args = append([]string{"docker"}, compatibility.Convert(os.Args[1:])...)
 	}
 	pluginMain()
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -436,6 +436,8 @@ const (
 	ContainerEventLog = iota
 	// ContainerEventAttach is a ContainerEvent of type attach. First event sent about a container
 	ContainerEventAttach
+	// ContainerEventStopped is a ContainerEvent of type stopped.
+	ContainerEventStopped
 	// ContainerEventExit is a ContainerEvent of type exit. ExitCode is set
 	ContainerEventExit
 	// UserCancel user cancelled compose up, we are stopping containers

--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -79,7 +79,7 @@ func (p *printer) Run(ctx context.Context, cascadeStop bool, exitCodeFrom string
 				}
 				containers[container] = struct{}{}
 				p.consumer.Register(container)
-			case api.ContainerEventExit:
+			case api.ContainerEventExit, api.ContainerEventStopped:
 				if !event.Restarting {
 					delete(containers, container)
 				}

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -111,6 +111,21 @@ func (s *composeService) watchContainers(ctx context.Context, projectName string
 			}
 			name := getContainerNameWithoutProject(container)
 
+			if event.Status == "stop" {
+				listener(api.ContainerEvent{
+					Type:      api.ContainerEventStopped,
+					Container: name,
+					Service:   container.Labels[api.ServiceLabel],
+				})
+
+				delete(watched, container.ID)
+				if len(watched) == 0 {
+					// all project containers stopped, we're done
+					stop()
+				}
+				return nil
+			}
+
 			if event.Status == "die" {
 				restarted := watched[container.ID]
 				watched[container.ID] = restarted + 1


### PR DESCRIPTION
**What I did**
This is an alternative to https://github.com/docker/compose/pull/9018
catching the `stop` event, we can stop watching a container and consider it "done"

this include moving `convert` to a non-main package as this prevent debugger to start in Goland

**Related issue**
fixes: #8523

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/145251344-8729dcda-9a12-4d94-bf1f-15b1deaf11ae.png)

(he won't run anymore)