### PR TITLE
Fix docker-compose convert that turns $ into $$ when using the --no-interpolate option

### DIFF
--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -142,6 +143,12 @@ func runConvert(ctx context.Context, backend api.Service, opts convertOptions, s
 	})
 	if err != nil {
 		return err
+	}
+
+	if !opts.noInterpolate {
+		dollar := []byte{'$'}
+		escDollar := []byte{'$', '$'}
+		json = bytes.ReplaceAll(json, dollar, escDollar)
 	}
 
 	if opts.quiet {

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -17,7 +17,6 @@
 package compose
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -95,26 +94,12 @@ func getContainerNameWithoutProject(c moby.Container) string {
 func (s *composeService) Convert(ctx context.Context, project *types.Project, options api.ConvertOptions) ([]byte, error) {
 	switch options.Format {
 	case "json":
-		marshal, err := json.MarshalIndent(project, "", "  ")
-		if err != nil {
-			return nil, err
-		}
-		return escapeDollarSign(marshal), nil
+		return json.MarshalIndent(project, "", "  ")
 	case "yaml":
-		marshal, err := yaml.Marshal(project)
-		if err != nil {
-			return nil, err
-		}
-		return escapeDollarSign(marshal), nil
+		return yaml.Marshal(project)
 	default:
 		return nil, fmt.Errorf("unsupported format %q", options)
 	}
-}
-
-func escapeDollarSign(marshal []byte) []byte {
-	dollar := []byte{'$'}
-	escDollar := []byte{'$', '$'}
-	return bytes.ReplaceAll(marshal, dollar, escDollar)
 }
 
 // projectFromName builds a types.Project based on actual resources with compose labels set

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -234,3 +234,25 @@ networks:
     name: compose-e2e-convert_default`, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
 	})
 }
+
+func TestConvertInterpolate(t *testing.T) {
+	const projectName = "compose-e2e-convert-interpolate"
+	c := NewParallelCLI(t)
+
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+
+	t.Run("convert", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose-interpolate.yaml", "-p", projectName, "convert", "--no-interpolate")
+		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`services:
+  nginx:
+    build:
+      context: %s
+      dockerfile: ${MYVAR}
+    networks:
+      default: null
+networks:
+  default:
+    name: compose-e2e-convert-interpolate_default`, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
+	})
+}

--- a/pkg/e2e/fixtures/simple-build-test/compose-interpolate.yaml
+++ b/pkg/e2e/fixtures/simple-build-test/compose-interpolate.yaml
@@ -1,0 +1,5 @@
+services:
+  nginx:
+    build:
+      context: nginx-build
+      dockerfile: ${MYVAR}


### PR DESCRIPTION
**What I did**
I checked the Python implementation of the interpolation feature in v1 and found out that the [`serialize_config`](https://github.com/docker/compose/blob/5db8d86f127848367e4d721e992c188923c89d42/compose/config/serialize.py#L75) function in the `compose.config.serialize` module was only escaping the $ when the `--no-interpolate` option was not enabled.

In the current implementation, which was partially modified by #8632, the `Convert` function always escapes the $ and therefore does not work the same way as in v1. It should first check if the `--no-interpolate` option was enabled or not.

However, this was not possible in the `Convert` function, because there were no parameters giving this information and the function was hidden under the `Service` interface, so it would have been difficult to change it. That's why I moved the code responsible for escaping the $ out of the `Convert` function and checked the value of the `--no-interpolate` option before calling it. By doing so, the bug is fixed and it works as in v1.

**Related issues**
fixes #9160
improves #8632

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![IMG_20200407_162414](https://user-images.githubusercontent.com/55436804/182268529-9de426b4-80c2-4e6c-b546-39c7a06589fa.png)

This is my first pull request and my first experience with go, so sorry if I did something wrong.