### PR TITLE
update to compose-go v1.4.0 as previous version introduced breaking changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.5
 	github.com/buger/goterm v1.0.4
 	github.com/cnabio/cnab-to-oci v0.3.5
-	github.com/compose-spec/compose-go v1.3.0
+	github.com/compose-spec/compose-go v1.4.0
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.6
 	github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/compose-spec/compose-go v1.2.1/go.mod h1:pAy7Mikpeft4pxkFU565/DRHEbDfR84G6AQuiL+Hdg8=
-github.com/compose-spec/compose-go v1.3.0 h1:n5fSOUXQsfnCpn/lZBgNM3qEu1PDhvcbWrWXVBlUNmA=
-github.com/compose-spec/compose-go v1.3.0/go.mod h1:l7RUULbFFLzlQHuxtJr7SVLyWdqEpbJEGTWCgcu6Eqw=
+github.com/compose-spec/compose-go v1.4.0 h1:zaYVAZ6lIByr7Jffi20AabfeUwcTrdXfH3X1R5HEm+g=
+github.com/compose-spec/compose-go v1.4.0/go.mod h1:l7RUULbFFLzlQHuxtJr7SVLyWdqEpbJEGTWCgcu6Eqw=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -49,7 +49,7 @@ func TestLocalComposeUp(t *testing.T) {
 		assert.Assert(t, strings.Contains(output, `"word":`))
 
 		res = c.RunDockerCmd(t, "network", "ls")
-		res.Assert(t, icmd.Expected{Out: projectName + "-default"})
+		res.Assert(t, icmd.Expected{Out: projectName + "_default"})
 	})
 
 	t.Run("top", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestLocalComposeUp(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.service": "web"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version":`})
 
-		res = c.RunDockerCmd(t, "network", "inspect", projectName+"-default")
+		res = c.RunDockerCmd(t, "network", "inspect", projectName+"_default")
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.network": "default"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": `})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version": `})
@@ -241,6 +241,6 @@ func TestConvert(t *testing.T) {
       default: null
 networks:
   default:
-    name: compose-e2e-convert-default`, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
+    name: compose-e2e-convert_default`, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
 	})
 }

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -52,7 +52,7 @@ func TestNetworks(t *testing.T) {
 		assert.Assert(t, strings.Contains(output, `"word":`))
 
 		res = c.RunDockerCmd(t, "network", "ls")
-		res.Assert(t, icmd.Expected{Out: projectName + "-dbnet"})
+		res.Assert(t, icmd.Expected{Out: projectName + "_dbnet"})
 		res.Assert(t, icmd.Expected{Out: "microservices"})
 	})
 
@@ -126,7 +126,7 @@ func TestIPAMConfig(t *testing.T) {
 	const projectName = "ipam_e2e"
 
 	t.Run("ensure we do not reuse previous networks", func(t *testing.T) {
-		c.RunDockerOrExitError(t, "network", "rm", projectName+"-default")
+		c.RunDockerOrExitError(t, "network", "rm", projectName+"_default")
 	})
 
 	t.Run("up", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestIPAMConfig(t *testing.T) {
 
 	t.Run("ensure service get fixed IP assigned", func(t *testing.T) {
 		res := c.RunDockerCmd(t, "inspect", projectName+"-foo-1", "-f",
-			fmt.Sprintf(`{{ $network := index .NetworkSettings.Networks "%s-default" }}{{ $network.IPAMConfig.IPv4Address }}`, projectName))
+			fmt.Sprintf(`{{ $network := index .NetworkSettings.Networks "%s_default" }}{{ $network.IPAMConfig.IPv4Address }}`, projectName))
 		res.Assert(t, icmd.Expected{Out: "10.1.0.100"})
 	})
 

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -107,7 +107,7 @@ func TestProjectVolumeBind(t *testing.T) {
 
 		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 
-		c.RunDockerOrExitError(t, "volume", "rm", "-f", projectName+"-project-data").Assert(t, icmd.Success)
+		c.RunDockerOrExitError(t, "volume", "rm", "-f", projectName+"_project-data").Assert(t, icmd.Success)
 		cmd := c.NewCmdWithEnv([]string{"TEST_DIR=" + tmpDir},
 			"docker", "compose", "--project-directory", "fixtures/project-volume-bind-test", "--project-name", projectName, "up", "-d")
 		icmd.RunCmd(cmd).Assert(t, icmd.Success)


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Bump version of compose-go to `v1.4.0` which remove the breaking changes introduced in version `v1.3.0` by this [PR](https://github.com/compose-spec/compose-go/pull/294)

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/182179541-247dadd1-d81d-4cbc-b561-dcaf8bca4680.png)
