### PR TITLE
Wait and scale 0

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -278,7 +278,7 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 	for dep, config := range dependencies {
 		if config.Condition == types.ServiceConditionStarted {
 			// already managed by InDependencyOrder
-			return nil
+			continue
 		}
 		if service, err := project.GetService(dep); err != nil {
 			return err

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -280,6 +280,12 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 			// already managed by InDependencyOrder
 			return nil
 		}
+		if service, err := project.GetService(dep); err != nil {
+			return err
+		} else if service.Scale == 0 {
+			// don't wait for the dependency which configured to have 0 containers running
+			continue
+		}
 
 		containers, err := s.getContainers(ctx, project.Name, oneOffExclude, false, dep)
 		if err != nil {

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -182,5 +183,23 @@ func TestServiceLinks(t *testing.T) {
 		assert.Equal(t, links[0], "testProject-web-1:web")
 		assert.Equal(t, links[1], "testProject-web-1:web-1")
 		assert.Equal(t, links[2], "testProject-web-1:testProject-web-1")
+	})
+}
+
+func TestWaitDependencies(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	api := mocks.NewMockAPIClient(mockCtrl)
+	tested.apiClient = api
+
+	t.Run("should skip dependencies with scale 0", func(t *testing.T) {
+		dbService := types.ServiceConfig{Name: "db", Scale: 0}
+		redisService := types.ServiceConfig{Name: "redis", Scale: 0}
+		project := types.Project{Name: strings.ToLower(testProject), Services: []types.ServiceConfig{dbService, redisService}}
+		dependencies := types.DependsOnConfig{
+			"db":    {Condition: ServiceConditionRunningOrHealthy},
+			"redis": {Condition: ServiceConditionRunningOrHealthy},
+		}
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies))
 	})
 }

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -202,4 +202,14 @@ func TestWaitDependencies(t *testing.T) {
 		}
 		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies))
 	})
+	t.Run("should skip dependencies with condition service_started", func(t *testing.T) {
+		dbService := types.ServiceConfig{Name: "db", Scale: 1}
+		redisService := types.ServiceConfig{Name: "redis", Scale: 1}
+		project := types.Project{Name: strings.ToLower(testProject), Services: []types.ServiceConfig{dbService, redisService}}
+		dependencies := types.DependsOnConfig{
+			"db":    {Condition: types.ServiceConditionStarted},
+			"redis": {Condition: types.ServiceConditionStarted},
+		}
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies))
+	})
 }


### PR DESCRIPTION
**What I did**
* During dependencies wait process, skip services with a scale property equals to 0 to avoid waiting indefinitely.
* Also fixed an early return in the wait process when reaching a dependency with a `service_started` condition, now the service is skipped and we continue with the rest of the dependencies
* Add tests for this 2 use cases

**Related issue**
fix #9149 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/154836506-2b6f7bd7-90e6-42ca-a97f-79c2cd368fda.png)
