### PR TITLE
Simplify e2e methods

### DIFF
--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -31,33 +31,33 @@ func TestLocalComposeBuild(t *testing.T) {
 
 	t.Run("build named and unnamed images", func(t *testing.T) {
 		// ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError(t, "rmi", "build-test_nginx")
-		c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+		c.RunDockerOrExitError("rmi", "build-test_nginx")
+		c.RunDockerOrExitError("rmi", "custom-nginx")
 
-		res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "build")
+		res := c.RunDockerComposeCmd("--project-directory", "fixtures/build-test", "build")
 
 		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
-		c.RunDockerCmd(t, "image", "inspect", "build-test_nginx")
-		c.RunDockerCmd(t, "image", "inspect", "custom-nginx")
+		c.RunDockerCmd("image", "inspect", "build-test_nginx")
+		c.RunDockerCmd("image", "inspect", "custom-nginx")
 	})
 
 	t.Run("build with build-arg", func(t *testing.T) {
 		// ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError(t, "rmi", "build-test_nginx")
-		c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+		c.RunDockerOrExitError("rmi", "build-test_nginx")
+		c.RunDockerOrExitError("rmi", "custom-nginx")
 
-		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "build", "--build-arg", "FOO=BAR")
+		c.RunDockerComposeCmd("--project-directory", "fixtures/build-test", "build", "--build-arg", "FOO=BAR")
 
-		res := c.RunDockerCmd(t, "image", "inspect", "build-test_nginx")
+		res := c.RunDockerCmd("image", "inspect", "build-test_nginx")
 		res.Assert(t, icmd.Expected{Out: `"FOO": "BAR"`})
 	})
 
 	t.Run("build with build-arg set by env", func(t *testing.T) {
 		// ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError(t, "rmi", "build-test_nginx")
-		c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+		c.RunDockerOrExitError("rmi", "build-test_nginx")
+		c.RunDockerOrExitError("rmi", "custom-nginx")
 
-		icmd.RunCmd(c.NewDockerComposeCmd(t,
+		icmd.RunCmd(c.NewDockerComposeCmd(
 			"--project-directory",
 			"fixtures/build-test",
 			"build",
@@ -67,25 +67,25 @@ func TestLocalComposeBuild(t *testing.T) {
 				cmd.Env = append(cmd.Env, "FOO=BAR")
 			})
 
-		res := c.RunDockerCmd(t, "image", "inspect", "build-test_nginx")
+		res := c.RunDockerCmd("image", "inspect", "build-test_nginx")
 		res.Assert(t, icmd.Expected{Out: `"FOO": "BAR"`})
 	})
 
 	t.Run("build with multiple build-args ", func(t *testing.T) {
 		// ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError(t, "rmi", "-f", "multi-args_multiargs")
-		cmd := c.NewDockerComposeCmd(t, "--project-directory", "fixtures/build-test/multi-args", "build")
+		c.RunDockerOrExitError("rmi", "-f", "multi-args_multiargs")
+		cmd := c.NewDockerComposeCmd("--project-directory", "fixtures/build-test/multi-args", "build")
 
 		icmd.RunCmd(cmd, func(cmd *icmd.Cmd) {
 			cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=0")
 		})
 
-		res := c.RunDockerCmd(t, "image", "inspect", "multi-args_multiargs")
+		res := c.RunDockerCmd("image", "inspect", "multi-args_multiargs")
 		res.Assert(t, icmd.Expected{Out: `"RESULT": "SUCCESS"`})
 	})
 
 	t.Run("build failed with ssh default value", func(t *testing.T) {
-		res := c.RunDockerComposeCmdNoCheck(t, "--project-directory", "fixtures/build-test", "build", "--ssh", "")
+		res := c.RunDockerComposeCmdNoCheck("--project-directory", "fixtures/build-test", "build", "--ssh", "")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "invalid empty ssh agent socket: make sure SSH_AUTH_SOCK is set",
@@ -94,24 +94,24 @@ func TestLocalComposeBuild(t *testing.T) {
 	})
 
 	t.Run("build succeed with ssh from Compose file", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "rmi", "build-test-ssh")
+		c.RunDockerOrExitError("rmi", "build-test-ssh")
 
-		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test/ssh", "build")
-		c.RunDockerCmd(t, "image", "inspect", "build-test-ssh")
+		c.RunDockerComposeCmd("--project-directory", "fixtures/build-test/ssh", "build")
+		c.RunDockerCmd("image", "inspect", "build-test-ssh")
 	})
 
 	t.Run("build succeed with ssh from CLI", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "rmi", "build-test-ssh")
+		c.RunDockerOrExitError("rmi", "build-test-ssh")
 
-		c.RunDockerComposeCmd(t, "-f", "fixtures/build-test/ssh/compose-without-ssh.yaml", "--project-directory",
+		c.RunDockerComposeCmd("-f", "fixtures/build-test/ssh/compose-without-ssh.yaml", "--project-directory",
 			"fixtures/build-test/ssh", "build", "--no-cache", "--ssh", "fake-ssh=./fixtures/build-test/ssh/fake_rsa")
-		c.RunDockerCmd(t, "image", "inspect", "build-test-ssh")
+		c.RunDockerCmd("image", "inspect", "build-test-ssh")
 	})
 
 	t.Run("build failed with wrong ssh key id from CLI", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "rmi", "build-test-ssh")
+		c.RunDockerOrExitError("rmi", "build-test-ssh")
 
-		res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/build-test/ssh/compose-without-ssh.yaml",
+		res := c.RunDockerComposeCmdNoCheck("-f", "fixtures/build-test/ssh/compose-without-ssh.yaml",
 			"--project-directory", "fixtures/build-test/ssh", "build", "--no-cache", "--ssh",
 			"wrong-ssh=./fixtures/build-test/ssh/fake_rsa")
 		res.Assert(t, icmd.Expected{
@@ -121,51 +121,51 @@ func TestLocalComposeBuild(t *testing.T) {
 	})
 
 	t.Run("build succeed as part of up with ssh from Compose file", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "rmi", "build-test-ssh")
+		c.RunDockerOrExitError("rmi", "build-test-ssh")
 
-		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test/ssh", "up", "-d", "--build")
+		c.RunDockerComposeCmd("--project-directory", "fixtures/build-test/ssh", "up", "-d", "--build")
 		t.Cleanup(func() {
-			c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test/ssh", "down")
+			c.RunDockerComposeCmd("--project-directory", "fixtures/build-test/ssh", "down")
 		})
-		c.RunDockerCmd(t, "image", "inspect", "build-test-ssh")
+		c.RunDockerCmd("image", "inspect", "build-test-ssh")
 	})
 
 	t.Run("build as part of up", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "rmi", "build-test_nginx")
-		c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+		c.RunDockerOrExitError("rmi", "build-test_nginx")
+		c.RunDockerOrExitError("rmi", "custom-nginx")
 
-		res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "up", "-d")
+		res := c.RunDockerComposeCmd("--project-directory", "fixtures/build-test", "up", "-d")
 		t.Cleanup(func() {
-			c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "down")
+			c.RunDockerComposeCmd("--project-directory", "fixtures/build-test", "down")
 		})
 
 		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
 		res.Assert(t, icmd.Expected{Out: "COPY static2 /usr/share/nginx/html"})
 
-		output := HTTPGetWithRetry(t, "http://localhost:8070", http.StatusOK, 2*time.Second, 20*time.Second)
+		output := c.HTTPGetWithRetry("http://localhost:8070", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, "Hello from Nginx container"))
 
-		c.RunDockerCmd(t, "image", "inspect", "build-test_nginx")
-		c.RunDockerCmd(t, "image", "inspect", "custom-nginx")
+		c.RunDockerCmd("image", "inspect", "build-test_nginx")
+		c.RunDockerCmd("image", "inspect", "custom-nginx")
 	})
 
 	t.Run("no rebuild when up again", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "up", "-d")
+		res := c.RunDockerComposeCmd("--project-directory", "fixtures/build-test", "up", "-d")
 
 		assert.Assert(t, !strings.Contains(res.Stdout(), "COPY static"), res.Stdout())
 	})
 
 	t.Run("rebuild when up --build", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--workdir", "fixtures/build-test", "up", "-d", "--build")
+		res := c.RunDockerComposeCmd("--workdir", "fixtures/build-test", "up", "-d", "--build")
 
 		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
 		res.Assert(t, icmd.Expected{Out: "COPY static2 /usr/share/nginx/html"})
 	})
 
 	t.Run("cleanup build project", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "down")
-		c.RunDockerCmd(t, "rmi", "build-test_nginx")
-		c.RunDockerCmd(t, "rmi", "custom-nginx")
+		c.RunDockerComposeCmd("--project-directory", "fixtures/build-test", "down")
+		c.RunDockerCmd("rmi", "build-test_nginx")
+		c.RunDockerCmd("rmi", "custom-nginx")
 	})
 }
 
