### PR TITLE
Support COMPOSE_IGNORE_ORPHANS for `compose run`

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -53,6 +53,7 @@ type runOptions struct {
 	servicePorts  bool
 	name          string
 	noDeps        bool
+	ignoreOrphans bool
 	quietPull     bool
 }
 
@@ -134,6 +135,8 @@ func runCommand(p *projectOptions, backend api.Service) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			ignore := project.Environment["COMPOSE_IGNORE_ORPHANS"]
+			opts.ignoreOrphans = strings.ToLower(ignore) == "true"
 			return runRun(ctx, backend, project, opts)
 		}),
 		ValidArgsFunction: serviceCompletion(p),
@@ -177,7 +180,7 @@ func runRun(ctx context.Context, backend api.Service, project *types.Project, op
 	}
 
 	err = progress.Run(ctx, func(ctx context.Context) error {
-		return startDependencies(ctx, backend, *project, opts.Service)
+		return startDependencies(ctx, backend, *project, opts.Service, opts.ignoreOrphans)
 	})
 	if err != nil {
 		return err
@@ -224,7 +227,7 @@ func runRun(ctx context.Context, backend api.Service, project *types.Project, op
 	return err
 }
 
-func startDependencies(ctx context.Context, backend api.Service, project types.Project, requestedServiceName string) error {
+func startDependencies(ctx context.Context, backend api.Service, project types.Project, requestedServiceName string, ignoreOrphans bool) error {
 	dependencies := types.Services{}
 	var requestedService types.ServiceConfig
 	for _, service := range project.Services {
@@ -237,7 +240,9 @@ func startDependencies(ctx context.Context, backend api.Service, project types.P
 
 	project.Services = dependencies
 	project.DisabledServices = append(project.DisabledServices, requestedService)
-	if err := backend.Create(ctx, &project, api.CreateOptions{}); err != nil {
+	if err := backend.Create(ctx, &project, api.CreateOptions{
+		IgnoreOrphans: ignoreOrphans,
+	}); err != nil {
 		return err
 	}
 	return backend.Start(ctx, project.Name, api.StartOptions{})

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -99,3 +99,6 @@ Setting the `COMPOSE_FILE` environment variable is equivalent to passing the `-f
 and so does `COMPOSE_PROFILES` environment variable for to the `--profiles` flag.
 
 If flags are explicitly set on command line, associated environment variable is ignored
+
+Setting the `COMPOSE_IGNORE_ORPHANS` environment variable to `true` will stop docker compose from detecting orphaned 
+containers for the project.

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -98,6 +98,9 @@ long: |-
   and so does `COMPOSE_PROFILES` environment variable for to the `--profiles` flag.
 
   If flags are explicitly set on command line, associated environment variable is ignored
+  
+  Setting the `COMPOSE_IGNORE_ORPHANS` environment variable to `true` will stop docker compose from detecting orphaned
+  containers for the project.
 usage: docker compose
 pname: docker
 plink: docker.yaml

--- a/pkg/e2e/fixtures/run-test/orphan.yaml
+++ b/pkg/e2e/fixtures/run-test/orphan.yaml
@@ -1,0 +1,5 @@
+version: '3.8'
+services:
+  simple:
+    image: alpine
+    command: echo "Hi there!!"


### PR DESCRIPTION
**What I did**
Made `compose run` respect the env var COMPOSE_IGNORE_ORPHANS. E2E test cases added.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
This revives #7020 and resolves the issue mentioned in [#4992 (comment)](https://github.com/docker/compose/pull/4992#issuecomment-696569463).

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![mimi](https://user-images.githubusercontent.com/39874143/149420770-8c66e3ce-df6d-481f-9b5b-0c4616622cfd.png)
