### PR TITLE
recreate container after image has been rebuilt/pulled

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -188,6 +188,15 @@ func (s *composeService) getLocalImagesDigests(ctx context.Context, project *typ
 	for name, info := range imgs {
 		images[name] = info.ID
 	}
+
+	for _, s := range project.Services {
+		imgName := getImageName(s, project.Name)
+		digest, ok := images[imgName]
+		if ok {
+			s.CustomLabels[api.ImageDigestLabel] = digest
+		}
+	}
+
 	return images, nil
 }
 

--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -93,7 +93,6 @@ func (s *composeService) getImages(ctx context.Context, images []string) (map[st
 			tag := ""
 			repository := ""
 			if len(inspect.RepoTags) > 0 {
-
 				repotag := strings.Split(inspect.RepoTags[0], ":")
 				repository = repotag[0]
 				if len(repotag) > 1 {


### PR DESCRIPTION
**What I did**
Fix service being re-created after image is rebuilt (`docker compose up --build`)
This also includes an improvement to set com.docker.compose.image to image ID when image exists in local store, so we can detect image tag been pulled with a refreshed content

**Related issue**
closes https://github.com/docker/compose/issues/9259

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
