### PR TITLE
COMPOSE_REMOVE_ORPHANS can be set to always apply --remove-orphans

### DIFF
--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -19,6 +19,8 @@ package compose
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/compose-spec/compose-go/types"
@@ -60,7 +62,8 @@ func downCommand(p *projectOptions, backend api.Service) *cobra.Command {
 		ValidArgsFunction: noCompletion(),
 	}
 	flags := downCmd.Flags()
-	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
+	removeOrphans := strings.ToLower(os.Getenv("COMPOSE_REMOVE_ORPHANS ")) == "true"
+	flags.BoolVar(&opts.removeOrphans, "remove-orphans", removeOrphans, "Remove containers for services not defined in the Compose file.")
 	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")
 	flags.BoolVarP(&opts.volumes, "volumes", "v", false, " Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.")
 	flags.StringVar(&opts.images, "rmi", "", `Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")`)


### PR DESCRIPTION
**What I did**
`--remove-orphans` default value is computed based on `COMPOSE_REMOVE_ORPHANS` env variable

**Related issue**
closes #9199

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
