### PR TITLE
keep the container reference when volumes_from target a container and not a service

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -680,7 +680,7 @@ func getVolumesFrom(project *types.Project, volumesFrom []string) ([]string, []s
 			continue
 		}
 		if spec[0] == "container" {
-			volumes = append(volumes, strings.Join(spec[1:], ":"))
+			volumes = append(volumes, vol)
 			continue
 		}
 		serviceName := spec[0]


### PR DESCRIPTION
**What I did**
Keep the `container:` prefix when `volumes_from` target a container

**Related issue**
Fix #8874 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/178479865-ce74d158-a3d9-413f-ac92-b3e6c3cc9ddd.png)
