### PR TITLE
Use appropriate dependency condition for one-shot containers when running `compose up --wait`

### DIFF
--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -1,0 +1,47 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestUpWait(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-deps-wait"
+
+	timeout := time.After(30 * time.Second)
+	done := make(chan bool)
+	go func() {
+		res := c.RunDockerComposeCmd(t, "-f", "fixtures/dependencies/deps-completed-successfully.yaml", "--project-name", projectName, "up", "--wait", "-d")
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-deps-wait-oneshot-1"), res.Combined())
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("test did not finish in time")
+	case <-done:
+		break
+	}
+
+	c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+}

--- a/pkg/e2e/fixtures/dependencies/deps-completed-successfully.yaml
+++ b/pkg/e2e/fixtures/dependencies/deps-completed-successfully.yaml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  oneshot:
+    image: ubuntu
+    command: echo 'hello world'
+  longrunning:
+    image: ubuntu
+    depends_on:
+      oneshot:
+        condition: service_completed_successfully
+    command: sleep infinity

--- a/pkg/e2e/fixtures/dependencies/deps-completed-successfully.yaml
+++ b/pkg/e2e/fixtures/dependencies/deps-completed-successfully.yaml
@@ -1,10 +1,9 @@
-version: '3'
 services:
   oneshot:
-    image: ubuntu
+    image: alpine
     command: echo 'hello world'
   longrunning:
-    image: ubuntu
+    image: alpine
     depends_on:
       oneshot:
         condition: service_completed_successfully


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

When creating a dependency map to wait on during `compose up --wait`, we were previously applying the `running_or_healthy` condition to all containers indiscriminately. 

However, in compose files with one-shot containers used for setup (database migrations, etc.) that are configured as dependencies of others with the condition `service_completed_successfully`, this does not work and the command will get stuck as it is expected that these containers run and then exit, and so they never satisfy `running_or_healthy`.

This PR changes the dependency logic to use the appropriate condition for these containers so that `compose up --wait` exits properly when all services have reach the desired state (running/healthy for some, exited for one-shots).

Also add e2e tests to ensure `compose up --wait` does not get stuck forever waiting for one-shot containers.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Fixes #9273

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![IMG_2944](https://user-images.githubusercontent.com/70572044/174409767-dc4a2575-f3ad-430b-9354-fb3dba0efa0d.jpg)

