### PR TITLE
Fix search/replace typo in --no-TTY documentation

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -150,7 +150,7 @@ func runCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *
 	flags.StringArrayVarP(&opts.environment, "env", "e", []string{}, "Set environment variables")
 	flags.StringArrayVarP(&opts.labels, "label", "l", []string{}, "Add or override a label")
 	flags.BoolVar(&opts.Remove, "rm", false, "Automatically remove the container when it exits")
-	flags.BoolVarP(&opts.noTty, "no-TTY", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-noTty allocation (default: auto-detected).")
+	flags.BoolVarP(&opts.noTty, "no-TTY", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-TTY allocation (default: auto-detected).")
 	flags.StringVar(&opts.name, "name", "", " Assign a name to the container")
 	flags.StringVarP(&opts.user, "user", "u", "", "Run as specified username or uid")
 	flags.StringVarP(&opts.workdir, "workdir", "w", "", "Working directory inside the container")

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -13,7 +13,7 @@ Run a one-off command on a service.
 | `-i`, `--interactive` |  |  | Keep STDIN open even if not attached. |
 | `-l`, `--label` | `stringArray` |  | Add or override a label |
 | `--name` | `string` |  |  Assign a name to the container |
-| `-T`, `--no-TTY` |  |  | Disable pseudo-noTty allocation (default: auto-detected). |
+| `-T`, `--no-TTY` |  |  | Disable pseudo-TTY allocation (default: auto-detected). |
 | `--no-deps` |  |  | Don't start linked services. |
 | `-p`, `--publish` | `stringArray` |  | Publish a container's port(s) to the host. |
 | `--quiet-pull` |  |  | Pull without printing progress information. |

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -125,7 +125,7 @@ options:
   shorthand: T
   value_type: bool
   default_value: "true"
-  description: 'Disable pseudo-noTty allocation (default: auto-detected).'
+  description: 'Disable pseudo-TTY allocation (default: auto-detected).'
   deprecated: false
   hidden: false
   experimental: false


### PR DESCRIPTION
**What I did**

Commit abbba74b27bfbcb7e5dea8018f02e2b065ad51d7 looks to have accidentally replaced `pseudo-tty` with `pseudo-noTty` in several places. In other places, it looks like it replaced `pseudo-tty` with `pseudo-TTY`, so I used the uppercased version in these places as well.

For example, running version 2.3.3, I get this output:

```
% docker-compose run --help

...

Options:
  ...
  -T, --no-TTY                Disable pseudo-noTty allocation. By default docker compose run allocates a TTY
  ...
```

I fixed what I believe were typos.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
