### PR TITLE
e2e: ensure all Compose cmds standalone compatible

### DIFF
--- a/pkg/e2e/cancel_test.go
+++ b/pkg/e2e/cancel_test.go
@@ -41,7 +41,8 @@ func TestComposeCancel(t *testing.T) {
 
 		// require a separate groupID from the process running tests, in order to simulate ctrl+C from a terminal.
 		// sending kill signal
-		cmd, stdout, stderr, err := StartWithNewGroupID(c.NewDockerCmd("compose", "-f", buildProjectPath, "build", "--progress", "plain"))
+		cmd, stdout, stderr, err := StartWithNewGroupID(c.NewDockerComposeCmd(t, "-f", buildProjectPath, "build",
+			"--progress", "plain"))
 		assert.NilError(t, err)
 
 		c.WaitForCondition(t, func() (bool, string) {

--- a/pkg/e2e/cascade_stop_test.go
+++ b/pkg/e2e/cascade_stop_test.go
@@ -28,19 +28,19 @@ func TestCascadeStop(t *testing.T) {
 	const projectName = "e2e-cascade-stop"
 
 	t.Run("abort-on-container-exit", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
 		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `should_fail-1 exited with code 1`})
 		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `Aborting on container exit...`})
 	})
 
 	t.Run("exit-code-from", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
 		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `should_fail-1 exited with code 1`})
 		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `Aborting on container exit...`})
 	})
 
 	t.Run("exit-code-from unknown", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=unknown")
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=unknown")
 		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `no such service: unknown`})
 	})
 