@@ -174,9 +174,9 @@ func TestBuildSecrets(t *testing.T) {
 
 	t.Run("build with secrets", func(t *testing.T) {
 		// ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError(t, "rmi", "build-test-secret")
+		c.RunDockerOrExitError("rmi", "build-test-secret")
 
-		cmd := c.NewDockerComposeCmd(t, "--project-directory", "fixtures/build-test/secrets", "build")
+		cmd := c.NewDockerComposeCmd("--project-directory", "fixtures/build-test/secrets", "build")
 
 		res := icmd.RunCmd(cmd, func(cmd *icmd.Cmd) {
 			cmd.Env = append(cmd.Env, "SOME_SECRET=bar")
@@ -192,11 +192,11 @@ func TestBuildTags(t *testing.T) {
 	t.Run("build with tags", func(t *testing.T) {
 
 		// ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError(t, "rmi", "build-test-tags")
+		c.RunDockerOrExitError("rmi", "build-test-tags")
 
-		c.RunDockerComposeCmd(t, "--project-directory", "./fixtures/build-test/tags", "build", "--no-cache")
+		c.RunDockerComposeCmd("--project-directory", "./fixtures/build-test/tags", "build", "--no-cache")
 
-		res := c.RunDockerCmd(t, "image", "inspect", "build-test-tags")
+		res := c.RunDockerCmd("image", "inspect", "build-test-tags")
 		expectedOutput := `"RepoTags": [
             "docker/build-test-tags:1.0.0",
             "build-test-tags:latest",
@@ -210,22 +210,22 @@ func TestBuildTags(t *testing.T) {
 func TestBuildImageDependencies(t *testing.T) {
 	doTest := func(t *testing.T, cli *CLI) {
 		resetState := func() {
-			cli.RunDockerComposeCmd(t, "down", "--rmi=all", "-t=0")
+			cli.RunDockerComposeCmd("down", "--rmi=all", "-t=0")
 		}
 		resetState()
 		t.Cleanup(resetState)
 
 		// the image should NOT exist now
-		res := cli.RunDockerOrExitError(t, "image", "inspect", "build-dependencies_service")
+		res := cli.RunDockerOrExitError("image", "inspect", "build-dependencies_service")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "Error: No such image: build-dependencies_service",
 		})
 
-		res = cli.RunDockerComposeCmd(t, "build")
+		res = cli.RunDockerComposeCmd("build")
 		t.Log(res.Combined())
 
-		res = cli.RunDockerCmd(t,
+		res = cli.RunDockerCmd(
 			"image", "inspect", "--format={{ index .RepoTags 0 }}",
 			"build-dependencies_service")
 		res.Assert(t, icmd.Expected{Out: "build-dependencies_service:latest"})

--- a/pkg/e2e/cancel_test.go
+++ b/pkg/e2e/cancel_test.go
@@ -36,16 +36,16 @@ func TestComposeCancel(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	t.Run("metrics on cancel Compose build", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "ls")
+		c.RunDockerComposeCmd("ls")
 		buildProjectPath := "fixtures/build-infinite/compose.yaml"
 
 		// require a separate groupID from the process running tests, in order to simulate ctrl+C from a terminal.
 		// sending kill signal
-		cmd, stdout, stderr, err := StartWithNewGroupID(c.NewDockerComposeCmd(t, "-f", buildProjectPath, "build",
+		cmd, stdout, stderr, err := StartWithNewGroupID(c.NewDockerComposeCmd("-f", buildProjectPath, "build",
 			"--progress", "plain"))
 		assert.NilError(t, err)
 
-		c.WaitForCondition(t, func() (bool, string) {
+		c.WaitForCondition(func() (bool, string) {
 			out := stdout.String()
 			errors := stderr.String()
 			return strings.Contains(out,
@@ -56,7 +56,7 @@ func TestComposeCancel(t *testing.T) {
 		err = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT) // simulate Ctrl-C : send signal to processGroup, children will have same groupId by default
 
 		assert.NilError(t, err)
-		c.WaitForCondition(t, func() (bool, string) {
+		c.WaitForCondition(func() (bool, string) {
 			out := stdout.String()
 			errors := stderr.String()
 			return strings.Contains(out, "CANCELED"), fmt.Sprintf("'CANCELED' not found in : \n%s\nStderr: \n%s\n", out,

--- a/pkg/e2e/cascade_stop_test.go
+++ b/pkg/e2e/cascade_stop_test.go
@@ -28,23 +28,23 @@ func TestCascadeStop(t *testing.T) {
 	const projectName = "e2e-cascade-stop"
 
 	t.Run("abort-on-container-exit", func(t *testing.T) {
-		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
+		res := c.RunDockerComposeCmdNoCheck("-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
 		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `should_fail-1 exited with code 1`})
 		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `Aborting on container exit...`})
 	})
 
 	t.Run("exit-code-from", func(t *testing.T) {
-		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
+		res := c.RunDockerComposeCmdNoCheck("-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
 		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `should_fail-1 exited with code 1`})
 		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `Aborting on container exit...`})
 	})
 
 	t.Run("exit-code-from unknown", func(t *testing.T) {
-		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=unknown")
+		res := c.RunDockerComposeCmdNoCheck("-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=unknown")
 		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `no such service: unknown`})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }

--- a/pkg/e2e/compose_down_test.go
+++ b/pkg/e2e/compose_down_test.go
@@ -28,7 +28,7 @@ func TestDown(t *testing.T) {
 	const projectName = "e2e-down"
 
 	t.Run("no resource to remove", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "down")
 		res.Assert(t, icmd.Expected{ExitCode: 0, Err: `No resource found to remove for project "e2e-down"`})
 	})
 }

--- a/pkg/e2e/compose_environment_test.go
+++ b/pkg/e2e/compose_environment_test.go
@@ -30,8 +30,8 @@ func TestEnvPriority(t *testing.T) {
 	projectDir := "./fixtures/environment/env-priority"
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "rmi", "env-compose-priority")
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose-with-env.yaml",
+		c.RunDockerOrExitError("rmi", "env-compose-priority")
+		c.RunDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose-with-env.yaml",
 			"--project-directory", projectDir, "up", "-d", "--build")
 	})
 
@@ -42,7 +42,7 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("compose file priority", func(t *testing.T) {
-		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose-with-env.yaml",
+		cmd := c.NewDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose-with-env.yaml",
 			"--project-directory", projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run",
 			"--rm", "-e", "WHEREAMI", "env-compose-priority")
 		cmd.Env = append(cmd.Env, "WHEREAMI=shell")
@@ -57,7 +57,7 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("shell priority", func(t *testing.T) {
-		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
+		cmd := c.NewDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
 			projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run", "--rm", "-e",
 			"WHEREAMI", "env-compose-priority")
 		cmd.Env = append(cmd.Env, "WHEREAMI=shell")
@@ -72,7 +72,7 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("shell priority from run command", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
 			projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run", "--rm", "-e",
 			"WHEREAMI=shell-run", "env-compose-priority")
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "shell-run")
@@ -85,7 +85,7 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("override env file", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
 			projectDir, "--env-file", "./fixtures/environment/env-priority/.env.override", "run", "--rm", "-e",
 			"WHEREAMI", "env-compose-priority")
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "override")
@@ -98,7 +98,7 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("env file", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
 			projectDir, "run", "--rm", "-e", "WHEREAMI", "env-compose-priority")
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "Env File")
 	})
@@ -110,14 +110,14 @@ func TestEnvPriority(t *testing.T) {
 	// 4. Dockerfile   <-- Result expected
 	// 5. Variable is not defined
 	t.Run("use Dockerfile", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/environment/env-priority/compose.yaml", "--project-directory",
 			projectDir, "--env-file", "./fixtures/environment/env-priority/.env.empty", "run", "--rm", "-e", "WHEREAMI",
 			"env-compose-priority")
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "Dockerfile")
 	})
 
 	t.Run("down", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "--project-directory", projectDir, "down")
+		c.RunDockerComposeCmd("--project-directory", projectDir, "down")
 	})
 }
 
@@ -133,7 +133,7 @@ func TestEnvInterpolation(t *testing.T) {
 	// 4. Dockerfile
 	// 5. Variable is not defined
 	t.Run("shell priority from run command", func(t *testing.T) {
-		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-interpolation/compose.yaml",
+		cmd := c.NewDockerComposeCmd("-f", "./fixtures/environment/env-interpolation/compose.yaml",
 			"--project-directory", projectDir, "config")
 		cmd.Env = append(cmd.Env, "WHEREAMI=shell")
 		res := icmd.RunCmd(cmd)
@@ -147,17 +147,17 @@ func TestCommentsInEnvFile(t *testing.T) {
 	projectDir := "./fixtures/environment/env-file-comments"
 
 	t.Run("comments in env files", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "rmi", "env-file-comments")
+		c.RunDockerOrExitError("rmi", "env-file-comments")
 
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-file-comments/compose.yaml", "--project-directory",
+		c.RunDockerComposeCmd("-f", "./fixtures/environment/env-file-comments/compose.yaml", "--project-directory",
 			projectDir, "up", "-d", "--build")
 
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/environment/env-file-comments/compose.yaml",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/environment/env-file-comments/compose.yaml",
 			"--project-directory", projectDir, "run", "--rm", "-e", "COMMENT", "-e", "NO_COMMENT", "env-file-comments")
 
 		res.Assert(t, icmd.Expected{Out: `COMMENT=1234`})
 		res.Assert(t, icmd.Expected{Out: `NO_COMMENT=1234#5`})
 
-		c.RunDockerComposeCmd(t, "--project-directory", projectDir, "down", "--rmi", "all")
+		c.RunDockerComposeCmd("--project-directory", projectDir, "down", "--rmi", "all")
 	})
 }

--- a/pkg/e2e/compose_exec_test.go
+++ b/pkg/e2e/compose_exec_test.go
@@ -35,19 +35,19 @@ func TestLocalComposeExec(t *testing.T) {
 		return ret
 	}
 
-	c.RunDockerComposeCmd(t, cmdArgs("up", "-d")...)
+	c.RunDockerComposeCmd(cmdArgs("up", "-d")...)
 
 	t.Run("exec true", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, cmdArgs("exec", "simple", "/bin/true")...)
+		c.RunDockerComposeCmd(cmdArgs("exec", "simple", "/bin/true")...)
 	})
 
 	t.Run("exec false", func(t *testing.T) {
-		res := c.RunDockerComposeCmdNoCheck(t, cmdArgs("exec", "simple", "/bin/false")...)
+		res := c.RunDockerComposeCmdNoCheck(cmdArgs("exec", "simple", "/bin/false")...)
 		res.Assert(t, icmd.Expected{ExitCode: 1})
 	})
 
 	t.Run("exec with env set", func(t *testing.T) {
-		res := icmd.RunCmd(c.NewDockerComposeCmd(t, cmdArgs("exec", "-e", "FOO", "simple", "/usr/bin/env")...),
+		res := icmd.RunCmd(c.NewDockerComposeCmd(cmdArgs("exec", "-e", "FOO", "simple", "/usr/bin/env")...),
 			func(cmd *icmd.Cmd) {
 				cmd.Env = append(cmd.Env, "FOO=BAR")
 			})
@@ -55,7 +55,7 @@ func TestLocalComposeExec(t *testing.T) {
 	})
 
 	t.Run("exec without env set", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, cmdArgs("exec", "-e", "FOO", "simple", "/usr/bin/env")...)
+		res := c.RunDockerComposeCmd(cmdArgs("exec", "-e", "FOO", "simple", "/usr/bin/env")...)
 		assert.Check(t, !strings.Contains(res.Stdout(), "FOO="), res.Combined())
 	})
 }

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -29,11 +29,11 @@ func TestLocalComposeRun(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	t.Run("compose run", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "back")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "run", "back")
 		lines := Lines(res.Stdout())
 		assert.Equal(t, lines[len(lines)-1], "Hello there!!", res.Stdout())
 		assert.Assert(t, !strings.Contains(res.Combined(), "orphan"))
-		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo",
+		res = c.RunDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo",
 			"Hello one more time")
 		lines = Lines(res.Stdout())
 		assert.Equal(t, lines[len(lines)-1], "Hello one more time", res.Stdout())
@@ -41,7 +41,7 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("check run container exited", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "ps", "--all")
+		res := c.RunDockerCmd("ps", "--all")
 		lines := Lines(res.Stdout())
 		var runContainerID string
 		var truncatedSlug string
@@ -60,7 +60,7 @@ func TestLocalComposeRun(t *testing.T) {
 			}
 		}
 		assert.Assert(t, runContainerID != "")
