### PR TITLE
keep the platform defined via DOCKER_DEFAULT_PLATFORM during build if no build platforms provided

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -368,7 +368,10 @@ func addPlatforms(project *types.Project, service types.ServiceConfig) ([]specs.
 		}
 		// User defined a service platform and no build platforms, so we should keep the one define on the service level
 		p, err := platforms.Parse(service.Platform)
-		return append(plats, p), err
+		if !utils.Contains(plats, p) {
+			plats = append(plats, p)
+		}
+		return plats, err
 	}
 
 	for _, buildPlatform := range service.Build.Platforms {
@@ -400,7 +403,7 @@ func getImageBuildLabels(project *types.Project, service types.ServiceConfig) ty
 func useDockerDefaultPlatform(project *types.Project, platformList types.StringList) ([]specs.Platform, error) {
 	var plats []specs.Platform
 	if platform, ok := project.Environment["DOCKER_DEFAULT_PLATFORM"]; ok {
-		if !utils.StringContains(platformList, platform) {
+		if len(platformList) > 0 && !utils.StringContains(platformList, platform) {
 			return nil, fmt.Errorf("the DOCKER_DEFAULT_PLATFORM value should be part of the service.build.platforms: %q", platform)
 		}
 		p, err := platforms.Parse(platform)


### PR DESCRIPTION
**What I did**
Don't throw an error when DOCKER_DEFAULT_PLATFORM is set and `service.build.platforms`  isn't set

**Related issue**
fixes #9853 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/190726752-e7607a9c-599e-4fb8-8982-c2c8eb797511.png)
