### PR TITLE
Exclude docker-py 5.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2021.5.30
 chardet==3.0.4
 colorama==0.4.4; sys_platform == 'win32'
 distro==1.5.0
-docker==5.0.0
+docker>=5,!=5.0.1
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'texttable >= 0.9.0, < 2',
     'websocket-client >= 0.32.0, < 1',
     'distro >= 1.5.0, < 2',
-    'docker[ssh] >= 5',
+    'docker[ssh] >= 5, != 5.0.1',
     'dockerpty >= 0.4.1, < 1',
     'jsonschema >= 2.5.1, < 4',
     'python-dotenv >= 0.13.0, < 1',


### PR DESCRIPTION
Signed-off-by: Adam Aposhian <aposhian.dev@gmail.com>
Exclude docker-py 5.0.1 which is has broken `exec_run` documented here: https://github.com/docker/docker-py/issues/2885
This was fixed in docker-py 5.0.2: https://github.com/docker/docker-py/releases/tag/5.0.2

**Related issue**
Fixes #8500