-		res = c.RunDockerCmd(t, "inspect", runContainerID)
+		res = c.RunDockerCmd("inspect", runContainerID)
 		res.Assert(t, icmd.Expected{Out: ` "Status": "exited"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.container-number": "1"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": "run-test"`})
@@ -69,46 +69,46 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("compose run --rm", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--rm", "back", "echo",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "run", "--rm", "back", "echo",
 			"Hello again")
 		lines := Lines(res.Stdout())
 		assert.Equal(t, lines[len(lines)-1], "Hello again", res.Stdout())
 
-		res = c.RunDockerCmd(t, "ps", "--all")
+		res = c.RunDockerCmd("ps", "--all")
 		assert.Assert(t, strings.Contains(res.Stdout(), "run-test_back"), res.Stdout())
 	})
 
 	t.Run("down", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "down")
-		res := c.RunDockerCmd(t, "ps", "--all")
+		c.RunDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "down")
+		res := c.RunDockerCmd("ps", "--all")
 		assert.Assert(t, !strings.Contains(res.Stdout(), "run-test"), res.Stdout())
 	})
 
 	t.Run("compose run --volumes", func(t *testing.T) {
 		wd, err := os.Getwd()
 		assert.NilError(t, err)
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--volumes", wd+":/foo",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "run", "--volumes", wd+":/foo",
 			"back", "/bin/sh", "-c", "ls /foo")
 		res.Assert(t, icmd.Expected{Out: "compose_run_test.go"})
 
-		res = c.RunDockerCmd(t, "ps", "--all")
+		res = c.RunDockerCmd("ps", "--all")
 		assert.Assert(t, strings.Contains(res.Stdout(), "run-test_back"), res.Stdout())
 	})
 
 	t.Run("compose run --publish", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--publish", "8081:80", "-d", "back",
+		c.RunDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "run", "--publish", "8081:80", "-d", "back",
 			"/bin/sh", "-c", "sleep 1")
-		res := c.RunDockerCmd(t, "ps")
+		res := c.RunDockerCmd("ps")
 		assert.Assert(t, strings.Contains(res.Stdout(), "8081->80/tcp"), res.Stdout())
 	})
 
 	t.Run("compose run orphan", func(t *testing.T) {
 		// Use different compose files to get an orphan container
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/orphan.yaml", "run", "simple")
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo", "Hello")
+		c.RunDockerComposeCmd("-f", "./fixtures/run-test/orphan.yaml", "run", "simple")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo", "Hello")
 		assert.Assert(t, strings.Contains(res.Combined(), "orphan"))
 
-		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo", "Hello")
+		cmd := c.NewDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "run", "back", "echo", "Hello")
 		res = icmd.RunCmd(cmd, func(cmd *icmd.Cmd) {
 			cmd.Env = append(cmd.Env, "COMPOSE_IGNORE_ORPHANS=True")
 		})
@@ -116,23 +116,23 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("down", func(t *testing.T) {
-		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "down")
+		cmd := c.NewDockerComposeCmd("-f", "./fixtures/run-test/compose.yaml", "down")
 		icmd.RunCmd(cmd, func(c *icmd.Cmd) {
 			c.Env = append(c.Env, "COMPOSE_REMOVE_ORPHANS=True")
 		})
-		res := c.RunDockerCmd(t, "ps", "--all")
+		res := c.RunDockerCmd("ps", "--all")
 		assert.Assert(t, !strings.Contains(res.Stdout(), "run-test"), res.Stdout())
 	})
 
 	t.Run("run starts only container and dependencies", func(t *testing.T) {
 		// ensure that even if another service is up run does not start it: https://github.com/docker/compose/issues/9459
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/deps.yaml", "up", "service_b")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/run-test/deps.yaml", "up", "service_b")
 		res.Assert(t, icmd.Success)
 
-		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/deps.yaml", "run", "service_a")
+		res = c.RunDockerComposeCmd("-f", "./fixtures/run-test/deps.yaml", "run", "service_a")
 		assert.Assert(t, strings.Contains(res.Combined(), "shared_dep"), res.Combined())
 		assert.Assert(t, !strings.Contains(res.Combined(), "service_b"), res.Combined())
 
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/deps.yaml", "down", "--remove-orphans")
+		c.RunDockerComposeCmd("-f", "./fixtures/run-test/deps.yaml", "down", "--remove-orphans")
 	})
 }

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -37,23 +37,23 @@ func TestLocalComposeUp(t *testing.T) {
 	const projectName = "compose-e2e-demo"
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/sentences/compose.yaml", "--project-name", projectName, "up", "-d")
+		c.RunDockerComposeCmd("-f", "./fixtures/sentences/compose.yaml", "--project-name", projectName, "up", "-d")
 	})
 
 	t.Run("check accessing running app", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res := c.RunDockerComposeCmd("-p", projectName, "ps")
 		res.Assert(t, icmd.Expected{Out: `web`})
 
 		endpoint := "http://localhost:90"
-		output := HTTPGetWithRetry(t, endpoint+"/words/noun", http.StatusOK, 2*time.Second, 20*time.Second)
+		output := c.HTTPGetWithRetry(endpoint+"/words/noun", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, `"word":`))
 
-		res = c.RunDockerCmd(t, "network", "ls")
+		res = c.RunDockerCmd("network", "ls")
 		res.Assert(t, icmd.Expected{Out: projectName + "_default"})
 	})
 
 	t.Run("top", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-p", projectName, "top")
+		res := c.RunDockerComposeCmd("-p", projectName, "top")
 		output := res.Stdout()
 		head := []string{"UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"}
 		for _, h := range head {
@@ -64,7 +64,7 @@ func TestLocalComposeUp(t *testing.T) {
 	})
 
 	t.Run("check compose labels", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "inspect", projectName+"-web-1")
+		res := c.RunDockerCmd("inspect", projectName+"-web-1")
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.container-number": "1"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": "compose-e2e-demo"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.oneoff": "False",`})
@@ -74,47 +74,47 @@ func TestLocalComposeUp(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.service": "web"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version":`})
 
-		res = c.RunDockerCmd(t, "network", "inspect", projectName+"_default")
+		res = c.RunDockerCmd("network", "inspect", projectName+"_default")
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.network": "default"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": `})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version": `})
 	})
 
 	t.Run("check user labels", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "inspect", projectName+"-web-1")
