### PR TITLE
cp command: copy to all containers of a service as default behaviour

### DIFF
--- a/cmd/compose/cp.go
+++ b/cmd/compose/cp.go
@@ -64,7 +64,7 @@ func copyCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	}
 
 	flags := copyCmd.Flags()
-	flags.IntVar(&opts.index, "index", 0, "Index of the container if there are multiple instances of a service [default: 1 when copying from a container].")
+	flags.IntVar(&opts.index, "index", 0, "Index of the container if there are multiple instances of a service .")
 	flags.BoolVar(&opts.all, "all", false, "Copy to all the containers of the service.")
 	flags.MarkHidden("all")                                                                                                      //nolint:errcheck
 	flags.MarkDeprecated("all", "By default all the containers of the service will get the source file/directory to be copied.") //nolint:errcheck

--- a/cmd/compose/cp.go
+++ b/cmd/compose/cp.go
@@ -55,7 +55,7 @@ func copyCommand(p *projectOptions, backend api.Service) *cobra.Command {
 			}
 			return nil
 		}),
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		RunE: AdaptCmd(func(ctx context.Context, cmd *cobra.Command, args []string) error {
 			opts.source = args[0]
 			opts.destination = args[1]
 			return runCopy(ctx, backend, opts)
@@ -64,8 +64,10 @@ func copyCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	}
 
 	flags := copyCmd.Flags()
-	flags.IntVar(&opts.index, "index", 1, "Index of the container if there are multiple instances of a service [default: 1].")
+	flags.IntVar(&opts.index, "index", 0, "Index of the container if there are multiple instances of a service [default: 1 when copying from a container].")
 	flags.BoolVar(&opts.all, "all", false, "Copy to all the containers of the service.")
+	flags.MarkHidden("all")                                                                                                      //nolint:errcheck
+	flags.MarkDeprecated("all", "By default all the containers of the service will get the source file/directory to be copied.") //nolint:errcheck
 	flags.BoolVarP(&opts.followLink, "follow-link", "L", false, "Always follow symbol link in SRC_PATH")
 	flags.BoolVarP(&opts.copyUIDGID, "archive", "a", false, "Archive mode (copy all uid/gid information)")
 

--- a/docs/reference/compose_cp.md
+++ b/docs/reference/compose_cp.md
@@ -9,7 +9,7 @@ Copy files/folders between a service container and the local filesystem
 | --- | --- | --- | --- |
 | `-a`, `--archive` |  |  | Archive mode (copy all uid/gid information) |
 | `-L`, `--follow-link` |  |  | Always follow symbol link in SRC_PATH |
-| `--index` | `int` | `0` | Index of the container if there are multiple instances of a service [default: 1 when copying from a container]. |
+| `--index` | `int` | `0` | Index of the container if there are multiple instances of a service . |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_cp.md
+++ b/docs/reference/compose_cp.md
@@ -7,10 +7,9 @@ Copy files/folders between a service container and the local filesystem
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `--all` |  |  | Copy to all the containers of the service. |
 | `-a`, `--archive` |  |  | Archive mode (copy all uid/gid information) |
 | `-L`, `--follow-link` |  |  | Always follow symbol link in SRC_PATH |
-| `--index` | `int` | `1` | Index of the container if there are multiple instances of a service [default: 1]. |
+| `--index` | `int` | `0` | Index of the container if there are multiple instances of a service [default: 1 when copying from a container]. |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_cp.yaml
+++ b/docs/reference/docker_compose_cp.yaml
@@ -42,7 +42,7 @@ options:
   value_type: int
   default_value: "0"
   description: |
-    Index of the container if there are multiple instances of a service [default: 1 when copying from a container].
+    Index of the container if there are multiple instances of a service .
   deprecated: false
   hidden: false
   experimental: false

--- a/docs/reference/docker_compose_cp.yaml
+++ b/docs/reference/docker_compose_cp.yaml
@@ -10,8 +10,8 @@ options:
   value_type: bool
   default_value: "false"
   description: Copy to all the containers of the service.
-  deprecated: false
-  hidden: false
+  deprecated: true
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -40,9 +40,9 @@ options:
   swarm: false
 - option: index
   value_type: int
-  default_value: "1"
+  default_value: "0"
   description: |
-    Index of the container if there are multiple instances of a service [default: 1].
+    Index of the container if there are multiple instances of a service [default: 1 when copying from a container].
   deprecated: false
   hidden: false
   experimental: false

--- a/pkg/compose/cp.go
+++ b/pkg/compose/cp.go
@@ -66,18 +66,23 @@ func (s *composeService) Copy(ctx context.Context, projectName string, options a
 		direction |= toService
 		serviceName = destService
 	}
-
-	containers, err := s.getContainers(ctx, projectName, oneOffExclude, true, serviceName)
-	if err != nil {
-		return err
-	}
-
-	if len(containers) < 1 {
-		return fmt.Errorf("no container found for service %q", serviceName)
-	}
-
+	var containers Containers
+	var err error
 	if direction == fromService || (direction == toService && options.Index > 0) {
-		containers = containers.filter(indexed(options.Index))
+		container, err := s.getSpecifiedContainer(ctx, projectName, oneOffExclude, true, serviceName, options.Index)
+		if err != nil {
+			return err
+		}
+		containers = append(containers, container)
+	} else {
+		containers, err = s.getContainers(ctx, projectName, oneOffExclude, true, serviceName)
+		if err != nil {
+			return err
+		}
+
+		if len(containers) < 1 {
+			return fmt.Errorf("no container found for service %q", serviceName)
+		}
 	}
 
 	g := errgroup.Group{}

--- a/pkg/compose/cp.go
+++ b/pkg/compose/cp.go
@@ -57,6 +57,10 @@ func (s *composeService) Copy(ctx context.Context, projectName string, options a
 		if options.All {
 			return errors.New("cannot use the --all flag when copying from a service")
 		}
+		// due to remove of the --all flag, restore the default value to 1 when copying from a service container to the host.
+		if options.Index == 0 {
+			options.Index = 1
+		}
 	}
 	if destService != "" {
 		direction |= toService
@@ -72,7 +76,7 @@ func (s *composeService) Copy(ctx context.Context, projectName string, options a
 		return fmt.Errorf("no container found for service %q", serviceName)
 	}
 
-	if !options.All {
+	if direction == fromService || (direction == toService && options.Index > 0) {
 		containers = containers.filter(indexed(options.Index))
 	}
 

--- a/pkg/compose/cp.go
+++ b/pkg/compose/cp.go
@@ -49,60 +49,71 @@ func (s *composeService) Copy(ctx context.Context, projectName string, options a
 
 	var direction copyDirection
 	var serviceName string
+	var copyFunc func(ctx context.Context, containerID string, srcPath string, dstPath string, opts api.CopyOptions) error
 	if srcService != "" {
 		direction |= fromService
 		serviceName = srcService
+		copyFunc = s.copyFromContainer
 
 		// copying from multiple containers of a services doesn't make sense.
 		if options.All {
 			return errors.New("cannot use the --all flag when copying from a service")
 		}
-		// due to remove of the --all flag, restore the default value to 1 when copying from a service container to the host.
-		if options.Index == 0 {
-			options.Index = 1
-		}
 	}
 	if destService != "" {
 		direction |= toService
 		serviceName = destService
+		copyFunc = s.copyToContainer
 	}
-	var containers Containers
-	var err error
-	if direction == fromService || (direction == toService && options.Index > 0) {
-		container, err := s.getSpecifiedContainer(ctx, projectName, oneOffExclude, true, serviceName, options.Index)
-		if err != nil {
-			return err
-		}
-		containers = append(containers, container)
-	} else {
-		containers, err = s.getContainers(ctx, projectName, oneOffExclude, true, serviceName)
-		if err != nil {
-			return err
-		}
+	if direction == acrossServices {
+		return errors.New("copying between services is not supported")
+	}
 
-		if len(containers) < 1 {
-			return fmt.Errorf("no container found for service %q", serviceName)
-		}
+	if direction == 0 {
+		return errors.New("unknown copy direction")
+	}
+
+	containers, err := s.listContainersTargetedForCopy(ctx, projectName, options.Index, direction, serviceName)
+	if err != nil {
+		return err
 	}
 
 	g := errgroup.Group{}
 	for _, container := range containers {
 		containerID := container.ID
 		g.Go(func() error {
-			switch direction {
-			case fromService:
-				return s.copyFromContainer(ctx, containerID, srcPath, dstPath, options)
-			case toService:
-				return s.copyToContainer(ctx, containerID, srcPath, dstPath, options)
-			case acrossServices:
-				return errors.New("copying between services is not supported")
-			default:
-				return errors.New("unknown copy direction")
-			}
+			return copyFunc(ctx, containerID, srcPath, dstPath, options)
 		})
 	}
 
 	return g.Wait()
+}
+
+func (s *composeService) listContainersTargetedForCopy(ctx context.Context, projectName string, index int, direction copyDirection, serviceName string) (Containers, error) {
+	var containers Containers
+	var err error
+	switch {
+	case index > 0:
+		container, err := s.getSpecifiedContainer(ctx, projectName, oneOffExclude, true, serviceName, index)
+		if err != nil {
+			return nil, err
+		}
+		return append(containers, container), nil
+	default:
+		containers, err = s.getContainers(ctx, projectName, oneOffExclude, true, serviceName)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(containers) < 1 {
+			return nil, fmt.Errorf("no container found for service %q", serviceName)
+		}
+		if direction == fromService {
+			return containers[:1], err
+
+		}
+		return containers, err
+	}
 }
 
 func (s *composeService) copyToContainer(ctx context.Context, containerID string, srcPath string, dstPath string, opts api.CopyOptions) error {

--- a/pkg/compose/exec.go
+++ b/pkg/compose/exec.go
@@ -18,14 +18,12 @@ package compose
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command/container"
 	"github.com/docker/compose/v2/pkg/api"
 	moby "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 )
 
 func (s *composeService) Exec(ctx context.Context, projectName string, options api.RunOptions) (int, error) {
@@ -59,19 +57,5 @@ func (s *composeService) Exec(ctx context.Context, projectName string, options a
 }
 
 func (s *composeService) getExecTarget(ctx context.Context, projectName string, opts api.RunOptions) (moby.Container, error) {
-	containers, err := s.apiClient().ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(
-			projectFilter(projectName),
-			serviceFilter(opts.Service),
-			containerNumberFilter(opts.Index),
-		),
-	})
-	if err != nil {
-		return moby.Container{}, err
-	}
-	if len(containers) < 1 {
-		return moby.Container{}, fmt.Errorf("service %q is not running container #%d", opts.Service, opts.Index)
-	}
-	container := containers[0]
-	return container, nil
+	return s.getSpecifiedContainer(ctx, projectName, oneOffInclude, false, opts.Service, opts.Index)
 }

--- a/pkg/e2e/cp_test.go
+++ b/pkg/e2e/cp_test.go
@@ -47,15 +47,18 @@ func TestCopy(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `nginx               running`})
 	})
 
-	t.Run("copy to container copies the file to the first container by default", func(t *testing.T) {
+	t.Run("copy to container copies the file to the all containers by default", func(t *testing.T) {
 		res := c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "./fixtures/cp-test/cp-me.txt", "nginx:/tmp/default.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
 		output := c.RunDockerCmd("exec", projectName+"-nginx-1", "cat", "/tmp/default.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
-		res = c.RunDockerOrExitError("exec", projectName+"_nginx_2", "cat", "/tmp/default.txt")
-		res.Assert(t, icmd.Expected{ExitCode: 1})
+		output = c.RunDockerCmd("exec", projectName+"-nginx-2", "cat", "/tmp/default.txt").Stdout()
+		assert.Assert(t, strings.Contains(output, `hello world`), output)
+
+		output = c.RunDockerCmd("exec", projectName+"-nginx-3", "cat", "/tmp/default.txt").Stdout()
+		assert.Assert(t, strings.Contains(output, `hello world`), output)
 	})
 
 	t.Run("copy to container with a given index copies the file to the given container", func(t *testing.T) {
@@ -67,20 +70,6 @@ func TestCopy(t *testing.T) {
 
 		res = c.RunDockerOrExitError("exec", projectName+"-nginx-2", "cat", "/tmp/indexed.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 1})
-	})
-
-	t.Run("copy to container with the all flag copies the file to all containers", func(t *testing.T) {
-		res := c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "--all", "./fixtures/cp-test/cp-me.txt", "nginx:/tmp/all.txt")
-		res.Assert(t, icmd.Expected{ExitCode: 0})
-
-		output := c.RunDockerCmd("exec", projectName+"-nginx-1", "cat", "/tmp/all.txt").Stdout()
-		assert.Assert(t, strings.Contains(output, `hello world`), output)
-
-		output = c.RunDockerCmd("exec", projectName+"-nginx-2", "cat", "/tmp/all.txt").Stdout()
-		assert.Assert(t, strings.Contains(output, `hello world`), output)
-
-		output = c.RunDockerCmd("exec", projectName+"-nginx-3", "cat", "/tmp/all.txt").Stdout()
-		assert.Assert(t, strings.Contains(output, `hello world`), output)
 	})
 
 	t.Run("copy from a container copies the file to the host from the first container by default", func(t *testing.T) {


### PR DESCRIPTION
**What I did**
Change the default behaviour of the `cp` command when copying from host to a service. Now it will copy the source to all the containers of a service instead of the first one previously

Deprecation of the `--all` flag


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/166538291-9bdb1781-3ba0-4bee-a171-b0632b0947f5.png)

