### PR TITLE
kill only need project name

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -54,7 +54,7 @@ type Service interface {
 	// Convert translate compose model into backend's native format
 	Convert(ctx context.Context, project *types.Project, options ConvertOptions) ([]byte, error)
 	// Kill executes the equivalent to a `compose kill`
-	Kill(ctx context.Context, project *types.Project, options KillOptions) error
+	Kill(ctx context.Context, project string, options KillOptions) error
 	// RunOneOffContainer creates a service oneoff container and starts its dependencies
 	RunOneOffContainer(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 	// Remove executes the equivalent to a `compose rm`

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -37,7 +37,7 @@ type ServiceProxy struct {
 	PsFn                 func(ctx context.Context, projectName string, options PsOptions) ([]ContainerSummary, error)
 	ListFn               func(ctx context.Context, options ListOptions) ([]Stack, error)
 	ConvertFn            func(ctx context.Context, project *types.Project, options ConvertOptions) ([]byte, error)
-	KillFn               func(ctx context.Context, project *types.Project, options KillOptions) error
+	KillFn               func(ctx context.Context, project string, options KillOptions) error
 	RunOneOffContainerFn func(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 	RemoveFn             func(ctx context.Context, project string, options RemoveOptions) error
 	ExecFn               func(ctx context.Context, project string, opts RunOptions) (int, error)
@@ -219,12 +219,9 @@ func (s *ServiceProxy) Convert(ctx context.Context, project *types.Project, opti
 }
 
 // Kill implements Service interface
-func (s *ServiceProxy) Kill(ctx context.Context, project *types.Project, options KillOptions) error {
+func (s *ServiceProxy) Kill(ctx context.Context, project string, options KillOptions) error {
 	if s.KillFn == nil {
 		return ErrNotImplemented
-	}
-	for _, i := range s.interceptors {
-		i(ctx, project)
 	}
 	return s.KillFn(ctx, project, options)
 }

--- a/pkg/compose/kill.go
+++ b/pkg/compose/kill.go
@@ -18,8 +18,8 @@ package compose
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"golang.org/x/sync/errgroup"
 
@@ -27,29 +27,29 @@ import (
 	"github.com/docker/compose/v2/pkg/progress"
 )
 
-func (s *composeService) Kill(ctx context.Context, project *types.Project, options api.KillOptions) error {
+func (s *composeService) Kill(ctx context.Context, project string, options api.KillOptions) error {
 	return progress.Run(ctx, func(ctx context.Context) error {
 		return s.kill(ctx, project, options)
 	})
 }
 
-func (s *composeService) kill(ctx context.Context, project *types.Project, options api.KillOptions) error {
+func (s *composeService) kill(ctx context.Context, project string, options api.KillOptions) error {
 	w := progress.ContextWriter(ctx)
 
 	services := options.Services
-	if len(services) == 0 {
-		services = project.ServiceNames()
-	}
 
 	var containers Containers
-	containers, err := s.getContainers(ctx, project.Name, oneOffInclude, false, services...)
+	containers, err := s.getContainers(ctx, project, oneOffInclude, false, services...)
 	if err != nil {
 		return err
 	}
 
+	if len(containers) == 0 {
+		fmt.Fprintf(s.stderr(), "no container to kill")
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 	containers.
-		filter(isService(project.ServiceNames()...)).
 		forEach(func(container moby.Container) {
 			eg.Go(func() error {
 				eventName := getContainerProgressName(container)

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -60,7 +60,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		return progress.Run(ctx, func(ctx context.Context) error {
 			go func() {
 				<-signalChan
-				s.Kill(ctx, project, api.KillOptions{ // nolint:errcheck
+				s.Kill(ctx, project.Name, api.KillOptions{ // nolint:errcheck
 					Services: options.Create.Services,
 				})
 			}()


### PR DESCRIPTION
**What I did**
Removed need to get the original compose.yaml file to run `docker compose kill`

![image](https://user-images.githubusercontent.com/132757/158124152-abb5ed86-9680-4d60-a5d4-5c568dd966f9.png)