+		res := c.RunDockerCmd("inspect", projectName+"-web-1")
 		res.Assert(t, icmd.Expected{Out: `"my-label": "test"`})
 
 	})
 
 	t.Run("check healthcheck output", func(t *testing.T) {
-		c.WaitForCmdResult(t, c.NewDockerComposeCmd(t, "-p", projectName, "ps", "--format", "json"),
+		c.WaitForCmdResult(c.NewDockerComposeCmd("-p", projectName, "ps", "--format", "json"),
 			StdoutContains(`"Name":"compose-e2e-demo-web-1","Command":"/dispatcher","Project":"compose-e2e-demo","Service":"web","State":"running","Health":"healthy"`),
 			5*time.Second, 1*time.Second)
 
-		res := c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res := c.RunDockerComposeCmd("-p", projectName, "ps")
 		res.Assert(t, icmd.Expected{Out: `NAME                       COMMAND                  SERVICE             STATUS              PORTS`})
 		res.Assert(t, icmd.Expected{Out: `compose-e2e-demo-web-1     "/dispatcher"            web                 running (healthy)   0.0.0.0:90->80/tcp`})
 		res.Assert(t, icmd.Expected{Out: `compose-e2e-demo-db-1      "docker-entrypoint.s…"   db                  running             5432/tcp`})
 	})
 
 	t.Run("images", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-p", projectName, "images")
+		res := c.RunDockerComposeCmd("-p", projectName, "images")
 		res.Assert(t, icmd.Expected{Out: `compose-e2e-demo-db-1      gtardif/sentences-db    latest`})
 		res.Assert(t, icmd.Expected{Out: `compose-e2e-demo-web-1     gtardif/sentences-web   latest`})
 		res.Assert(t, icmd.Expected{Out: `compose-e2e-demo-words-1   gtardif/sentences-api   latest`})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 
 	t.Run("check containers after down", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "ps", "--all")
+		res := c.RunDockerCmd("ps", "--all")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 
 	t.Run("check networks after down", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "network", "ls")
+		res := c.RunDockerCmd("network", "ls")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }
@@ -122,7 +122,7 @@ func TestLocalComposeUp(t *testing.T) {
 func TestComposePull(t *testing.T) {
 	c := NewParallelCLI(t)
 
-	res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/simple-composefile", "pull")
+	res := c.RunDockerComposeCmd("--project-directory", "fixtures/simple-composefile", "pull")
 	output := res.Combined()
 
 	assert.Assert(t, strings.Contains(output, "simple Pulled"))
@@ -137,21 +137,21 @@ func TestDownComposefileInParentFolder(t *testing.T) {
 	defer os.Remove(tmpFolder) // nolint: errcheck
 	projectName := filepath.Base(tmpFolder)
 
-	res := c.RunDockerComposeCmd(t, "--project-directory", tmpFolder, "up", "-d")
+	res := c.RunDockerComposeCmd("--project-directory", tmpFolder, "up", "-d")
 	res.Assert(t, icmd.Expected{Err: "Started", ExitCode: 0})
 
-	res = c.RunDockerComposeCmd(t, "-p", projectName, "down")
+	res = c.RunDockerComposeCmd("-p", projectName, "down")
 	res.Assert(t, icmd.Expected{Err: "Removed", ExitCode: 0})
 }
 
 func TestAttachRestart(t *testing.T) {
 	c := NewParallelCLI(t)
 
-	cmd := c.NewDockerComposeCmd(t, "--ansi=never", "--project-directory", "./fixtures/attach-restart", "up")
+	cmd := c.NewDockerComposeCmd("--ansi=never", "--project-directory", "./fixtures/attach-restart", "up")
 	res := icmd.StartCmd(cmd)
-	defer c.RunDockerComposeCmd(t, "-p", "attach-restart", "down")
+	defer c.RunDockerComposeCmd("-p", "attach-restart", "down")
 
-	c.WaitForCondition(t, func() (bool, string) {
+	c.WaitForCondition(func() (bool, string) {
 		debug := res.Combined()
 		return strings.Count(res.Stdout(),
 				"failing-1 exited with code 1") == 3, fmt.Sprintf("'failing-1 exited with code 1' not found 3 times in : \n%s\n",
@@ -164,8 +164,8 @@ func TestAttachRestart(t *testing.T) {
 func TestInitContainer(t *testing.T) {
 	c := NewParallelCLI(t)
 
-	res := c.RunDockerComposeCmd(t, "--ansi=never", "--project-directory", "./fixtures/init-container", "up")
-	defer c.RunDockerComposeCmd(t, "-p", "init-container", "down")
+	res := c.RunDockerComposeCmd("--ansi=never", "--project-directory", "./fixtures/init-container", "up")
+	defer c.RunDockerComposeCmd("-p", "init-container", "down")
 	testify.Regexp(t, "foo-1  | hello(?m:.*)bar-1  | world", res.Stdout())
 }
 
@@ -175,28 +175,28 @@ func TestRm(t *testing.T) {
 	const projectName = "compose-e2e-rm"
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "up", "-d")
+		c.RunDockerComposeCmd("-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "up", "-d")
 	})
 
 	t.Run("rm -sf", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "rm",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "rm",
 			"-sf", "simple")
 		res.Assert(t, icmd.Expected{Err: "Removed", ExitCode: 0})
 	})
 
 	t.Run("check containers after rm -sf", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "ps", "--all")
+		res := c.RunDockerCmd("ps", "--all")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName+"_simple"), res.Combined())
 	})
 
 	t.Run("rm -sf <none>", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "rm",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "rm",
 			"-sf", "simple")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-p", projectName, "down")
+		c.RunDockerComposeCmd("-p", projectName, "down")
 	})
 }
 
@@ -207,19 +207,19 @@ func TestCompatibility(t *testing.T) {
 	const projectName = "compose-e2e-compatibility"
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "--compatibility", "-f", "./fixtures/sentences/compose.yaml", "--project-name",
+		c.RunDockerComposeCmd("--compatibility", "-f", "./fixtures/sentences/compose.yaml", "--project-name",
 			projectName, "up", "-d")
 	})
 
 	t.Run("check container names", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "ps", "--format", "{{.Names}}")
+		res := c.RunDockerCmd("ps", "--format", "{{.Names}}")
 		res.Assert(t, icmd.Expected{Out: "compose-e2e-compatibility_web_1"})
 		res.Assert(t, icmd.Expected{Out: "compose-e2e-compatibility_words_1"})
 		res.Assert(t, icmd.Expected{Out: "compose-e2e-compatibility_db_1"})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-p", projectName, "down")
+		c.RunDockerComposeCmd("-p", projectName, "down")
 	})
 }
 
@@ -231,7 +231,7 @@ func TestConvert(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("up", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose.yaml", "-p", projectName, "convert")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/simple-build-test/compose.yaml", "-p", projectName, "convert")
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`services:
   nginx:
     build:

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -31,7 +31,7 @@ func TestUpWait(t *testing.T) {
 	timeout := time.After(30 * time.Second)
 	done := make(chan bool)
 	go func() {
-		res := c.RunDockerComposeCmd(t, "-f", "fixtures/dependencies/deps-completed-successfully.yaml", "--project-name", projectName, "up", "--wait", "-d")
+		res := c.RunDockerComposeCmd("-f", "fixtures/dependencies/deps-completed-successfully.yaml", "--project-name", projectName, "up", "--wait", "-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-deps-wait-oneshot-1"), res.Combined())
 		done <- true
 	}()
@@ -43,5 +43,5 @@ func TestUpWait(t *testing.T) {
 		break
 	}
 
-	c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	c.RunDockerComposeCmd("--project-name", projectName, "down")
 }

--- a/pkg/e2e/cp_test.go
+++ b/pkg/e2e/cp_test.go
@@ -31,7 +31,7 @@ func TestCopy(t *testing.T) {
 	const projectName = "copy_e2e"
 
 	t.Cleanup(func() {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "--project-name", projectName, "down")
+		c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "--project-name", projectName, "down")
 
 		os.Remove("./fixtures/cp-test/from-default.txt") //nolint:errcheck
 		os.Remove("./fixtures/cp-test/from-indexed.txt") //nolint:errcheck
@@ -39,44 +39,44 @@ func TestCopy(t *testing.T) {
 	})
 
 	t.Run("start service", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "--project-name", projectName, "up",
+		c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "--project-name", projectName, "up",
 			"--scale", "nginx=5", "-d")
 	})
 
 	t.Run("make sure service is running", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res := c.RunDockerComposeCmd("-p", projectName, "ps")
 		res.Assert(t, icmd.Expected{Out: `nginx               running`})
 	})
 
 	t.Run("copy to container copies the file to the all containers by default", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
 			"./fixtures/cp-test/cp-me.txt", "nginx:/tmp/default.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
-		output := c.RunDockerCmd(t, "exec", projectName+"-nginx-1", "cat", "/tmp/default.txt").Stdout()
+		output := c.RunDockerCmd("exec", projectName+"-nginx-1", "cat", "/tmp/default.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
-		output = c.RunDockerCmd(t, "exec", projectName+"-nginx-2", "cat", "/tmp/default.txt").Stdout()
+		output = c.RunDockerCmd("exec", projectName+"-nginx-2", "cat", "/tmp/default.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
-		output = c.RunDockerCmd(t, "exec", projectName+"-nginx-3", "cat", "/tmp/default.txt").Stdout()
+		output = c.RunDockerCmd("exec", projectName+"-nginx-3", "cat", "/tmp/default.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 	})
 
 	t.Run("copy to container with a given index copies the file to the given container", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "--index=3",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "--index=3",
 			"./fixtures/cp-test/cp-me.txt", "nginx:/tmp/indexed.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
-		output := c.RunDockerCmd(t, "exec", projectName+"-nginx-3", "cat", "/tmp/indexed.txt").Stdout()
+		output := c.RunDockerCmd("exec", projectName+"-nginx-3", "cat", "/tmp/indexed.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world`), output)
 
-		res = c.RunDockerOrExitError(t, "exec", projectName+"-nginx-2", "cat", "/tmp/indexed.txt")
+		res = c.RunDockerOrExitError("exec", projectName+"-nginx-2", "cat", "/tmp/indexed.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 1})
 	})
 
 	t.Run("copy from a container copies the file to the host from the first container by default", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
 			"nginx:/tmp/default.txt", "./fixtures/cp-test/from-default.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
@@ -86,7 +86,7 @@ func TestCopy(t *testing.T) {
 	})
 
 	t.Run("copy from a container with a given index copies the file to host", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "--index=3",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp", "--index=3",
 			"nginx:/tmp/indexed.txt", "./fixtures/cp-test/from-indexed.txt")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
