### PR TITLE
Fix down command without any resource to delete

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/cli/cli/registry/client"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"golang.org/x/sync/errgroup"
@@ -131,6 +132,11 @@ func (s *composeService) ensureNetworksDown(ctx context.Context, project *types.
 			continue
 		}
 		networkName := n.Name
+		_, err := s.apiClient().NetworkInspect(ctx, networkName, moby.NetworkInspectOptions{})
+		if client.IsNotFound(err) {
+			return nil
+		}
+
 		ops = append(ops, func() error {
 			return s.removeNetwork(ctx, networkName, w)
 		})

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -23,7 +23,6 @@ import (
 
 	compose "github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/mocks"
-
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
@@ -60,6 +59,7 @@ func TestDown(t *testing.T) {
 	api.EXPECT().ContainerRemove(gomock.Any(), "456", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "789", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 
+	api.EXPECT().NetworkInspect(gomock.Any(), "myProject_default", moby.NetworkInspectOptions{}).Return(moby.NetworkResource{Name: "myProject_default"}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "myProject_default").Return(nil)
 
 	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{})
@@ -94,6 +94,7 @@ func TestDownRemoveOrphans(t *testing.T) {
 	api.EXPECT().ContainerRemove(gomock.Any(), "789", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "321", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 
+	api.EXPECT().NetworkInspect(gomock.Any(), "myProject_default", moby.NetworkInspectOptions{}).Return(moby.NetworkResource{Name: "myProject_default"}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "myProject_default").Return(nil)
 
 	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{RemoveOrphans: true})


### PR DESCRIPTION

**What I did**
A command down without any resource to delete was
trying to remove a default network that doesn't exist

**Related issue**
Resolves https://github.com/docker/compose/issues/9333

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
