### PR TITLE
Improve contributing instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,6 +43,7 @@ make e2e-compose
 ```
 
 Note that this requires a local Docker Engine to be running.
+Make sure you have built the CLI (see "Building the CLI"). Otherwise it uses `docker compose` available in your system.
 
 ## Releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Fork the repository and make changes on your fork in a feature branch:
 
 Submit unit tests for your changes. Go has a great test framework built in; use
 it! Take a look at existing tests for inspiration. [Run the full test
-suite](README.md) on your branch before
+suite](BUILDING.md) on your branch before
 submitting a pull request.
 
 Write clean code. Universally formatted code promotes ease of writing, reading,


### PR DESCRIPTION
**What I did**

* Minor improves for contributing instructions:
    * Link to BUILDING.md for testing instructions.
    * Not that you have to build the binary prior to `make e2e-compose`.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

None

