### PR TITLE
Clarify what default work dir is when multiple compose files

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -129,8 +129,8 @@ func (o *projectOptions) addProjectFlags(f *pflag.FlagSet) {
 	f.StringVarP(&o.ProjectName, "project-name", "p", "", "Project name")
 	f.StringArrayVarP(&o.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	f.StringVar(&o.EnvFile, "env-file", "", "Specify an alternate environment file.")
-	f.StringVar(&o.ProjectDir, "project-directory", "", "Specify an alternate working directory\n(default: the path of the Compose file)")
-	f.StringVar(&o.WorkDir, "workdir", "", "DEPRECATED! USE --project-directory INSTEAD.\nSpecify an alternate working directory\n(default: the path of the Compose file)")
+	f.StringVar(&o.ProjectDir, "project-directory", "", "Specify an alternate working directory\n(default: the path of the, first specified, Compose file)")
+	f.StringVar(&o.WorkDir, "workdir", "", "DEPRECATED! USE --project-directory INSTEAD.\nSpecify an alternate working directory\n(default: the path of the, first specified, Compose file)")
 	f.BoolVar(&o.Compatibility, "compatibility", false, "Run compose in backward compatibility mode")
 	_ = f.MarkHidden("workdir")
 }

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -44,7 +44,7 @@ Docker Compose
 | `-f`, `--file` | `stringArray` |  | Compose configuration files |
 | `--profile` | `stringArray` |  | Specify a profile to enable |
 | `--project-directory` | `string` |  | Specify an alternate working directory
-(default: the path of the Compose file) |
+(default: the path of the, first specified, Compose file) |
 | `-p`, `--project-name` | `string` |  | Project name |
 
 

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -222,7 +222,7 @@ options:
   value_type: string
   description: |-
     Specify an alternate working directory
-    (default: the path of the Compose file)
+    (default: the path of the, first specified, Compose file)
   deprecated: false
   hidden: false
   experimental: false
@@ -265,7 +265,7 @@ options:
   description: |-
     DEPRECATED! USE --project-directory INSTEAD.
     Specify an alternate working directory
-    (default: the path of the Compose file)
+    (default: the path of the, first specified, Compose file)
   deprecated: false
   hidden: true
   experimental: false


### PR DESCRIPTION
Signed-off-by: Daniel Lublin <daniel@lublin.se>

Clarify what default work dir is when multiple compose files is passed

:owl: 