### PR TITLE
config: use correct YAML marshal func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,13 +27,13 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/pkg/errors v0.9.1
-	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	github.com/theupdateframework/notary v0.7.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
+	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.3.0
 )
@@ -120,7 +120,6 @@ require (
 	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.24.1 // indirect; see replace for the actual version used
 	k8s.io/client-go v0.24.1 // indirect; see replace for the actual version used

--- a/go.sum
+++ b/go.sum
@@ -1222,8 +1222,6 @@ github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUcc
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
-github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b h1:jUK33OXuZP/l6babJtnLo1qsGvq6G9so9KMflGAm4YA=
-github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b/go.mod h1:8458kAagoME2+LN5//WxE71ysZ3B7r22fdgb7qVmXSY=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"strings"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
@@ -33,7 +35,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
-	"github.com/sanathkr/go-yaml"
 )
 
 // NewComposeService create a local implementation of the compose.Service API


### PR DESCRIPTION
**What I did**
When marshalling via CLI (`compose convert` / `compose config`), we
were using a _different_ YAML lib, which was a fork of `go-yaml`,
which is what `gopkg.in/yaml.v2` is based off of.

The `compose-spec/compose-go` lib is written with `gopkg.in/yaml.v2`
as a target, so I changed it to use that for marshalling the config.

The fork that was being used was [sanathkr/go-yaml](https://github.com/sanathkr/go-yaml).
Looking through `git log`, this was originally introduced transitively by
old ECS/CloudFormation code (that now lives in `compose-cli`), so its
usage was likely the result of IDE auto-complete and not intentional.

The only change it added compared to the upstream lib was custom tag
support, which is not something we use (and regardless, since the **unmarshal**
is done with a different lib, it wouldn't work regardless). See https://github.com/go-yaml/yaml/commit/ed9d249f429b3f5a69f80a7abef6bfce81fef894.

**Related issue**
I discovered this when working on compose-spec/compose-go#298.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![a cat in a shark costume](https://user-images.githubusercontent.com/841263/182660874-48dce91e-d3b1-4df1-a09d-92420212aa34.png)
