### PR TITLE
use NamedContext so buildkit is aware of cross service build dependencies

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -243,10 +243,22 @@ func (s *composeService) toBuildOptions(project *types.Project, service types.Se
 		return build.Options{}, err
 	}
 
+	// Let buildkit know about other service being built, so that we can rely on a service image to build another one
+	otherServices := map[string]build.NamedContext{}
+	for _, s := range project.Services {
+		if s.Build != nil {
+			name := getImageName(service, project.Name)
+			otherServices[name] = build.NamedContext{
+				Path: s.Build.Context,
+			}
+		}
+	}
+
 	return build.Options{
 		Inputs: build.Inputs{
 			ContextPath:    service.Build.Context,
 			DockerfilePath: dockerFilePath(service.Build.Context, service.Build.Dockerfile),
+			NamedContexts:  otherServices,
 		},
 		CacheFrom:   cacheFrom,
 		CacheTo:     cacheTo,


### PR DESCRIPTION
**What I did**
Used `NamedContexts` so buildkit is aware of base image for a service being the actual result of another service build.

**Related issue**
closes https://github.com/docker/compose/issues/9232
closes https://github.com/docker/compose/issues/8538