### PR TITLE
add support for ppc64le for docker compose

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -42,6 +42,12 @@ jobs:
           name: docker-compose-linux-amd64
           path: ${{ github.workspace }}/bin/docker-compose-linux-amd64
 
+      - name: Upload linux-ppc64le binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker-compose-linux-ppc64le
+          path: ${{ github.workspace }}/bin/docker-compose-linux-ppc64le
+
       - name: Upload windows-amd64 binary
         uses: actions/upload-artifact@v2
         with:

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -47,6 +47,7 @@ compose-plugin:
 .PHONY: cross
 cross:
 	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-x86_64 ./cmd
+	GOOS=linux   GOARCH=ppc64le $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-ppc64le ./cmd
 	GOOS=linux   GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-aarch64 ./cmd
 	GOOS=linux   GOARM=6 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-armv6 ./cmd
 	GOOS=linux   GOARM=7 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-armv7 ./cmd


### PR DESCRIPTION
Adding changes to CI pipeline to build and publish docker compose binary for ppc64le architecture.

