### PR TITLE
Takes COMPOSE_PROJECT_NAME into consideration on commands

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -143,6 +143,11 @@ func (o *projectOptions) toProjectName() (string, error) {
 		return o.ProjectName, nil
 	}
 
+	envProjectName := os.Getenv("COMPOSE_PROJECT_NAME")
+	if envProjectName != "" {
+		return envProjectName, nil
+	}
+
 	project, err := o.toProject(nil)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What I did**
Take `COMPOSE_PROJECT_NAME` into consideration on commands

**Related issue**
Resolves https://github.com/docker/compose/issues/9316
