### PR TITLE
don't fail when trying to remove an orphan container during down command

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -270,7 +270,7 @@ func (s *composeService) removeContainers(ctx context.Context, w progress.Writer
 				Force:         true,
 				RemoveVolumes: volumes,
 			})
-			if err != nil {
+			if err != nil && !errdefs.IsNotFound(err) {
 				w.Event(progress.ErrorMessageEvent(eventName, "Error while Removing"))
 				return err
 			}


### PR DESCRIPTION
**What I did**
Currently the down process stop when it tries to remove an orphan container that already have been removed.
Now we don't stop the process if such kind of containers is already gone.

**Related issue**
Reported internally by the extension team

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/194340623-5cfb42e1-16b4-4ca8-9f98-523815260b86.png)
