### PR TITLE
Fix cannot setup IPAM gateway

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1059,7 +1059,10 @@ func (s *composeService) ensureNetwork(ctx context.Context, n types.NetworkConfi
 
 			for _, ipamConfig := range n.Ipam.Config {
 				config := network.IPAMConfig{
-					Subnet: ipamConfig.Subnet,
+					Subnet:     ipamConfig.Subnet,
+					IPRange:    ipamConfig.IPRange,
+					Gateway:    ipamConfig.Gateway,
+					AuxAddress: ipamConfig.AuxiliaryAddresses,
 				}
 				createOpts.IPAM.Config = append(createOpts.IPAM.Config, config)
 			}


### PR DESCRIPTION
**What I did**
Here is my docker-compose-yaml
```
services:
  test:
    image: nginx
    networks:
      - br-test

networks:
  br-test:
    driver: bridge
    ipam:
      config:
        - subnet: 172.17.4.0/24
          gateway: 172.17.4.1
```
I execute command `docker-compose up`, then I inspect `br-test` network.
But IPAM gateway doesn't be setup correctly.
```
[
    {
       ...
        "IPAM": {
            "Driver": "default",
            "Config": [
                {
                    "Subnet": "172.17.4.0/24"
                }
            ]
        }
        ...
    }
]
```

**Related issue**
fixes https://github.com/docker/compose/issues/9330

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
