### PR TITLE
chore: add improvement output warning when pulling image

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -181,6 +181,18 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 		RegistryAuth: base64.URLEncoding.EncodeToString(buf),
 		Platform:     service.Platform,
 	})
+
+	// check if has error and the service has a build section
+	// then the status should be warning instead of error
+	if err != nil && service.Build != nil {
+		w.Event(progress.Event{
+			ID:     service.Name,
+			Status: progress.Warning,
+			Text:   "Warning",
+		})
+		return "", WrapCategorisedComposeError(err, PullFailure)
+	}
+
 	if err != nil {
 		w.Event(progress.Event{
 			ID:     service.Name,

--- a/pkg/progress/event.go
+++ b/pkg/progress/event.go
@@ -28,6 +28,8 @@ const (
 	Done
 	// Error means that the current task has errored
 	Error
+	// Warning means that the current task has warning
+	Warning
 )
 
 // Event represents a progress event.

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -75,7 +75,7 @@ func (w *ttyWriter) Event(e Event) {
 	if _, ok := w.events[e.ID]; ok {
 		last := w.events[e.ID]
 		switch e.Status {
-		case Done, Error:
+		case Done, Error, Warning:
 			if last.Status != e.Status {
 				last.stop()
 			}
@@ -221,6 +221,9 @@ func lineText(event Event, pad string, terminalWidth, statusPadding int, color b
 		}
 		if event.Status == Error {
 			color = aec.RedF
+		}
+		if event.Status == Warning {
+			color = aec.YellowF
 		}
 		return aec.Apply(o, color)
 	}

--- a/pkg/progress/tty_test.go
+++ b/pkg/progress/tty_test.go
@@ -54,6 +54,10 @@ func TestLineText(t *testing.T) {
 	ev.Status = Error
 	out = lineText(ev, "", 50, lineWidth, true)
 	assert.Equal(t, out, "\x1b[31m . id Text Status                            0.0s\n\x1b[0m")
+
+	ev.Status = Warning
+	out = lineText(ev, "", 50, lineWidth, true)
+	assert.Equal(t, out, "\x1b[33m . id Text Status                            0.0s\n\x1b[0m")
 }
 
 func TestLineTextSingleEvent(t *testing.T) {
@@ -98,6 +102,35 @@ func TestErrorEvent(t *testing.T) {
 
 	// Fire "Error" event and check end time is set
 	e.Status = Error
+	w.Event(e)
+	event, ok = w.events[e.ID]
+	assert.Assert(t, ok)
+	assert.Assert(t, event.endTime.After(time.Now().Add(-10*time.Second)))
+}
+
+func TestWarningEvent(t *testing.T) {
+	w := &ttyWriter{
+		events: map[string]Event{},
+		mtx:    &sync.Mutex{},
+	}
+	e := Event{
+		ID:         "id",
+		Text:       "Text",
+		Status:     Working,
+		StatusText: "Working",
+		startTime:  time.Now(),
+		spinner: &spinner{
+			chars: []string{"."},
+		},
+	}
+	// Fire "Working" event and check end time isn't touched
+	w.Event(e)
+	event, ok := w.events[e.ID]
+	assert.Assert(t, ok)
+	assert.Assert(t, event.endTime.Equal(time.Time{}))
+
+	// Fire "Warning" event and check end time is set
+	e.Status = Warning
 	w.Event(e)
 	event, ok = w.events[e.ID]
 	assert.Assert(t, ok)


### PR DESCRIPTION
**What I did**

Related to [this](https://github.com/docker/compose/issues/9820) issue, I added some improvements in the console output, where I added a `warning` status instead of an `error` when pulling an image produces an error but in the service has a build section.

Before Changes:
<img width="993" alt="Screen Shot 2022-09-11 at 23 44 04" src="https://user-images.githubusercontent.com/36788585/189539437-5337c408-5577-4015-aa8a-8e852b1781d9.png">

After Changes:
<img width="1001" alt="Screen Shot 2022-09-11 at 23 45 06" src="https://user-images.githubusercontent.com/36788585/189539455-8aeb2b34-b891-47f6-8f87-17a1dff14c1b.png">


**Related issue**
fixes #9820 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/36788585/189539520-f2913a5e-37e9-4cda-bdbc-268fdde6920c.png)

