### PR TITLE
build windows/arm64 and linux/riscv64 binaries

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -100,8 +100,10 @@ target "binary-cross" {
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
+    "linux/riscv64",
     "linux/s390x",
-    "windows/amd64"
+    "windows/amd64",
+    "windows/arm64"
   ]
 }
 


### PR DESCRIPTION
adds support for `windows/arm64` and `linux/riscv64`.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>