### PR TITLE
don't fail trying to remove container with no candidate

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -165,7 +165,7 @@ SERVICES:
 				continue SERVICES
 			}
 		}
-		return project, errors.New("no such service: " + qs)
+		return project, errors.Wrapf(api.ErrNotFound, "no such service: %q", qs)
 	}
 	err := project.ForServices(services)
 	if err != nil {

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -32,6 +32,10 @@ import (
 func (s *composeService) Remove(ctx context.Context, projectName string, options api.RemoveOptions) error {
 	containers, _, err := s.actualState(ctx, projectName, options.Services)
 	if err != nil {
+		if api.IsNotFoundError(err) {
+			fmt.Fprintln(s.stderr(), "No stopped containers")
+			return nil
+		}
 		return err
 	}
 
@@ -45,7 +49,7 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 	})
 
 	if len(names) == 0 {
-		fmt.Println("No stopped containers")
+		fmt.Fprintln(s.stderr(), "No stopped containers")
 		return nil
 	}
 	msg := fmt.Sprintf("Going to remove %s", strings.Join(names, ", "))

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -188,6 +188,11 @@ func TestRm(t *testing.T) {
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName+"_simple"), res.Combined())
 	})
 
+	t.Run("rm -sf <none>", func(t *testing.T) {
+		res := c.RunDockerComposeCmd("-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "rm", "-sf", "simple")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+	})
+
 	t.Run("down", func(t *testing.T) {
 		c.RunDockerComposeCmd("-p", projectName, "down")
 	})


### PR DESCRIPTION
**What I did**
mark "service not found" as ErrNotFound so we can filter this our trying to remove containers while none match. Then just dump a warning, but exit with 0.
includes e2e test to prevent such regression in the future.

**Related issue**
closes #9255

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
