### PR TITLE
Overwrite parent commands PreRun code for `compose version`

### DIFF
--- a/cmd/compose/version.go
+++ b/cmd/compose/version.go
@@ -42,6 +42,11 @@ func versionCommand() *cobra.Command {
 			runVersion(opts)
 			return nil
 		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// overwrite parent PersistentPreRunE to avoid trying to load
+			// compose file on version command if COMPOSE_FILE is set
+			return nil
+		},
 	}
 	// define flags for backward compatibility with com.docker.cli
 	flags := cmd.Flags()


### PR DESCRIPTION
.. to avoid trying (and failing) to load a compose file if the COMPOSE_FILE env var is set such as `COMPOSE_FILE=foo compose version`

Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Overwrite parent `compose` command's `PersistentPreRunE` that attempts to load compose file for `compose version` command.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Closes #9662

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![BktxGkF5zqXdVGcJ5TKYs-1200-80](https://user-images.githubusercontent.com/70572044/182122855-e245700d-bc94-48b1-8a28-35564194ac56.jpg)

