### PR TITLE
keep the platform defined at service level during build if no build patforms provided

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -363,7 +363,12 @@ func addPlatforms(project *types.Project, service types.ServiceConfig) ([]specs.
 	}
 
 	if service.Platform != "" && !utils.StringContains(service.Build.Platforms, service.Platform) {
-		return nil, fmt.Errorf("service.platform should be part of the service.build.platforms: %q", service.Platform)
+		if len(service.Build.Platforms) > 0 {
+			return nil, fmt.Errorf("service.platform should be part of the service.build.platforms: %q", service.Platform)
+		}
+		// User defined a service platform and no build platforms, so we should keep the one define on the service level
+		p, err := platforms.Parse(service.Platform)
+		return append(plats, p), err
 	}
 
 	for _, buildPlatform := range service.Build.Platforms {

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -314,6 +314,14 @@ func TestBuildPlatformsWithCorrectBuildxConfig(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: "I am building for linux/amd64"})
 		assert.Assert(t, !strings.Contains(res.Stdout(), "I am building for linux/arm64"))
 	})
+
+	t.Run("use service platform value when no build platforms defined ", func(t *testing.T) {
+		res := c.RunDockerComposeCmdNoCheck(t, "--project-directory", "fixtures/build-test/platforms",
+			"-f", "fixtures/build-test/platforms/compose-service-platform-and-no-build-platforms.yaml", "build")
+		assert.NilError(t, res.Error, res.Stderr())
+		res.Assert(t, icmd.Expected{Out: "I am building for linux/386"})
+	})
+
 }
 
 func TestBuildPlatformsStandardErrors(t *testing.T) {

--- a/pkg/e2e/fixtures/build-test/platforms/compose-service-platform-and-no-build-platforms.yaml
+++ b/pkg/e2e/fixtures/build-test/platforms/compose-service-platform-and-no-build-platforms.yaml
@@ -1,0 +1,6 @@
+services:
+  platforms:
+    image: build-test-platform:test
+    platform: linux/386
+    build:
+      context: .


### PR DESCRIPTION

Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Fix an issue when the compose file defines a `service.platform` and don't provide `services.build.platforms`


**Related issue**
https://github.com/docker/compose/pull/9729#issuecomment-1246748144

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/190265347-f99c5cf2-ebb5-4b7b-a2dd-2f60b4564120.png)
