### PR TITLE
filter containers after project has been rebuilt from resources

### DIFF
--- a/pkg/compose/stop.go
+++ b/pkg/compose/stop.go
@@ -48,6 +48,10 @@ func (s *composeService) stop(ctx context.Context, projectName string, options a
 		return err
 	}
 
+	if len(services) > 0 {
+		containers = containers.filter(isService(services...))
+	}
+
 	return InReverseDependencyOrder(ctx, project, func(c context.Context, service string) error {
 		return s.stopContainers(ctx, w, containers.filter(isService(service)), options.Timeout)
 	})


### PR DESCRIPTION
**What I did**
Don't filter out container not matching requested service, so we can fully rebuild the compose model

**Related issue**
closes #9241

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
