### PR TITLE
ci: update docs repo path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GHPAT_DOCS_DISPATCH }}
-          repository: docker/docker.github.io
+          repository: docker/docs
           ref: master
       -
         name: Prepare

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ FROM scratch AS release
 COPY --from=releaser /out/ /
 
 # docs-reference is a target used as remote context to update docs on release
-# with latest changes on docker.github.io.
+# with latest changes on docs.docker.com.
 # see open-pr job in .github/workflows/docs.yml for more details
 FROM scratch AS docs-reference
 COPY docs/reference/*.yaml .


### PR DESCRIPTION
**What I did**
Updated a string because the Docker docs now live at `docker/docs` instead of `docker/docker.github.io`.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![a dog in a squirrel costume](https://user-images.githubusercontent.com/841263/193096289-49a71e9c-840a-4237-ba16-96457be5961e.png)
