### PR TITLE
use COMPOSE_PROFILES value only if no command line arg profiles used

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -209,16 +209,16 @@ func (o *projectOptions) toProject(services []string, po ...cli.ProjectOptionsFn
 		project.Services[i] = s
 	}
 
+	if profiles, ok := options.Environment["COMPOSE_PROFILES"]; ok && len(o.Profiles) == 0 {
+		o.Profiles = append(o.Profiles, strings.Split(profiles, ",")...)
+	}
+
 	if len(services) > 0 {
 		s, err := project.GetServices(services...)
 		if err != nil {
 			return nil, err
 		}
 		o.Profiles = append(o.Profiles, s.GetProfiles()...)
-	}
-
-	if profiles, ok := options.Environment["COMPOSE_PROFILES"]; ok {
-		o.Profiles = append(o.Profiles, strings.Split(profiles, ",")...)
 	}
 
 	project.ApplyProfiles(o.Profiles)


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Don't add the value of `COMPOSE_PROFILES` if at least one profile is set via `--profile` command argument

**Related issue**
fixes #9895 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/194861002-313032f8-b003-4487-b4eb-587898736c38.png)
