### PR TITLE
Add support to push images quietly via compose cli 🤫

### DIFF
--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -29,6 +29,7 @@ type pushOptions struct {
 	composeOptions
 
 	Ignorefailures bool
+	Quiet          bool
 }
 
 func pushCommand(p *projectOptions, backend api.Service) *cobra.Command {
@@ -44,6 +45,7 @@ func pushCommand(p *projectOptions, backend api.Service) *cobra.Command {
 		ValidArgsFunction: completeServiceNames(p),
 	}
 	pushCmd.Flags().BoolVar(&opts.Ignorefailures, "ignore-push-failures", false, "Push what it can and ignores images with push failures")
+	pushCmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Push without printing progress information")
 
 	return pushCmd
 }
@@ -56,5 +58,6 @@ func runPush(ctx context.Context, backend api.Service, opts pushOptions, service
 
 	return backend.Push(ctx, project, api.PushOptions{
 		IgnoreFailures: opts.Ignorefailures,
+		Quiet:          opts.Quiet,
 	})
 }

--- a/docs/reference/compose_push.md
+++ b/docs/reference/compose_push.md
@@ -8,6 +8,7 @@ Push service images
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--ignore-push-failures` |  |  | Push what it can and ignores images with push failures |
+| `-q`, `--quiet` |  |  | Push without printing progress information |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_push.yaml
+++ b/docs/reference/docker_compose_push.yaml
@@ -33,6 +33,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: quiet
+      shorthand: q
+      value_type: bool
+      default_value: "false"
+      description: Push without printing progress information
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -183,6 +183,7 @@ type ConvertOptions struct {
 
 // PushOptions group options of the Push API
 type PushOptions struct {
+	Quiet          bool
 	IgnoreFailures bool
 }
 

--- a/pkg/compose/push.go
+++ b/pkg/compose/push.go
@@ -37,6 +37,9 @@ import (
 )
 
 func (s *composeService) Push(ctx context.Context, project *types.Project, options api.PushOptions) error {
+	if options.Quiet {
+		return s.push(ctx, project, options)
+	}
 	return progress.Run(ctx, func(ctx context.Context) error {
 		return s.push(ctx, project, options)
 	})
@@ -65,7 +68,7 @@ func (s *composeService) push(ctx context.Context, project *types.Project, optio
 		}
 		service := service
 		eg.Go(func() error {
-			err := s.pushServiceImage(ctx, service, info, s.configFile(), w)
+			err := s.pushServiceImage(ctx, service, info, s.configFile(), w, options.Quiet)
 			if err != nil {
 				if !options.IgnoreFailures {
 					return err
@@ -78,7 +81,7 @@ func (s *composeService) push(ctx context.Context, project *types.Project, optio
 	return eg.Wait()
 }
 
-func (s *composeService) pushServiceImage(ctx context.Context, service types.ServiceConfig, info moby.Info, configFile driver.Auth, w progress.Writer) error {
+func (s *composeService) pushServiceImage(ctx context.Context, service types.ServiceConfig, info moby.Info, configFile driver.Auth, w progress.Writer, quietPush bool) error {
 	ref, err := reference.ParseNormalizedNamed(service.Image)
 	if err != nil {
 		return err
@@ -121,7 +124,10 @@ func (s *composeService) pushServiceImage(ctx context.Context, service types.Ser
 		if jm.Error != nil {
 			return errors.New(jm.Error.Message)
 		}
-		toPushProgressEvent(service.Name, jm, w)
+
+		if !quietPush {
+			toPushProgressEvent(service.Name, jm, w)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What I did**
Add support to docker compose push --quiet option.

**Related issue**
#9089 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/18693839/153766792-66d87873-dc28-4e75-b7de-4a64cb30ca9f.png)
