### PR TITLE
fix: panic caused by empty string argument

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -50,7 +50,7 @@ func Convert(args []string) []string {
 	l := len(args)
 	for i := 0; i < l; i++ {
 		arg := args[i]
-		if arg[0] != '-' {
+		if len(arg) > 0 && arg[0] != '-' {
 			// not a top-level flag anymore, keep the rest of the command unmodified
 			if arg == compose.PluginName {
 				i++

--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -68,6 +68,11 @@ func Test_convert(t *testing.T) {
 			args: []string{"--log-level", "INFO", "up"},
 			want: []string{"--log-level", "INFO", "compose", "up"},
 		},
+		{
+			name: "empty string argument",
+			args: []string{"--project-directory", "", "ps"},
+			want: []string{"compose", "--project-directory", "", "ps"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What I did**

Remove duplicated code and use compose-switch routine fixed in v1.0.5.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
docker/compose-switch#35

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![Photo by Skyler Ewing from Pexels](https://images.pexels.com/photos/6608102/pexels-photo-6608102.jpeg?auto=compress&cs=tinysrgb&h=640&dpr=1)
