### PR TITLE
fix formatting of "nolint" tags for go1.19

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -65,7 +65,7 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 	return nameDigests, errs
 }
 
-// nolint: gocyclo
+//nolint:gocyclo
 func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options buildx.Options) (string, error) {
 	var (
 		buildCtx      io.ReadCloser

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -134,7 +134,7 @@ func TestDownComposefileInParentFolder(t *testing.T) {
 
 	tmpFolder, err := os.MkdirTemp("fixtures/simple-composefile", "test-tmp")
 	assert.NilError(t, err)
-	defer os.Remove(tmpFolder) // nolint: errcheck
+	defer os.Remove(tmpFolder) //nolint:errcheck
 	projectName := filepath.Base(tmpFolder)
 
 	res := c.RunDockerComposeCmd(t, "--project-directory", tmpFolder, "up", "-d")


### PR DESCRIPTION
- follow-up to https://github.com/docker/compose/pull/9728 https://github.com/docker/compose/pull/9728#discussion_r940397357

The correct formatting for machine-readable comments is;

    //<namespace>:<options>[,<option>...][ // comment]

Which basically means:

- MUST NOT have a space before `<namespace>` (e.g. `nolint`)
- Namespace MUST be alphanumeric
- MUST be followed by a colon
- MUST be followed by at least one `<option>`
- Optionally additional `<options>` (comma-separated)
- Optionally followed by a comment

Any other format will not be considered a machine-readable comment by `gofmt`,
and thus formatted as a regular comment. Note that this also means that a
`//nolint` (without anything after it) is considered invalid, same for `//#nosec`
(starts with a `#`).

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
