### PR TITLE
pull: always pull when policy not specified

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -96,15 +96,6 @@ func (s *composeService) pull(ctx context.Context, project *types.Project, opts 
 				})
 				continue
 			}
-		default:
-			if _, ok := images[service.Image]; ok {
-				w.Event(progress.Event{
-					ID:     service.Name,
-					Status: progress.Done,
-					Text:   "Skipped - Image is already present locally",
-				})
-				continue
-			}
 		}
 
 		if s, ok := imagesBeingPulled[service.Image]; ok {

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -131,6 +131,13 @@ func TestComposePull(t *testing.T) {
 
 		assert.Assert(t, strings.Contains(output, "simple Pulled"))
 		assert.Assert(t, strings.Contains(output, "another Pulled"))
+
+		// verify default policy is 'always' for pull command
+		res = c.RunDockerComposeCmd(t, "--project-directory", "fixtures/compose-pull/simple", "pull")
+		output = res.Combined()
+
+		assert.Assert(t, strings.Contains(output, "simple Pulled"))
+		assert.Assert(t, strings.Contains(output, "another Pulled"))
 	})
 
 	t.Run("Verify a image is pulled once", func(t *testing.T) {

--- a/pkg/e2e/fixtures/compose-pull/image-present-locally/docker-compose.yaml
+++ b/pkg/e2e/fixtures/compose-pull/image-present-locally/docker-compose.yaml
@@ -1,4 +1,5 @@
 services:
   simple:
     image: alpine:3.13.12
+    pull_policy: missing
     command: top


### PR DESCRIPTION
**What I did**

Handle `always` pull policy, reverting a change in logic from #9173.

**Related issue**

Fixes #9773.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![elephants](https://images.pexels.com/photos/12278086/pexels-photo-12278086.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=720)
