### PR TITLE
e2e: isolate test command env from system env

### DIFF
--- a/pkg/e2e/compose_build_test.go
+++ b/pkg/e2e/compose_build_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -81,11 +80,6 @@ func TestLocalComposeBuild(t *testing.T) {
 	})
 
 	t.Run("build failed with ssh default value", func(t *testing.T) {
-		//unset SSH_AUTH_SOCK to be sure we don't have a default value for the SSH Agent
-		defaultSSHAUTHSOCK := os.Getenv("SSH_AUTH_SOCK")
-		os.Unsetenv("SSH_AUTH_SOCK")                         //nolint:errcheck
-		defer os.Setenv("SSH_AUTH_SOCK", defaultSSHAUTHSOCK) //nolint:errcheck
-
 		res := c.RunDockerComposeCmdNoCheck(t, "--project-directory", "fixtures/build-test", "build", "--ssh", "")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,

--- a/pkg/e2e/compose_environment_test.go
+++ b/pkg/e2e/compose_environment_test.go
@@ -45,7 +45,8 @@ func TestEnvPriority(t *testing.T) {
 		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose-with-env.yaml",
 			"--project-directory", projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run",
 			"--rm", "-e", "WHEREAMI", "env-compose-priority")
-		res := icmd.RunCmd(cmd, icmd.WithEnv("WHEREAMI=shell"))
+		cmd.Env = append(cmd.Env, "WHEREAMI=shell")
+		res := icmd.RunCmd(cmd)
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "Compose File")
 	})
 
@@ -59,7 +60,8 @@ func TestEnvPriority(t *testing.T) {
 		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
 			projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run", "--rm", "-e",
 			"WHEREAMI", "env-compose-priority")
-		res := icmd.RunCmd(cmd, icmd.WithEnv("WHEREAMI=shell"))
+		cmd.Env = append(cmd.Env, "WHEREAMI=shell")
+		res := icmd.RunCmd(cmd)
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "shell")
 	})
 
@@ -133,7 +135,8 @@ func TestEnvInterpolation(t *testing.T) {
 	t.Run("shell priority from run command", func(t *testing.T) {
 		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-interpolation/compose.yaml",
 			"--project-directory", projectDir, "config")
-		res := icmd.RunCmd(cmd, icmd.WithEnv("WHEREAMI=shell"))
+		cmd.Env = append(cmd.Env, "WHEREAMI=shell")
+		res := icmd.RunCmd(cmd)
 		res.Assert(t, icmd.Expected{Out: `IMAGE: default_env:shell`})
 	})
 }

--- a/pkg/e2e/compose_environment_test.go
+++ b/pkg/e2e/compose_environment_test.go
@@ -17,7 +17,6 @@
 package e2e
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -43,13 +42,10 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("compose file priority", func(t *testing.T) {
-		os.Setenv("WHEREAMI", "shell") //nolint:errcheck
-		defer os.Unsetenv("WHEREAMI")  //nolint:errcheck
-
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose-with-env.yaml",
-			"--project-directory", projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override",
-			"run", "--rm", "-e", "WHEREAMI", "env-compose-priority")
-
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose-with-env.yaml",
+			"--project-directory", projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run",
+			"--rm", "-e", "WHEREAMI", "env-compose-priority")
+		res := icmd.RunCmd(cmd, icmd.WithEnv("WHEREAMI=shell"))
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "Compose File")
 	})
 
@@ -60,12 +56,10 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("shell priority", func(t *testing.T) {
-		os.Setenv("WHEREAMI", "shell") //nolint:errcheck
-		defer os.Unsetenv("WHEREAMI")  //nolint:errcheck
-
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml",
-			"--project-directory", projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override",
-			"run", "--rm", "-e", "WHEREAMI", "env-compose-priority")
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
+			projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run", "--rm", "-e",
+			"WHEREAMI", "env-compose-priority")
+		res := icmd.RunCmd(cmd, icmd.WithEnv("WHEREAMI=shell"))
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "shell")
 	})
 
