### PR TITLE
fix: bring up services with deps with --no-deps

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -183,7 +183,11 @@ func prepareServicesDependsOn(p *types.Project) error {
 		if service.DependsOn == nil {
 			service.DependsOn = make(types.DependsOnConfig)
 		}
-		deps, err := p.GetServices(dependencies...)
+
+		// Verify dependencies exist in the project, whether disabled or not
+		projAllServices := types.Project{}
+		projAllServices.Services = p.AllServices()
+		deps, err := projAllServices.GetServices(dependencies...)
 		if err != nil {
 			return err
 		}

--- a/pkg/e2e/fixtures/links/compose.yaml
+++ b/pkg/e2e/fixtures/links/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  foo:
+    image: nginx:alpine
+    links:
+      - bar
+
+  bar:
+    image: nginx:alpine

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -131,10 +131,11 @@ func TestStartStopWithDependencies(t *testing.T) {
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-dependencies-foo-1"), res.Combined())
 	})
 
-	t.Run("Up no-deps", func(t *testing.T) {
+	t.Run("Up no-deps links", func(t *testing.T) {
 		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
-		res := c.RunDockerComposeCmd("-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName, "up", "--no-deps", "-d", "foo")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/links/compose.yaml", "--project-name", projectName, "up", "--no-deps", "-d", "foo")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-foo-1  Started"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-bar-1  Started"), res.Combined())
 	})
 
 	t.Run("down", func(t *testing.T) {

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -131,6 +131,12 @@ func TestStartStopWithDependencies(t *testing.T) {
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-dependencies-foo-1"), res.Combined())
 	})
 
+	t.Run("Up no-deps", func(t *testing.T) {
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName, "up", "--no-deps", "-d", "foo")
+		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-foo-1  Started"), res.Combined())
+	})
+
 	t.Run("down", func(t *testing.T) {
 		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})


### PR DESCRIPTION
**What I did**

Don't fail on not finding dependent services because they were put in the disabled slice.

**Related issue**
#9427.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![Photo by Artem Lysenko from Pexels](https://images.pexels.com/photos/2168831/pexels-photo-2168831.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1)
