### PR TITLE
build: respect dependency order for classic builder

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -205,7 +205,7 @@ func (s *composeService) doBuild(ctx context.Context, project *types.Project, op
 		return nil, nil
 	}
 	if buildkitEnabled, err := s.dockerCli.BuildKitEnabled(); err != nil || !buildkitEnabled {
-		return s.doBuildClassic(ctx, opts)
+		return s.doBuildClassic(ctx, project, opts)
 	}
 	return s.doBuildBuildkit(ctx, project, opts, mode)
 }

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -201,3 +201,40 @@ func TestBuildTags(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: expectedOutput})
 	})
 }
+
+func TestBuildImageDependencies(t *testing.T) {
+	doTest := func(t *testing.T, cli *CLI) {
+		resetState := func() {
+			cli.RunDockerComposeCmd(t, "down", "--rmi=all", "-t=0")
+		}
+		resetState()
+		t.Cleanup(resetState)
+
+		// the image should NOT exist now
+		res := cli.RunDockerOrExitError(t, "image", "inspect", "build-dependencies_service")
+		res.Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      "Error: No such image: build-dependencies_service",
+		})
+
+		res = cli.RunDockerComposeCmd(t, "build")
+		t.Log(res.Combined())
+
+		res = cli.RunDockerCmd(t,
+			"image", "inspect", "--format={{ index .RepoTags 0 }}",
+			"build-dependencies_service")
+		res.Assert(t, icmd.Expected{Out: "build-dependencies_service:latest"})
+	}
+
+	t.Run("ClassicBuilder", func(t *testing.T) {
+		cli := NewParallelCLI(t, WithEnv(
+			"DOCKER_BUILDKIT=0",
+			"COMPOSE_FILE=./fixtures/build-dependencies/compose.yaml",
+		))
+		doTest(t, cli)
+	})
+
+	t.Run("BuildKit", func(t *testing.T) {
+		t.Skip("See https://github.com/docker/compose/issues/9232")
+	})
+}

--- a/pkg/e2e/fixtures/build-dependencies/base.dockerfile
+++ b/pkg/e2e/fixtures/build-dependencies/base.dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+COPY hello.txt /hello.txt
+
+CMD [ "/bin/true" ]

--- a/pkg/e2e/fixtures/build-dependencies/base.dockerfile
+++ b/pkg/e2e/fixtures/build-dependencies/base.dockerfile
@@ -1,3 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 FROM alpine
 
 COPY hello.txt /hello.txt

--- a/pkg/e2e/fixtures/build-dependencies/compose.yaml
+++ b/pkg/e2e/fixtures/build-dependencies/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  base:
+    image: base
+    build:
+      context: .
+      dockerfile: base.dockerfile
+  service:
+    depends_on:
+      - base
+    build:
+      context: .
+      dockerfile: service.dockerfile

--- a/pkg/e2e/fixtures/build-dependencies/hello.txt
+++ b/pkg/e2e/fixtures/build-dependencies/hello.txt
@@ -1,0 +1,1 @@
+this file was copied from base -> service

--- a/pkg/e2e/fixtures/build-dependencies/service.dockerfile
+++ b/pkg/e2e/fixtures/build-dependencies/service.dockerfile
@@ -1,3 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 FROM alpine
 
 COPY --from=base /hello.txt /hello.txt

--- a/pkg/e2e/fixtures/build-dependencies/service.dockerfile
+++ b/pkg/e2e/fixtures/build-dependencies/service.dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+COPY --from=base /hello.txt /hello.txt
+
+CMD [ "cat", "/hello.txt" ]


### PR DESCRIPTION
**What I did**
When using the "classic" (non-BuildKit) builder, ensure that
services are iterated in dependency order for a build so that
it's possible to guarantee the presence of a base image that's
been added as a dependency with `depends_on`. This is a very
common pattern when using base images with Compose.

A fix for BuildKit is blocked currently until we can rely on a
newer version of the engine (see docker/compose#9324).

**Related issue**
* docker/compose#9324
* docker/compose#8538
**⚠️ These are not being closed, as this doesn't fix things if you're using BuildKit**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![American mink](https://user-images.githubusercontent.com/841263/175130015-0eca3273-3e1d-4af1-8fef-ab621d18263d.png)