### PR TITLE
Keep `depends_on` condition when service has `volumes_from`

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -125,7 +125,8 @@ func prepareVolumes(p *types.Project) error {
 				p.Services[i].DependsOn = make(types.DependsOnConfig, len(dependServices))
 			}
 			for _, service := range p.Services {
-				if utils.StringContains(dependServices, service.Name) {
+				if utils.StringContains(dependServices, service.Name) &&
+					p.Services[i].DependsOn[service.Name].Condition == "" {
 					p.Services[i].DependsOn[service.Name] = types.ServiceDependency{
 						Condition: types.ServiceConditionStarted,
 					}

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -110,7 +110,8 @@ func TestPrepareVolumes(t *testing.T) {
 				},
 			},
 		}
-		prepareVolumes(&project)
+		err := prepareVolumes(&project)
+		assert.NilError(t, err)
 		assert.Equal(t, project.Services[0].DependsOn["anotherService"].Condition, composetypes.ServiceConditionStarted)
 	})
 	t.Run("doesn't overwrite existing dependency condition", func(t *testing.T) {
@@ -129,7 +130,8 @@ func TestPrepareVolumes(t *testing.T) {
 				},
 			},
 		}
-		prepareVolumes(&project)
+		err := prepareVolumes(&project)
+		assert.NilError(t, err)
 		assert.Equal(t, project.Services[0].DependsOn["anotherService"].Condition, composetypes.ServiceConditionHealthy)
 	})
 }

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -96,6 +96,44 @@ func TestPrepareNetworkLabels(t *testing.T) {
 	}))
 }
 
+func TestPrepareVolumes(t *testing.T) {
+	t.Run("adds dependency condition if service depends on volume from another service", func(t *testing.T) {
+		project := composetypes.Project{
+			Name: "myProject",
+			Services: []composetypes.ServiceConfig{
+				{
+					Name:        "aService",
+					VolumesFrom: []string{"anotherService"},
+				},
+				{
+					Name: "anotherService",
+				},
+			},
+		}
+		prepareVolumes(&project)
+		assert.Equal(t, project.Services[0].DependsOn["anotherService"].Condition, composetypes.ServiceConditionStarted)
+	})
+	t.Run("doesn't overwrite existing dependency condition", func(t *testing.T) {
+		project := composetypes.Project{
+			Name: "myProject",
+			Services: []composetypes.ServiceConfig{
+				{
+					Name:        "aService",
+					VolumesFrom: []string{"anotherService"},
+					DependsOn: map[string]composetypes.ServiceDependency{
+						"anotherService": {Condition: composetypes.ServiceConditionHealthy},
+					},
+				},
+				{
+					Name: "anotherService",
+				},
+			},
+		}
+		prepareVolumes(&project)
+		assert.Equal(t, project.Services[0].DependsOn["anotherService"].Condition, composetypes.ServiceConditionHealthy)
+	})
+}
+
 func TestBuildContainerMountOptions(t *testing.T) {
 	project := composetypes.Project{
 		Name: "myProject",


### PR DESCRIPTION
**What I did**

Check if service already has a dependency condition before overwriting

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

fixes https://github.com/docker/compose/issues/9843

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![Poodle-Moth](https://user-images.githubusercontent.com/70572044/190423228-f74943f9-7c01-43a6-9032-cda0ef86fc0a.jpg)