@@ -96,14 +96,14 @@ func TestCopy(t *testing.T) {
 	})
 
 	t.Run("copy to and from a container also work with folder", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
 			"./fixtures/cp-test/cp-folder", "nginx:/tmp")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
-		output := c.RunDockerCmd(t, "exec", projectName+"-nginx-1", "cat", "/tmp/cp-folder/cp-me.txt").Stdout()
+		output := c.RunDockerCmd("exec", projectName+"-nginx-1", "cat", "/tmp/cp-folder/cp-me.txt").Stdout()
 		assert.Assert(t, strings.Contains(output, `hello world from folder`), output)
 
-		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
+		res = c.RunDockerComposeCmd("-f", "./fixtures/cp-test/compose.yaml", "-p", projectName, "cp",
 			"nginx:/tmp/cp-folder", "./fixtures/cp-test/cp-folder2")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 

--- a/pkg/e2e/ddev_test.go
+++ b/pkg/e2e/ddev_test.go
@@ -63,8 +63,8 @@ func TestComposeRunDdev(t *testing.T) {
 	siteName := filepath.Base(ddevDir)
 
 	t.Cleanup(func() {
-		_ = c.RunCmdInDir(t, ddevDir, "./ddev", "delete", "-Oy")
-		_ = c.RunCmdInDir(t, ddevDir, "./ddev", "poweroff")
+		_ = c.RunCmdInDir(ddevDir, "./ddev", "delete", "-Oy")
+		_ = c.RunCmdInDir(ddevDir, "./ddev", "poweroff")
 	})
 
 	osName := "linux"
@@ -73,26 +73,26 @@ func TestComposeRunDdev(t *testing.T) {
 	}
 
 	compressedFilename := fmt.Sprintf("ddev_%s-%s.%s.tar.gz", osName, runtime.GOARCH, ddevVersion)
-	c.RunCmdInDir(t, ddevDir, "curl", "-LO", fmt.Sprintf("https://github.com/drud/ddev/releases/download/%s/%s",
+	c.RunCmdInDir(ddevDir, "curl", "-LO", fmt.Sprintf("https://github.com/drud/ddev/releases/download/%s/%s",
 		ddevVersion,
 		compressedFilename))
 
-	c.RunCmdInDir(t, ddevDir, "tar", "-xzf", compressedFilename)
+	c.RunCmdInDir(ddevDir, "tar", "-xzf", compressedFilename)
 
 	// Create a simple index.php we can test against.
-	c.RunCmdInDir(t, ddevDir, "sh", "-c", "echo '<?php\nprint \"ddev is working\";' >index.php")
+	c.RunCmdInDir(ddevDir, "sh", "-c", "echo '<?php\nprint \"ddev is working\";' >index.php")
 
-	c.RunCmdInDir(t, ddevDir, "./ddev", "config", "--auto")
-	c.RunCmdInDir(t, ddevDir, "./ddev", "config", "global", "--use-docker-compose-from-path")
-	vRes := c.RunCmdInDir(t, ddevDir, "./ddev", "version")
+	c.RunCmdInDir(ddevDir, "./ddev", "config", "--auto")
+	c.RunCmdInDir(ddevDir, "./ddev", "config", "global", "--use-docker-compose-from-path")
+	vRes := c.RunCmdInDir(ddevDir, "./ddev", "version")
 	out := vRes.Stdout()
 	fmt.Printf("ddev version: %s\n", out)
 
-	c.RunCmdInDir(t, ddevDir, "./ddev", "poweroff")
+	c.RunCmdInDir(ddevDir, "./ddev", "poweroff")
 
-	c.RunCmdInDir(t, ddevDir, "./ddev", "start", "-y")
+	c.RunCmdInDir(ddevDir, "./ddev", "start", "-y")
 
-	curlRes := c.RunCmdInDir(t, ddevDir, "curl", "-sSL", fmt.Sprintf("http://%s.ddev.site", siteName))
+	curlRes := c.RunCmdInDir(ddevDir, "curl", "-sSL", fmt.Sprintf("http://%s.ddev.site", siteName))
 	out = curlRes.Stdout()
 	fmt.Println(out)
 	assert.Assert(t, strings.Contains(out, "ddev is working"), "Could not start project")

--- a/pkg/e2e/ipc_test.go
+++ b/pkg/e2e/ipc_test.go
@@ -30,35 +30,35 @@ func TestIPC(t *testing.T) {
 	const projectName = "ipc_e2e"
 	var cid string
 	t.Run("create ipc mode container", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "run", "-d", "--rm", "--ipc=shareable", "--name", "ipc_mode_container", "alpine",
+		res := c.RunDockerCmd("run", "-d", "--rm", "--ipc=shareable", "--name", "ipc_mode_container", "alpine",
 			"top")
 		cid = strings.Trim(res.Stdout(), "\n")
 	})
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/ipc-test/compose.yaml", "--project-name", projectName, "up", "-d")
+		c.RunDockerComposeCmd("-f", "./fixtures/ipc-test/compose.yaml", "--project-name", projectName, "up", "-d")
 	})
 
 	t.Run("check running project", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res := c.RunDockerComposeCmd("-p", projectName, "ps")
 		res.Assert(t, icmd.Expected{Out: `shareable`})
 	})
 
 	t.Run("check ipcmode in container inspect", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "inspect", projectName+"-shareable-1")
+		res := c.RunDockerCmd("inspect", projectName+"-shareable-1")
 		res.Assert(t, icmd.Expected{Out: `"IpcMode": "shareable",`})
 
-		res = c.RunDockerCmd(t, "inspect", projectName+"-service-1")
+		res = c.RunDockerCmd("inspect", projectName+"-service-1")
 		res.Assert(t, icmd.Expected{Out: `"IpcMode": "container:`})
 
-		res = c.RunDockerCmd(t, "inspect", projectName+"-container-1")
+		res = c.RunDockerCmd("inspect", projectName+"-container-1")
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`"IpcMode": "container:%s",`, cid)})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 	t.Run("remove ipc mode container", func(t *testing.T) {
-		_ = c.RunDockerCmd(t, "rm", "-f", "ipc_mode_container")
+		_ = c.RunDockerCmd("rm", "-f", "ipc_mode_container")
 	})
 }

--- a/pkg/e2e/logs_test.go
+++ b/pkg/e2e/logs_test.go
@@ -31,28 +31,28 @@ func TestLocalComposeLogs(t *testing.T) {
 	const projectName = "compose-e2e-logs"
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/logs-test/compose.yaml", "--project-name", projectName, "up", "-d")
+		c.RunDockerComposeCmd("-f", "./fixtures/logs-test/compose.yaml", "--project-name", projectName, "up", "-d")
 	})
 
 	t.Run("logs", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "logs")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "logs")
 		res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
 		res.Assert(t, icmd.Expected{Out: `hello`})
 	})
 
 	t.Run("logs ping", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "logs", "ping")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "logs", "ping")
 		res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
 		assert.Assert(t, !strings.Contains(res.Stdout(), "hello"))
 	})
 
 	t.Run("logs hello", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "logs", "hello", "ping")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "logs", "hello", "ping")
 		res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
 		res.Assert(t, icmd.Expected{Out: `hello`})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }

