### PR TITLE
Don't use ansi even when deprecated option is requested

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -272,7 +272,7 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command {
 					return errors.New(`cannot specify DEPRECATED "--no-ansi" and "--ansi". Please use only "--ansi"`)
 				}
 				ansi = "never"
-				fmt.Fprint(os.Stderr, aec.Apply("option '--no-ansi' is DEPRECATED ! Please use '--ansi' instead.\n", aec.RedF))
+				fmt.Fprint(os.Stderr, "option '--no-ansi' is DEPRECATED ! Please use '--ansi' instead.\n")
 			}
 			if verbose {
 				logrus.SetLevel(logrus.TraceLevel)


### PR DESCRIPTION
Signed-off-by: Daniel Lublin <daniel@lublin.se>

**I thought it insolent of docker-compose to emit ansi characters in the warning message, when it does in fact otherwise detect and honour --no-ansi, even though the option is deprecated**

**capybara_emoji**