### PR TITLE
Validate doc on pr

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-.git/
 bin/
 dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Validate go-mod is up-to-date and license headers
+      - name: Validate go-mod, license headers and docs are up-to-date
         run: make validate
 
       - name: Run golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,14 @@ lint: ## run linter(s)
 
 .PHONY: docs
 docs: ## generate documentation
-	@docker build . \
-	--output type=local,dest=./docs/ \
+	$(eval $@_TMP_OUT := $(shell mktemp -d -t dockercli-output.XXXXXXXXXX))
+	docker build . \
+	--output type=local,dest=$($@_TMP_OUT) \
 	-f ./docs/docs.Dockerfile \
 	--target update
+	rm -rf ./docs/internal
+	cp -R "$($@_TMP_OUT)"/out/* ./docs/
+	rm -rf "$($@_TMP_OUT)"/*
 
 .PHONY: validate-docs
 validate-docs: ## validate the doc does not change

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,19 @@ lint: ## run linter(s)
 	--build-arg GIT_TAG=$(GIT_TAG) \
 	--target lint
 
+.PHONY: docs
+docs: ## generate documentation
+	@docker build . \
+	--output type=local,dest=./docs/ \
+	-f ./docs/docs.Dockerfile \
+	--target update
+
+.PHONY: validate-docs
+validate-docs: ## validate the doc does not change
+	@docker build . \
+	-f ./docs/docs.Dockerfile \
+	--target validate
+
 .PHONY: check-dependencies
 check-dependencies: ## check dependency updates
 	go list -u -m -f '{{if not .Indirect}}{{if .Update}}{{.}}{{end}}{{end}}' all
@@ -98,7 +111,7 @@ go-mod-tidy: ## Run go mod tidy in a container and output resulting go.mod and g
 validate-go-mod: ## Validate go.mod and go.sum are up-to-date
 	@docker build . --target check-go-mod
 
-validate: validate-go-mod validate-headers ## Validate sources
+validate: validate-go-mod validate-headers validate-docs ## Validate sources
 
 pre-commit: validate check-dependencies lint compose-plugin test e2e-compose
 

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -70,7 +70,3 @@ check-license-headers:
 .PHONY: check-go-mod
 check-go-mod:
 	./scripts/validate/check-go-mod
-
-.PHONY: yamldocs
-yamldocs:
-	go run docs/yaml/main/generate.go

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -150,7 +150,7 @@ func runCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *
 	flags.StringArrayVarP(&opts.environment, "env", "e", []string{}, "Set environment variables")
 	flags.StringArrayVarP(&opts.labels, "label", "l", []string{}, "Add or override a label")
 	flags.BoolVar(&opts.Remove, "rm", false, "Automatically remove the container when it exits")
-	flags.BoolVarP(&opts.noTty, "no-TTY", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-noTty allocation. By default docker compose run allocates a TTY")
+	flags.BoolVarP(&opts.noTty, "no-TTY", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-noTty allocation (default: auto-detected).")
 	flags.StringVar(&opts.name, "name", "", " Assign a name to the container")
 	flags.StringVarP(&opts.user, "user", "u", "", "Run as specified username or uid")
 	flags.StringVarP(&opts.workdir, "workdir", "w", "", "Working directory inside the container")

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.3-labs
+
+
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+ARG GO_VERSION=1.17
+ARG FORMATS=md,yaml
+
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS docsgen
+WORKDIR /src
+RUN --mount=target=. \
+  --mount=target=/root/.cache,type=cache \
+  go build -o /out/docsgen ./docs/yaml/main/generate.go
+
+FROM --platform=${BUILDPLATFORM} alpine AS gen
+RUN apk add --no-cache rsync git
+WORKDIR /src
+COPY --from=docsgen /out/docsgen /usr/bin
+ARG FORMATS
+RUN --mount=target=/context \
+  --mount=target=.,type=tmpfs <<EOT
+set -e
+rsync -a /context/. .
+docsgen --formats "$FORMATS" --source "docs/reference"
+mkdir /out
+cp -r docs/reference /out
+EOT
+
+FROM scratch AS update
+COPY --from=gen /out /
+
+FROM gen AS validate
+RUN --mount=target=/context \
+  --mount=target=.,type=tmpfs <<EOT
+set -e
+rsync -a /context/. .
+git add -A
+rm -rf docs/reference/*
+cp -rf /out/* ./docs/
+if [ -n "$(git status --porcelain -- docs/reference)" ]; then
+  echo >&2 'ERROR: Docs result differs. Please update with "make docs"'
+  git status --porcelain -- docs/reference
+  exit 1
+fi
+EOT

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -39,7 +39,7 @@ cp -r docs/reference /out
 EOT
 
 FROM scratch AS update
-COPY --from=gen /out /
+COPY --from=gen /out /out
 
 FROM gen AS validate
 RUN --mount=target=/context \

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -13,7 +13,7 @@ Run a one-off command on a service.
 | `-i`, `--interactive` |  |  | Keep STDIN open even if not attached. |
 | `-l`, `--label` | `stringArray` |  | Add or override a label |
 | `--name` | `string` |  |  Assign a name to the container |
-| `-T`, `--no-TTY` |  |  | Disable pseudo-noTty allocation. By default docker compose run allocates a TTY |
+| `-T`, `--no-TTY` |  |  | Disable pseudo-noTty allocation (default: auto-detected). |
 | `--no-deps` |  |  | Don't start linked services. |
 | `-p`, `--publish` | `stringArray` |  | Publish a container's port(s) to the host. |
 | `--quiet-pull` |  |  | Pull without printing progress information. |

--- a/docs/reference/docker_compose_exec.yaml
+++ b/docs/reference/docker_compose_exec.yaml
@@ -46,7 +46,7 @@ options:
   shorthand: i
   value_type: bool
   default_value: "true"
-  description: Keep STDIN open even if not attached. DEPRECATED
+  description: Keep STDIN open even if not attached.
   deprecated: false
   hidden: true
   experimental: false
@@ -56,7 +56,7 @@ options:
 - option: no-TTY
   shorthand: T
   value_type: bool
-  default_value: "false"
+  default_value: "true"
   description: |
     Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.
   deprecated: false
@@ -79,7 +79,7 @@ options:
   shorthand: t
   value_type: bool
   default_value: "true"
-  description: Allocate a pseudo-TTY. DEPRECATED
+  description: Allocate a pseudo-TTY.
   deprecated: false
   hidden: true
   experimental: false

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -125,8 +125,7 @@ options:
   shorthand: T
   value_type: bool
   default_value: "true"
-  description: |
-    Disable pseudo-noTty allocation. By default docker compose run allocates a TTY
+  description: 'Disable pseudo-noTty allocation (default: auto-detected).'
   deprecated: false
   hidden: false
   experimental: false

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -124,7 +124,7 @@ options:
 - option: no-TTY
   shorthand: T
   value_type: bool
-  default_value: "false"
+  default_value: "true"
   description: |
     Disable pseudo-noTty allocation. By default docker compose run allocates a TTY
   deprecated: false

--- a/docs/yaml/main/generate.go
+++ b/docs/yaml/main/generate.go
@@ -22,16 +22,21 @@ import (
 	"path/filepath"
 
 	clidocstool "github.com/docker/cli-docs-tool"
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v2/cmd/compose"
 	"github.com/spf13/cobra"
 )
 
 func generateDocs(opts *options) error {
+	dockerCLI, err := command.NewDockerCli()
+	if err != nil {
+		return err
+	}
 	cmd := &cobra.Command{
 		Use:               "docker",
 		DisableAutoGenTag: true,
 	}
-	cmd.AddCommand(compose.RootCommand(nil, nil))
+	cmd.AddCommand(compose.RootCommand(dockerCLI, nil))
 	disableFlagsInUseLine(cmd)
 
 	tool, err := clidocstool.New(clidocstool.Options{


### PR DESCRIPTION
**What I did**
To be sure we're always in sync between the code and the reference documentation, we added in the Makefile:
- a command to generate the doc from a container
- a command to check if the documentation is up to date or not


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/158699513-a2e5f69d-e8f3-48e4-b897-ffd84ee38eba.png)
