### PR TITLE
exclude com.docker.compose.image label from service hash

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -141,7 +141,7 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 			if project.Services[i].Labels == nil {
 				project.Services[i].Labels = types.Labels{}
 			}
-			project.Services[i].Labels[api.ImageDigestLabel] = digest
+			project.Services[i].CustomLabels[api.ImageDigestLabel] = digest
 			project.Services[i].Image = image
 		}
 	}


### PR DESCRIPTION
**What I did**
set `com.docker.compose.image label` as a custom label so it get excluded from config hash computation

**Related issue**
closes #9211

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
