### PR TITLE
Fix golangci syntax error in run configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
+run:
+  concurrency: 2
 linters:
-  run:
-    concurrency: 2
-    skip-dirs:
-      - tests/composefiles
   enable-all: false
   disable-all: true
   enable:


### PR DESCRIPTION
Hi,
I found a syntax error on `.golangci.yml` file and there is no longer a directory named `tests/composefiles`. According to the golangci-lint's [document](https://golangci-lint.run/usage/configuration/#run-configuration), `run` options should be at the top level.

Same issues in [scan-cli-plugin](https://github.com/docker/scan-cli-plugin/blob/main/.golangci.yml), [compose-cli](https://github.com/docker/compose-cli/blob/main/.golangci.yml).

![iOS 이미지](https://user-images.githubusercontent.com/37772279/177009247-0aa68599-c861-4dc8-a10b-88167d706756.jpg)
