### PR TITLE
Add -i and -t to run and exec

### DIFF
--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -73,6 +73,11 @@ func execCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	runCmd.Flags().BoolVarP(&opts.noTty, "no-TTY", "T", false, "Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.")
 	runCmd.Flags().StringVarP(&opts.workingDir, "workdir", "w", "", "Path to workdir directory for this command.")
 
+	runCmd.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached. DEPRECATED")
+	runCmd.Flags().MarkHidden("interactive") //nolint:errcheck
+	runCmd.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY. DEPRECATED")
+	runCmd.Flags().MarkHidden("tty") //nolint:errcheck
+
 	runCmd.Flags().SetInterspersed(false)
 	return runCmd
 }

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -155,6 +155,11 @@ func runCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	flags.BoolVar(&opts.servicePorts, "service-ports", false, "Run command with the service's ports enabled and mapped to the host.")
 	flags.BoolVar(&opts.quietPull, "quiet-pull", false, "Pull without printing progress information.")
 
+	cmd.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached. DEPRECATED")
+	cmd.Flags().MarkHidden("interactive") //nolint:errcheck
+	cmd.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY. DEPRECATED")
+	cmd.Flags().MarkHidden("tty") //nolint:errcheck
+
 	flags.SetNormalizeFunc(normalizeRunFlags)
 	flags.SetInterspersed(false)
 	return cmd


### PR DESCRIPTION
**What I did**
Add `-i` and `-t` to commands `run` and `exec` as hidden options, since they are not used.
This is just to avoid breakage on scripts or old usages from users.

**Related issue**
Resolves https://github.com/docker/compose/issues/9207
