### PR TITLE
add new targets to build Compose binary before running e2e tests

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -34,15 +34,51 @@ make test
 
 If you need to update a golden file simply do `go test ./... -test.update-golden`.
 
-### End to end tests
+### End-to-end tests
+To run e2e tests, the Compose CLI binary need to be build. All the commands to run e2e tests propose a version
+with the prefix `build-and-e2e` to first build the CLI before executing tests.
 
-To run the end to end tests, run:
+
+Note that this requires a local Docker Engine to be running.
+
+#### Whole end-to-end tests suite
+
+To execute both CLI and standalone e2e tests, run :
+
+```console
+make e2e
+```
+
+Or if you need to build the CLI, run: 
+```console
+make build-and-e2e
+```
+
+#### Plugin end-to-end tests suite
+
+To execute CLI plugin e2e tests, run :
 
 ```console
 make e2e-compose
 ```
 
-Note that this requires a local Docker Engine to be running.
+Or if you need to build the CLI, run:
+```console
+make build-and-e2e-compose
+```
+
+#### Standalone end-to-end tests suite
+
+To execute the standalone CLI e2e tests, run :
+
+```console
+make e2e-compose-standalone
+```
+
+Or if you need to build the CLI, run:
+```console
+make build-and-e2e-compose-standalone
+```
 
 ## Releases
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2
 	docker-compose version
 	go test $(TEST_FLAGS) -v -count=1 -parallel=1 --tags=standalone ./pkg/e2e
 
+.PHONY: build-and-e2e-compose
+build-and-e2e-compose: compose-plugin e2e-compose ## Compile the compose cli-plugin and run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
+
+.PHONY: build-and-e2e-compose-standalone
+build-and-e2e-compose-standalone: compose-plugin e2e-compose-standalone ## Compile the compose cli-plugin and run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test
+
 .PHONY: mocks
 mocks:
 	mockgen -destination pkg/mocks/mock_docker_cli.go -package mocks github.com/docker/cli/cli/command Cli
@@ -59,6 +65,9 @@ mocks:
 
 .PHONY: e2e
 e2e: e2e-compose e2e-compose-standalone ## Run end to end local tests in both modes. Set E2E_TEST=TestName to run a single test
+
+.PHONY: build-and-e2e
+build-and-e2e: compose-plugin e2e-compose e2e-compose-standalone ## Compile the compose cli-plugin and run end to end local tests in both modes. Set E2E_TEST=TestName to run a single test
 
 .PHONY: cross
 cross: ## Compile the CLI for linux, darwin and windows


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Add new targets in `Makefile` to allow user to build compose binary then run e2e test suites: 

- `build-and-e2e` --> run both cli plugin and standalone e2e tests suites
- `build-and-e2e-compose` --> run cli plugin e2e tests suite
- `build-and-e2e-compose-standalone` --> run standalone e2e tests suite

**Related issue**
replace #9439 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/177169237-aad26e73-8da8-49c7-8bdb-c7cd5cda578f.png)
