### PR TITLE
Remove error message showing exit code when using --exit-code-from

### DIFF
--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 
 	"github.com/docker/compose/v2/pkg/api"
-
-	"github.com/sirupsen/logrus"
 )
 
 // logPrinter watch application containers an collect their logs
@@ -99,7 +97,6 @@ func (p *printer) Run(ctx context.Context, cascadeStop bool, exitCodeFrom string
 						exitCodeFrom = event.Service
 					}
 					if exitCodeFrom == event.Service {
-						logrus.Error(event.ExitCode)
 						exitCode = event.ExitCode
 					}
 				}


### PR DESCRIPTION
**What I did**

Remove the unnecessary error message

**Related issue**
Fixes #9782

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![Panda chilling out](https://images.unsplash.com/photo-1570288685369-f7305163d0e3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTd8fGN1dGUlMjBhbmltYWx8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60)