### PR TITLE
use env variable for golang version and updates gh actions from v2 to v3

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,4 +1,6 @@
 name: Publish Artifacts
+env:
+  GO_VERSION: 1.18.4
 on:
   issue_comment:
     types: [created]
@@ -7,49 +9,44 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/generate-artifacts')
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18.4
-        id: go
-
       - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3
         with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Build cross platform compose-plugin binaries
         run: make -f builder.Makefile cross
 
       - name: Upload macos-amd64 binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-compose-darwin-amd64
           path: ${{ github.workspace }}/bin/docker-compose-darwin-amd64
 
       - name: Upload macos-arm64 binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-compose-darwin-arm64
           path: ${{ github.workspace }}/bin/docker-compose-darwin-arm64
 
       - name: Upload linux-amd64 binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-compose-linux-amd64
           path: ${{ github.workspace }}/bin/docker-compose-linux-amd64
 
       - name: Upload linux-ppc64le binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-compose-linux-ppc64le
           path: ${{ github.workspace }}/bin/docker-compose-linux-ppc64le
 
       - name: Upload windows-amd64 binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-compose-windows-amd64.exe
           path: ${{ github.workspace }}/bin/docker-compose-windows-amd64.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ on:
         description: 'To run with tmate enter "debug_enabled"'
         required: false
         default: "false"
-
+env:
+  GO_VERSION: 1.18.4
 jobs:
   lint:
     name: Lint
@@ -19,14 +20,14 @@ jobs:
     env:
       GO111MODULE: "on"
     steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18.4
-        id: go
-
       - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Validate go-mod, license headers and docs are up-to-date
         run: make validate
@@ -46,19 +47,14 @@ jobs:
     env:
       GO111MODULE: "on"
     steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18.4
-        id: go
-
       - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3
         with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       # Ensure we don't discover cross platform build issues at release time.
       # Time used to build linux here is gained back in the build for local E2E step
@@ -71,24 +67,19 @@ jobs:
     env:
       GO111MODULE: "on"
     steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18.4
-        id: go
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
           curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
 
       - name: Test
         run: make -f builder.Makefile test
@@ -107,24 +98,19 @@ jobs:
     env:
       GO111MODULE: "on"
     steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18.4
-        id: go
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
           curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
 
       - name: Build for local E2E
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     steps:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v3
@@ -44,8 +42,6 @@ jobs:
     name: Validate cross build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    env:
-      GO111MODULE: "on"
     steps:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v3
@@ -64,8 +60,6 @@ jobs:
   build-plugin:
     name: Build and tests in plugin mode
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     steps:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v3
@@ -95,8 +89,6 @@ jobs:
   build-standalone:
     name: Build and tests in standalone mode
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     steps:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,31 +6,25 @@ on:
       tag:
         description: "Release Tag"
         required: true
-
+env:
+  GO_VERSION: 1.18.4
 jobs:
   upload-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18.4
-        id: go
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
           curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Build
         run: make GIT_TAG=${{ github.event.inputs.tag }} -f builder.Makefile cross


### PR DESCRIPTION
**What I did**
Update the GitHub actions workflows:
* use an env variable to define the version of Golang used
* update GitHub base actions to v3

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/180876324-92c70276-c614-4348-8c63-f84c96b72032.png)
