### PR TITLE
Remove extra whitespaces in help text of some subcommands

### DIFF
--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -66,7 +66,7 @@ func downCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	removeOrphans := utils.StringToBool(os.Getenv("COMPOSE_REMOVE_ORPHANS"))
 	flags.BoolVar(&opts.removeOrphans, "remove-orphans", removeOrphans, "Remove containers for services not defined in the Compose file.")
 	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")
-	flags.BoolVarP(&opts.volumes, "volumes", "v", false, " Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.")
+	flags.BoolVarP(&opts.volumes, "volumes", "v", false, "Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.")
 	flags.StringVar(&opts.images, "rmi", "", `Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")`)
 	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		if name == "volume" {

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -151,7 +151,7 @@ func runCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *
 	flags.StringArrayVarP(&opts.labels, "label", "l", []string{}, "Add or override a label")
 	flags.BoolVar(&opts.Remove, "rm", false, "Automatically remove the container when it exits")
 	flags.BoolVarP(&opts.noTty, "no-TTY", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-TTY allocation (default: auto-detected).")
-	flags.StringVar(&opts.name, "name", "", " Assign a name to the container")
+	flags.StringVar(&opts.name, "name", "", "Assign a name to the container")
 	flags.StringVarP(&opts.user, "user", "u", "", "Run as specified username or uid")
 	flags.StringVarP(&opts.workdir, "workdir", "w", "", "Working directory inside the container")
 	flags.StringVar(&opts.entrypoint, "entrypoint", "", "Override the entrypoint of the image")

--- a/docs/reference/compose_down.md
+++ b/docs/reference/compose_down.md
@@ -10,7 +10,7 @@ Stop and remove containers, networks
 | `--remove-orphans` |  |  | Remove containers for services not defined in the Compose file. |
 | `--rmi` | `string` |  | Remove images used by services. "local" remove only images that don't have a custom tag ("local"\|"all") |
 | `-t`, `--timeout` | `int` | `10` | Specify a shutdown timeout in seconds |
-| `-v`, `--volumes` |  |  |  Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers. |
+| `-v`, `--volumes` |  |  | Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers. |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -12,7 +12,7 @@ Run a one-off command on a service.
 | `-e`, `--env` | `stringArray` |  | Set environment variables |
 | `-i`, `--interactive` |  |  | Keep STDIN open even if not attached. |
 | `-l`, `--label` | `stringArray` |  | Add or override a label |
-| `--name` | `string` |  |  Assign a name to the container |
+| `--name` | `string` |  | Assign a name to the container |
 | `-T`, `--no-TTY` |  |  | Disable pseudo-TTY allocation (default: auto-detected). |
 | `--no-deps` |  |  | Don't start linked services. |
 | `-p`, `--publish` | `stringArray` |  | Publish a container's port(s) to the host. |


### PR DESCRIPTION
**What I did**

A relatively small and simple change to just remove extra leading whitespaces in help text of the `run` and `down` subcommands.

What it currently looks like before the change (note the second last line):

```
> docker compose down --help

Usage:  docker compose down

Stop and remove containers, networks

Options:
      --remove-orphans    Remove containers for services not defined in the Compose file.
      --rmi string        Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")
  -t, --timeout int       Specify a shutdown timeout in seconds (default 10)
  -v, --volumes volumes    Remove named volumes declared in the volumes section of the Compose file and anonymous volumes attached to
                          containers.
```

**Related issue**
I didn't create an issue since this is a relatively small.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
