### PR TITLE
Correctly capture exit code when service has dependencies

### DIFF
--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -93,11 +93,13 @@ func (p *printer) Run(ctx context.Context, cascadeStop bool, exitCodeFrom string
 							return 0, err
 						}
 					}
-					if exitCodeFrom == "" {
-						exitCodeFrom = event.Service
-					}
-					if exitCodeFrom == event.Service {
-						exitCode = event.ExitCode
+					if event.Type == api.ContainerEventExit {
+						if exitCodeFrom == "" {
+							exitCodeFrom = event.Service
+						}
+						if exitCodeFrom == event.Service {
+							exitCode = event.ExitCode
+						}
 					}
 				}
 				if len(containers) == 0 {

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
 )
 
 func TestUpWait(t *testing.T) {
@@ -44,4 +45,14 @@ func TestUpWait(t *testing.T) {
 	}
 
 	c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+}
+
+func TestUpExitCodeFrom(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-exit-code-from"
+
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/start-fail/start-depends_on-long-lived.yaml", "--project-name", projectName, "up", "--exit-code-from=test")
+	res.Assert(t, icmd.Expected{ExitCode: 137})
+
+	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
 }

--- a/pkg/e2e/fixtures/start-fail/start-depends_on-long-lived.yaml
+++ b/pkg/e2e/fixtures/start-fail/start-depends_on-long-lived.yaml
@@ -1,0 +1,11 @@
+services:
+  safe:
+    image: 'alpine'
+    command: ['/bin/sh', '-c', 'sleep infinity']  # never exiting
+  failure:
+    image: 'alpine'
+    command: ['/bin/sh', '-c', 'sleep 2 ; echo "exiting" ; exit 42']
+  test:
+    image: 'alpine'
+    command: ['/bin/sh', '-c', 'sleep 99999 ; echo "tests are OK"']  # very long job
+    depends_on: [safe]


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Only capture exit code from `exit` events.

Previously, we were capturing exit codes from both `exit` and `stop` events. Usually this is not a problem, as all containers get killed/stop around the same time and after we get the last `exit` event, we stop streaming events.

However, if the service we're trying to get an exit code for depends on another, long lived service, which doesn't respond to a `SIGTERM` and hence stays alive for another `10s` (the default timeout before `SIGKILL` is sent), we keep streaming events for longer. During that time, the daemon sends an extra `stop` event, even for containers which have already exited. With the way we were handling events previously, this event's exit code (0, because `stop` events don't carry exit codes) would override the correct exit code, resulting in an incorrect exit code being reported.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

resolves https://github.com/docker/compose/issues/9778

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![butterfly](https://user-images.githubusercontent.com/70572044/187085394-bf24f578-1b7e-429b-86c1-628fec8f2224.jpg)

