### PR TITLE
readme: fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Docker Compose v2
 
-[![Actions Status](https://github.com/docker/compose/workflows/Continuous%20integration/badge.svg)](https://github.com/docker/compose/actions)
+[![GitHub release](https://img.shields.io/github/release/docker/compose.svg?style=flat-square)](https://github.com/docker/compose/releases/latest)
+[![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?style=flat-square&logo=go&logoColor=white)](https://pkg.go.dev/github.com/docker/compose/v2)
+[![Build Status](https://img.shields.io/github/workflow/status/docker/compose/ci?label=ci&logo=github&style=flat-square)](https://github.com/docker/compose/actions?query=workflow%3Aci)
+[![Go Report Card](https://goreportcard.com/badge/github.com/docker/compose/v2?style=flat-square)](https://goreportcard.com/report/github.com/docker/compose/v2)
 
 ![Docker Compose](logo.png?raw=true "Docker Compose Logo")
 


### PR DESCRIPTION
follow-up #9744 

fix broken GHA status badge in the README and add other useful ones:

![image](https://user-images.githubusercontent.com/1951866/184447510-764bfc82-d383-48d3-9717-eec9ae8e5403.png)

cc @glours 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>