@@ -137,11 +131,9 @@ func TestEnvInterpolation(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("shell priority from run command", func(t *testing.T) {
-		os.Setenv("WHEREAMI", "shell") //nolint:errcheck
-		defer os.Unsetenv("WHEREAMI")  //nolint:errcheck
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-interpolation/compose.yaml",
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-interpolation/compose.yaml",
 			"--project-directory", projectDir, "config")
-
+		res := icmd.RunCmd(cmd, icmd.WithEnv("WHEREAMI=shell"))
 		res.Assert(t, icmd.Expected{Out: `IMAGE: default_env:shell`})
 	})
 }

--- a/pkg/e2e/ddev_test.go
+++ b/pkg/e2e/ddev_test.go
@@ -56,8 +56,6 @@ func TestComposeRunDdev(t *testing.T) {
 
 	c := NewCLI(t, WithEnv(
 		"DDEV_DEBUG=true",
-		fmt.Sprintf("HOME=%s", t.TempDir()),
-		fmt.Sprintf("USER=%s", os.Getenv("USER")),
 		fmt.Sprintf("PATH=%s", pathDir),
 	))
 

--- a/pkg/e2e/ddev_test.go
+++ b/pkg/e2e/ddev_test.go
@@ -19,11 +19,13 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 )
 
