### PR TITLE
Introduction compose config --parameters feature

### DIFF
--- a/cmd/compose/compose_test.go
+++ b/cmd/compose/compose_test.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"os"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -50,4 +51,226 @@ func TestFilterServices(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = p.GetService("zot")
 	assert.NilError(t, err)
+}
+
+func TestPrintParametersWithEnvFile(t *testing.T) {
+	dirName, err := os.MkdirTemp("", "docker_compose_dir")
+	if err != nil {
+		assert.NilError(t, err)
+	}
+
+	defer func() {
+		err := os.RemoveAll(dirName)
+		assert.NilError(t, err)
+	}()
+
+	dockerCompFile, err := os.CreateTemp(dirName, "docker-compose-*.yml")
+
+	if err != nil {
+		assert.NilError(t, err)
+	}
+	defer func() {
+		err := dockerCompFile.Close()
+		assert.NilError(t, err)
+	}()
+
+	defer func() {
+		err := os.Remove(dockerCompFile.Name())
+		assert.NilError(t, err)
+	}()
+
+	_, err = dockerCompFile.WriteString(`
+services:
+  redis:
+    image: redis
+  pg:
+    networks:
+      - backend
+    image: postgres
+    command: "${LOGGIN_LEVEL:-log_info}"
+networks:
+  frontend:
+    driver: custom-driver-1
+  backend:
+    driver: custom-driver-2
+    driver_opts:
+      foo: "${FOO_TEST_ENV_VAR}"
+      bar: "${BAR?error}"
+      buzz: "${BUZZ:-buzz}"`)
+
+	assert.NilError(t, err)
+
+	envFile, err := os.CreateTemp(dirName, "env_file-*")
+	assert.NilError(t, err)
+
+	defer func() {
+		err := envFile.Close()
+		assert.NilError(t, err)
+	}()
+	defer func() {
+		err := os.Remove(envFile.Name())
+		assert.NilError(t, err)
+	}()
+
+	_, err = envFile.WriteString("FOO_TEST_ENV_VAR=FILE_FOO_VALUE\nBAR=BAR_VALUE\n")
+	assert.NilError(t, err)
+
+	err = os.Setenv("FOO_TEST_ENV_VAR", "ENV_FOO_VALUE")
+	assert.NilError(t, err)
+
+	defer func() {
+		err := os.Unsetenv("FOO_TEST_ENV_VAR")
+		assert.NilError(t, err)
+	}()
+
+	p := projectOptions{
+		ConfigPaths: []string{dockerCompFile.Name()},
+		EnvFile:     envFile.Name(),
+		ProjectDir:  dirName,
+	}
+	opts := convertOptions{
+		projectOptions: &p,
+	}
+	params, err := getParameters(opts)
+
+	assert.NilError(t, err)
+
+	expectedMap := Parameters{
+		"BAR": Parameter{
+			Name:     "BAR",
+			Default:  "",
+			Required: true,
+			Actual:   "BAR_VALUE",
+			Source:   envFile.Name(),
+		},
+		"BUZZ": Parameter{
+			Name:     "BUZZ",
+			Default:  "buzz",
+			Required: false,
+			Actual:   "buzz",
+			Source:   dockerCompFile.Name(),
+		},
+		"FOO_TEST_ENV_VAR": Parameter{
+			Name:     "FOO_TEST_ENV_VAR",
+			Default:  "",
+			Required: false,
+			Actual:   "ENV_FOO_VALUE",
+			Source:   "os.Env",
+		},
+		"LOGGIN_LEVEL": Parameter{
+			Name:     "LOGGIN_LEVEL",
+			Default:  "log_info",
+			Required: false,
+			Actual:   "log_info",
+			Source:   dockerCompFile.Name(),
+		},
+	}
+	assert.Equal(t, len(params), len(expectedMap))
+	for key, val := range expectedMap {
+		assert.Equal(t, params[key], val)
+	}
+}
+
+func TestPrintParametersWithDotFile(t *testing.T) {
+	dirName, err := os.MkdirTemp("", "docker_compose_dir")
+	assert.NilError(t, err)
+
+	defer func() {
+		err := os.RemoveAll(dirName)
+		assert.NilError(t, err)
+	}()
+
+	dockerCompFile, err := os.CreateTemp(dirName, "docker-compose-*.yml")
+	assert.NilError(t, err)
+
+	defer func() {
+		err := dockerCompFile.Close()
+		assert.NilError(t, err)
+	}()
+	defer func() {
+		err := os.Remove(dockerCompFile.Name())
+		assert.NilError(t, err)
+	}()
+
+	_, err = dockerCompFile.WriteString(`
+services:
+  redis:
+    image: redis
+  pg:
+    networks:
+      - backend
+    image: postgres
+    command: "${LOGGIN_LEVEL:-log_info}"
+networks:
+  frontend:
+    driver: custom-driver-1
+  backend:
+    driver: custom-driver-2
+    driver_opts:
+      foo: "${FOO}"
+      bar: "${BAR?error}"
+      buzz: "${BUZZ:-buzz}"`)
+
+	assert.NilError(t, err)
+
+	envFile, err := os.Create(dirName + "/" + ".env")
+	assert.NilError(t, err)
+
+	defer func() {
+		err := envFile.Close()
+		assert.NilError(t, err)
+	}()
+	defer func() {
+		err := os.Remove(envFile.Name())
+		assert.NilError(t, err)
+	}()
+
+	_, err = envFile.WriteString("FOO=FOO_VALUE\nBAR=BAR_VALUE\n")
+	assert.NilError(t, err)
+
+	p := projectOptions{
+		ConfigPaths: []string{dockerCompFile.Name()},
+		ProjectDir:  dirName,
+	}
+	opts := convertOptions{
+		projectOptions: &p,
+	}
+	params, err := getParameters(opts)
+
+	assert.NilError(t, err)
+
+	expectedMap := Parameters{
+		"BAR": Parameter{
+			Name:     "BAR",
+			Default:  "",
+			Required: true,
+			Actual:   "BAR_VALUE",
+			Source:   ".env",
+		},
+		"BUZZ": Parameter{
+			Name:     "BUZZ",
+			Default:  "buzz",
+			Required: false,
+			Actual:   "buzz",
+			Source:   dockerCompFile.Name(),
+		},
+		"FOO": Parameter{
+			Name:     "FOO",
+			Default:  "",
+			Required: false,
+			Actual:   "FOO_VALUE",
+			Source:   ".env",
+		},
+		"LOGGIN_LEVEL": Parameter{
+			Name:     "LOGGIN_LEVEL",
+			Default:  "log_info",
+			Required: false,
+			Actual:   "log_info",
+			Source:   dockerCompFile.Name(),
+		},
+	}
+	assert.Equal(t, len(params), len(expectedMap))
+	for key, val := range expectedMap {
+		assert.Equal(t, params[key], val)
+	}
 }

