### PR TITLE
Fix LinkLocalIPs in V2

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -605,8 +605,9 @@ func (s *composeService) connectContainerToNetwork(ctx context.Context, id strin
 		ipv4Address = cfg.Ipv4Address
 		ipv6Address = cfg.Ipv6Address
 		ipam = &network.EndpointIPAMConfig{
-			IPv4Address: ipv4Address,
-			IPv6Address: ipv6Address,
+			IPv4Address:  ipv4Address,
+			IPv6Address:  ipv6Address,
+			LinkLocalIPs: cfg.LinkLocalIPs,
 		}
 	}
 	err := s.apiClient().NetworkConnect(ctx, netwrk, id, &network.EndpointSettings{

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -306,8 +306,9 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 			ipv4Address = config.Ipv4Address
 			ipv6Address = config.Ipv6Address
 			ipam = &network.EndpointIPAMConfig{
-				IPv4Address: ipv4Address,
-				IPv6Address: ipv6Address,
+				IPv4Address:  ipv4Address,
+				IPv6Address:  ipv6Address,
+				LinkLocalIPs: config.LinkLocalIPs,
 			}
 		}
 		networkConfig = &network.NetworkingConfig{


### PR DESCRIPTION
Signed-off-by: Jeremiah Millay <jmillay@fastly.com>

**What I did**

As described in #9659 `link_local_ips` in compose yaml is no longer honored in compose V2. This change pulls in fixes in compose-go v1.3.0 that allow us set the `LinkLocalIPs` field in `network.EndpointIPAMConfig{}`.

I have validated this is working with the following compose yaml:

```bash
services:
  foo:
    image: alpine
    entrypoint: ["sleep", "infinity"]
    networks:
      default:
        ipv4_address: 10.1.0.100
        ipv6_address: 2001:db8:0:1::100
        link_local_ips:
          - fe80::1:95ff:fe20:100
networks:
  default:
    driver: bridge
    enable_ipv6: true
    ipam:
      config:
        - subnet: 10.1.0.0/16
        - subnet: 2001:db8:0:1::/64
```

Building the `compose` plugin locally with `make compose-plugin` we see the following:

```bash
$ bin/docker-compose -f ~/Desktop/compose.yaml up -d
$ bin/docker-compose --version
Docker Compose version v2.7.0-26-g2e7b4074
$ bin/docker-compose -f ~/Desktop/compose.yaml up -d
[+] Running 2/2
 ⠿ Network desktop_default  Created                                                                                                                                                                            0.0s
 ⠿ Container desktop-foo-1  Started                                                                                                                                                                            0.4s
$ bin/docker-compose -f ~/Desktop/compose.yaml exec foo ip -6 a s
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1000
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
194: eth0@if195: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 state UP
    inet6 2001:db8:0:1::100/64 scope global flags 02
       valid_lft forever preferred_lft forever
    inet6 fe80::42:aff:fe01:64/64 scope link
       valid_lft forever preferred_lft forever
    inet6 fe80::1:95ff:fe20:100/64 scope link
       valid_lft forever preferred_lft forever
```

As expected we now see `fe80::1:95ff:fe20:100` assigned to the container, whereas in #9659 with the same compose yaml this was not working in V2.


**Related issue**
Fixes #9659 after changes in https://github.com/compose-spec/compose-go/pull/289

