### PR TITLE
fix"convert --images" output to right format

### DIFF
--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -240,7 +240,7 @@ func runConfigImages(opts convertOptions, services []string) error {
 		if s.Image != "" {
 			fmt.Println(s.Image)
 		} else {
-			fmt.Printf("%s_%s\n", project.Name, s.Name)
+			fmt.Printf("%s%s%s\n", project.Name, api.Separator, s.Name)
 		}
 	}
 	return nil


### PR DESCRIPTION

Signed-off-by: Windforce17 <42843391+Windforce17@users.noreply.github.com>

**What I did**
According to docker images name rule: https://docs.docker.com/engine/reference/commandline/tag/#description `docker compose convert --images` should not contain underscores.

closes https://github.com/docker/compose/issues/9920