--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -50,6 +50,7 @@ type convertOptions struct {
 	profiles            bool
 	images              bool
 	hash                string
+	parameters          bool
 }
 
 func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
@@ -89,6 +90,9 @@ func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
 			if opts.images {
 				return runConfigImages(opts, args)
 			}
+			if opts.parameters {
+				return runParameters(opts)
+			}
 
 			return runConvert(ctx, backend, opts, args)
 		}),
@@ -107,6 +111,7 @@ func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	flags.BoolVar(&opts.images, "images", false, "Print the image names, one per line.")
 	flags.StringVar(&opts.hash, "hash", "", "Print the service config hash, one per line.")
 	flags.StringVarP(&opts.Output, "output", "o", "", "Save to file (default to stdout)")
+	flags.BoolVar(&opts.parameters, "parameters", false, "Print the variables from the compose files")
 
 	return cmd
 }
@@ -235,5 +240,14 @@ func runConfigImages(opts convertOptions, services []string) error {
 			fmt.Printf("%s_%s\n", project.Name, s.Name)
 		}
 	}
+	return nil
+}
+
+func runParameters(opts convertOptions) error {
+	parameters, err := getParameters(opts)
+	if err != nil {
+		return err
+	}
+	fmt.Print(parameters)
 	return nil
 }

--- a/docs/reference/compose_convert.md
+++ b/docs/reference/compose_convert.md
@@ -17,6 +17,7 @@ Converts the compose file to platform's canonical format
 | `--no-interpolate` |  |  | Don't interpolate environment variables. |
 | `--no-normalize` |  |  | Don't normalize compose model. |
 | `-o`, `--output` | `string` |  | Save to file (default to stdout) |
+| `--parameters` |  |  | Print the variables from the compose files |
 | `--profiles` |  |  | Print the profile names, one per line. |
 | `-q`, `--quiet` |  |  | Only validate the configuration, don't print anything. |
 | `--resolve-image-digests` |  |  | Pin image tags to digests. |

--- a/docs/reference/docker_compose_convert.yaml
+++ b/docs/reference/docker_compose_convert.yaml
@@ -70,6 +70,16 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+- option: parameters
+  value_type: bool
+  default_value: "false"
+  description: Print the variables from the compose files
+  deprecated: false
+  hidden: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 - option: profiles
   value_type: bool
   default_value: "false"


### PR DESCRIPTION
Introduced the feature to print variables from config files with additional info like default value, required flag, actual value, source.

example usage:

```
❯ ./docker-compose config --parameters
NAME           DEFAULT    REQUIRED   ACTUAL      SOURCE
LOGGIN_LEVEL   log_info   false      log_info    /home/user/projects/compose/bin/docker-compose.yml
BAR                       true       BAR_VALUE   .env
BUZZ           buzz       false      buzz        /home/user/projects/compose/bin/docker-compose.yml
FOO                       false                  /home/user/projects/compose/bin/docker-compose.yml

```

**Related issue**
[feature proposal](https://github.com/docker/compose/issues/9226)

**Cute animal**

![image](https://user-images.githubusercontent.com/10071749/158072830-c7dafeaf-3703-4491-9e95-6e63b31a1803.png)

