### PR TITLE
Stop only project services

### DIFF
--- a/cmd/compose/stop.go
+++ b/cmd/compose/stop.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v2/pkg/api"
@@ -53,9 +54,15 @@ func stopCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runStop(ctx context.Context, backend api.Service, opts stopOptions, services []string) error {
-	projectName, err := opts.toProjectName()
-	if err != nil {
-		return err
+	name := opts.ProjectName
+	var project *types.Project
+	if opts.ProjectName == "" {
+		p, err := opts.toProject(nil)
+		if err != nil {
+			return err
+		}
+		project = p
+		name = p.Name
 	}
 
 	var timeout *time.Duration
@@ -63,7 +70,9 @@ func runStop(ctx context.Context, backend api.Service, opts stopOptions, service
 		timeoutValue := time.Duration(opts.timeout) * time.Second
 		timeout = &timeoutValue
 	}
-	return backend.Stop(ctx, projectName, api.StopOptions{
+
+	return backend.Stop(ctx, name, api.StopOptions{
+		Project:  project,
 		Timeout:  timeout,
 		Services: services,
 	})

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -141,6 +141,8 @@ type RestartOptions struct {
 
 // StopOptions group options of the Stop API
 type StopOptions struct {
+	// Project is the compose project used to define this app.
+	Project *types.Project
 	// Timeout override container stop timeout
 	Timeout *time.Duration
 	// Services passed in the command line to be stopped

--- a/pkg/compose/stop.go
+++ b/pkg/compose/stop.go
@@ -33,12 +33,13 @@ func (s *composeService) Stop(ctx context.Context, projectName string, options a
 func (s *composeService) stop(ctx context.Context, projectName string, options api.StopOptions) error {
 	w := progress.ContextWriter(ctx)
 
-	containers, project, err := s.actualState(ctx, projectName, options.Services)
+	var containers Containers
+	containers, err := s.getContainers(ctx, projectName, oneOffExclude, true)
 	if err != nil {
 		return err
 	}
 
-	return InReverseDependencyOrder(ctx, project, func(c context.Context, service string) error {
+	return InReverseDependencyOrder(ctx, options.Project, func(c context.Context, service string) error {
 		containersToStop := containers.filter(isService(service)).filter(isNotOneOff)
 		return s.stopContainers(ctx, w, containersToStop, options.Timeout)
 	})

--- a/pkg/e2e/fixtures/start-stop/other.yaml
+++ b/pkg/e2e/fixtures/start-stop/other.yaml
@@ -1,0 +1,5 @@
+services:
+  a-different-one:
+    image:  nginx:alpine
+  and-another-one:
+    image:  nginx:alpine

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -246,3 +246,19 @@ func TestStartStopMultipleServices(t *testing.T) {
 			fmt.Sprintf("Missing start message for %s\n%s", svc, res.Combined()))
 	}
 }
+
+func TestStartStopMultipleFiles(t *testing.T) {
+	cli := NewParallelCLI(t, WithEnv("COMPOSE_PROJECT_NAME=e2e-start-stop-svc-multiple-files"))
+	t.Cleanup(func() {
+		cli.RunDockerComposeCmd(t, "-p", "e2e-start-stop-svc-multiple-files", "down", "--remove-orphans")
+	})
+
+	cli.RunDockerComposeCmd(t, "-f", "./fixtures/start-stop/compose.yaml", "up", "-d")
+	cli.RunDockerComposeCmd(t, "-f", "./fixtures/start-stop/other.yaml", "up", "-d")
+
+	res := cli.RunDockerComposeCmd(t, "-f", "./fixtures/start-stop/compose.yaml", "stop")
+	assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-svc-multiple-files-simple-1  Stopped"), res.Combined())
+	assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-start-stop-svc-multiple-files-another-1  Stopped"), res.Combined())
+	assert.Assert(t, !strings.Contains(res.Combined(), "Container e2e-start-stop-svc-multiple-files-a-different-one-1  Stopped"), res.Combined())
+	assert.Assert(t, !strings.Contains(res.Combined(), "Container e2e-start-stop-svc-multiple-files-and-another-one-1  Stopped"), res.Combined())
+}


### PR DESCRIPTION
.. so that, if loaded with a specific compose file `-f compose.yaml`, stop only affects the services defined in the loaded file.

Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Made `compose stop` explicitly pass loaded compose model when calling stop so that only the services defined are affected.

Also added e2e tests for this scenario

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

closes #9671

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![getty_177697635_365195](https://user-images.githubusercontent.com/70572044/182134756-9bb631d9-edf9-4134-aece-54d25543e6c7.jpg)

