### PR TITLE
lint: run gofmt from Go 1.19

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -65,7 +65,7 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 	return nameDigests, errs
 }
 
-//nolint: gocyclo
+// nolint: gocyclo
 func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options buildx.Options) (string, error) {
 	var (
 		buildCtx      io.ReadCloser


### PR DESCRIPTION
**What I did**
`gofmt -w -l -s .` with Go 1.19 😛 

**Related issue**
See #9722 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![hamster with some broccoli](https://user-images.githubusercontent.com/841263/183429856-b8a04acd-e089-4a26-89b0-66c44a83166f.png)