--- a/pkg/e2e/compose_build_test.go
+++ b/pkg/e2e/compose_build_test.go
@@ -57,7 +57,12 @@ func TestLocalComposeBuild(t *testing.T) {
 		c.RunDockerOrExitError(t, "rmi", "build-test_nginx")
 		c.RunDockerOrExitError(t, "rmi", "custom-nginx")
 
-		icmd.RunCmd(c.NewDockerCmd("compose", "--project-directory", "fixtures/build-test", "build", "--build-arg", "FOO"),
+		icmd.RunCmd(c.NewDockerComposeCmd(t,
+			"--project-directory",
+			"fixtures/build-test",
+			"build",
+			"--build-arg",
+			"FOO"),
 			func(cmd *icmd.Cmd) {
 				cmd.Env = append(cmd.Env, "FOO=BAR")
 			})
@@ -69,7 +74,7 @@ func TestLocalComposeBuild(t *testing.T) {
 	t.Run("build with multiple build-args ", func(t *testing.T) {
 		// ensure local test run does not reuse previously build image
 		c.RunDockerOrExitError(t, "rmi", "-f", "multi-args_multiargs")
-		cmd := c.NewDockerCmd("compose", "--project-directory", "fixtures/build-test/multi-args", "build")
+		cmd := c.NewDockerComposeCmd(t, "--project-directory", "fixtures/build-test/multi-args", "build")
 
 		icmd.RunCmd(cmd, func(cmd *icmd.Cmd) {
 			cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=0")

--- a/pkg/e2e/compose_down_test.go
+++ b/pkg/e2e/compose_down_test.go
@@ -28,7 +28,7 @@ func TestDown(t *testing.T) {
 	const projectName = "e2e-down"
 
 	t.Run("no resource to remove", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "compose", "--project-name", projectName, "down")
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 		res.Assert(t, icmd.Expected{ExitCode: 0, Err: `No resource found to remove for project "e2e-down"`})
 	})
 }

--- a/pkg/e2e/compose_exec_test.go
+++ b/pkg/e2e/compose_exec_test.go
@@ -43,7 +43,7 @@ func TestLocalComposeExec(t *testing.T) {
 	})
 
 	t.Run("exec with env set", func(t *testing.T) {
-		res := icmd.RunCmd(c.NewDockerCmd("exec", "-e", "FOO", "compose-e2e-exec-simple-1", "/usr/bin/env"),
+		res := icmd.RunCmd(c.NewDockerCmd(t, "exec", "-e", "FOO", "compose-e2e-exec-simple-1", "/usr/bin/env"),
 			func(cmd *icmd.Cmd) {
 				cmd.Env = append(cmd.Env, "FOO=BAR")
 			})

--- a/pkg/e2e/compose_exec_test.go
+++ b/pkg/e2e/compose_exec_test.go
@@ -29,21 +29,25 @@ func TestLocalComposeExec(t *testing.T) {
 
 	const projectName = "compose-e2e-exec"
 
-	c.RunDockerComposeCmd(t, "--project-directory", "fixtures/simple-composefile", "--project-name", projectName, "up",
-		"-d")
+	cmdArgs := func(cmd string, args ...string) []string {
+		ret := []string{"--project-directory", "fixtures/simple-composefile", "--project-name", projectName, cmd}
+		ret = append(ret, args...)
+		return ret
+	}
+
+	c.RunDockerComposeCmd(t, cmdArgs("up", "-d")...)
 
 	t.Run("exec true", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "exec", "compose-e2e-exec-simple-1", "/bin/true")
-		res.Assert(t, icmd.Expected{ExitCode: 0})
+		c.RunDockerComposeCmd(t, cmdArgs("exec", "simple", "/bin/true")...)
 	})
 
 	t.Run("exec false", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "exec", "compose-e2e-exec-simple-1", "/bin/false")
+		res := c.RunDockerComposeCmdNoCheck(t, cmdArgs("exec", "simple", "/bin/false")...)
 		res.Assert(t, icmd.Expected{ExitCode: 1})
 	})
 
 	t.Run("exec with env set", func(t *testing.T) {
-		res := icmd.RunCmd(c.NewDockerCmd(t, "exec", "-e", "FOO", "compose-e2e-exec-simple-1", "/usr/bin/env"),
+		res := icmd.RunCmd(c.NewDockerComposeCmd(t, cmdArgs("exec", "-e", "FOO", "simple", "/usr/bin/env")...),
 			func(cmd *icmd.Cmd) {
 				cmd.Env = append(cmd.Env, "FOO=BAR")
 			})
@@ -51,8 +55,7 @@ func TestLocalComposeExec(t *testing.T) {
 	})
 
 	t.Run("exec without env set", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "exec", "-e", "FOO", "compose-e2e-exec-simple-1", "/usr/bin/env")
-		res.Assert(t, icmd.Expected{ExitCode: 0})
-		assert.Check(t, !strings.Contains(res.Stdout(), "FOO="))
+		res := c.RunDockerComposeCmd(t, cmdArgs("exec", "-e", "FOO", "simple", "/usr/bin/env")...)
+		assert.Check(t, !strings.Contains(res.Stdout(), "FOO="), res.Combined())
 	})
 }

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -108,7 +108,7 @@ func TestLocalComposeRun(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo", "Hello")
 		assert.Assert(t, strings.Contains(res.Combined(), "orphan"))
 
-		cmd := c.NewDockerCmd("compose", "-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo", "Hello")
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo", "Hello")
 		res = icmd.RunCmd(cmd, func(cmd *icmd.Cmd) {
 			cmd.Env = append(cmd.Env, "COMPOSE_IGNORE_ORPHANS=True")
 		})
@@ -116,7 +116,7 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("down", func(t *testing.T) {
-		cmd := c.NewDockerCmd("compose", "-f", "./fixtures/run-test/compose.yaml", "down")
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "down")
 		icmd.RunCmd(cmd, func(c *icmd.Cmd) {
 			c.Env = append(c.Env, "COMPOSE_REMOVE_ORPHANS=True")
 		})

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -88,7 +88,7 @@ func TestLocalComposeUp(t *testing.T) {
 	})
 
 	t.Run("check healthcheck output", func(t *testing.T) {
-		c.WaitForCmdResult(t, c.NewDockerCmd("compose", "-p", projectName, "ps", "--format", "json"),
+		c.WaitForCmdResult(t, c.NewDockerComposeCmd(t, "-p", projectName, "ps", "--format", "json"),
 			StdoutContains(`"Name":"compose-e2e-demo-web-1","Command":"/dispatcher","Project":"compose-e2e-demo","Service":"web","State":"running","Health":"healthy"`),
 			5*time.Second, 1*time.Second)
 
@@ -123,7 +123,7 @@ func TestLocalComposeUp(t *testing.T) {
 func TestComposePull(t *testing.T) {
 	c := NewParallelCLI(t)
 
-	res := c.RunDockerOrExitError(t, "compose", "--project-directory", "fixtures/simple-composefile", "pull")
+	res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/simple-composefile", "pull")
 	output := res.Combined()
 
 	assert.Assert(t, strings.Contains(output, "simple Pulled"))
@@ -148,9 +148,9 @@ func TestDownComposefileInParentFolder(t *testing.T) {
 func TestAttachRestart(t *testing.T) {
 	c := NewParallelCLI(t)
 
-	cmd := c.NewDockerCmd("compose", "--ansi=never", "--project-directory", "./fixtures/attach-restart", "up")
+	cmd := c.NewDockerComposeCmd(t, "--ansi=never", "--project-directory", "./fixtures/attach-restart", "up")
 	res := icmd.StartCmd(cmd)
-	defer c.RunDockerOrExitError(t, "compose", "-p", "attach-restart", "down")
+	defer c.RunDockerComposeCmd(t, "-p", "attach-restart", "down")
 
 	c.WaitForCondition(t, func() (bool, string) {
 		debug := res.Combined()
@@ -165,8 +165,8 @@ func TestAttachRestart(t *testing.T) {
 func TestInitContainer(t *testing.T) {
 	c := NewParallelCLI(t)
 
-	res := c.RunDockerOrExitError(t, "compose", "--ansi=never", "--project-directory", "./fixtures/init-container", "up")
-	defer c.RunDockerOrExitError(t, "compose", "-p", "init-container", "down")
+	res := c.RunDockerComposeCmd(t, "--ansi=never", "--project-directory", "./fixtures/init-container", "up")
+	defer c.RunDockerComposeCmd(t, "-p", "init-container", "down")
 	testify.Regexp(t, "foo-1  | hello(?m:.*)bar-1  | world", res.Stdout())
 }
 

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -228,14 +228,19 @@ func (c *CLI) MetricsSocket() string {
 }
 
 // NewDockerCmd creates a docker cmd without running it
-func (c *CLI) NewDockerCmd(args ...string) icmd.Cmd {
+func (c *CLI) NewDockerCmd(t testing.TB, args ...string) icmd.Cmd {
+	for _, arg := range args {
+		if arg == compose.PluginName {
+			t.Fatal("This test called 'RunDockerCmd' for 'compose'. Please prefer 'RunDockerComposeCmd' to be able to test as a plugin and standalone")
+		}
+	}
 	return c.NewCmd(DockerExecutableName, args...)
 }
 
 // RunDockerOrExitError runs a docker command and returns a result
 func (c *CLI) RunDockerOrExitError(t testing.TB, args ...string) *icmd.Result {
 	fmt.Printf("\t[%s] docker %s\n", t.Name(), strings.Join(args, " "))
-	return icmd.RunCmd(c.NewDockerCmd(args...))
+	return icmd.RunCmd(c.NewDockerCmd(t, args...))
 }
 
 // RunCmd runs a command, expects no error and returns a result
@@ -260,9 +265,6 @@ func (c *CLI) RunCmdInDir(t testing.TB, dir string, args ...string) *icmd.Result
 
 // RunDockerCmd runs a docker command, expects no error and returns a result
 func (c *CLI) RunDockerCmd(t testing.TB, args ...string) *icmd.Result {
-	if len(args) > 0 && args[0] == compose.PluginName {
-		t.Fatal("This test called 'RunDockerCmd' for 'compose'. Please prefer 'RunDockerComposeCmd' to be able to test as a plugin and standalone")
-	}
 	res := c.RunDockerOrExitError(t, args...)
 	res.Assert(t, icmd.Success)
 	return res

--- a/pkg/e2e/metrics_test.go
+++ b/pkg/e2e/metrics_test.go
@@ -27,29 +27,29 @@ func TestComposeMetrics(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	t.Run("catch specific failure metrics", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "compose", "-f", "fixtures/does-not-exist/compose.yaml", "build")
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/does-not-exist/compose.yaml", "build")
 		expectedErr := "fixtures/does-not-exist/compose.yaml: no such file or directory"
 		if runtime.GOOS == "windows" {
 			expectedErr = "does-not-exist\\compose.yaml: The system cannot find the path specified"
 		}
 		res.Assert(t, icmd.Expected{ExitCode: 14, Err: expectedErr})
-		res = c.RunDockerOrExitError(t, "compose", "-f", "fixtures/wrong-composefile/compose.yaml", "up", "-d")
+		res = c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/wrong-composefile/compose.yaml", "up", "-d")
 		res.Assert(t, icmd.Expected{ExitCode: 15, Err: "services.simple Additional property wrongField is not allowed"})
-		res = c.RunDockerOrExitError(t, "compose", "up")
+		res = c.RunDockerComposeCmdNoCheck(t, "up")
 		res.Assert(t, icmd.Expected{ExitCode: 14, Err: "no configuration file provided: not found"})
-		res = c.RunDockerOrExitError(t, "compose", "up", "-f", "fixtures/wrong-composefile/compose.yaml")
+		res = c.RunDockerComposeCmdNoCheck(t, "up", "-f", "fixtures/wrong-composefile/compose.yaml")
 		res.Assert(t, icmd.Expected{ExitCode: 16, Err: "unknown shorthand flag: 'f' in -f"})
-		res = c.RunDockerOrExitError(t, "compose", "up", "--file", "fixtures/wrong-composefile/compose.yaml")
+		res = c.RunDockerComposeCmdNoCheck(t, "up", "--file", "fixtures/wrong-composefile/compose.yaml")
 		res.Assert(t, icmd.Expected{ExitCode: 16, Err: "unknown flag: --file"})
-		res = c.RunDockerOrExitError(t, "compose", "donw", "--file", "fixtures/wrong-composefile/compose.yaml")
+		res = c.RunDockerComposeCmdNoCheck(t, "donw", "--file", "fixtures/wrong-composefile/compose.yaml")
 		res.Assert(t, icmd.Expected{ExitCode: 16, Err: `unknown docker command: "compose donw"`})
-		res = c.RunDockerOrExitError(t, "compose", "--file", "fixtures/wrong-composefile/build-error.yml", "build")
+		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/build-error.yml", "build")
 		res.Assert(t, icmd.Expected{ExitCode: 17, Err: `line 17: unknown instruction: WRONG`})
-		res = c.RunDockerOrExitError(t, "compose", "--file", "fixtures/wrong-composefile/build-error.yml", "up")
+		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/build-error.yml", "up")
 		res.Assert(t, icmd.Expected{ExitCode: 17, Err: `line 17: unknown instruction: WRONG`})
-		res = c.RunDockerOrExitError(t, "compose", "--file", "fixtures/wrong-composefile/unknown-image.yml", "pull")
+		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/unknown-image.yml", "pull")
 		res.Assert(t, icmd.Expected{ExitCode: 18, Err: `pull access denied for unknownimage, repository does not exist or may require 'docker login'`})
-		res = c.RunDockerOrExitError(t, "compose", "--file", "fixtures/wrong-composefile/unknown-image.yml", "up")
+		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/unknown-image.yml", "up")
 		res.Assert(t, icmd.Expected{ExitCode: 18, Err: `pull access denied for unknownimage, repository does not exist or may require 'docker login'`})
 	})
 }

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -150,7 +150,7 @@ func TestNetworkModes(t *testing.T) {
 	const projectName = "network_mode_service_run"
 
 	t.Run("run with service mode dependency", func(t *testing.T) {
-		res := c.RunDockerOrExitError(t, "compose", "-f", "./fixtures/network-test/compose.yaml", "--project-name", projectName, "run", "-T", "mydb", "echo", "success")
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-test/compose.yaml", "--project-name", projectName, "run", "-T", "mydb", "echo", "success")
 		res.Assert(t, icmd.Expected{Out: "success"})
 
 	})

--- a/pkg/e2e/restart_test.go
+++ b/pkg/e2e/restart_test.go
@@ -38,26 +38,27 @@ func TestRestart(t *testing.T) {
 
 	t.Run("Up a project", func(t *testing.T) {
 		// This is just to ensure the containers do NOT exist
-		c.RunDockerOrExitError(t, "compose", "--project-name", projectName, "down")
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 
-		res := c.RunDockerOrExitError(t, "compose", "-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "up", "-d")
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "up", "-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-restart-restart-1  Started"), res.Combined())
 
-		c.WaitForCmdResult(t, c.NewDockerCmd("compose", "--project-name", projectName, "ps", "-a", "--format", "json"),
+		c.WaitForCmdResult(t, c.NewDockerComposeCmd(t, "--project-name", projectName, "ps", "-a", "--format",
+			"json"),
 			StdoutContains(`"State":"exited"`), 10*time.Second, 1*time.Second)
 
-		res = c.RunDockerOrExitError(t, "compose", "--project-name", projectName, "ps", "-a")
+		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a")
 		testify.Regexp(t, getServiceRegx("restart", "exited"), res.Stdout())
 
-		_ = c.RunDockerOrExitError(t, "compose", "-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "restart")
+		c.RunDockerComposeCmd(t, "-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "restart")
 
 		// Give the same time but it must NOT exit
 		time.Sleep(time.Second)
 
-		res = c.RunDockerOrExitError(t, "compose", "--project-name", projectName, "ps")
+		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps")
 		testify.Regexp(t, getServiceRegx("restart", "running"), res.Stdout())
 
 		// Clean up
-		c.RunDockerOrExitError(t, "compose", "--project-name", projectName, "down")
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 	})
 }

--- a/pkg/e2e/scan_message_test.go
+++ b/pkg/e2e/scan_message_test.go
@@ -60,14 +60,14 @@ func TestDisplayScanMessageAfterBuild(t *testing.T) {
 	t.Run("display on compose up if image is built", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "up",
 			"-d")
-		defer c.RunDockerOrExitError(t, "compose", "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down")
+		defer c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down")
 		res.Assert(t, icmd.Expected{Err: utils.ScanSuggestMsg})
 	})
 
 	t.Run("do not display on compose up if no image built", func(t *testing.T) { // re-run the same Compose aproject
 		res := c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "up",
 			"-d")
-		defer c.RunDockerOrExitError(t, "compose", "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down", "--rmi", "all")
+		defer c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down", "--rmi", "all")
 		assert.Assert(t, !strings.Contains(res.Combined(), "docker scan"), res.Combined())
 	})
 

--- a/pkg/e2e/secrets_test.go
+++ b/pkg/e2e/secrets_test.go
@@ -26,7 +26,7 @@ func TestSecretFromEnv(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	t.Run("compose run", func(t *testing.T) {
-		res := icmd.RunCmd(c.NewDockerCmd("compose", "-f", "./fixtures/env-secret/compose.yaml", "run", "foo"),
+		res := icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/env-secret/compose.yaml", "run", "foo"),
 			func(cmd *icmd.Cmd) {
 				cmd.Env = append(cmd.Env, "SECRET=BAR")
 			})

--- a/pkg/e2e/start_fail_test.go
+++ b/pkg/e2e/start_fail_test.go
@@ -26,7 +26,7 @@ func TestStartFail(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "e2e-start-fail"
 
-	res := c.RunDockerOrExitError(t, "compose", "-f", "fixtures/start-fail/compose.yaml", "--project-name", projectName, "up", "-d")
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/start-fail/compose.yaml", "--project-name", projectName, "up", "-d")
 	res.Assert(t, icmd.Expected{ExitCode: 1, Err: `container for service "fail" is unhealthy`})
 
 	c.RunDockerComposeCmd(t, "--project-name", projectName, "down")

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -75,13 +75,13 @@ func TestLocalComposeVolume(t *testing.T) {
 
 	t.Run("should inherit anonymous volumes", func(t *testing.T) {
 		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
-		c.RunDockerOrExitError(t, "compose", "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "-d")
+		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "-d")
 		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
 	})
 
 	t.Run("should renew anonymous volumes", func(t *testing.T) {
 		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
-		c.RunDockerOrExitError(t, "compose", "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "--renew-anon-volumes", "-d")
+		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "--renew-anon-volumes", "-d")
 		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
 	})
 


### PR DESCRIPTION
**What I did**
The E2E tests can be run in plugin (`docker compose`) or standalone
(`docker-compose`) mode. Existing logic was in place to ensure that
the helper method is always used, which will invoke the right one
based on how tests are being executed.

However, this logic was too easy to (unintentionally) bypass given
the myriad of ways that commands can be run. The check has been
made stricter and pushed to a lower-level to more aggressively
catch instances.

As a result, a bunch of calls to `RunDockerCmd` are now updated
to be `RunDockerComposeCmd`, which will ensure that the invocation
is correct based on test mode.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![field mouse](https://user-images.githubusercontent.com/841263/174153118-4a7ce58d-d5b4-4a81-842f-6d015c1e3a9c.png)