### PR TITLE
use Google addlicense instead of kunalkushwaha/ltag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN --mount=target=. \
     make -f builder.Makefile test
 
 FROM base AS check-license-headers
-RUN go install github.com/kunalkushwaha/ltag@latest
+RUN go install github.com/google/addlicense@latest
 RUN --mount=target=. \
     make -f builder.Makefile check-license-headers
 

--- a/scripts/validate/fileheader
+++ b/scripts/validate/fileheader
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-#   Copyright Docker Compose CLI authors
+#   Copyright 2020,2022 Docker Compose CLI authors
 
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 set -eu -o pipefail
 
-if ! command -v ltag; then
-    >&2 echo "ERROR: ltag not found. Install with:"
-    >&2 echo "    go get -u github.com/kunalkushwaha/ltag"
+if ! command -v addlicense; then
+    >&2 echo "ERROR: addlicense not found. Install with:"
+    >&2 echo "    go install -u github.com/google/addlicense@latest"
     exit 1
 fi
 
 BASEPATH="${1-}"
 
-ltag -t "${BASEPATH}scripts/validate/template" -excludes "validate testdata resolvepath" --check -v
+find . -regex '.*\.sh' -o -regex '.*\.go' -o -regex '.*Makefile' -o -regex '.*Dockerfile' | xargs addlicense -check -l apache -c 'Docker Compose CLI authors' -ignore validate -ignore testdata -ignore resolvepath -v 1>&2


### PR DESCRIPTION
**What I did**
Use the same license header checker that the one use for `compose-cli` project, this one is much more active than the previous one.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/181015558-ca56c973-562b-4403-b5b6-b7a197f95936.png)
