### PR TITLE
pass interactive flag to ExecOptions for the RunExec command

### DIFF
--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -35,11 +35,12 @@ type execOpts struct {
 	environment []string
 	workingDir  string
 
-	noTty      bool
-	user       string
-	detach     bool
-	index      int
-	privileged bool
+	noTty       bool
+	user        string
+	detach      bool
+	index       int
+	privileged  bool
+	interactive bool
 }
 
 func execCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
@@ -71,7 +72,7 @@ func execCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) 
 	runCmd.Flags().BoolVarP(&opts.noTty, "no-TTY", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.")
 	runCmd.Flags().StringVarP(&opts.workingDir, "workdir", "w", "", "Path to workdir directory for this command.")
 
-	runCmd.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached.")
+	runCmd.Flags().BoolVarP(&opts.interactive, "interactive", "i", true, "Keep STDIN open even if not attached.")
 	runCmd.Flags().MarkHidden("interactive") //nolint:errcheck
 	runCmd.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY.")
 	runCmd.Flags().MarkHidden("tty") //nolint:errcheck
@@ -103,6 +104,7 @@ func runExec(ctx context.Context, backend api.Service, opts execOpts) error {
 		Index:       opts.index,
 		Detach:      opts.detach,
 		WorkingDir:  opts.workingDir,
+		Interactive: opts.interactive,
 	}
 
 	exitCode, err := backend.Exec(ctx, projectName, execOpts)


### PR DESCRIPTION
**What I did**
Pass the `interactive` flag from the Compose CLI to the Docker one to run exec command

**Related issue**
#9315 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/160209979-9b13e35b-394f-48ef-9db4-4cc072f5e2d7.png)
