### PR TITLE
ci: reduce noise from dependabot on Docker deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      # docker/buildx + docker/cli + docker/docker require coordination to
+      # ensure compatibility between them
+      - dependency-name: "github.com/docker/buildx"
+        # buildx is still 0.x
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "github.com/docker/cli"
+        # docker/cli uses CalVer rather than SemVer
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "github.com/docker/docker"
+        # docker/docker uses CalVer rather than SemVer
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
**What I did**
There's a complex dependency situation with `docker/docker`,
`docker/cli`, and `docker/buildkit`. Upgrading them usually
needs to happen in unison to ensure compatible versions
between them, particularly because `docker/buildx` is not
1.0, so has no guarantees re: compatibility, and `docker/docker`
& `docker/cli` use CalVer rather than SemVer, so also have
different compatibility guarantees than necessarily expected
by Go tooling.

Patch versions are still considered for these to ensure we
don't miss important bugfixes.

**Related issue**
#9766 & #9758 😒 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![sleeping cat covering its face with its paw](https://user-images.githubusercontent.com/841263/185661546-b6400fc0-7a7d-4caa-9aba-b5ab2148798d.png)
