### PR TITLE
build full compose model from resources, then filter by services

### DIFF
--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -59,13 +59,13 @@ Any data which is not in a volume will be lost.`,
 }
 
 func runRemove(ctx context.Context, backend api.Service, opts removeOptions, services []string) error {
-	project, err := opts.toProject(services)
+	project, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
 
 	if opts.stop {
-		err := backend.Stop(ctx, project.Name, api.StopOptions{
+		err := backend.Stop(ctx, project, api.StopOptions{
 			Services: services,
 		})
 		if err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -59,7 +59,7 @@ type Service interface {
 	// RunOneOffContainer creates a service oneoff container and starts its dependencies
 	RunOneOffContainer(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 	// Remove executes the equivalent to a `compose rm`
-	Remove(ctx context.Context, project *types.Project, options RemoveOptions) error
+	Remove(ctx context.Context, project string, options RemoveOptions) error
 	// Exec executes a command in a running service container
 	Exec(ctx context.Context, project string, opts RunOptions) (int, error)
 	// Copy copies a file/folder between a service container and the local filesystem

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -39,7 +39,7 @@ type ServiceProxy struct {
 	ConvertFn            func(ctx context.Context, project *types.Project, options ConvertOptions) ([]byte, error)
 	KillFn               func(ctx context.Context, project *types.Project, options KillOptions) error
 	RunOneOffContainerFn func(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
-	RemoveFn             func(ctx context.Context, project *types.Project, options RemoveOptions) error
+	RemoveFn             func(ctx context.Context, project string, options RemoveOptions) error
 	ExecFn               func(ctx context.Context, project string, opts RunOptions) (int, error)
 	CopyFn               func(ctx context.Context, project string, options CopyOptions) error
 	PauseFn              func(ctx context.Context, project string, options PauseOptions) error
@@ -241,12 +241,9 @@ func (s *ServiceProxy) RunOneOffContainer(ctx context.Context, project *types.Pr
 }
 
 // Remove implements Service interface
-func (s *ServiceProxy) Remove(ctx context.Context, project *types.Project, options RemoveOptions) error {
+func (s *ServiceProxy) Remove(ctx context.Context, project string, options RemoveOptions) error {
 	if s.RemoveFn == nil {
 		return ErrNotImplemented
-	}
-	for _, i := range s.interceptors {
-		i(ctx, project)
 	}
 	return s.RemoveFn(ctx, project, options)
 }

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -149,3 +149,23 @@ SERVICES:
 
 	return project, nil
 }
+
+// actualState list resources labelled by projectName to rebuild compose project model
+func (s *composeService) actualState(ctx context.Context, projectName string, services []string) (Containers, *types.Project, error) {
+	var containers Containers
+	// don't filter containers by options.Services so projectFromName can rebuild project with all existing resources
+	containers, err := s.getContainers(ctx, projectName, oneOffInclude, true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	project, err := s.projectFromName(containers, projectName, services...)
+	if err != nil && !api.IsNotFoundError(err) {
+		return nil, nil, err
+	}
+
+	if len(services) > 0 {
+		containers = containers.filter(isService(services...))
+	}
+	return containers, project, nil
+}

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/compose/v2/pkg/api"
 	moby "github.com/docker/docker/api/types"
 	"golang.org/x/sync/errgroup"
@@ -30,13 +29,8 @@ import (
 	"github.com/docker/compose/v2/pkg/prompt"
 )
 
-func (s *composeService) Remove(ctx context.Context, project *types.Project, options api.RemoveOptions) error {
-	services := options.Services
-	if len(services) == 0 {
-		services = project.ServiceNames()
-	}
-
-	containers, err := s.getContainers(ctx, project.Name, oneOffInclude, true, services...)
+func (s *composeService) Remove(ctx context.Context, projectName string, options api.RemoveOptions) error {
+	containers, _, err := s.actualState(ctx, projectName, options.Services)
 	if err != nil {
 		return err
 	}

--- a/pkg/e2e/fixtures/dependencies/compose.yaml
+++ b/pkg/e2e/fixtures/dependencies/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  foo:
+    image: nginx:alpine
+    depends_on:
+      - bar
+
+  bar:
+    image: nginx:alpine


### PR DESCRIPTION
**What I did**
introduced `actualState` (this reduces code duplication and risk to have same bug in other places) to list resources, rebuild compose project model, then filter by requested services

fix `docker compose stop SERVICE` with reference to other dependencies
bonus: `docker compose rm` doesn't need a compose file anymore

includes e2e test so we get rid of this bug and don't need yet another patch release🤞

**Related issue**
closes https://github.com/docker/compose/issues/9241
closes https://github.com/docker/compose/issues/9249

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
