### PR TITLE
include services declared by `links` as implicit dependencies

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -143,17 +143,8 @@ func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options 
 		return "", err
 	}
 
-	// if up to this point nothing has set the context then we must have another
-	// way for sending it(streaming) and set the context to the Dockerfile
-	if dockerfileCtx != nil && buildCtx == nil {
-		buildCtx = dockerfileCtx
-	}
-
 	progressOutput := streamformatter.NewProgressOutput(progBuff)
-	var body io.Reader
-	if buildCtx != nil {
-		body = progress.NewProgressReader(buildCtx, progressOutput, 0, "", "Sending build context to Docker daemon")
-	}
+	body := progress.NewProgressReader(buildCtx, progressOutput, 0, "", "Sending build context to Docker daemon")
 
 	configFile := s.configFile()
 	creds, err := configFile.GetAllCredentials()

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -173,6 +173,10 @@ func prepareServicesDependsOn(p *types.Project) error {
 			dependencies = append(dependencies, spec[0])
 		}
 
+		for _, link := range service.Links {
+			dependencies = append(dependencies, strings.Split(link, ":")[0])
+		}
+
 		if len(dependencies) == 0 {
 			continue
 		}


### PR DESCRIPTION
**What I did**
include services declared by `links` as implicit dependencies

also fix linter error, as build.Compress never returns a nil interface value

**Related issue**
see https://github.com/docker/compose/issues/9301

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/162397818-f4d6566a-5676-446a-a131-384d01afed01.png)
(Hanneton "Melolontha Melolontha")