### PR TITLE
publish a draft release with auto generate release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,8 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "bin/*"
-          prerelease: true
+          generateReleaseNotes: true
+          draft: true
           commit: "v2"
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
**What I did**
remove the `prerelease` flag
Mark the release as `draft` and autogenerate the release notes

**Related issue**
#9243 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/157205379-29b99f1d-ce88-4b95-98b9-1dc3a9284d5b.png)
