### PR TITLE
build.go: initialize CustomLabels map if nil

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -189,11 +189,11 @@ func (s *composeService) getLocalImagesDigests(ctx context.Context, project *typ
 		images[name] = info.ID
 	}
 
-	for _, s := range project.Services {
-		imgName := getImageName(s, project.Name)
+	for i := range project.Services {
+		imgName := getImageName(project.Services[i], project.Name)
 		digest, ok := images[imgName]
 		if ok {
-			s.CustomLabels[api.ImageDigestLabel] = digest
+			project.Services[i].CustomLabels.Add(api.ImageDigestLabel, digest)
 		}
 	}
 


### PR DESCRIPTION
This change fixes the` panic: assignment to entry in nil map` error.
I also accessed the map directly instead of the copy value, otherwise the label doesn't get set.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Error that got me here:
```
panic: assignment to entry in nil map

goroutine 16 [running]:
github.com/docker/compose/v2/pkg/compose.(*composeService).getLocalImagesDigests(0x1c0006d4318?, {0x1579128?, 0xc00069f710?}, 0xc000419220)
        /home/prodrigu/go/pkg/mod/github.com/docker/compose/v2@v2.6.0/pkg/compose/build.go:195 +0x305
github.com/docker/compose/v2/pkg/compose.(*composeService).ensureImagesExists(0x0?, {0x1579128, 0xc00069f710}, 0xc000419220, 0x0)
        /home/prodrigu/go/pkg/mod/github.com/docker/compose/v2@v2.6.0/pkg/compose/build.go:105 +0x7b
github.com/docker/compose/v2/pkg/compose.(*composeService).create(0xc0003efc30?, {0x1579128, 0xc00069f710}, 0xc000419220, {{0xc0004284e0, 0x2, 0x2}, 0x1, 0x0, {0x0, ...}, ...})
        /home/prodrigu/go/pkg/mod/github.com/docker/compose/v2@v2.6.0/pkg/compose/create.go:66 +0x173
github.com/docker/compose/v2/pkg/compose.(*composeService).Up.func1({0x1579128, 0xc00069f710})
        /home/prodrigu/go/pkg/mod/github.com/docker/compose/v2@v2.6.0/pkg/compose/up.go:36 +0x8e
github.com/docker/compose/v2/pkg/progress.Run.func1({0x1579128?, 0xc00069f710?})
```

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/6299297/175665090-87ec7b2a-606b-4f2f-9d69-62e2e131462e.png)
