### PR TITLE
fix listing of services

### DIFF
--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -128,10 +128,15 @@ SERVICES:
 	}
 
 	if opts.Services {
+		project, err := opts.toProject(services)
+		if err != nil {
+			return err
+		}
+
 		services := []string{}
-		for _, s := range containers {
-			if !utils.StringContains(services, s.Service) {
-				services = append(services, s.Service)
+		for _, s := range project.Services {
+			if !utils.StringContains(services, s.Name) {
+				services = append(services, s.Name)
 			}
 		}
 		fmt.Println(strings.Join(services, "\n"))


### PR DESCRIPTION
**What I did**

Currently, when listing services in v2 (`compose ps --services`) only running containers are observed and listed since in the background the docker api is asked for matching containers. This pr fixes this behavior by using the full list of services provided by compose itself.

Since this is my first pr here, I would appreciate any feedback or ideas on how to better implement this. For example, I was thinking of a flag that would allow the user to select the desired behavior themselves, but since v1's service list was different, I just implemented the fix.

**Related issue**

The issue is described in #9391.

closes #9391
