### PR TITLE
Return only numbers in short version

### DIFF
--- a/cmd/compose/version.go
+++ b/cmd/compose/version.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/docker/compose/v2/cmd/formatter"
 
@@ -52,7 +53,7 @@ func versionCommand() *cobra.Command {
 
 func runVersion(opts versionOptions) {
 	if opts.short {
-		fmt.Println(internal.Version)
+		fmt.Println(strings.TrimPrefix(internal.Version, "v"))
 		return
 	}
 	if opts.format == formatter.JSON {


### PR DESCRIPTION
**What I did**

Python version of docker compose removes the v prefix in the version.

```
$ docker-compose version --short
1.25.5
```

Some projects are using this command to check the version. I think it might be good to keep the old behavior.
Example: https://github.com/openmaptiles/openmaptiles/blob/master/quickstart.sh#L84

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![image](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/IcelandicHorseInWinter.jpg/2880px-IcelandicHorseInWinter.jpg)