### PR TITLE
create also a checksums.txt file, add --binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
         run: make GIT_TAG=${{ github.event.inputs.tag }} -f builder.Makefile cross
 
       - name: Compute checksums
-        run: cd bin; for f in *; do shasum --algorithm 256 $f > $f.sha256; done
+        run: cd bin; for f in *; do shasum --binary --algorithm 256 $f | tee -a checksums.txt > $f.sha256; done
 
       - name: License
         run: cp packaging/* bin/


### PR DESCRIPTION
**What I did**
create also a checksums.txt file
and switch shasum to --binary,
to Fix problems with the verification on different OS systems

**Related issue**
fixes #9388
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->