--- a/pkg/e2e/metrics_test.go
+++ b/pkg/e2e/metrics_test.go
@@ -27,29 +27,29 @@ func TestComposeMetrics(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	t.Run("catch specific failure metrics", func(t *testing.T) {
-		res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/does-not-exist/compose.yaml", "build")
+		res := c.RunDockerComposeCmdNoCheck("-f", "fixtures/does-not-exist/compose.yaml", "build")
 		expectedErr := "fixtures/does-not-exist/compose.yaml: no such file or directory"
 		if runtime.GOOS == "windows" {
 			expectedErr = "does-not-exist\\compose.yaml: The system cannot find the path specified"
 		}
 		res.Assert(t, icmd.Expected{ExitCode: 14, Err: expectedErr})
-		res = c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/wrong-composefile/compose.yaml", "up", "-d")
+		res = c.RunDockerComposeCmdNoCheck("-f", "fixtures/wrong-composefile/compose.yaml", "up", "-d")
 		res.Assert(t, icmd.Expected{ExitCode: 15, Err: "services.simple Additional property wrongField is not allowed"})
-		res = c.RunDockerComposeCmdNoCheck(t, "up")
+		res = c.RunDockerComposeCmdNoCheck("up")
 		res.Assert(t, icmd.Expected{ExitCode: 14, Err: "no configuration file provided: not found"})
-		res = c.RunDockerComposeCmdNoCheck(t, "up", "-f", "fixtures/wrong-composefile/compose.yaml")
+		res = c.RunDockerComposeCmdNoCheck("up", "-f", "fixtures/wrong-composefile/compose.yaml")
 		res.Assert(t, icmd.Expected{ExitCode: 16, Err: "unknown shorthand flag: 'f' in -f"})
-		res = c.RunDockerComposeCmdNoCheck(t, "up", "--file", "fixtures/wrong-composefile/compose.yaml")
+		res = c.RunDockerComposeCmdNoCheck("up", "--file", "fixtures/wrong-composefile/compose.yaml")
 		res.Assert(t, icmd.Expected{ExitCode: 16, Err: "unknown flag: --file"})
-		res = c.RunDockerComposeCmdNoCheck(t, "donw", "--file", "fixtures/wrong-composefile/compose.yaml")
+		res = c.RunDockerComposeCmdNoCheck("donw", "--file", "fixtures/wrong-composefile/compose.yaml")
 		res.Assert(t, icmd.Expected{ExitCode: 16, Err: `unknown docker command: "compose donw"`})
-		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/build-error.yml", "build")
+		res = c.RunDockerComposeCmdNoCheck("--file", "fixtures/wrong-composefile/build-error.yml", "build")
 		res.Assert(t, icmd.Expected{ExitCode: 17, Err: `line 17: unknown instruction: WRONG`})
-		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/build-error.yml", "up")
+		res = c.RunDockerComposeCmdNoCheck("--file", "fixtures/wrong-composefile/build-error.yml", "up")
 		res.Assert(t, icmd.Expected{ExitCode: 17, Err: `line 17: unknown instruction: WRONG`})
-		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/unknown-image.yml", "pull")
+		res = c.RunDockerComposeCmdNoCheck("--file", "fixtures/wrong-composefile/unknown-image.yml", "pull")
 		res.Assert(t, icmd.Expected{ExitCode: 18, Err: `pull access denied for unknownimage, repository does not exist or may require 'docker login'`})
-		res = c.RunDockerComposeCmdNoCheck(t, "--file", "fixtures/wrong-composefile/unknown-image.yml", "up")
+		res = c.RunDockerComposeCmdNoCheck("--file", "fixtures/wrong-composefile/unknown-image.yml", "up")
 		res.Assert(t, icmd.Expected{ExitCode: 18, Err: `pull access denied for unknownimage, repository does not exist or may require 'docker login'`})
 	})
 }

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -33,39 +33,39 @@ func TestNetworks(t *testing.T) {
 	const projectName = "network_e2e"
 
 	t.Run("ensure we do not reuse previous networks", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "network", "rm", projectName+"_dbnet")
-		c.RunDockerOrExitError(t, "network", "rm", "microservices")
+		c.RunDockerOrExitError("network", "rm", projectName+"_dbnet")
+		c.RunDockerOrExitError("network", "rm", "microservices")
 	})
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/network-test/compose.yaml", "--project-name", projectName, "up",
+		c.RunDockerComposeCmd("-f", "./fixtures/network-test/compose.yaml", "--project-name", projectName, "up",
 			"-d")
 	})
 
 	t.Run("check running project", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res := c.RunDockerComposeCmd("-p", projectName, "ps")
 		res.Assert(t, icmd.Expected{Out: `web`})
 
 		endpoint := "http://localhost:80"
-		output := HTTPGetWithRetry(t, endpoint+"/words/noun", http.StatusOK, 2*time.Second, 20*time.Second)
+		output := c.HTTPGetWithRetry(endpoint+"/words/noun", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, `"word":`))
 
-		res = c.RunDockerCmd(t, "network", "ls")
+		res = c.RunDockerCmd("network", "ls")
 		res.Assert(t, icmd.Expected{Out: projectName + "_dbnet"})
 		res.Assert(t, icmd.Expected{Out: "microservices"})
 	})
 
 	t.Run("port", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "port", "words", "8080")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "port", "words", "8080")
 		res.Assert(t, icmd.Expected{Out: `0.0.0.0:8080`})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 
 	t.Run("check networks after down", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "network", "ls")
+		res := c.RunDockerCmd("network", "ls")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 		assert.Assert(t, !strings.Contains(res.Combined(), "microservices"), res.Combined())
 	})
@@ -77,24 +77,24 @@ func TestNetworkAliases(t *testing.T) {
 	const projectName = "network_alias_e2e"
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName, "up",
+		c.RunDockerComposeCmd("-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName, "up",
 			"-d")
 	})
 
 	t.Run("curl alias", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName,
+		res := c.RunDockerComposeCmd("-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName,
 			"exec", "-T", "container1", "curl", "http://alias-of-container2/")
 		assert.Assert(t, strings.Contains(res.Stdout(), "Welcome to nginx!"), res.Stdout())
 	})
 
 	t.Run("curl links", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName,
+		res := c.RunDockerComposeCmd("-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName,
 			"exec", "-T", "container1", "curl", "http://container/")
 		assert.Assert(t, strings.Contains(res.Stdout(), "Welcome to nginx!"), res.Stdout())
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }
 
@@ -104,18 +104,18 @@ func TestNetworkLinks(t *testing.T) {
 	const projectName = "network_link_e2e"
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/network-links/compose.yaml", "--project-name", projectName, "up",
+		c.RunDockerComposeCmd("-f", "./fixtures/network-links/compose.yaml", "--project-name", projectName, "up",
 			"-d")
 	})
 
 	t.Run("curl links in default bridge network", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-links/compose.yaml", "--project-name", projectName,
+		res := c.RunDockerComposeCmd("-f", "./fixtures/network-links/compose.yaml", "--project-name", projectName,
 			"exec", "-T", "container2", "curl", "http://container1/")
 		assert.Assert(t, strings.Contains(res.Stdout(), "Welcome to nginx!"), res.Stdout())
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }
 
@@ -125,21 +125,21 @@ func TestIPAMConfig(t *testing.T) {
 	const projectName = "ipam_e2e"
 
 	t.Run("ensure we do not reuse previous networks", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "network", "rm", projectName+"_default")
+		c.RunDockerOrExitError("network", "rm", projectName+"_default")
 	})
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/ipam/compose.yaml", "--project-name", projectName, "up", "-d")
+		c.RunDockerComposeCmd("-f", "./fixtures/ipam/compose.yaml", "--project-name", projectName, "up", "-d")
 	})
 
 	t.Run("ensure service get fixed IP assigned", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "inspect", projectName+"-foo-1", "-f",
+		res := c.RunDockerCmd("inspect", projectName+"-foo-1", "-f",
 			"{{ .NetworkSettings.Networks."+projectName+"_default.IPAddress }}")
 		res.Assert(t, icmd.Expected{Out: "10.1.0.100"})
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }
 
@@ -150,12 +150,12 @@ func TestNetworkModes(t *testing.T) {
 	const projectName = "network_mode_service_run"
 
 	t.Run("run with service mode dependency", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-test/compose.yaml", "--project-name", projectName, "run", "-T", "mydb", "echo", "success")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/network-test/compose.yaml", "--project-name", projectName, "run", "-T", "mydb", "echo", "success")
 		res.Assert(t, icmd.Expected{Out: "success"})
 
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }

--- a/pkg/e2e/ps_test.go
+++ b/pkg/e2e/ps_test.go
@@ -31,17 +31,17 @@ func TestPs(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "e2e-ps"
 
-	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "up", "-d")
+	res := c.RunDockerComposeCmd("-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "up", "-d")
 	if assert.NoError(t, res.Error) {
 		t.Cleanup(func() {
-			_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+			_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 		})
 	}
 
 	assert.Contains(t, res.Combined(), "Container e2e-ps-busybox-1  Started", res.Combined())
 
 	t.Run("pretty", func(t *testing.T) {
-		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps")
+		res = c.RunDockerComposeCmd("-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps")
 		lines := strings.Split(res.Stdout(), "\n")
 		assert.Equal(t, 4, len(lines))
 		count := 0
@@ -59,7 +59,7 @@ func TestPs(t *testing.T) {
 	})
 
 	t.Run("json", func(t *testing.T) {
-		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps",
+		res = c.RunDockerComposeCmd("-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps",
 			"--format", "json")
 		var output []api.ContainerSummary
 		err := json.Unmarshal([]byte(res.Stdout()), &output)

--- a/pkg/e2e/restart_test.go
+++ b/pkg/e2e/restart_test.go
@@ -38,27 +38,27 @@ func TestRestart(t *testing.T) {
 
 	t.Run("Up a project", func(t *testing.T) {
 		// This is just to ensure the containers do NOT exist
-		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		c.RunDockerComposeCmd("--project-name", projectName, "down")
 
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "up", "-d")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "up", "-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-restart-restart-1  Started"), res.Combined())
 
-		c.WaitForCmdResult(t, c.NewDockerComposeCmd(t, "--project-name", projectName, "ps", "-a", "--format",
+		c.WaitForCmdResult(c.NewDockerComposeCmd("--project-name", projectName, "ps", "-a", "--format",
 			"json"),
 			StdoutContains(`"State":"exited"`), 10*time.Second, 1*time.Second)
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps", "-a")
 		testify.Regexp(t, getServiceRegx("restart", "exited"), res.Stdout())
 
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "restart")
+		c.RunDockerComposeCmd("-f", "./fixtures/restart-test/compose.yaml", "--project-name", projectName, "restart")
 
 		// Give the same time but it must NOT exit
 		time.Sleep(time.Second)
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps")
 		testify.Regexp(t, getServiceRegx("restart", "running"), res.Stdout())
 
 		// Clean up
-		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }

--- a/pkg/e2e/scan_message_test.go
+++ b/pkg/e2e/scan_message_test.go
@@ -32,41 +32,41 @@ func TestDisplayScanMessageAfterBuild(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	// assert docker scan plugin is available
-	c.RunDockerOrExitError(t, "scan", "--help")
+	c.RunDockerOrExitError("scan", "--help")
 
 	t.Run("display on compose build", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p",
+		res := c.RunDockerComposeCmd("-f", "fixtures/simple-build-test/compose.yaml", "-p",
 			"scan-msg-test-compose-build", "build")
-		defer c.RunDockerOrExitError(t, "rmi", "-f", "scan-msg-test-compose-build_nginx")
+		defer c.RunDockerOrExitError("rmi", "-f", "scan-msg-test-compose-build_nginx")
 		res.Assert(t, icmd.Expected{Err: utils.ScanSuggestMsg})
 	})
 
 	t.Run("do not display on compose build with quiet flag", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test-quiet",
+		res := c.RunDockerComposeCmd("-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test-quiet",
 			"build", "--quiet")
 		assert.Assert(t, !strings.Contains(res.Combined(), "docker scan"), res.Combined())
-		res = c.RunDockerCmd(t, "rmi", "-f", "scan-msg-test-quiet_nginx")
+		res = c.RunDockerCmd("rmi", "-f", "scan-msg-test-quiet_nginx")
 		assert.Assert(t, !strings.Contains(res.Combined(), "No such image"))
 
-		res = c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test-q",
+		res = c.RunDockerComposeCmd("-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test-q",
 			"build", "-q")
-		defer c.RunDockerOrExitError(t, "rmi", "-f", "scan-msg-test-q_nginx")
+		defer c.RunDockerOrExitError("rmi", "-f", "scan-msg-test-q_nginx")
 		assert.Assert(t, !strings.Contains(res.Combined(), "docker scan"), res.Combined())
 	})
 
-	_ = c.RunDockerOrExitError(t, "rmi", "scan-msg-test_nginx")
+	_ = c.RunDockerOrExitError("rmi", "scan-msg-test_nginx")
 
 	t.Run("display on compose up if image is built", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "up",
+		res := c.RunDockerComposeCmd("-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "up",
 			"-d")
-		defer c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down")
+		defer c.RunDockerComposeCmd("-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down")
 		res.Assert(t, icmd.Expected{Err: utils.ScanSuggestMsg})
 	})
 
 	t.Run("do not display on compose up if no image built", func(t *testing.T) { // re-run the same Compose aproject
-		res := c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "up",
+		res := c.RunDockerComposeCmd("-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "up",
 			"-d")
-		defer c.RunDockerComposeCmd(t, "-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down", "--rmi", "all")
+		defer c.RunDockerComposeCmd("-f", "fixtures/simple-build-test/compose.yaml", "-p", "scan-msg-test", "down", "--rmi", "all")
 		assert.Assert(t, !strings.Contains(res.Combined(), "docker scan"), res.Combined())
 	})
 
@@ -76,7 +76,7 @@ func TestDisplayScanMessageAfterBuild(t *testing.T) {
 		err := os.WriteFile(scanConfigFile, []byte(`{"optin":true}`), 0644)
 		assert.NilError(t, err)
 
-		res := c.RunDockerCmd(t, "build", "-t", "test-image-scan-msg", "fixtures/simple-build-test/nginx-build")
+		res := c.RunDockerCmd("build", "-t", "test-image-scan-msg", "fixtures/simple-build-test/nginx-build")
 		assert.Assert(t, !strings.Contains(res.Combined(), "docker scan"), res.Combined())
 	})
 }

