### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ env:
   DESTDIR: "./bin"
   DOCKER_CLI_VERSION: "20.10.17"
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -182,6 +185,9 @@ jobs:
           make e2e-compose-standalone
 
   release:
+    permissions:
+      contents: write # to create a release (ncipollo/release-action)
+
     runs-on: ubuntu-latest
     needs:
       - binary

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,13 @@ on:
   release:
     types: [published]
 
+permissions: {}
 jobs:
   open-pr:
+    permissions:
+      contents: write # to create branch (peter-evans/create-pull-request)
+      pull-requests: write # to create a PR (peter-evans/create-pull-request)
+
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,6 +12,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   e2e:
     name: Build and test


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.