### PR TITLE
Fix panic with down command when -p flag specified

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -82,7 +82,7 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 	ops := s.ensureNetworksDown(ctx, project, w)
 
 	if options.Images != "" {
-		ops = append(ops, s.ensureImagesDown(ctx, projectName, options, w)...)
+		ops = append(ops, s.ensureImagesDown(ctx, project, options, w)...)
 	}
 
 	if options.Volumes {
@@ -114,9 +114,9 @@ func (s *composeService) ensureVolumesDown(ctx context.Context, project *types.P
 	return ops
 }
 
-func (s *composeService) ensureImagesDown(ctx context.Context, projectName string, options api.DownOptions, w progress.Writer) []downOp {
+func (s *composeService) ensureImagesDown(ctx context.Context, project *types.Project, options api.DownOptions, w progress.Writer) []downOp {
 	var ops []downOp
-	for image := range s.getServiceImages(options, projectName) {
+	for image := range s.getServiceImages(options, project) {
 		image := image
 		ops = append(ops, func() error {
 			return s.removeImage(ctx, image, w)
@@ -144,15 +144,15 @@ func (s *composeService) ensureNetworksDown(ctx context.Context, project *types.
 	return ops
 }
 
-func (s *composeService) getServiceImages(options api.DownOptions, projectName string) map[string]struct{} {
+func (s *composeService) getServiceImages(options api.DownOptions, project *types.Project) map[string]struct{} {
 	images := map[string]struct{}{}
-	for _, service := range options.Project.Services {
+	for _, service := range project.Services {
 		image := service.Image
 		if options.Images == "local" && image != "" {
 			continue
 		}
 		if image == "" {
-			image = getImageName(service, projectName)
+			image = getImageName(service, project.Name)
 		}
 		images[image] = struct{}{}
 	}


### PR DESCRIPTION
use project instead of DownOptions.project to list service images in pkg.compose.down

**What I did**
Use  project structure get from project name instead of the potential nil project structure from the DownOptions when listing services images.

**Related issue**
fixes #9353 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/161624310-3c3c000f-2397-434e-85b8-1f54a29d3e56.png)
