### PR TITLE
Add a local builder Makefile to easy local dev with compose-go replace

### DIFF
--- a/local.Makefile
+++ b/local.Makefile
@@ -1,0 +1,42 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+GOOS?=$(shell go env GOOS)
+GOARCH?=$(shell go env GOARCH)
+
+PKG_NAME := github.com/docker/compose/v2
+
+EXTENSION:=
+ifeq ($(GOOS),windows)
+  EXTENSION:=.exe
+endif
+
+STATIC_FLAGS=CGO_ENABLED=0
+
+GIT_TAG?=$(shell git describe --tags --match "v[0-9]*")
+
+LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG}"
+GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
+
+COMPOSE_BINARY?=bin/docker-compose
+COMPOSE_BINARY_WITH_EXTENSION=$(COMPOSE_BINARY)$(EXTENSION)
+
+TAGS:=
+ifdef BUILD_TAGS
+  TAGS=-tags $(BUILD_TAGS)
+endif
+
+.PHONY: compose-plugin-local
+compose-plugin-local:
+	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY_WITH_EXTENSION) ./cmd


### PR DESCRIPTION
**What I did**
Facilitate local development by allowing build with a `replace` clause in local file system for `compose-spec/compose-go` in `go.mod`

```console
make -f local.Makefile
```
