### PR TITLE
Misleading error message for port command.

### DIFF
--- a/pkg/compose/port.go
+++ b/pkg/compose/port.go
@@ -40,7 +40,7 @@ func (s *composeService) Port(ctx context.Context, projectName string, service s
 		return "", 0, err
 	}
 	if len(list) == 0 {
-		return "", 0, fmt.Errorf("no container found for %s_%d", service, options.Index)
+		return "", 0, fmt.Errorf("no container found for %s%s%d", service, api.Separator, options.Index)
 	}
 	container := list[0]
 	for _, p := range container.Ports {


### PR DESCRIPTION
The error message is using V1 separator hardcoded, it should be using the configured separator value

Signed-off-by: Tiago Silva <Tiago.MB.Silva@edu.azores.gov.pt>

**What I did**
changed hardcoded underscore to configured separator in the api