### PR TITLE
patch: build.go access custom labels directly cause panic

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -138,8 +138,8 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 			if project.Services[i].Labels == nil {
 				project.Services[i].Labels = types.Labels{}
 			}
-			project.Services[i].CustomLabels[api.ImageDigestLabel] = digest
-			project.Services[i].CustomLabels[api.ImageNameLabel] = service.Image
+			project.Services[i].CustomLabels.Add(api.ImageDigestLabel, digest)
+			project.Services[i].CustomLabels.Add(api.ImageNameLabel, service.Image)
 		}
 	}
 	return nil


### PR DESCRIPTION
This change fixes the panic: assignment to entry in nil map error when want to assigning value to `CustomLabel`. I think this related to this [PR](https://github.com/docker/compose/pull/9579) that forgot to change this line code too.

**What I did**

**Related issue**
Error that got me here:

```
panic: assignment to entry in nil map

goroutine 10 [running]:
github.com/docker/compose/v2/pkg/compose.(*composeService).ensureImagesExists(0x1400003d0c0?, {0x1030de670, 0x1400045be90}, 0x1400044e3c0, 0x0)
        /Users/ruangguru/Go/pkg/mod/github.com/docker/compose/v2@v2.10.2/pkg/compose/build.go:141 +0x3a4
github.com/docker/compose/v2/pkg/compose.(*composeService).create(0x1400003d0c0?, {0x1030de670, 0x1400045be90}, 0x1400044e3c0, {{0x1400003d100, 0x1, 0x1}, 0x0, 0x0, {0x102c2558c, ...}, ...})
        /Users/ruangguru/Go/pkg/mod/github.com/docker/compose/v2@v2.10.2/pkg/compose/create.go:67 +0x114
github.com/docker/compose/v2/pkg/compose.(*composeService).Create.func1({0x1030de670?, 0x1400045be90?})
        /Users/ruangguru/Go/pkg/mod/github.com/docker/compose/v2@v2.10.2/pkg/compose/create.go:52 +0x6c
github.com/docker/compose/v2/pkg/progress.Run.func1({0x1030de670?, 0x1400045be90?})
        /Users/ruangguru/Go/pkg/mod/github.com/docker/compose/v2@v2.10.2/pkg/progress/writer.go:61 +0x30
github.com/docker/compose/v2/pkg/progress.RunWithStatus.func2()
        /Users/ruangguru/Go/pkg/mod/github.com/docker/compose/v2@v2.10.2/pkg/progress/writer.go:82 +0x7c
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/ruangguru/Go/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/errgroup/errgroup.go:75 +0x60
created by golang.org/x/sync/errgroup.(*Group).Go
        /Users/ruangguru/Go/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/errgroup/errgroup.go:72 +0xa8
```

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![gopher](https://user-images.githubusercontent.com/36788585/188677512-51c5a146-1e81-4789-8428-af6bfe79e4ea.jpeg)
