### PR TITLE
ci: fix checksums file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,12 @@ jobs:
           name: compose
           path: ${{ env.DESTDIR }}
       -
+        name: Create checksums
+        working-directory: ${{ env.DESTDIR }}
+        run: |
+          find . -type f -print0 | sort -z | xargs -r0 shasum -a 256 -b | sed 's# .*/#  #' > checksums.txt
+          shasum -a 256 -U -c checksums.txt
+      -
         name: License
         run: cp packaging/* ${{ env.DESTDIR }}/
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,6 @@ COPY --link --from=build /usr/bin/docker-compose /docker-compose.exe
 FROM binary-$TARGETOS AS binary
 
 FROM --platform=$BUILDPLATFORM alpine AS releaser
-RUN apk add --no-cache file perl-utils
 WORKDIR /work
 ARG TARGETOS
 ARG TARGETARCH
@@ -177,8 +176,7 @@ RUN --mount=from=binary \
     # TODO: should just use standard arch
     TARGETARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "$TARGETARCH"); \
     TARGETARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "$TARGETARCH"); \
-    cp docker-compose* "/out/docker-compose-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}$(ls docker-compose* | sed -e 's/^docker-compose//')" && \
-    (cd /out ; for f in *; do shasum --binary --algorithm 256 $f | tee -a /out/checksums.txt > $f.sha256; done)
+    cp docker-compose* "/out/docker-compose-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}$(ls docker-compose* | sed -e 's/^docker-compose//')"
 
 FROM scratch AS release
 COPY --from=releaser /out/ /


### PR DESCRIPTION
regression from #9744, checksums file is not correctly generated in our pipeline.

also adds a step that checks if checksums file is correct:

![image](https://user-images.githubusercontent.com/1951866/184554098-2e66a927-e2c5-44ea-8c2b-5fd5d394d8ef.png)

`.sha256` files are not generated anymore as they are redundant with checksums file.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>