### PR TITLE
Add links to container create request.

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -355,6 +355,11 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		volumesFrom = append(volumesFrom, v[len("container:"):])
 	}
 
+	links, err := s.getLinks(ctx, p.Name, service, number)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	securityOpts, err := parseSecurityOpts(p, service.SecurityOpt)
 	if err != nil {
 		return nil, nil, nil, err
@@ -389,6 +394,7 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		Runtime:        service.Runtime,
 		LogConfig:      logConfig,
 		GroupAdd:       service.GroupAdd,
+		Links:          links,
 	}
 
 	return &containerConfig, &hostConfig, networkConfig, nil

--- a/pkg/e2e/fixtures/network-links/compose.yaml
+++ b/pkg/e2e/fixtures/network-links/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  container1:
+    image: nginx
+    network_mode: bridge
+  container2:
+    image: nginx
+    network_mode: bridge
+    links:
+      - container1

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -69,7 +69,7 @@ func TestNetworks(t *testing.T) {
 	})
 }
 
-func TestNetworkAliassesAndLinks(t *testing.T) {
+func TestNetworkAliasses(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 
 	const projectName = "network_alias_e2e"
@@ -85,6 +85,25 @@ func TestNetworkAliassesAndLinks(t *testing.T) {
 
 	t.Run("curl links", func(t *testing.T) {
 		res := c.RunDockerComposeCmd("-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName, "exec", "-T", "container1", "curl", "http://container/")
+		assert.Assert(t, strings.Contains(res.Stdout(), "Welcome to nginx!"), res.Stdout())
+	})
+
+	t.Run("down", func(t *testing.T) {
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
+	})
+}
+
+func TestNetworkLinks(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	const projectName = "network_link_e2e"
+
+	t.Run("up", func(t *testing.T) {
+		c.RunDockerComposeCmd("-f", "./fixtures/network-links/compose.yaml", "--project-name", projectName, "up", "-d")
+	})
+
+	t.Run("curl links in default bridge network", func(t *testing.T) {
+		res := c.RunDockerComposeCmd("-f", "./fixtures/network-links/compose.yaml", "--project-name", projectName, "exec", "-T", "container2", "curl", "http://container1/")
 		assert.Assert(t, strings.Contains(res.Stdout(), "Welcome to nginx!"), res.Stdout())
 	})
 


### PR DESCRIPTION
In v1, links were sent alongside the rest of the container create request, as part of `HostConfig`. In v2, links are usually set on the connect container to network request that happens after the create. However, this only happens if the service has one or more networks defined for it. If the services are configured to use the default bridge network, this request is not made and so links are never configured.

**What I did**

Add service links to container create request.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Resolves #9513

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![IMG_2205](https://user-images.githubusercontent.com/70572044/171525311-c36207f0-4a7f-4b4e-918e-f8d31f75be34.jpg)


Signed-off-by: Laura Brehm <laurabrehm@hey.com>
