### PR TITLE
down: Reject all arguments

### DIFF
--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -59,6 +59,7 @@ func downCommand(p *projectOptions, backend api.Service) *cobra.Command {
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runDown(ctx, backend, opts)
 		}),
+		Args:              cobra.NoArgs,
 		ValidArgsFunction: noCompletion(),
 	}
 	flags := downCmd.Flags()


### PR DESCRIPTION
The down command silently ignored all arguments, which might cause
confusion and/or outages if someone expects `docker-compose down
$service` to be the opposite of `docker-compose up $service`, rather
than turning down everything.

**What I did**
Make docker-compose down reject any given arguments.

**Related issue**
closes #9151 