### PR TITLE
now we use directly the Docker CLI to run autoremove flag should be p…

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -89,7 +89,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	updateServices(&service, observedState)
 
 	created, err := s.createContainer(ctx, project, service, service.ContainerName, 1,
-		opts.Detach && opts.AutoRemove, opts.UseNetworkAliases, opts.Interactive)
+		opts.AutoRemove, opts.UseNetworkAliases, opts.Interactive)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
…ass as is

**What I did**
Pass the `rm` flag value as is to the Docker CLI when running a container with this flag

fix #9314 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/161335318-b15e7678-7cce-430c-8a59-5d23fbd60036.png)