--- a/pkg/e2e/secrets_test.go
+++ b/pkg/e2e/secrets_test.go
@@ -26,7 +26,7 @@ func TestSecretFromEnv(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	t.Run("compose run", func(t *testing.T) {
-		res := icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/env-secret/compose.yaml", "run", "foo"),
+		res := icmd.RunCmd(c.NewDockerComposeCmd("-f", "./fixtures/env-secret/compose.yaml", "run", "foo"),
 			func(cmd *icmd.Cmd) {
 				cmd.Env = append(cmd.Env, "SECRET=BAR")
 			})

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -43,44 +43,44 @@ func TestStartStop(t *testing.T) {
 	}
 
 	t.Run("Up a project", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/start-stop/compose.yaml", "--project-name", projectName, "up",
+		res := c.RunDockerComposeCmd("-f", "./fixtures/start-stop/compose.yaml", "--project-name", projectName, "up",
 			"-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-no-dependencies-simple-1  Started"), res.Combined())
 
-		res = c.RunDockerComposeCmd(t, "ls", "--all")
+		res = c.RunDockerComposeCmd("ls", "--all")
 		testify.Regexp(t, getProjectRegx("running"), res.Stdout())
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps")
 		testify.Regexp(t, getServiceRegx("simple", "running"), res.Stdout())
 		testify.Regexp(t, getServiceRegx("another", "running"), res.Stdout())
 	})
 
 	t.Run("stop project", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/start-stop/compose.yaml", "--project-name", projectName, "stop")
+		c.RunDockerComposeCmd("-f", "./fixtures/start-stop/compose.yaml", "--project-name", projectName, "stop")
 
-		res := c.RunDockerComposeCmd(t, "ls")
+		res := c.RunDockerComposeCmd("ls")
 		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-no-dependencies"), res.Combined())
 
-		res = c.RunDockerComposeCmd(t, "ls", "--all")
+		res = c.RunDockerComposeCmd("ls", "--all")
 		testify.Regexp(t, getProjectRegx("exited"), res.Stdout())
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps")
 		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-no-dependencies-words-1"), res.Combined())
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "--all")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps", "--all")
 		testify.Regexp(t, getServiceRegx("simple", "exited"), res.Stdout())
 		testify.Regexp(t, getServiceRegx("another", "exited"), res.Stdout())
 	})
 
 	t.Run("start project", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/start-stop/compose.yaml", "--project-name", projectName, "start")
+		c.RunDockerComposeCmd("-f", "./fixtures/start-stop/compose.yaml", "--project-name", projectName, "start")
 
-		res := c.RunDockerComposeCmd(t, "ls")
+		res := c.RunDockerComposeCmd("ls")
 		testify.Regexp(t, getProjectRegx("running"), res.Stdout())
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }
 
@@ -88,48 +88,48 @@ func TestStartStopWithDependencies(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "e2e-start-stop-with-dependencies"
 
-	defer c.RunDockerComposeCmd(t, "--project-name", projectName, "rm", "-fsv")
+	defer c.RunDockerComposeCmd("--project-name", projectName, "rm", "-fsv")
 
 	t.Run("Up", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName,
+		res := c.RunDockerComposeCmd("-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName,
 			"up", "-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-foo-1  Started"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-bar-1  Started"), res.Combined())
 	})
 
 	t.Run("stop foo", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "stop", "foo")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "stop", "foo")
 
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-foo-1  Stopped"), res.Combined())
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "--status", "running")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps", "--status", "running")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-dependencies-bar-1"), res.Combined())
 		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-dependencies-foo-1"), res.Combined())
 	})
 
 	t.Run("start foo", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "stop")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "stop")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-bar-1  Stopped"), res.Combined())
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "start", "foo")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "start", "foo")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-bar-1  Started"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-foo-1  Started"), res.Combined())
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "--status", "running")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps", "--status", "running")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-dependencies-bar-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-dependencies-foo-1"), res.Combined())
 	})
 
 	t.Run("Up no-deps links", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/links/compose.yaml", "--project-name", projectName, "up",
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
+		res := c.RunDockerComposeCmd("-f", "./fixtures/links/compose.yaml", "--project-name", projectName, "up",
 			"--no-deps", "-d", "foo")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-foo-1  Started"), res.Combined())
 		assert.Assert(t, !strings.Contains(res.Combined(), "Container e2e-start-stop-with-dependencies-bar-1  Started"), res.Combined())
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		_ = c.RunDockerComposeCmd("--project-name", projectName, "down")
 	})
 }
 
@@ -138,48 +138,48 @@ func TestStartStopWithOneOffs(t *testing.T) {
 	const projectName = "e2e-start-stop-with-oneoffs"
 
 	t.Run("Up", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName,
+		res := c.RunDockerComposeCmd("-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName,
 			"up", "-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-oneoffs-foo-1  Started"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-with-oneoffs-bar-1  Started"), res.Combined())
 	})
 
 	t.Run("run one-off", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName, "run", "-d", "bar", "sleep", "infinity")
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a")
+		c.RunDockerComposeCmd("-f", "./fixtures/dependencies/compose.yaml", "--project-name", projectName, "run", "-d", "bar", "sleep", "infinity")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "ps", "-a")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
 	})
 
 	t.Run("stop (not one-off containers)", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "stop")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "stop")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
 		assert.Assert(t, !strings.Contains(res.Combined(), "e2e_start_stop_with_oneoffs_bar_run"), res.Combined())
 
-		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a", "--status", "running")
+		res = c.RunDockerComposeCmd("--project-name", projectName, "ps", "-a", "--status", "running")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
 	})
 
 	t.Run("start (not one-off containers)", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "start")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "start")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
 		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
 	})
 
 	t.Run("restart (not one-off containers)", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "restart")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "restart")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
 		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
 	})
 
 	t.Run("down", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
+		c.RunDockerComposeCmd("--project-name", projectName, "down", "--remove-orphans")
 
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a", "--status", "running")
+		res := c.RunDockerComposeCmd("--project-name", projectName, "ps", "-a", "--status", "running")
 		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar"), res.Combined())
 	})
 }
@@ -189,12 +189,12 @@ func TestStartAlreadyRunning(t *testing.T) {
 		"COMPOSE_PROJECT_NAME=e2e-start-stop-svc-already-running",
 		"COMPOSE_FILE=./fixtures/start-stop/compose.yaml"))
 	t.Cleanup(func() {
-		cli.RunDockerComposeCmd(t, "down", "--remove-orphans", "-v", "-t", "0")
+		cli.RunDockerComposeCmd("down", "--remove-orphans", "-v", "-t", "0")
 	})
 
