### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   disable-all: true
   enable:
     - deadcode
+    - depguard
     - errcheck
     - gocyclo
     - gofmt
@@ -26,6 +27,13 @@ linters:
     - unused
     - varcheck
 linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      # The io/ioutil package has been deprecated.
+      # https://go.dev/doc/go1.16#ioutil
+      - io/ioutil
   gocyclo:
     min-complexity: 16
   lll:

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -215,7 +214,7 @@ func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options 
 		if imageID == "" {
 			return "", errors.Errorf("Server did not provide an image ID. Cannot write %s", options.ImageIDFile)
 		}
-		if err := ioutil.WriteFile(options.ImageIDFile, []byte(imageID), 0666); err != nil {
+		if err := os.WriteFile(options.ImageIDFile, []byte(imageID), 0666); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -414,7 +414,7 @@ func parseSecurityOpts(p *types.Project, securityOpts []string) ([]string, error
 			}
 		}
 		if con[0] == "seccomp" && con[1] != "unconfined" {
-			f, err := ioutil.ReadFile(p.RelativePath(con[1]))
+			f, err := os.ReadFile(p.RelativePath(con[1]))
 			if err != nil {
 				return securityOpts, errors.Errorf("opening seccomp profile (%s) failed: %v", con[1], err)
 			}

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -133,7 +132,7 @@ func TestComposePull(t *testing.T) {
 func TestDownComposefileInParentFolder(t *testing.T) {
 	c := NewParallelCLI(t)
 
-	tmpFolder, err := ioutil.TempDir("fixtures/simple-composefile", "test-tmp")
+	tmpFolder, err := os.MkdirTemp("fixtures/simple-composefile", "test-tmp")
 	assert.NilError(t, err)
 	defer os.Remove(tmpFolder) // nolint: errcheck
 	projectName := filepath.Base(tmpFolder)

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -115,7 +114,7 @@ func initializePlugins(t testing.TB, configDir string) {
 
 	t.Cleanup(func() {
 		if t.Failed() {
-			if conf, err := ioutil.ReadFile(filepath.Join(configDir, "config.json")); err == nil {
+			if conf, err := os.ReadFile(filepath.Join(configDir, "config.json")); err == nil {
 				t.Logf("Config: %s\n", string(conf))
 			}
 			t.Log("Contents of config dir:")
@@ -389,7 +388,7 @@ func HTTPGetWithRetry(
 	}
 	poll.WaitOn(t, checkUp, poll.WithDelay(retryDelay), poll.WithTimeout(timeout))
 	if r != nil {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		assert.NilError(t, err)
 		return string(b)
 	}

--- a/pkg/e2e/scan_message_test.go
+++ b/pkg/e2e/scan_message_test.go
@@ -17,7 +17,6 @@
 package e2e
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,7 +73,7 @@ func TestDisplayScanMessageAfterBuild(t *testing.T) {
 	t.Run("do not display if scan already invoked", func(t *testing.T) {
 		_ = os.MkdirAll(filepath.Join(c.ConfigDir, "scan"), 0755)
 		scanConfigFile := filepath.Join(c.ConfigDir, "scan", "config.json")
-		err := ioutil.WriteFile(scanConfigFile, []byte(`{"optin":true}`), 0644)
+		err := os.WriteFile(scanConfigFile, []byte(`{"optin":true}`), 0644)
 		assert.NilError(t, err)
 
 		res := c.RunDockerCmd(t, "build", "-t", "test-image-scan-msg", "fixtures/simple-build-test/nginx-build")

--- a/pkg/utils/scan_suggest.go
+++ b/pkg/utils/scan_suggest.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -57,7 +56,7 @@ func scanAlreadyInvoked() bool {
 	type scanOptin struct {
 		Optin bool `json:"optin"`
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return true
 	}


### PR DESCRIPTION
**What I did**
As of Go 1.16, the same functionality of `ioutil` pkg is now provided by package `io` or
package `os`, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.

**Related issue**
None

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
