### PR TITLE
fix: prevent flickering prompt when pulling same image from N services

### DIFF
--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -83,7 +83,10 @@ func (w *ttyWriter) Event(e Event) {
 		last.Status = e.Status
 		last.Text = e.Text
 		last.StatusText = e.StatusText
-		last.ParentID = e.ParentID
+		// allow set/unset of parent, but not swapping otherwise prompt is flickering
+		if last.ParentID == "" || e.ParentID == "" {
+			last.ParentID = e.ParentID
+		}
 		w.events[e.ID] = last
 	} else {
 		e.startTime = time.Now()


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@docker.com>

**What I did**

Prevent event's parent to be swapped for another, since it uses the same ID it would make the prompt to flicker.

Current issue can be seen by using the following compose file : 

```yaml
services:
  a:
    image: ubuntu:22.10
  b:
    image: ubuntu:22.10
```

*Note: Use both same large images to make the issue appear longer*

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Fixes #9469 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![](https://i.pinimg.com/originals/f7/ff/e7/f7ffe77a7281fa4ed241d1b6f70a2b10.jpg)
