### PR TITLE
Only start direct dependencies of service on `compose run ...`

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -262,7 +262,9 @@ func startDependencies(ctx context.Context, backend api.Service, project types.P
 	}
 
 	if len(dependencies) > 0 {
-		return backend.Start(ctx, project.Name, api.StartOptions{})
+		return backend.Start(ctx, project.Name, api.StartOptions{
+			Project: &project,
+		})
 	}
 	return nil
 }

--- a/pkg/e2e/fixtures/run-test/deps.yaml
+++ b/pkg/e2e/fixtures/run-test/deps.yaml
@@ -1,0 +1,14 @@
+version: "3.6"
+services:
+  service_a:
+    image: bash
+    command: echo "a"
+    depends_on:
+      - shared_dep
+  service_b:
+    image: bash
+    command: echo "b"
+    depends_on:
+      - shared_dep
+  shared_dep:
+    image: bash


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Send project w/ services on start request when starting dependencies so that only the dependencies we want get started before `compose run ...`

Also adds e2e test for this scenario.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Fixes #9459

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![B994D8D1-D59E-4224-A5D0-7792268B4AF4](https://user-images.githubusercontent.com/70572044/173461754-9a24d0fa-24ee-49ec-ae1f-437c5b0c4f50.JPG)

