### PR TITLE
use AdaptCmd when executing run command to properly propagate syscall…

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -134,7 +134,7 @@ func runCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *
 			}
 			return nil
 		}),
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		RunE: AdaptCmd(func(ctx context.Context, cmd *cobra.Command, args []string) error {
 			project, err := p.toProject([]string{opts.Service}, cgo.WithResolvedPaths(true))
 			if err != nil {
 				return err


### PR DESCRIPTION
… to the container process

**What I did**
Use the AdaptCmd when executing `run` command and correctly intercept and propagate syscall to the container

**Related issue**
Internal support ticket

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/169403566-b4c004cd-fd44-4e50-a0f3-71f1d7f97bfb.png)
