### PR TITLE
clean service command if entrypoint is overrided in run command

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -112,6 +112,9 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 	}
 	if opts.Entrypoint != nil {
 		service.Entrypoint = opts.Entrypoint
+		if len(opts.Command) == 0 {
+			service.Command = []string{}
+		}
 	}
 	if len(opts.Environment) > 0 {
 		cmdEnv := types.NewMappingWithEquals(opts.Environment)


### PR DESCRIPTION
**What I did**
re-init default service command when the `--entrypoint` is used with `docker compose run`

**Related issue**
fixes #9622 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/189869093-80d3d05a-a103-4532-ba32-9e3553aafb56.png)
