### PR TITLE
Add progress output while waiting for dependencies

### DIFF
--- a/pkg/progress/event.go
+++ b/pkg/progress/event.go
@@ -68,6 +68,21 @@ func StartedEvent(ID string) Event {
 	return NewEvent(ID, Done, "Started")
 }
 
+// Waiting creates a new waiting event
+func Waiting(ID string) Event {
+	return NewEvent(ID, Working, "Waiting")
+}
+
+// Healthy creates a new healthy event
+func Healthy(ID string) Event {
+	return NewEvent(ID, Done, "Healthy")
+}
+
+// Exited creates a new exited event
+func Exited(ID string) Event {
+	return NewEvent(ID, Done, "Exited")
+}
+
 // RestartingEvent creates a new Restarting in progress Event
 func RestartingEvent(ID string) Event {
 	return NewEvent(ID, Working, "Restarting")

--- a/pkg/progress/noop.go
+++ b/pkg/progress/noop.go
@@ -27,7 +27,10 @@ func (p *noopWriter) Start(ctx context.Context) error {
 	return nil
 }
 
-func (p *noopWriter) Event(e Event) {
+func (p *noopWriter) Event(Event) {
+}
+
+func (p *noopWriter) Events([]Event) {
 }
 
 func (p *noopWriter) TailMsgf(_ string, _ ...interface{}) {

--- a/pkg/progress/plain.go
+++ b/pkg/progress/plain.go
@@ -40,6 +40,12 @@ func (p *plainWriter) Event(e Event) {
 	fmt.Fprintln(p.out, e.ID, e.Text, e.StatusText)
 }
 
+func (p *plainWriter) Events(events []Event) {
+	for _, e := range events {
+		p.Event(e)
+	}
+}
+
 func (p *plainWriter) TailMsgf(m string, args ...interface{}) {
 	fmt.Fprintln(p.out, append([]interface{}{m}, args...)...)
 }

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -95,6 +95,12 @@ func (w *ttyWriter) Event(e Event) {
 	}
 }
 
+func (w *ttyWriter) Events(events []Event) {
+	for _, e := range events {
+		w.Event(e)
+	}
+}
+
 func (w *ttyWriter) TailMsgf(msg string, args ...interface{}) {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -31,6 +31,7 @@ type Writer interface {
 	Start(context.Context) error
 	Stop()
 	Event(Event)
+	Events([]Event)
 	TailMsgf(string, ...interface{})
 }
 


### PR DESCRIPTION
Hi @ndeloof, I thought this was a nice addition to the `--wait` flag you added a few months back. It's much more pleasant to use `depends_on` conditions and the `--wait` flag with this progress output because you can see _which_ containers are in an unhealthy state. (Before your terminal would just hang with all containers `Running`, which was pretty confusing!)

**What I did**

This commit adds progress output while waiting for `depends_on`
conditions to resolve. The initial output looks like so:

     ⠿ Container chbench-zookeeper-1        Waiting      0s
     ⠿ Container chbench-kafka-1            Waiting      0s
     ⠿ Container chbench-one-off            Waiting      0s

Once all conditions have been resolved, the ouput looks like this:

     ⠿ Container chbench-zookeeper-1        Healthy      1.2s
     ⠿ Container chbench-kafka-1            Healthy      3.2s
     ⠿ Container chbench-schema-registry-1  Exited       4s

As shown above, `service_healthy` conditions result in a terminal status
of "Healthy" while `service_exited_successfully` conditions result in a
terminal status of "Exited".

Fix #8761.