### PR TITLE
Don't SetRawTerminal() when exec is run with -T

### DIFF
--- a/pkg/compose/exec.go
+++ b/pkg/compose/exec.go
@@ -96,7 +96,7 @@ func (s *composeService) interactiveExec(ctx context.Context, opts api.RunOption
 	}
 
 	in := streams.NewIn(opts.Stdin)
-	if in.IsTerminal() {
+	if in.IsTerminal() && opts.Tty {
 		state, err := term.SetRawTerminal(in.FD())
 		if err != nil {
 			return err


### PR DESCRIPTION
**What I did**

Made it not put the terminal into raw mode.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Fixes #9086.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

https://giphy.com/gifs/cW64pEEZe0YZa