### PR TITLE
configure default builder export when no build.platforms defined

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -81,6 +81,12 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 				Attrs: map[string]string{"ref": image},
 			})
 		}
+		buildOptions.Exports = []bclient.ExportEntry{{
+			Type: "docker",
+			Attrs: map[string]string{
+				"load": "true",
+			},
+		}}
 		if len(buildOptions.Platforms) > 1 {
 			buildOptions.Exports = []bclient.ExportEntry{{
 				Type:  "image",


### PR DESCRIPTION
**What I did**
Defined a docker builder exporter by default to make the image available in the engine context

**Related issue**
fixes #9856 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/191271053-cc6135a2-4a56-4267-b7b3-e4f373bd5d63.png)
