### PR TITLE
update Docker CLI version use in CI to v20.10.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
         default: "false"
 env:
   GO_VERSION: 1.18.5
+  DOCKER_CLI_VERSION: 20.10.17
 jobs:
   lint:
     name: Lint
@@ -73,7 +74,7 @@ jobs:
 
       - name: Setup docker CLI
         run: |
-          curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
 
       - name: Test
@@ -102,7 +103,7 @@ jobs:
 
       - name: Setup docker CLI
         run: |
-          curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
 
       - name: Build for local E2E


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Update the version of Docker CLI used by GitHub action CI workflow

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/183033574-d35764e0-b1d7-4277-9806-39eae9d8b5b8.png)
