### PR TITLE
use golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Run golangci-lint
         env:
           BUILD_TAGS: e2e
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin/ v1.39.0
-          make -f builder.Makefile lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          args: --timeout=180s
 
   # only on main branch, costs too much for the gain on every PR
   validate-cross-build:


### PR DESCRIPTION
**What I did**
Configure CI to use golangci-lint-action, so that linter errors directly appear under code review as review notes

