### PR TITLE
report external volume name not found

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1102,7 +1102,7 @@ func (s *composeService) ensureVolume(ctx context.Context, volume types.VolumeCo
 			return err
 		}
 		if volume.External.External {
-			return fmt.Errorf("external volume %q not found", volume.External.Name)
+			return fmt.Errorf("external volume %q not found", volume.Name)
 		}
 		err := s.createVolume(ctx, volume)
 		return err


### PR DESCRIPTION
**What I did**
report volume.name when external volume is not found
compose-go LoadVolume enforce volume.Name is always set to the relevant name

**Related issue**
closes #9063

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
