### PR TITLE
introduce --pull

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -57,6 +57,7 @@ func createCommand(p *projectOptions, backend api.Service) *cobra.Command {
 			return nil
 		}),
 		RunE: p.WithProject(func(ctx context.Context, project *types.Project) error {
+			opts.Apply(project)
 			return backend.Create(ctx, project, api.CreateOptions{
 				RemoveOrphans:        opts.removeOrphans,
 				IgnoreOrphans:        opts.ignoreOrphans,

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -115,6 +115,7 @@ func upCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	flags.BoolVarP(&up.Detach, "detach", "d", false, "Detached mode: Run containers in the background")
 	flags.BoolVar(&create.Build, "build", false, "Build images before starting containers.")
 	flags.BoolVar(&create.noBuild, "no-build", false, "Don't build an image, even if it's missing.")
+	flags.StringVar(&create.Pull, "pull", "missing", `Pull image before running ("always"|"missing"|"never")`)
 	flags.BoolVar(&create.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
 	flags.StringArrayVar(&up.scale, "scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
 	flags.BoolVar(&up.noColor, "no-color", false, "Produce monochrome output.")

--- a/docs/reference/compose_create.md
+++ b/docs/reference/compose_create.md
@@ -11,6 +11,7 @@ Creates containers for a service.
 | `--force-recreate` |  |  | Recreate containers even if their configuration and image haven't changed. |
 | `--no-build` |  |  | Don't build an image, even if it's missing. |
 | `--no-recreate` |  |  | If containers already exist, don't recreate them. Incompatible with --force-recreate. |
+| `--pull` | `string` | `missing` | Pull image before running ("always"\|"missing"\|"never") |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -21,6 +21,7 @@ Create and start containers
 | `--no-log-prefix` |  |  | Don't print prefix in logs. |
 | `--no-recreate` |  |  | If containers already exist, don't recreate them. Incompatible with --force-recreate. |
 | `--no-start` |  |  | Don't start the services after creating them. |
+| `--pull` | `string` | `missing` | Pull image before running ("always"\|"missing"\|"never") |
 | `--quiet-pull` |  |  | Pull without printing progress information. |
 | `--remove-orphans` |  |  | Remove containers for services not defined in the Compose file. |
 | `-V`, `--renew-anon-volumes` |  |  | Recreate anonymous volumes instead of retrieving data from the previous containers. |

--- a/docs/reference/docker_compose_create.yaml
+++ b/docs/reference/docker_compose_create.yaml
@@ -47,6 +47,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: pull
+      value_type: string
+      default_value: missing
+      description: Pull image before running ("always"|"missing"|"never")
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -165,6 +165,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: pull
+      value_type: string
+      default_value: missing
+      description: Pull image before running ("always"|"missing"|"never")
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet-pull
       value_type: bool
       default_value: "false"


### PR DESCRIPTION
**What I did**
Introduce `--pull` flag so user can force pull of up-to-date service images (same as `docker run --pull`

**Related issue**
close https://github.com/docker/compose/issues/9451

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/168835131-75d4504c-584c-46cb-8315-089cad15d3c9.png)
