### PR TITLE
add more information when `service.platform` isn't part of `service.build.platforms`

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -368,6 +368,18 @@ func addPlatforms(project *types.Project, service types.ServiceConfig) ([]specs.
 		return nil, err
 	}
 
+	if service.Platform != "" && !utils.StringContains(service.Build.Platforms, service.Platform) {
+		if len(service.Build.Platforms) > 0 {
+			return nil, fmt.Errorf("service.platform %q should be part of the service.build.platforms: %q", service.Platform, service.Build.Platforms)
+		}
+		// User defined a service platform and no build platforms, so we should keep the one define on the service level
+		p, err := platforms.Parse(service.Platform)
+		if !utils.Contains(plats, p) {
+			plats = append(plats, p)
+		}
+		return plats, err
+	}
+
 	for _, buildPlatform := range service.Build.Platforms {
 		p, err := platforms.Parse(buildPlatform)
 		if err != nil {
@@ -398,7 +410,7 @@ func useDockerDefaultPlatform(project *types.Project, platformList types.StringL
 	var plats []specs.Platform
 	if platform, ok := project.Environment["DOCKER_DEFAULT_PLATFORM"]; ok {
 		if len(platformList) > 0 && !utils.StringContains(platformList, platform) {
-			return nil, fmt.Errorf("the DOCKER_DEFAULT_PLATFORM value should be part of the service.build.platforms: %q", platform)
+			return nil, fmt.Errorf("the DOCKER_DEFAULT_PLATFORM %q value should be part of the service.build.platforms: %q", platform, platformList)
 		}
 		p, err := platforms.Parse(platform)
 		if err != nil {
@@ -417,7 +429,7 @@ func useDockerDefaultOrServicePlatform(project *types.Project, service types.Ser
 
 	if service.Platform != "" && !utils.StringContains(service.Build.Platforms, service.Platform) {
 		if len(service.Build.Platforms) > 0 {
-			return nil, fmt.Errorf("service.platform should be part of the service.build.platforms: %q", service.Platform)
+			return nil, fmt.Errorf("service.platform %q should be part of the service.build.platforms: %q", service.Platform, service.Build.Platforms)
 		}
 		// User defined a service platform and no build platforms, so we should keep the one define on the service level
 		p, err := platforms.Parse(service.Platform)

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -368,18 +368,6 @@ func addPlatforms(project *types.Project, service types.ServiceConfig) ([]specs.
 		return nil, err
 	}
 
-	if service.Platform != "" && !utils.StringContains(service.Build.Platforms, service.Platform) {
-		if len(service.Build.Platforms) > 0 {
-			return nil, fmt.Errorf("service.platform %q should be part of the service.build.platforms: %q", service.Platform, service.Build.Platforms)
-		}
-		// User defined a service platform and no build platforms, so we should keep the one define on the service level
-		p, err := platforms.Parse(service.Platform)
-		if !utils.Contains(plats, p) {
-			plats = append(plats, p)
-		}
-		return plats, err
-	}
-
 	for _, buildPlatform := range service.Build.Platforms {
 		p, err := platforms.Parse(buildPlatform)
 		if err != nil {

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -366,7 +366,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 			"-f", "fixtures/build-test/platforms/compose-service-platform-not-in-build-platforms.yaml", "build")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      `service.platform should be part of the service.build.platforms: "linux/riscv64"`,
+			Err:      `service.platform "linux/riscv64" should be part of the service.build.platforms: ["linux/amd64" "linux/arm64"]`,
 		})
 	})
 
@@ -377,7 +377,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 		})
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      `DOCKER_DEFAULT_PLATFORM value should be part of the service.build.platforms: "windows/amd64"`,
+			Err:      `DOCKER_DEFAULT_PLATFORM "windows/amd64" value should be part of the service.build.platforms: ["linux/amd64" "linux/arm64"]`,
 		})
 	})
 }


### PR DESCRIPTION
**What I did**

I found it a bit problematic to debug so I added a bit more detailed error messages when `service.platform` isn't part of `service.build.platforms`.
