### PR TITLE
don't apply default pull policy from command line if one is define in service configuration

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -31,6 +31,7 @@ type createOptions struct {
 	Build         bool
 	noBuild       bool
 	Pull          string
+	pullChanged   bool
 	removeOrphans bool
 	ignoreOrphans bool
 	forceRecreate bool
@@ -47,7 +48,8 @@ func createCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [OPTIONS] [SERVICE...]",
 		Short: "Creates containers for a service.",
-		PreRunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: AdaptCmd(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+			opts.pullChanged = cmd.Flags().Changed("pull")
 			if opts.Build && opts.noBuild {
 				return fmt.Errorf("--build and --no-build are incompatible")
 			}
@@ -108,7 +110,7 @@ func (opts createOptions) GetTimeout() *time.Duration {
 }
 
 func (opts createOptions) Apply(project *types.Project) {
-	if opts.Pull != "" {
+	if opts.pullChanged {
 		for i, service := range project.Services {
 			service.PullPolicy = opts.Pull
 			project.Services[i] = service


### PR DESCRIPTION
**What I did**
Don't override service pull policy if the value from the command line is the default one

**Related issue**
fix #9717 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/182963505-3f040f90-4908-440b-b65e-99ae5eb5105f.png)
