### PR TITLE
use ssh config when building from compose up

### DIFF
--- a/pkg/e2e/compose_build_test.go
+++ b/pkg/e2e/compose_build_test.go
@@ -121,6 +121,16 @@ func TestLocalComposeBuild(t *testing.T) {
 		})
 	})
 
+	t.Run("build succeed as part of up with ssh from Compose file", func(t *testing.T) {
+		c.RunDockerOrExitError("rmi", "build-test-ssh")
+
+		c.RunDockerComposeCmd("--project-directory", "fixtures/build-test/ssh", "up", "-d", "--build")
+		t.Cleanup(func() {
+			c.RunDockerComposeCmd("--project-directory", "fixtures/build-test/ssh", "down")
+		})
+		c.RunDockerCmd("image", "inspect", "build-test-ssh")
+	})
+
 	t.Run("build as part of up", func(t *testing.T) {
 		c.RunDockerOrExitError("rmi", "build-test_nginx")
 		c.RunDockerOrExitError("rmi", "custom-nginx")


### PR DESCRIPTION
**What I did**
Add ssh config to the build options when building image from a `docker compose up` command

**Related issue**
Fix #9338 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/161341898-af8b9757-bb85-4f63-9bf3-012adea92a0b.png)
