### PR TITLE
fix version of golangci-lint to v1.47.3, issue with v1.48.0 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Run golangci-lint
         env:
           BUILD_TAGS: e2e
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.47.3
           args: --timeout=180s
 
   # only on main branch, costs too much for the gain on every PR


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Fix the version of golangci-lint because we're currently facing issues with the `v1.48.0`


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/183036391-0fa644b3-10e1-4094-a6a1-c663baaaf6ec.png)
