### PR TITLE
Build and push docker/docker-compose images upon release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
   GO_VERSION: "1.18.5" # for non sandboxed e2e tests
   DESTDIR: "./bin"
   DOCKER_CLI_VERSION: "20.10.17"
+  REPO_SLUG: "docker/docker-compose"
 
 jobs:
   prepare:
@@ -223,3 +224,49 @@ jobs:
           generateReleaseNotes: true
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  bin-image:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: latest
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REPO_SLUG }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push image
+        uses: docker/bake-action@v2
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: release-image
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          set: |
+            *.cache-from=type=gha,scope=bin-image
+            *.cache-to=type=gha,scope=bin-image,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,3 +186,9 @@ COPY --from=releaser /out/ /
 # see open-pr job in .github/workflows/docs.yml for more details
 FROM scratch AS docs-reference
 COPY docs/reference/*.yaml .
+
+FROM base AS release-image
+WORKDIR /root
+COPY --link --from=build /usr/bin/docker-compose /usr/bin/
+RUN mkdir -p /usr/local/lib/docker/cli-plugins
+RUN ln -s /usr/bin/docker-compose /usr/local/lib/docker/cli-plugins/

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ build-and-e2e: compose-plugin e2e-compose e2e-compose-standalone ## Compile the 
 cross: ## Compile the CLI for linux, darwin and windows
 	$(BUILDX_CMD) bake binary
 
+.PHONY: image
+image: ## Build the docker/docker-compose image locally and load it into Docker
+	$(BUILDX_CMD) bake image
+
 .PHONY: test
 test: ## Run unit tests
 	$(BUILDX_CMD) bake test

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -124,3 +124,23 @@ target "docs-update" {
   target = "docs-update"
   output = ["./docs"]
 }
+
+target "docker-metadata-action" {}
+
+target "release-image" {
+  inherits = ["docker-metadata-action"]
+  target = "release-image"
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v6",
+    "linux/arm/v7",
+    "linux/arm64",
+  ]
+}
+
+target "image" {
+  inherits = ["release-image"]
+  platforms = []
+  tags = ["docker.io/docker/docker-compose"]
+  output = ["type=docker"]
+}


### PR DESCRIPTION
**What I did**

Add release-image bake target and bin-image ci workflow for pushing docker/docker-compose image.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![butterfly emerging from cocoon](https://images.pexels.com/photos/63643/brown-white-butterfly-butterflies-colorful-63643.jpeg?auto=compress&cs=tinysrgb&w=720)
