### PR TITLE
Fix extra space printed with `--no-log-prefix` option

### DIFF
--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -79,7 +79,7 @@ func (l *logConsumer) Log(container, service, message string) {
 	}
 	p := l.getPresenter(container)
 	for _, line := range strings.Split(message, "\n") {
-		fmt.Fprintf(l.writer, "%s %s\n", p.prefix, line) // nolint:errcheck
+		fmt.Fprintf(l.writer, "%s%s\n", p.prefix, line) // nolint:errcheck
 	}
 }
 
@@ -118,5 +118,5 @@ type presenter struct {
 }
 
 func (p *presenter) setPrefix(width int) {
-	p.prefix = p.colors(fmt.Sprintf("%-"+strconv.Itoa(width)+"s |", p.name))
+	p.prefix = p.colors(fmt.Sprintf("%-"+strconv.Itoa(width)+"s | ", p.name))
 }


### PR DESCRIPTION
**What I did**

Fix a bug causing the `up` and `logs` commands to prepend a single space to every line output when using the `--no-log-prefix` option.

**Related issue**

Fixes #9464

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**