### PR TITLE
update compose-go version to v1.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/buger/goterm v1.0.4
 	github.com/cnabio/cnab-go v0.24.1-0.20220907172316-1ca5c8721bf7
 	github.com/cnabio/cnab-to-oci v0.3.7
-	github.com/compose-spec/compose-go v1.5.0
+	github.com/compose-spec/compose-go v1.5.1
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.8
 	github.com/distribution/distribution/v3 v3.0.0-20220902125104-0122d7ddaec0

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/compose-spec/compose-go v1.2.1/go.mod h1:pAy7Mikpeft4pxkFU565/DRHEbDfR84G6AQuiL+Hdg8=
-github.com/compose-spec/compose-go v1.5.0 h1:yOmYpIm13pYt2o+oKVe/JAD6o2Tv+eUyOcRhf0qF4fA=
-github.com/compose-spec/compose-go v1.5.0/go.mod h1:l7RUULbFFLzlQHuxtJr7SVLyWdqEpbJEGTWCgcu6Eqw=
+github.com/compose-spec/compose-go v1.5.1 h1:qch68VrytuoNMtklbdkhkI6FgDVLuFrUwWK1Lj828Xo=
+github.com/compose-spec/compose-go v1.5.1/go.mod h1:nVa8sWM16GzxGLZ1kGrUtEt6RGimsdMmIzULVVD6S9k=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=


### PR DESCRIPTION
**What I did**
Bump `compose-go` version to `v1.5.1`

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/190112276-89e92618-5378-4c23-8428-5043e1778875.png)
