### PR TITLE
Fix deploy cpus issue and support pids limit

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -595,8 +595,9 @@ func setLimits(limits *types.Resource, resources *container.Resources) {
 		resources.Memory = int64(limits.MemoryBytes)
 	}
 	if limits.NanoCPUs != "" {
-		i, _ := strconv.ParseInt(limits.NanoCPUs, 10, 64)
-		resources.NanoCPUs = i
+		if f, err := strconv.ParseFloat(limits.NanoCPUs, 64); err == nil {
+			resources.NanoCPUs = int64(f * 1e9)
+		}
 	}
 }
 

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -599,6 +599,9 @@ func setLimits(limits *types.Resource, resources *container.Resources) {
 			resources.NanoCPUs = int64(f * 1e9)
 		}
 	}
+	if limits.PIds > 0 {
+		resources.PidsLimit = &limits.PIds
+	}
 }
 
 func setBlkio(blkio *types.BlkioConfig, resources *container.Resources) {


### PR DESCRIPTION
**What I did**
`deploy.limits.cpus` value could be a float value, you may want to use only `0.5` or `1.4` cpus for your containers, so I changed the parsing of the property to match those cases

I also add the `deploy.limit.pids` property to the container configuration when this one is setup

**Related issue**
fix #9542 #9501 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/173033173-22e46e64-b9f4-4fac-8bf2-939bdaef381a.png)
