### PR TITLE
Adds support to list the config files on `docker compose ls`

### DIFF
--- a/cmd/compose/list.go
+++ b/cmd/compose/list.go
@@ -92,22 +92,24 @@ func runList(ctx context.Context, backend api.Service, opts lsOptions) error {
 	view := viewFromStackList(stackList)
 	return formatter.Print(view, opts.Format, os.Stdout, func(w io.Writer) {
 		for _, stack := range view {
-			_, _ = fmt.Fprintf(w, "%s\t%s\n", stack.Name, stack.Status)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", stack.Name, stack.Status, stack.ConfigFiles)
 		}
-	}, "NAME", "STATUS")
+	}, "NAME", "STATUS", "CONFIG FILES")
 }
 
 type stackView struct {
-	Name   string
-	Status string
+	Name        string
+	Status      string
+	ConfigFiles string
 }
 
 func viewFromStackList(stackList []api.Stack) []stackView {
 	retList := make([]stackView, len(stackList))
 	for i, s := range stackList {
 		retList[i] = stackView{
-			Name:   s.Name,
-			Status: strings.TrimSpace(fmt.Sprintf("%s %s", s.Status, s.Reason)),
+			Name:        s.Name,
+			Status:      strings.TrimSpace(fmt.Sprintf("%s %s", s.Status, s.Reason)),
+			ConfigFiles: s.ConfigFiles,
 		}
 	}
 	return retList

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -404,10 +404,11 @@ const (
 
 // Stack holds the name and state of a compose application/stack
 type Stack struct {
-	ID     string
-	Name   string
-	Status string
-	Reason string
+	ID          string
+	Name        string
+	Status      string
+	ConfigFiles string
+	Reason      string
 }
 
 // LogConsumer is a callback to process log messages from services

--- a/pkg/compose/ls_test.go
+++ b/pkg/compose/ls_test.go
@@ -30,31 +30,33 @@ func TestContainersToStacks(t *testing.T) {
 		{
 			ID:     "service1",
 			State:  "running",
-			Labels: map[string]string{api.ProjectLabel: "project1"},
+			Labels: map[string]string{api.ProjectLabel: "project1", api.ConfigFilesLabel: "/home/docker-compose.yaml"},
 		},
 		{
 			ID:     "service2",
 			State:  "running",
-			Labels: map[string]string{api.ProjectLabel: "project1"},
+			Labels: map[string]string{api.ProjectLabel: "project1", api.ConfigFilesLabel: "/home/docker-compose.yaml"},
 		},
 		{
 			ID:     "service3",
 			State:  "running",
-			Labels: map[string]string{api.ProjectLabel: "project2"},
+			Labels: map[string]string{api.ProjectLabel: "project2", api.ConfigFilesLabel: "/home/project2-docker-compose.yaml"},
 		},
 	}
 	stacks, err := containersToStacks(containers)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, stacks, []api.Stack{
 		{
-			ID:     "project1",
-			Name:   "project1",
-			Status: "running(2)",
+			ID:          "project1",
+			Name:        "project1",
+			Status:      "running(2)",
+			ConfigFiles: "/home/docker-compose.yaml",
 		},
 		{
-			ID:     "project2",
-			Name:   "project2",
-			Status: "running(1)",
+			ID:          "project2",
+			Name:        "project2",
+			Status:      "running(1)",
+			ConfigFiles: "/home/project2-docker-compose.yaml",
 		},
 	})
 }

--- a/pkg/compose/ls_test.go
+++ b/pkg/compose/ls_test.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/docker/compose/v2/pkg/api"
@@ -65,4 +66,57 @@ func TestStacksMixedStatus(t *testing.T) {
 	assert.Equal(t, combinedStatus([]string{"running"}), "running(1)")
 	assert.Equal(t, combinedStatus([]string{"running", "running", "running"}), "running(3)")
 	assert.Equal(t, combinedStatus([]string{"running", "exited", "running"}), "exited(1), running(2)")
+}
+
+func TestCombinedConfigFiles(t *testing.T) {
+	containersByLabel := map[string][]moby.Container{
+		"project1": {
+			{
+				ID:     "service1",
+				State:  "running",
+				Labels: map[string]string{api.ProjectLabel: "project1", api.ConfigFilesLabel: "/home/docker-compose.yaml"},
+			},
+			{
+				ID:     "service2",
+				State:  "running",
+				Labels: map[string]string{api.ProjectLabel: "project1", api.ConfigFilesLabel: "/home/docker-compose.yaml"},
+			},
+		},
+		"project2": {
+			{
+				ID:     "service3",
+				State:  "running",
+				Labels: map[string]string{api.ProjectLabel: "project2", api.ConfigFilesLabel: "/home/project2-docker-compose.yaml"},
+			},
+		},
+		"project3": {
+			{
+				ID:     "service4",
+				State:  "running",
+				Labels: map[string]string{api.ProjectLabel: "project3"},
+			},
+		},
+	}
+
+	testData := map[string]struct {
+		ConfigFiles string
+		Error       error
+	}{
+		"project1": {ConfigFiles: "/home/docker-compose.yaml", Error: nil},
+		"project2": {ConfigFiles: "/home/project2-docker-compose.yaml", Error: nil},
+		"project3": {ConfigFiles: "", Error: fmt.Errorf("No label %q set on container %q of compose project", api.ConfigFilesLabel, "service4")},
+	}
+
+	for project, containers := range containersByLabel {
+		configFiles, err := combinedConfigFiles(containers)
+
+		expected := testData[project]
+
+		if expected.Error != nil {
+			assert.Equal(t, err.Error(), expected.Error.Error())
+		} else {
+			assert.Equal(t, err, expected.Error)
+		}
+		assert.Equal(t, configFiles, expected.ConfigFiles)
+	}
 }


### PR DESCRIPTION
**What I did**
Adds support to list the config files used to create the project on `docker compose ls`.

**Related issue**
#8573

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/18693839/153889575-ed682871-5673-4efd-a06b-bb873228af80.png)
