### PR TITLE
Fix typo in compose pull documentation

### DIFF
--- a/docs/reference/compose_pull.md
+++ b/docs/reference/compose_pull.md
@@ -61,4 +61,4 @@ $ docker compose pull db
    ⠹ f63c47038e66 Waiting                                                  9.3s
    ⠹ 77a0c198cde5 Waiting                                                  9.3s
    ⠹ c8752d5b785c Waiting                                                  9.3s
-``̀`
+```

--- a/docs/reference/docker_compose_pull.yaml
+++ b/docs/reference/docker_compose_pull.yaml
@@ -98,7 +98,7 @@ examples: |-
      ⠹ f63c47038e66 Waiting                                                  9.3s
      ⠹ 77a0c198cde5 Waiting                                                  9.3s
      ⠹ c8752d5b785c Waiting                                                  9.3s
-  ``̀`
+  ```
 deprecated: false
 experimental: false
 experimentalcli: false


### PR DESCRIPTION
There was an invalid character between the two backticks at the end of the last snippet, causing the styling to break on the online documentation.

**What I did**
Replace it with a backtick.

![Stocksy_comp_watermarked_1995952](https://user-images.githubusercontent.com/71255433/177207904-fe2d3389-b246-4d99-8b9e-fabcc50d5ac7.jpg)

