### PR TITLE
fix typo in ssh option description

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -108,7 +108,7 @@ func buildCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.pull, "pull", false, "Always attempt to pull a newer version of the image.")
 	cmd.Flags().StringVar(&opts.progress, "progress", buildx.PrinterModeAuto, fmt.Sprintf(`Set type of progress output (%s)`, strings.Join(printerModes, ", ")))
 	cmd.Flags().StringArrayVar(&opts.args, "build-arg", []string{}, "Set build-time variables for services.")
-	cmd.Flags().StringVar(&opts.ssh, "ssh", "", "Set SSH authentications used when building service images. (use 'default' for using you default SSH Agent)")
+	cmd.Flags().StringVar(&opts.ssh, "ssh", "", "Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)")
 	cmd.Flags().Bool("parallel", true, "Build images in parallel. DEPRECATED")
 	cmd.Flags().MarkHidden("parallel") //nolint:errcheck
 	cmd.Flags().Bool("compress", true, "Compress the build context using gzip. DEPRECATED")

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -12,7 +12,7 @@ Build or rebuild services
 | `--progress` | `string` | `auto` | Set type of progress output (auto, tty, plain, quiet) |
 | `--pull` |  |  | Always attempt to pull a newer version of the image. |
 | `-q`, `--quiet` |  |  | Don't print anything to STDOUT |
-| `--ssh` | `string` |  | Set SSH authentications used when building service images. (use 'default' for using you default SSH Agent) |
+| `--ssh` | `string` |  | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -120,7 +120,7 @@ options:
 - option: ssh
   value_type: string
   description: |
-    Set SSH authentications used when building service images. (use 'default' for using you default SSH Agent)
+    Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)
   deprecated: false
   hidden: false
   experimental: false


### PR DESCRIPTION
**What I did**

I noticed a small typo in #9325 that was merged earlier and fixed that.

**Discussion:**

As I was looking at it more, I was wondering if it was helpful to reuse the description that `docker build` produces for `--ssh`:

> SSH agent socket or keys to expose to the build (only if BuildKit enabled) (format: default|\<id\>[=\<socket\>|\<key\>[,\<key\>]])
