### PR TITLE
ci(docs): use push-to-fork when creating pr

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,7 @@ jobs:
         uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27 # v4.0.4
         with:
           token: ${{ secrets.GHPAT_DOCS_DISPATCH }}
+          push-to-fork: docker-tools-robot/docker.github.io
           commit-message: Update Compose reference API to ${{ github.event.release.name }}
           signoff: true
           branch: dispatch/compose-api-reference-${{ github.event.release.name }}
@@ -47,5 +48,4 @@ jobs:
           title: Update Compose reference API to ${{ github.event.release.name }}
           body: |
             Update the Compose reference API documentation to keep in sync with the latest release `${{ github.event.release.name }}`
-          labels: area/Compose
           draft: false


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/1184

increase security so `docker-tools-robot` does not need write access on `docker/docker.github.io` and will push to its own fork at https://github.com/docker-tools-robot/docker.github.io and create the PR from it.

unfortunately we can't set the label anymore as it requires admin rights but I think it's fine:

```
  Applying labels 'area/Build'
  Error: Must have admin rights to Repository.
```

other advantage is it will not pollute `docker/docker.github.io` with other branches.

cc @glours 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>