### PR TITLE
don't try to start dependencies when there are none

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -245,10 +245,15 @@ func startDependencies(ctx context.Context, backend api.Service, project types.P
 
 	project.Services = dependencies
 	project.DisabledServices = append(project.DisabledServices, requestedService)
-	if err := backend.Create(ctx, &project, api.CreateOptions{
+	err := backend.Create(ctx, &project, api.CreateOptions{
 		IgnoreOrphans: ignoreOrphans,
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
-	return backend.Start(ctx, project.Name, api.StartOptions{})
+
+	if len(dependencies) > 0 {
+		return backend.Start(ctx, project.Name, api.StartOptions{})
+	}
+	return nil
 }

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -100,7 +100,7 @@ func (s *composeService) projectFromName(containers Containers, projectName stri
 		Name: projectName,
 	}
 	if len(containers) == 0 {
-		return project, errors.New("no such project: " + projectName)
+		return project, errors.Wrap(api.ErrNotFound, fmt.Sprintf("no container found for project %q", projectName))
 	}
 	set := map[string]*types.ServiceConfig{}
 	for _, c := range containers {


### PR DESCRIPTION
**What I did**
Skip create/start when `run` doesn't involve any dependency
as `start` will try to resolve resources by project name and fail if none found

**Related issue**
close #9234

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