-	cli.RunDockerComposeCmd(t, "up", "-d", "--wait")
+	cli.RunDockerComposeCmd("up", "-d", "--wait")
 
-	res := cli.RunDockerComposeCmd(t, "start", "simple")
+	res := cli.RunDockerComposeCmd("start", "simple")
 	assert.Equal(t, res.Stdout(), "", "No output should have been written to stdout")
 }
 
@@ -203,16 +203,16 @@ func TestStopAlreadyStopped(t *testing.T) {
 		"COMPOSE_PROJECT_NAME=e2e-start-stop-svc-already-stopped",
 		"COMPOSE_FILE=./fixtures/start-stop/compose.yaml"))
 	t.Cleanup(func() {
-		cli.RunDockerComposeCmd(t, "down", "--remove-orphans", "-v", "-t", "0")
+		cli.RunDockerComposeCmd("down", "--remove-orphans", "-v", "-t", "0")
 	})
 
-	cli.RunDockerComposeCmd(t, "up", "-d", "--wait")
+	cli.RunDockerComposeCmd("up", "-d", "--wait")
 
 	// stop the container
-	cli.RunDockerComposeCmd(t, "stop", "simple")
+	cli.RunDockerComposeCmd("stop", "simple")
 
 	// attempt to stop it again
-	res := cli.RunDockerComposeCmdNoCheck(t, "stop", "simple")
+	res := cli.RunDockerComposeCmdNoCheck("stop", "simple")
 	// TODO: for consistency, this should NOT write any output because the
 	// 		container is already stopped
 	res.Assert(t, icmd.Expected{
@@ -226,12 +226,12 @@ func TestStartStopMultipleServices(t *testing.T) {
 		"COMPOSE_PROJECT_NAME=e2e-start-stop-svc-multiple",
 		"COMPOSE_FILE=./fixtures/start-stop/compose.yaml"))
 	t.Cleanup(func() {
-		cli.RunDockerComposeCmd(t, "down", "--remove-orphans", "-v", "-t", "0")
+		cli.RunDockerComposeCmd("down", "--remove-orphans", "-v", "-t", "0")
 	})
 
-	cli.RunDockerComposeCmd(t, "up", "-d", "--wait")
+	cli.RunDockerComposeCmd("up", "-d", "--wait")
 
-	res := cli.RunDockerComposeCmd(t, "stop", "simple", "another")
+	res := cli.RunDockerComposeCmd("stop", "simple", "another")
 	services := []string{"simple", "another"}
 	for _, svc := range services {
 		stopMsg := fmt.Sprintf("Container e2e-start-stop-svc-multiple-%s-1  Stopped", svc)
@@ -239,7 +239,7 @@ func TestStartStopMultipleServices(t *testing.T) {
 			fmt.Sprintf("Missing stop message for %s\n%s", svc, res.Combined()))
 	}
 
-	res = cli.RunDockerComposeCmd(t, "start", "simple", "another")
+	res = cli.RunDockerComposeCmd("start", "simple", "another")
 	for _, svc := range services {
 		startMsg := fmt.Sprintf("Container e2e-start-stop-svc-multiple-%s-1  Started", svc)
 		assert.Assert(t, strings.Contains(res.Stderr(), startMsg),

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -26,8 +26,8 @@ func TestUpServiceUnhealthy(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "e2e-start-fail"
 
-	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/start-fail/compose.yaml", "--project-name", projectName, "up", "-d")
+	res := c.RunDockerComposeCmdNoCheck("-f", "fixtures/start-fail/compose.yaml", "--project-name", projectName, "up", "-d")
 	res.Assert(t, icmd.Expected{ExitCode: 1, Err: `container for service "fail" is unhealthy`})
 
-	c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	c.RunDockerComposeCmd("--project-name", projectName, "down")
 }

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -35,20 +35,20 @@ func TestLocalComposeVolume(t *testing.T) {
 
 	t.Run("up with build and no image name, volume", func(t *testing.T) {
 		// ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError(t, "rmi", "compose-e2e-volume_nginx")
-		c.RunDockerOrExitError(t, "volume", "rm", projectName+"_staticVol")
-		c.RunDockerOrExitError(t, "volume", "rm", "myvolume")
-		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up",
+		c.RunDockerOrExitError("rmi", "compose-e2e-volume_nginx")
+		c.RunDockerOrExitError("volume", "rm", projectName+"_staticVol")
+		c.RunDockerOrExitError("volume", "rm", "myvolume")
+		c.RunDockerComposeCmd("--project-directory", "fixtures/volume-test", "--project-name", projectName, "up",
 			"-d")
 	})
 
 	t.Run("access bind mount data", func(t *testing.T) {
-		output := HTTPGetWithRetry(t, "http://localhost:8090", http.StatusOK, 2*time.Second, 20*time.Second)
+		output := c.HTTPGetWithRetry("http://localhost:8090", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, "Hello from Nginx container"))
 	})
 
 	t.Run("check container volume specs", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "inspect", "compose-e2e-volume-nginx2-1", "--format", "{{ json .Mounts }}")
+		res := c.RunDockerCmd("inspect", "compose-e2e-volume-nginx2-1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
 		// nolint
 		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/src/app/node_modules","Driver":"local","Mode":"z","RW":true,"Propagation":""`), output)
@@ -56,17 +56,17 @@ func TestLocalComposeVolume(t *testing.T) {
 	})
 
 	t.Run("check config content", func(t *testing.T) {
-		output := c.RunDockerCmd(t, "exec", "compose-e2e-volume-nginx2-1", "cat", "/myconfig").Stdout()
+		output := c.RunDockerCmd("exec", "compose-e2e-volume-nginx2-1", "cat", "/myconfig").Stdout()
 		assert.Assert(t, strings.Contains(output, `Hello from Nginx container`), output)
 	})
 
 	t.Run("check secrets content", func(t *testing.T) {
-		output := c.RunDockerCmd(t, "exec", "compose-e2e-volume-nginx2-1", "cat", "/run/secrets/mysecret").Stdout()
+		output := c.RunDockerCmd("exec", "compose-e2e-volume-nginx2-1", "cat", "/run/secrets/mysecret").Stdout()
 		assert.Assert(t, strings.Contains(output, `Hello from Nginx container`), output)
 	})
 
 	t.Run("check container bind-mounts specs", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "inspect", "compose-e2e-volume-nginx-1", "--format", "{{ json .Mounts }}")
+		res := c.RunDockerCmd("inspect", "compose-e2e-volume-nginx-1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
 		// nolint
 		assert.Assert(t, strings.Contains(output, `"Type":"bind"`))
@@ -74,20 +74,20 @@ func TestLocalComposeVolume(t *testing.T) {
 	})
 
 	t.Run("should inherit anonymous volumes", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
-		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "-d")
-		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
+		c.RunDockerComposeCmd("--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "-d")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
 	})
 
 	t.Run("should renew anonymous volumes", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
-		c.RunDockerComposeCmd(t, "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "--renew-anon-volumes", "-d")
-		c.RunDockerOrExitError(t, "exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "touch", "/usr/src/app/node_modules/test")
+		c.RunDockerComposeCmd("--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "--force-recreate", "--renew-anon-volumes", "-d")
+		c.RunDockerOrExitError("exec", "compose-e2e-volume-nginx2-1", "ls", "/usr/src/app/node_modules/test")
 	})
 
 	t.Run("cleanup volume project", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--volumes")
-		ls := c.RunDockerCmd(t, "volume", "ls").Stdout()
+		c.RunDockerComposeCmd("--project-name", projectName, "down", "--volumes")
+		ls := c.RunDockerCmd("volume", "ls").Stdout()
 		assert.Assert(t, !strings.Contains(ls, projectName+"_staticVol"))
 		assert.Assert(t, !strings.Contains(ls, "myvolume"))
 	})
@@ -105,17 +105,17 @@ func TestProjectVolumeBind(t *testing.T) {
 		assert.NilError(t, err)
 		defer os.RemoveAll(tmpDir) // nolint
 
-		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		c.RunDockerComposeCmd("--project-name", projectName, "down")
 
-		c.RunDockerOrExitError(t, "volume", "rm", "-f", projectName+"_project_data").Assert(t, icmd.Success)
+		c.RunDockerOrExitError("volume", "rm", "-f", projectName+"_project_data").Assert(t, icmd.Success)
 		cmd := c.NewCmdWithEnv([]string{"TEST_DIR=" + tmpDir},
 			"docker", "compose", "--project-directory", "fixtures/project-volume-bind-test", "--project-name", projectName, "up", "-d")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)
-		defer c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+		defer c.RunDockerComposeCmd("--project-name", projectName, "down")
 
-		c.RunCmd(t, "sh", "-c", "echo SUCCESS > "+filepath.Join(tmpDir, "resultfile")).Assert(t, icmd.Success)
+		c.RunCmd("sh", "-c", "echo SUCCESS > "+filepath.Join(tmpDir, "resultfile")).Assert(t, icmd.Success)
 
-		ret := c.RunDockerOrExitError(t, "exec", "frontend", "bash", "-c", "cat /data/resultfile").Assert(t, icmd.Success)
+		ret := c.RunDockerOrExitError("exec", "frontend", "bash", "-c", "cat /data/resultfile").Assert(t, icmd.Success)
 		assert.Assert(t, strings.Contains(ret.Stdout(), "SUCCESS"))
 	})
 }


### PR DESCRIPTION
**What I did**
Add `testing.TB` to the struct `e2e.CLI` on e2e tests so it doesn't need to be passed on every method call.

This also let `e2e.CLI` to be passed where a `testing.TB` is expected.