@@ -31,26 +33,38 @@ const ddevVersion = "v1.19.1"
 
 func TestComposeRunDdev(t *testing.T) {
 	if !composeStandaloneMode {
-		t.Skip("Not running on standalone mode.")
+		t.Skip("Not running in plugin mode - ddev only supports invoking standalone `docker-compose`")
 	}
 	if runtime.GOOS == "windows" {
 		t.Skip("Running on Windows. Skipping...")
 	}
-	_ = os.Setenv("DDEV_DEBUG", "true")
 
-	c := NewParallelCLI(t)
-	dir, err := os.MkdirTemp("", t.Name()+"-")
-	assert.NilError(t, err)
+	// ddev shells out to `docker` and `docker-compose` (standalone), so a
+	// temporary directory is created with symlinks to system Docker and the
+	// locally-built standalone Compose binary to use as PATH
+	pathDir := t.TempDir()
+	dockerBin, err := exec.LookPath(DockerExecutableName)
+	require.NoError(t, err, "Could not find %q in path", DockerExecutableName)
+	require.NoError(t, os.Symlink(dockerBin, filepath.Join(pathDir, DockerExecutableName)),
+		"Could not create %q symlink", DockerExecutableName)
 
-	// ddev needs to be able to find mkcert to figure out where certs are.
-	_ = os.Setenv("PATH", fmt.Sprintf("%s:%s", os.Getenv("PATH"), dir))
+	composeBin := ComposeStandalonePath(t)
+	require.NoError(t, os.Symlink(composeBin, filepath.Join(pathDir, DockerComposeExecutableName)),
+		"Could not create %q symlink", DockerComposeExecutableName)
 
-	siteName := filepath.Base(dir)
+	c := NewCLI(t, WithEnv(
+		"DDEV_DEBUG=true",
+		fmt.Sprintf("HOME=%s", t.TempDir()),
+		fmt.Sprintf("USER=%s", os.Getenv("USER")),
+		fmt.Sprintf("PATH=%s", pathDir),
+	))
+
+	ddevDir := t.TempDir()
+	siteName := filepath.Base(ddevDir)
 
 	t.Cleanup(func() {
-		_ = c.RunCmdInDir(t, dir, "./ddev", "delete", "-Oy")
-		_ = c.RunCmdInDir(t, dir, "./ddev", "poweroff")
-		_ = os.RemoveAll(dir)
+		_ = c.RunCmdInDir(t, ddevDir, "./ddev", "delete", "-Oy")
+		_ = c.RunCmdInDir(t, ddevDir, "./ddev", "poweroff")
 	})
 
 	osName := "linux"
@@ -59,27 +73,26 @@ func TestComposeRunDdev(t *testing.T) {
 	}
 
 	compressedFilename := fmt.Sprintf("ddev_%s-%s.%s.tar.gz", osName, runtime.GOARCH, ddevVersion)
-	c.RunCmdInDir(t, dir, "curl", "-LO",
-		fmt.Sprintf("https://github.com/drud/ddev/releases/download/%s/%s",
-			ddevVersion,
-			compressedFilename))
+	c.RunCmdInDir(t, ddevDir, "curl", "-LO", fmt.Sprintf("https://github.com/drud/ddev/releases/download/%s/%s",
+		ddevVersion,
+		compressedFilename))
 
-	c.RunCmdInDir(t, dir, "tar", "-xzf", compressedFilename)
+	c.RunCmdInDir(t, ddevDir, "tar", "-xzf", compressedFilename)
 
 	// Create a simple index.php we can test against.
-	c.RunCmdInDir(t, dir, "sh", "-c", "echo '<?php\nprint \"ddev is working\";' >index.php")
+	c.RunCmdInDir(t, ddevDir, "sh", "-c", "echo '<?php\nprint \"ddev is working\";' >index.php")
 
-	c.RunCmdInDir(t, dir, "./ddev", "config", "--auto")
-	c.RunCmdInDir(t, dir, "./ddev", "config", "global", "--use-docker-compose-from-path")
-	vRes := c.RunCmdInDir(t, dir, "./ddev", "version")
+	c.RunCmdInDir(t, ddevDir, "./ddev", "config", "--auto")
+	c.RunCmdInDir(t, ddevDir, "./ddev", "config", "global", "--use-docker-compose-from-path")
+	vRes := c.RunCmdInDir(t, ddevDir, "./ddev", "version")
 	out := vRes.Stdout()
 	fmt.Printf("ddev version: %s\n", out)
 
-	c.RunCmdInDir(t, dir, "./ddev", "poweroff")
+	c.RunCmdInDir(t, ddevDir, "./ddev", "poweroff")
 
-	c.RunCmdInDir(t, dir, "./ddev", "start", "-y")
+	c.RunCmdInDir(t, ddevDir, "./ddev", "start", "-y")
 
-	curlRes := c.RunCmdInDir(t, dir, "curl", "-sSL", fmt.Sprintf("http://%s.ddev.site", siteName))
+	curlRes := c.RunCmdInDir(t, ddevDir, "curl", "-sSL", fmt.Sprintf("http://%s.ddev.site", siteName))
 	out = curlRes.Stdout()
 	fmt.Println(out)
 	assert.Assert(t, strings.Contains(out, "ddev is working"), "Could not start project")

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -59,8 +59,15 @@ func init() {
 
 // CLI is used to wrap the CLI for end to end testing
 type CLI struct {
+	// ConfigDir for Docker configuration (set as DOCKER_CONFIG)
 	ConfigDir string
 
+	// HomeDir for tools that look for user files (set as HOME)
+	HomeDir string
+
+	// env overrides to apply to every invoked command
+	//
+	// To populate, use WithEnv when creating a CLI instance.
 	env []string
 }
 
@@ -84,6 +91,7 @@ func NewCLI(t testing.TB, opts ...CLIOption) *CLI {
 
 	c := &CLI{
 		ConfigDir: configDir,
+		HomeDir:   t.TempDir(),
 	}
 
 	for _, opt := range opts {
@@ -188,6 +196,8 @@ func CopyFile(sourceFile string, destinationFile string) error {
 // Docker / Compose commands.
 func (c *CLI) BaseEnvironment() []string {
 	return []string{
+		"HOME=" + c.HomeDir,
+		"USER=" + os.Getenv("USER"),
 		"DOCKER_CONFIG=" + c.ConfigDir,
 		"KUBECONFIG=invalid",
 	}


### PR DESCRIPTION
### What I did

#### Environment (Shared)
When running Docker / Compose commands, do NOT inherit the system
environment to ensure that the tests are reproducible regardless
of host settings.

(As an example of why this was causing trouble, the scan tests would fail
for me locally because I had `DOCKER_SCAN_SUGGEST=false` set in my
environment.)

Additionally, per-command environment overrides are provided to
the command instead of using `os.SetEnv`, as this is not safe when
running tests in parallel (`testing.T::SetEnv` will actually error
if used in this way!)

#### `ddev` Test
The most important change here is to ensure that the correct Compose
standalone binary is used by `ddev`. Since it invokes Compose itself,
we need to ensure that `PATH` is set appropriately such that it finds
the binary we want to test rather than something from the system.

As part of this, the rest of the environment has been isolated, which
should make the test more reliable, and avoids polluting `~/.ddev`
with test artifacts by using a tmpdir as `HOME` for the test instead
of the user's real home folder.

### Cute Animal
![prairie dog](https://user-images.githubusercontent.com/841263/174070507-af239d3b-4855-4e39-b32c-5091de07bcfe.png)
