### PR TITLE
Fix issue with close networks name on up and down command

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1041,7 +1041,14 @@ func (s *composeService) ensureNetwork(ctx context.Context, n types.NetworkConfi
 	if err != nil {
 		return err
 	}
-	if len(networks) == 0 {
+	networkNotFound := true
+	for _, net := range networks {
+		if net.Name == n.Name {
+			networkNotFound = false
+			break
+		}
+	}
+	if networkNotFound {
 		if n.External.External {
 			if n.Driver == "overlay" {
 				// Swarm nodes do not register overlay networks that were

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -163,14 +163,16 @@ func (s *composeService) removeNetwork(ctx context.Context, name string, w progr
 
 	var removed int
 	for _, net := range networks {
-		if err := s.apiClient().NetworkRemove(ctx, net.ID); err != nil {
-			if errdefs.IsNotFound(err) {
-				continue
+		if net.Name == name {
+			if err := s.apiClient().NetworkRemove(ctx, net.ID); err != nil {
+				if errdefs.IsNotFound(err) {
+					continue
+				}
+				w.Event(progress.ErrorEvent(eventName))
+				return errors.Wrapf(err, fmt.Sprintf("failed to remove network %s", name))
 			}
-			w.Event(progress.ErrorEvent(eventName))
-			return errors.Wrapf(err, fmt.Sprintf("failed to remove network %s", name))
+			removed++
 		}
-		removed++
 	}
 
 	if removed == 0 {


### PR DESCRIPTION
**What I did**
Regarding the API documentation, [the list networks endpoints](https://docs.docker.com/engine/api/v1.41/#tag/Network/operation/NetworkList) when used with the `name` filter may return more than one result
> `name=<network-name>` Matches all or part of a network name.

So we check explicitly the name of the network to be sure we don't forget to create one during `up` process or to remove one during `down` process 

**Related issue**
fix #9630 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/178244398-9fa7cb1f-2699-4e01-820b-9a930da3e183.png)
