### PR TITLE
Revert "Apply newly loaded envvars to `DockerCli` and `APIClient`"

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -32,8 +32,6 @@ import (
 	dockercli "github.com/docker/cli/cli"
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/flags"
-	"github.com/docker/docker/client"
 	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -293,18 +291,6 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			// Reset DockerCli and APIClient to get possible `DOCKER_HOST` and/or `DOCKER_CONTEXT` loaded from environment file.
-			err = dockerCli.Apply(func(cli *command.DockerCli) error {
-				return cli.Initialize(flags.NewClientOptions(),
-					command.WithInitializeClient(func(_ *command.DockerCli) (client.APIClient, error) {
-						return nil, nil
-					}))
-			})
-			if err != nil {
-				return err
-			}
-
 			parent := cmd.Root()
 			if parent != nil {
 				parentPrerun := parent.PersistentPreRunE


### PR DESCRIPTION
**What I did**
Revert #9745 that introduced support for reading `DOCKER_HOST` & friends from `.env` files but broke TLS options.

**Related issue**
Fixes #9789.
