### PR TITLE
Enforce consistent args rejection for no-args commands: ls, restart, version

### DIFF
--- a/cmd/compose/list.go
+++ b/cmd/compose/list.go
@@ -46,6 +46,7 @@ func listCommand(backend api.Service) *cobra.Command {
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runList(ctx, backend, lsOpts)
 		}),
+		Args:              cobra.NoArgs,
 		ValidArgsFunction: noCompletion(),
 	}
 	lsCmd.Flags().StringVar(&lsOpts.Format, "format", "pretty", "Format the output. Values: [pretty | json].")

--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -35,8 +35,8 @@ func restartCommand(p *projectOptions, backend api.Service) *cobra.Command {
 		projectOptions: p,
 	}
 	restartCmd := &cobra.Command{
-		Use:   "restart",
-		Short: "Restart containers",
+		Use:   "restart [SERVICE...]",
+		Short: "Restart service containers",
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runRestart(ctx, backend, opts, args)
 		}),

--- a/cmd/compose/version.go
+++ b/cmd/compose/version.go
@@ -37,7 +37,7 @@ func versionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the Docker Compose version information",
-		Args:  cobra.MaximumNArgs(0),
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			runVersion(opts)
 			return nil

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -23,7 +23,7 @@ Docker Compose
 | [`ps`](compose_ps.md) | List containers |
 | [`pull`](compose_pull.md) | Pull service images |
 | [`push`](compose_push.md) | Push service images |
-| [`restart`](compose_restart.md) | Restart containers |
+| [`restart`](compose_restart.md) | Restart service containers |
 | [`rm`](compose_rm.md) | Removes stopped service containers |
 | [`run`](compose_run.md) | Run a one-off command on a service. |
 | [`start`](compose_start.md) | Start services |

--- a/docs/reference/compose_restart.md
+++ b/docs/reference/compose_restart.md
@@ -1,7 +1,7 @@
 # docker compose restart
 
 <!---MARKER_GEN_START-->
-Restart containers
+Restart service containers
 
 ### Options
 

--- a/docs/reference/compose_restart.md
+++ b/docs/reference/compose_restart.md
@@ -14,7 +14,7 @@ Restart containers
 
 ## Description
 
-Restarts all stopped and running services.
+Restarts all stopped and running services, or the specified services only.
 
 If you make changes to your `compose.yml` configuration, these changes are not reflected
 after running this command. For example, changes to environment variables (which are added

--- a/docs/reference/docker_compose_restart.yaml
+++ b/docs/reference/docker_compose_restart.yaml
@@ -1,7 +1,7 @@
 command: docker compose restart
-short: Restart containers
+short: Restart service containers
 long: |-
-    Restarts all stopped and running services.
+    Restarts all stopped and running services, or the specified services only.
 
     If you make changes to your `compose.yml` configuration, these changes are not reflected
     after running this command. For example, changes to environment variables (which are added
@@ -11,7 +11,7 @@ long: |-
     If you are looking to configure a service's restart policy, please refer to
     [restart](https://github.com/compose-spec/compose-spec/blob/master/spec.md#restart)
     or [restart_policy](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#restart_policy).
-usage: docker compose restart
+usage: docker compose restart [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:


### PR DESCRIPTION

**What I did**
Make cobra to reject arguments for no-args commands in the same manner:
- `ls`
- `version`
- (`down` was done already) 

For the `restart` command, the documentation is updated to let the user know that services can be passed as arguments.

**Related issue**

Based on #9158 which enforced it for the `down` command.

---
<details>
<summary>According to the listing below, these 4 commands were the only ones to not handle arguments.</summary>

```
➜ for c in (docker compose --help | awk '/^  [a-z]+ +.*/ {print $1}');
      docker compose $c --help | grep 'Usage:';
  end | cat
Usage:  docker compose build [SERVICE...]
Usage:  docker compose convert SERVICES
Usage:  docker compose cp [OPTIONS] SERVICE:SRC_PATH DEST_PATH|-
Usage:  docker compose create [SERVICE...]
Usage:  docker compose down
Usage:  docker compose events [options] [--] [SERVICE...]
Usage:  docker compose exec [options] [-e KEY=VAL...] [--] SERVICE COMMAND [ARGS...]
Usage:  docker compose images [SERVICE...]
Usage:  docker compose kill [options] [SERVICE...]
Usage:  docker compose logs [SERVICE...]
Usage:  docker compose ls
Usage:  docker compose pause [SERVICE...]
Usage:  docker compose port [options] [--] SERVICE PRIVATE_PORT
Usage:  docker compose ps [SERVICE...]
Usage:  docker compose pull [SERVICE...]
Usage:  docker compose push [SERVICE...]
Usage:  docker compose restart
Usage:  docker compose rm [SERVICE...]
Usage:  docker compose run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l KEY=VALUE...] SERVICE [COMMAND] [ARGS...]
Usage:  docker compose start [SERVICE...]
Usage:  docker compose stop [SERVICE...]
Usage:  docker compose top [SERVICES...]
Usage:  docker compose unpause [SERVICE...]
Usage:  docker compose up [SERVICE...]
Usage:  docker compose version
```

<br>
</details>