### PR TITLE
Always remove intermediate containers on building with the classical builder

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -232,6 +232,7 @@ func imageBuildOptions(options buildx.Options) dockertypes.ImageBuildOptions {
 		Tags:        options.Tags,
 		NoCache:     options.NoCache,
 		Remove:      true,
+		ForceRemove: true,
 		PullParent:  options.Pull,
 		BuildArgs:   toMapStringStringPtr(options.BuildArgs),
 		Labels:      options.Labels,


### PR DESCRIPTION
**What I did**
Set `ForceRemove` to `true` when running the classical builder.

**Related issue**
https://github.com/docker/compose/issues/9058