### PR TITLE
Don't wait forever for unhealthy dependencies

### DIFF
--- a/pkg/e2e/fixtures/start-fail/compose.yaml
+++ b/pkg/e2e/fixtures/start-fail/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  fail:
+    image: alpine
+    command: sleep infinity
+    healthcheck:
+      test: "false"
+      interval: 1s
+      retries: 3
+  depends:
+    image: alpine
+    command: sleep infinity
+    depends_on:
+      fail:
+        condition: service_healthy

--- a/pkg/e2e/start_fail_test.go
+++ b/pkg/e2e/start_fail_test.go
@@ -1,0 +1,33 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/v3/icmd"
+)
+
+func TestStartFail(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+	const projectName = "e2e-start-fail"
+
+	res := c.RunDockerOrExitError("compose", "-f", "fixtures/start-fail/compose.yaml", "--project-name", projectName, "up", "-d")
+	res.Assert(t, icmd.Expected{ExitCode: 1, Err: `container for service "fail" is unhealthy`})
+
+	c.RunDockerComposeCmd("--project-name", projectName, "down")
+}


### PR DESCRIPTION
@ndeloof I've got one more `--wait`-related fix for you here. Does the test case look ok?

**What I did**

The previous code would wait for dependencies to become healthy forever,
even if they'd become unhealthy in the meantime. I can't find an issue
report for this bug, but it was described in a comment on the PR that
introduced the `--wait` flag [0].

[0]: https://github.com/docker/compose/pull/8777#issuecomment-965643839
