### PR TITLE
e2e: add more start/stop test cases

### DIFF
--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -22,7 +22,7 @@ import (
 	"gotest.tools/v3/icmd"
 )
 
-func TestStartFail(t *testing.T) {
+func TestUpServiceUnhealthy(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "e2e-start-fail"
 


### PR DESCRIPTION
**What I did**
Added some `compose start` / `compose stop` test cases:
* Starting a service that's already running
* Stopping a service that's already stopped
* Starting/stopping multiple services (by name) at once

Also renamed a test that was about `up` behavior but was
misleadingly labeled start/stop.

**Related issue**
* EN-83

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![groundhog eating an apple](https://user-images.githubusercontent.com/841263/176695476-47a57f3a-6ecf-4774-9854-d6f26796e93c.png)