### PR TITLE
lint: add `nolintlint` and clean up `nolint` directives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - lll
     - misspell
     - nakedret
+    - nolintlint
     - staticcheck
     - structcheck
     - typecheck

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -89,7 +89,7 @@ func (l *logConsumer) Log(container, service, message string) {
 	}
 	p := l.getPresenter(container)
 	for _, line := range strings.Split(message, "\n") {
-		fmt.Fprintf(l.writer, "%s%s\n", p.prefix, line) //nolint:errcheck
+		fmt.Fprintf(l.writer, "%s%s\n", p.prefix, line)
 	}
 }
 

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -29,7 +29,6 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	buildx "github.com/docker/buildx/build"
 	"github.com/docker/cli/cli/command/image/build"
-	"github.com/docker/compose/v2/pkg/api"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/archive"
@@ -40,6 +39,8 @@ import (
 	"github.com/docker/docker/pkg/urlutil"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
+	"github.com/docker/compose/v2/pkg/api"
 )
 
 func (s *composeService) doBuildClassic(ctx context.Context, project *types.Project, opts map[string]buildx.Options) (map[string]string, error) {
@@ -65,7 +66,7 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 	return nameDigests, errs
 }
 
-// nolint: gocyclo
+//nolint:gocyclo
 func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options buildx.Options) (string, error) {
 	var (
 		buildCtx      io.ReadCloser

--- a/pkg/compose/container.go
+++ b/pkg/compose/container.go
@@ -30,13 +30,13 @@ const (
 	// ContainerRunning running status
 	ContainerRunning = "running"
 	// ContainerRemoving removing status
-	ContainerRemoving = "removing" //nolint
+	ContainerRemoving = "removing"
 	// ContainerPaused paused status
-	ContainerPaused = "paused" //nolint
+	ContainerPaused = "paused"
 	// ContainerExited exited status
-	ContainerExited = "exited" //nolint
+	ContainerExited = "exited"
 	// ContainerDead dead status
-	ContainerDead = "dead" //nolint
+	ContainerDead = "dead"
 )
 
 var _ io.ReadCloser = ContainerStdout{}

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -21,11 +21,12 @@ import (
 	"io"
 	"strings"
 
-	"github.com/docker/compose/v2/pkg/api"
-	"github.com/docker/compose/v2/pkg/utils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v2/pkg/api"
+	"github.com/docker/compose/v2/pkg/utils"
 )
 
 func (s *composeService) Logs(ctx context.Context, projectName string, consumer api.LogConsumer, options api.LogOptions) error {
@@ -95,7 +96,7 @@ func (s *composeService) logContainers(ctx context.Context, consumer api.LogCons
 	if err != nil {
 		return err
 	}
-	defer r.Close() //nolint errcheck
+	defer r.Close() //nolint:errcheck
 
 	name := getContainerNameWithoutProject(c)
 	w := utils.GetWriter(func(line string) {

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -134,7 +134,7 @@ func TestDownComposefileInParentFolder(t *testing.T) {
 
 	tmpFolder, err := os.MkdirTemp("fixtures/simple-composefile", "test-tmp")
 	assert.NilError(t, err)
-	defer os.Remove(tmpFolder) // nolint: errcheck
+	defer os.Remove(tmpFolder) //nolint:errcheck
 	projectName := filepath.Base(tmpFolder)
 
 	res := c.RunDockerComposeCmd(t, "--project-directory", tmpFolder, "up", "-d")

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -172,12 +172,12 @@ func CopyFile(t testing.TB, sourceFile string, destinationFile string) {
 
 	src, err := os.Open(sourceFile)
 	require.NoError(t, err, "Failed to open source file: %s")
-	//nolint: errcheck
+	//nolint:errcheck
 	defer src.Close()
 
 	dst, err := os.OpenFile(destinationFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
 	require.NoError(t, err, "Failed to open destination file: %s", destinationFile)
-	//nolint: errcheck
+	//nolint:errcheck
 	defer dst.Close()
 
 	_, err = io.Copy(dst, src)

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -50,7 +50,6 @@ func TestLocalComposeVolume(t *testing.T) {
 	t.Run("check container volume specs", func(t *testing.T) {
 		res := c.RunDockerCmd(t, "inspect", "compose-e2e-volume-nginx2-1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
-		//nolint
 		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/src/app/node_modules","Driver":"local","Mode":"z","RW":true,"Propagation":""`), output)
 		assert.Assert(t, strings.Contains(output, `"Destination":"/myconfig","Mode":"","RW":false,"Propagation":"rprivate"`), output)
 	})
@@ -68,7 +67,6 @@ func TestLocalComposeVolume(t *testing.T) {
 	t.Run("check container bind-mounts specs", func(t *testing.T) {
 		res := c.RunDockerCmd(t, "inspect", "compose-e2e-volume-nginx-1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
-		//nolint
 		assert.Assert(t, strings.Contains(output, `"Type":"bind"`))
 		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/share/nginx/html"`))
 	})

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -164,14 +164,12 @@ func (w *ttyWriter) print() {
 			continue
 		}
 		line := lineText(event, "", terminalWidth, statusPadding, runtime.GOOS != "windows")
-		//nolint: errcheck
 		fmt.Fprint(w.out, line)
 		numLines++
 		for _, v := range w.eventIDs {
 			ev := w.events[v]
 			if ev.ParentID == event.ID {
 				line := lineText(ev, "  ", terminalWidth, statusPadding, runtime.GOOS != "windows")
-				//nolint: errcheck
 				fmt.Fprint(w.out, line)
 				numLines++
 			}

--- a/pkg/utils/writer_test.go
+++ b/pkg/utils/writer_test.go
@@ -22,18 +22,19 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+//nolint:errcheck
 func TestSplitWriter(t *testing.T) {
 	var lines []string
 	w := GetWriter(func(line string) {
 		lines = append(lines, line)
 	})
-	w.Write([]byte("h"))        //nolint: errcheck
-	w.Write([]byte("e"))        //nolint: errcheck
-	w.Write([]byte("l"))        //nolint: errcheck
-	w.Write([]byte("l"))        //nolint: errcheck
-	w.Write([]byte("o"))        //nolint: errcheck
-	w.Write([]byte("\n"))       //nolint: errcheck
-	w.Write([]byte("world!\n")) //nolint: errcheck
+	w.Write([]byte("h"))
+	w.Write([]byte("e"))
+	w.Write([]byte("l"))
+	w.Write([]byte("l"))
+	w.Write([]byte("o"))
+	w.Write([]byte("\n"))
+	w.Write([]byte("world!\n"))
 	assert.DeepEqual(t, lines, []string{"hello", "world!"})
 
 }


### PR DESCRIPTION
**What I did**
We had some incorrectly formatted and/or ineffective `nolint` directives hanging around. I added `nolintlint` to the list of linters, fixed up some violations it flagged, and did some creative finds to look for some other weird/pointless ones (but spent about 5 mins on this, so it's not exhaustive).

Thanks to @thaJeztah for pointing this out @ https://github.com/docker/compose/pull/9728#pullrequestreview-1065409215

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![capybaras relaxing in the bath](https://user-images.githubusercontent.com/841263/183755754-80c2b8d2-f998-48a4-869e-fff5f61f6b1b.png)
