### PR TITLE
Environment variables priority

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -354,10 +354,8 @@ func setEnvWithDotEnv(prjOpts *projectOptions) error {
 		return err
 	}
 	for k, v := range envFromFile {
-		if _, ok := os.LookupEnv(k); !ok {
-			if err := os.Setenv(k, v); err != nil {
-				return err
-			}
+		if err := os.Setenv(k, v); err != nil { // overwrite the process env with merged OS + env file results
+			return err
 		}
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -151,3 +151,5 @@ replace (
 	k8s.io/apimachinery => k8s.io/apimachinery v0.22.4
 	k8s.io/client-go => k8s.io/client-go v0.22.4
 )
+
+replace github.com/compose-spec/compose-go => github.com/compose-spec/compose-go v1.2.9-0.20220712021117-dcfe0889b601 // TODO Remove and bump require section when PR is merged

--- a/go.sum
+++ b/go.sum
@@ -285,9 +285,8 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v1.2.1/go.mod h1:pAy7Mikpeft4pxkFU565/DRHEbDfR84G6AQuiL+Hdg8=
-github.com/compose-spec/compose-go v1.2.9 h1:+7q2X8gCd16qUX+FU5EPtepK9lWZSGfc8Xe2cGmZqDc=
-github.com/compose-spec/compose-go v1.2.9/go.mod h1:rGaQw1U8uhZhmANQHIocMnQ+qu6ER2+1OwhWjRqQEPI=
+github.com/compose-spec/compose-go v1.2.9-0.20220712021117-dcfe0889b601 h1:dG3F1lPuUkmpxGs5qB3dFhqsXp06bpJHd0Btt6K15cU=
+github.com/compose-spec/compose-go v1.2.9-0.20220712021117-dcfe0889b601/go.mod h1:rGaQw1U8uhZhmANQHIocMnQ+qu6ER2+1OwhWjRqQEPI=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
@@ -1007,7 +1006,6 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
@@ -2121,7 +2119,6 @@ gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
-gotest.tools/v3 v3.1.0/go.mod h1:fHy7eyTmJFO5bQbUsEGQ1v4m2J3Jz9eWL54TP2/ZuYQ=
 gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
 gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -114,15 +114,12 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 		service.Entrypoint = opts.Entrypoint
 	}
 	if len(opts.Environment) > 0 {
-		env := types.NewMappingWithEquals(opts.Environment)
-		projectEnv := env.Resolve(func(s string) (string, bool) {
-			if _, ok := service.Environment[s]; ok {
-				return "", false
-			}
+		cmdEnv := types.NewMappingWithEquals(opts.Environment)
+		serviceOverrideEnv := cmdEnv.Resolve(func(s string) (string, bool) {
 			v, ok := project.Environment[s]
 			return v, ok
 		}).RemoveEmpty()
-		service.Environment.OverrideBy(projectEnv)
+		service.Environment.OverrideBy(serviceOverrideEnv)
 	}
 	for k, v := range opts.Labels {
 		service.Labels = service.Labels.Add(k, v)

--- a/pkg/e2e/compose_environment_test.go
+++ b/pkg/e2e/compose_environment_test.go
@@ -84,6 +84,19 @@ func TestEnvPriority(t *testing.T) {
 	// 3. Environment file <-- Result expected
 	// 4. Dockerfile
 	// 5. Variable is not defined
+	t.Run("override env file from compose", func(t *testing.T) {
+		res := c.RunDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose-with-env-file.yaml",
+			"--project-directory", projectDir,
+			"run", "--rm", "-e", "WHEREAMI", "env-compose-priority")
+		assert.Equal(t, strings.TrimSpace(res.Stdout()), "override")
+	})
+
+	//  No Compose file & no env variable but override env file
+	// 1. Compose file
+	// 2. Shell environment variables
+	// 3. Environment file <-- Result expected
+	// 4. Dockerfile
+	// 5. Variable is not defined
 	t.Run("override env file", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
 			projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run", "--rm", "-e",

--- a/pkg/e2e/fixtures/environment/env-interpolation-default-value/.env
+++ b/pkg/e2e/fixtures/environment/env-interpolation-default-value/.env
@@ -1,0 +1,1 @@
+IMAGE=default_env:${WHEREAMI:-EnvFileDefaultValue}

--- a/pkg/e2e/fixtures/environment/env-interpolation-default-value/compose.yaml
+++ b/pkg/e2e/fixtures/environment/env-interpolation-default-value/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  env-interpolation:
+    image: bash
+    environment:
+      IMAGE: ${IMAGE}
+    command: echo "$IMAGE"

--- a/pkg/e2e/fixtures/environment/env-interpolation/.env
+++ b/pkg/e2e/fixtures/environment/env-interpolation/.env
@@ -1,2 +1,2 @@
-WHEREAMI=Env File
+WHEREAMI=EnvFile
 IMAGE=default_env:${WHEREAMI}

--- a/pkg/e2e/fixtures/environment/env-priority/.env.override.with.default
+++ b/pkg/e2e/fixtures/environment/env-priority/.env.override.with.default
@@ -1,0 +1,1 @@
+WHEREAMI=${WHEREAMI:-EnvFileDefaultValue}

--- a/pkg/e2e/fixtures/environment/env-priority/compose-with-env-file.yaml
+++ b/pkg/e2e/fixtures/environment/env-priority/compose-with-env-file.yaml
@@ -1,0 +1,7 @@
+services:
+  env-compose-priority:
+    image: env-compose-priority
+    build:
+      context: .
+    env_file:
+      - .env.override


### PR DESCRIPTION
**What I did**
This PR is meant to define the precedence of the environment variables evaluation.

For the environment variables to be **available in the container**:
1. Command Line (`docker compose run --env <KEY[=VAL]>` https://docs.docker.com/engine/reference/commandline/compose_run/#options)
2. Compose File (`service::environment` section: https://docs.docker.com/compose/compose-file/#environment)
3. Compose File (`service::env_file` section file: https://docs.docker.com/compose/compose-file/#env_file)
4. Container Image `ENV` directive (https://docs.docker.com/engine/reference/builder/#env)

---

For the environment variables available for **`docker compose`'s runtime**:
1. Command Line parent command option `docker compose --env-file <FILE>` (or `.env` in the root of the project by default)
2. OS Environment Variables

Obs: Note that the variables available for runtime will not be available in the container unless it's imported by one of the methods on the list above

**Related issue**
Resolves https://github.com/docker/compose/issues/9521
Resolves https://github.com/docker/compose/issues/9638
Resolves https://github.com/docker/compose/issues/9608
Resolves https://github.com/docker/compose/issues/9578
Resolves https://github.com/docker/compose/issues/9468
Resolves https://github.com/docker/compose/issues/9683

Depends on https://github.com/compose-spec/compose-go/pull/280

Documentation update [PR](https://github.com/docker/docker.github.io/pull/15161)

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![beautiful-goat](https://user-images.githubusercontent.com/373485/178592172-4a9cfc57-b47a-402a-af58-22f49daf2236.jpeg)

