### PR TITLE
attach _only_ to services declared by project applying profiles

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -185,6 +185,9 @@ func runUp(ctx context.Context, backend api.Service, createOptions createOptions
 	if upOptions.attachDependencies {
 		attachTo = project.ServiceNames()
 	}
+	if len(attachTo) == 0 {
+		attachTo = project.ServiceNames()
+	}
 
 	create := api.CreateOptions{
 		Services:             services,

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -61,12 +61,12 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 			go func() {
 				<-signalChan
 				s.Kill(ctx, project.Name, api.KillOptions{ // nolint:errcheck
-					Services: options.Create.Services,
+					Services: project.ServiceNames(),
 				})
 			}()
 
 			return s.Stop(ctx, project.Name, api.StopOptions{
-				Services: options.Create.Services,
+				Services: project.ServiceNames(),
 			})
 		})
 	}


### PR DESCRIPTION
**What I did**
ensure we only attach to services defined by project with applied profiles
if we don't, we will attach to all containers created with project label, which might match disabled profiles

**Related issue**
close https://github.com/docker/compose/issues/9286

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
