### PR TITLE
Fixes #9403: Exclude Named Pipes from volumeMounts

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -727,8 +727,12 @@ func (s *composeService) buildContainerVolumes(ctx context.Context, p types.Proj
 	binds := []string{}
 MOUNTS:
 	for _, m := range mountOptions {
+		if m.Type == mount.TypeNamedPipe {
+			mounts = append(mounts, m)
+			continue
+		}
 		volumeMounts[m.Target] = struct{}{}
-		if m.Type == mount.TypeBind || m.Type == mount.TypeNamedPipe {
+		if m.Type == mount.TypeBind {
 			// `Mount` is preferred but does not offer option to created host path if missing
 			// so `Bind` API is used here with raw volume string
 			// see https://github.com/moby/moby/issues/43483

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -44,6 +44,18 @@ func TestBuildBindMount(t *testing.T) {
 	assert.Equal(t, mount.Type, mountTypes.TypeBind)
 }
 
+func TestBuildNamedPipeMount(t *testing.T) {
+	project := composetypes.Project{}
+	volume := composetypes.ServiceVolumeConfig{
+		Type:   composetypes.VolumeTypeNamedPipe,
+		Source: "\\\\.\\pipe\\docker_engine_windows",
+		Target: "\\\\.\\pipe\\docker_engine",
+	}
+	mount, err := buildMount(project, volume)
+	assert.NilError(t, err)
+	assert.Equal(t, mount.Type, mountTypes.TypeNamedPipe)
+}
+
 func TestBuildVolumeMount(t *testing.T) {
 	project := composetypes.Project{
 		Name: "myProject",
@@ -97,6 +109,11 @@ func TestBuildContainerMountOptions(t *testing.T) {
 						Type:   composetypes.VolumeTypeVolume,
 						Target: "/var/myvolume2",
 					},
+					{
+						Type:   composetypes.VolumeTypeNamedPipe,
+						Source: "\\\\.\\pipe\\docker_engine_windows",
+						Target: "\\\\.\\pipe\\docker_engine",
+					},
 				},
 			},
 		},
@@ -128,18 +145,20 @@ func TestBuildContainerMountOptions(t *testing.T) {
 		return mounts[i].Target < mounts[j].Target
 	})
 	assert.NilError(t, err)
-	assert.Assert(t, len(mounts) == 2)
+	assert.Assert(t, len(mounts) == 3)
 	assert.Equal(t, mounts[0].Target, "/var/myvolume1")
 	assert.Equal(t, mounts[1].Target, "/var/myvolume2")
+	assert.Equal(t, mounts[2].Target, "\\\\.\\pipe\\docker_engine")
 
 	mounts, err = buildContainerMountOptions(project, project.Services[0], moby.ImageInspect{}, inherit)
 	sort.Slice(mounts, func(i, j int) bool {
 		return mounts[i].Target < mounts[j].Target
 	})
 	assert.NilError(t, err)
-	assert.Assert(t, len(mounts) == 2)
+	assert.Assert(t, len(mounts) == 3)
 	assert.Equal(t, mounts[0].Target, "/var/myvolume1")
 	assert.Equal(t, mounts[1].Target, "/var/myvolume2")
+	assert.Equal(t, mounts[2].Target, "\\\\.\\pipe\\docker_engine")
 }
 
 func TestGetDefaultNetworkMode(t *testing.T) {


### PR DESCRIPTION
If named pipe mounts are added to the `volumeMounts` mapping, the docker daemon will report an error that it cannot be mapped. This PR produces containers that inspect the same as ones created via `docker container create --mount "type=npipe,src=...,dst=..."`.

Note: the added tests do not actually test the changed lines -- the changed behavior is in a function that makes network calls (inspect?), so it isn't obvious to me how to test it without more refactoring. I wanted to keep this PR as minimal as possible to ease review. However, the tests do at least add some npipe-manipulation coverage.

**What I did**
Remove Named Pipes from `volumeMounts`

**Related issue**
#9403 