### PR TITLE
(re)start should not impact one-off containers

### DIFF
--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -35,7 +35,7 @@ func (s *composeService) Restart(ctx context.Context, projectName string, option
 
 func (s *composeService) restart(ctx context.Context, projectName string, options api.RestartOptions) error {
 
-	observedState, err := s.getContainers(ctx, projectName, oneOffInclude, true)
+	observedState, err := s.getContainers(ctx, projectName, oneOffExclude, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/stop.go
+++ b/pkg/compose/stop.go
@@ -39,6 +39,7 @@ func (s *composeService) stop(ctx context.Context, projectName string, options a
 	}
 
 	return InReverseDependencyOrder(ctx, project, func(c context.Context, service string) error {
-		return s.stopContainers(ctx, w, containers.filter(isService(service)), options.Timeout)
+		containersToStop := containers.filter(isService(service)).filter(isNotOneOff)
+		return s.stopContainers(ctx, w, containersToStop, options.Timeout)
 	})
 }

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -145,3 +145,54 @@ func TestStartStopWithDependencies(t *testing.T) {
 		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 	})
 }
+
+func TestStartStopWithOneOffs(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-start-stop-with-oneoffs"
+
+	t.Run("Up", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName,
+			"up", "-d")
+		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-oneoffs-foo-1  Started"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-oneoffs-bar-1  Started"), res.Combined())
+	})
+
+	t.Run("run one-off", func(t *testing.T) {
+		c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName, "run", "-d", "bar", "sleep", "infinity")
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a")
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+	})
+
+	t.Run("stop (not one-off containers)", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "stop")
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e_start_stop_with_oneoffs_bar_run"), res.Combined())
+
+		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a", "--status", "running")
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+	})
+
+	t.Run("start (not one-off containers)", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "start")
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+	})
+
+	t.Run("restart (not one-off containers)", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "restart")
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+	})
+
+	t.Run("down", func(t *testing.T) {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
+
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a", "--status", "running")
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar"), res.Combined())
+	})
+}


### PR DESCRIPTION
**What I did**
start/restart only considered service containers

**Related issue**
https://github.com/docker/compose/issues/9044

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
