### PR TITLE
don't failed when trying to stop or rm services with no containers ru…

### DIFF
--- a/pkg/compose/stop.go
+++ b/pkg/compose/stop.go
@@ -44,7 +44,7 @@ func (s *composeService) stop(ctx context.Context, projectName string, options a
 	}
 
 	project, err := s.projectFromName(containers, projectName, services...)
-	if err != nil {
+	if err != nil && !api.IsNotFoundError(err) {
 		return err
 	}
 


### PR DESCRIPTION
…nning

**What I did**
Don't fail the process when trying to stop or rm services when no container are running. We check the error and failed only if not concerning number of containers running.
