### PR TITLE
TC: Use switch case to simplify flag conversion and avoid multiple if statements

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -43,7 +43,7 @@ func getStringFlags() []string {
 	}
 }
 
-var argToActualFlag = map[string]string{
+var argToActualArgument = map[string]string{
 	"--verbose": "--debug",
 	// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
 	"-h": "--help",
@@ -67,8 +67,8 @@ func Convert(args []string) []string {
 			command = append(command, args[i:]...)
 			break
 		}
-		if actualFlag, ok := argToActualFlag[arg]; ok {
-			arg = actualFlag
+		if actualArgument, ok := argToActualArgument[arg]; ok {
+			arg = actualArgument
 		}
 		if contains(getBoolFlags(), arg) {
 			rootFlags = append(rootFlags, arg)

--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -43,15 +43,6 @@ func getStringFlags() []string {
 	}
 }
 
-var argToActualArgument = map[string]string{
-	"--verbose": "--debug",
-	// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
-	"-h": "--help",
-	// redirect --version pseudo-command to actual command
-	"--version": "version",
-	"-v":        "version",
-}
-
 // Convert transforms standalone docker-compose args into CLI plugin compliant ones
 func Convert(args []string) []string {
 	var rootFlags []string
@@ -67,9 +58,18 @@ func Convert(args []string) []string {
 			command = append(command, args[i:]...)
 			break
 		}
-		if actualArgument, ok := argToActualArgument[arg]; ok {
-			arg = actualArgument
+
+		switch arg {
+		case "--verbose":
+			arg = "--debug"
+		case "-h":
+			// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
+			arg = "--help"
+		case "--version", "-v":
+			// redirect --version pseudo-command to actual command
+			arg = "version"
 		}
+
 		if contains(getBoolFlags(), arg) {
 			rootFlags = append(rootFlags, arg)
 			continue

--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -43,6 +43,15 @@ func getStringFlags() []string {
 	}
 }
 
+var argToActualFlag = map[string]string{
+	"--verbose": "--debug",
+	// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
+	"-h": "--help",
+	// redirect --version pseudo-command to actual command
+	"--version": "version",
+	"-v":        "version",
+}
+
 // Convert transforms standalone docker-compose args into CLI plugin compliant ones
 func Convert(args []string) []string {
 	var rootFlags []string
@@ -58,16 +67,8 @@ func Convert(args []string) []string {
 			command = append(command, args[i:]...)
 			break
 		}
-		if arg == "--verbose" {
-			arg = "--debug"
-		}
-		if arg == "-h" {
-			// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
-			arg = "--help"
-		}
-		if arg == "--version" || arg == "-v" {
-			// redirect --version pseudo-command to actual command
-			arg = "version"
+		if actualFlag, ok := argToActualFlag[arg]; ok {
+			arg = actualFlag
 		}
 		if contains(getBoolFlags(), arg) {
 			rootFlags = append(rootFlags, arg)

--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -44,8 +44,18 @@ func Test_convert(t *testing.T) {
 			want: []string{"--host", "tcp://1.2.3.4", "compose", "up"},
 		},
 		{
+			name: "compose --verbose",
+			args: []string{"--verbose"},
+			want: []string{"--debug", "compose"},
+		},
+		{
 			name: "compose --version",
 			args: []string{"--version"},
+			want: []string{"compose", "version"},
+		},
+		{
+			name: "compose -v",
+			args: []string{"-v"},
 			want: []string{"compose", "version"},
 		},
 		{


### PR DESCRIPTION
**What I did**
I used a map to remove multiple if statements from the code and make it easier to add new argument conversions.
Also, I added missing tests for `-v` and `--verbose`.

**Related issue**
There are no related issues.
