### PR TITLE
Apply newly loaded envvars to "DockerCli" and "APIClient"

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -32,6 +32,8 @@ import (
 	dockercli "github.com/docker/cli/cli"
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/flags"
+	"github.com/docker/docker/client"
 	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -291,6 +293,18 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Reset DockerCli and APIClient to get possible `DOCKER_HOST` and/or `DOCKER_CONTEXT` loaded from environment file
+			err = dockerCli.Apply(func(cli *command.DockerCli) error {
+				return cli.Initialize(flags.NewClientOptions(),
+					command.WithInitializeClient(func(_ *command.DockerCli) (client.APIClient, error) {
+						return nil, nil
+					}))
+			})
+			if err != nil {
+				return err
+			}
+
 			parent := cmd.Root()
 			if parent != nil {
 				parentPrerun := parent.PersistentPreRunE

--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -294,7 +294,7 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command {
 				return err
 			}
 
-			// Reset DockerCli and APIClient to get possible `DOCKER_HOST` and/or `DOCKER_CONTEXT` loaded from environment file
+			// Reset DockerCli and APIClient to get possible `DOCKER_HOST` and/or `DOCKER_CONTEXT` loaded from environment file.
 			err = dockerCli.Apply(func(cli *command.DockerCli) error {
 				return cli.Initialize(flags.NewClientOptions(),
 					command.WithInitializeClient(func(_ *command.DockerCli) (client.APIClient, error) {

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -22,6 +22,8 @@ import (
 	"github.com/compose-spec/compose-go/types"
 )
 
+var _ Service = &ServiceProxy{}
+
 // ServiceProxy implements Service by delegating to implementation functions. This allows lazy init and per-method overrides
 type ServiceProxy struct {
 	BuildFn              func(ctx context.Context, project *types.Project, options BuildOptions) error
@@ -58,8 +60,6 @@ func NewServiceProxy() *ServiceProxy {
 
 // Interceptor allow to customize the compose types.Project before the actual Service method is executed
 type Interceptor func(ctx context.Context, project *types.Project)
-
-var _ Service = &ServiceProxy{}
 
 // WithService configure proxy to use specified Service as delegate
 func (s *ServiceProxy) WithService(service Service) *ServiceProxy {


### PR DESCRIPTION
**What I did**
Re-evaluate `DockerCli` and `APIClient` after reading the environment file.
I can contain `DOCKER_HOST` and/or `DOCKER_CONTEXT` so the `DockerCli` passed by `docker/cli` has to be re-evaluated.

**Related issue**
Resolves https://github.com/docker/compose/issues/9210