### PR TITLE
Fix downing all container with -p option.

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -44,7 +44,7 @@ type Service interface {
 	// Up executes the equivalent to a `compose up`
 	Up(ctx context.Context, project *types.Project, options UpOptions) error
 	// Down executes the equivalent to a `compose down`
-	Down(ctx context.Context, projectName string, options DownOptions) error
+	Down(ctx context.Context, project *types.Project, options DownOptions) error
 	// Logs executes the equivalent to a `compose logs`
 	Logs(ctx context.Context, projectName string, consumer LogConsumer, options LogOptions) error
 	// Ps executes the equivalent to a `compose ps`
@@ -163,8 +163,6 @@ type UpOptions struct {
 type DownOptions struct {
 	// RemoveOrphans will cleanup containers that are not declared on the compose model but own the same labels
 	RemoveOrphans bool
-	// Project is the compose project used to define this app. Might be nil if user ran `down` just with project name
-	Project *types.Project
 	// Timeout override container stop timeout
 	Timeout *time.Duration
 	// Images remove image used by services. 'all': Remove all images. 'local': Remove only images that don't have a tag

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -34,7 +34,7 @@ type ServiceProxy struct {
 	RestartFn            func(ctx context.Context, projectName string, options RestartOptions) error
 	StopFn               func(ctx context.Context, projectName string, options StopOptions) error
 	UpFn                 func(ctx context.Context, project *types.Project, options UpOptions) error
-	DownFn               func(ctx context.Context, projectName string, options DownOptions) error
+	DownFn               func(ctx context.Context, project *types.Project, options DownOptions) error
 	LogsFn               func(ctx context.Context, projectName string, consumer LogConsumer, options LogOptions) error
 	PsFn                 func(ctx context.Context, projectName string, options PsOptions) ([]ContainerSummary, error)
 	ListFn               func(ctx context.Context, options ListOptions) ([]Stack, error)
@@ -176,7 +176,7 @@ func (s *ServiceProxy) Up(ctx context.Context, project *types.Project, options U
 }
 
 // Down implements Service interface
-func (s *ServiceProxy) Down(ctx context.Context, project string, options DownOptions) error {
+func (s *ServiceProxy) Down(ctx context.Context, project *types.Project, options DownOptions) error {
 	if s.DownFn == nil {
 		return ErrNotImplemented
 	}

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
 	"github.com/golang/mock/gomock"
 	"gotest.tools/v3/assert"
@@ -38,6 +37,15 @@ func TestDown(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	p := &types.Project{
+		Name:     strings.ToLower(testProject),
+		Networks: types.Networks{"myProject_default": types.NetworkConfig{Name: "myProject_default"}},
+		Services: types.Services{
+			types.ServiceConfig{Name: "service1"},
+			types.ServiceConfig{Name: "service2"},
+			types.ServiceConfig{Name: "service3"},
+		},
+	}
 	api := mocks.NewMockAPIClient(mockCtrl)
 	cli := mocks.NewMockCli(mockCtrl)
 	tested := composeService{
@@ -52,16 +60,6 @@ func TestDown(t *testing.T) {
 			testContainer("service2", "789", false),
 			testContainer("service_orphan", "321", true),
 		}, nil)
-	api.EXPECT().VolumeList(gomock.Any(), filters.NewArgs(projectFilter(strings.ToLower(testProject)))).
-		Return(volume.VolumeListOKBody{}, nil)
-
-	// network names are not guaranteed to be unique, ensure Compose handles
-	// cleanup properly if duplicates are inadvertently created
-	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).
-		Return([]moby.NetworkResource{
-			{ID: "abc123", Name: "myProject_default"},
-			{ID: "def456", Name: "myProject_default"},
-		}, nil)
 
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
 	api.EXPECT().ContainerStop(gomock.Any(), "456", nil).Return(nil)
@@ -71,6 +69,8 @@ func TestDown(t *testing.T) {
 	api.EXPECT().ContainerRemove(gomock.Any(), "456", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "789", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 
+	// network names are not guaranteed to be unique, ensure Compose handles
+	// cleanup properly if duplicates are inadvertently created
 	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", "myProject_default")),
 	}).Return([]moby.NetworkResource{
@@ -80,7 +80,7 @@ func TestDown(t *testing.T) {
 	api.EXPECT().NetworkRemove(gomock.Any(), "abc123").Return(nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "def456").Return(nil)
 
-	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{})
+	err := tested.Down(context.Background(), p, compose.DownOptions{})
 	assert.NilError(t, err)
 }
 
@@ -88,6 +88,14 @@ func TestDownRemoveOrphans(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	p := &types.Project{
+		Name:     strings.ToLower(testProject),
+		Networks: types.Networks{"myProject_default": types.NetworkConfig{Name: "myProject_default"}},
+		Services: types.Services{
+			types.ServiceConfig{Name: "service1"},
+			types.ServiceConfig{Name: "service2"},
+		},
+	}
 	api := mocks.NewMockAPIClient(mockCtrl)
 	cli := mocks.NewMockCli(mockCtrl)
 	tested := composeService{
@@ -101,10 +109,6 @@ func TestDownRemoveOrphans(t *testing.T) {
 			testContainer("service2", "789", false),
 			testContainer("service_orphan", "321", true),
 		}, nil)
-	api.EXPECT().VolumeList(gomock.Any(), filters.NewArgs(projectFilter(strings.ToLower(testProject)))).
-		Return(volume.VolumeListOKBody{}, nil)
-	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).
-		Return([]moby.NetworkResource{{Name: "myProject_default"}}, nil)
 
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
 	api.EXPECT().ContainerStop(gomock.Any(), "789", nil).Return(nil)
@@ -119,7 +123,7 @@ func TestDownRemoveOrphans(t *testing.T) {
 	}).Return([]moby.NetworkResource{{ID: "abc123", Name: "myProject_default"}}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "abc123").Return(nil)
 
-	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{RemoveOrphans: true})
+	err := tested.Down(context.Background(), p, compose.DownOptions{RemoveOrphans: true})
 	assert.NilError(t, err)
 }
 
@@ -127,6 +131,16 @@ func TestDownRemoveVolumes(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	p := &types.Project{
+		Name:     strings.ToLower(testProject),
+		Networks: types.Networks{"myProject_default": types.NetworkConfig{Name: "myProject_default"}},
+		Volumes: types.Volumes{
+			"myProject_volume": types.VolumeConfig{Name: "myProject_volume"},
+		},
+		Services: types.Services{
+			types.ServiceConfig{Name: "service1"},
+		},
+	}
 	api := mocks.NewMockAPIClient(mockCtrl)
 	cli := mocks.NewMockCli(mockCtrl)
 	tested := composeService{
@@ -136,19 +150,16 @@ func TestDownRemoveVolumes(t *testing.T) {
 
 	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt(false)).Return(
 		[]moby.Container{testContainer("service1", "123", false)}, nil)
-	api.EXPECT().VolumeList(gomock.Any(), filters.NewArgs(projectFilter(strings.ToLower(testProject)))).
-		Return(volume.VolumeListOKBody{
-			Volumes: []*moby.Volume{{Name: "myProject_volume"}},
-		}, nil)
-	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).
-		Return(nil, nil)
+	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{
+		Filters: filters.NewArgs(filters.Arg("name", "myProject_default")),
+	}).Return(nil, nil)
 
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "123", moby.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
 
 	api.EXPECT().VolumeRemove(gomock.Any(), "myProject_volume", true).Return(nil)
 
-	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{Volumes: true})
+	err := tested.Down(context.Background(), p, compose.DownOptions{Volumes: true})
 	assert.NilError(t, err)
 }
 
@@ -156,17 +167,17 @@ func TestDownRemoveImages(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	opts := compose.DownOptions{
-		Project: &types.Project{
-			Name: strings.ToLower(testProject),
-			Services: types.Services{
-				{Name: "local-anonymous"},
-				{Name: "local-named", Image: "local-named-image"},
-				{Name: "remote", Image: "remote-image"},
-				{Name: "remote-tagged", Image: "registry.example.com/remote-image-tagged:v1.0"},
-				{Name: "no-images-anonymous"},
-				{Name: "no-images-named", Image: "missing-named-image"},
-			},
+	opts := compose.DownOptions{}
+
+	p := &types.Project{
+		Name: strings.ToLower(testProject),
+		Services: types.Services{
+			{Name: "local-anonymous"},
+			{Name: "local-named", Image: "local-named-image"},
+			{Name: "remote", Image: "remote-image"},
+			{Name: "remote-tagged", Image: "registry.example.com/remote-image-tagged:v1.0"},
+			{Name: "no-images-anonymous"},
+			{Name: "no-images-named", Image: "missing-named-image"},
 		},
 	}
 
@@ -237,7 +248,7 @@ func TestDownRemoveImages(t *testing.T) {
 
 	t.Log("-> docker compose down --rmi=local")
 	opts.Images = "local"
-	err := tested.Down(context.Background(), strings.ToLower(testProject), opts)
+	err := tested.Down(context.Background(), p, opts)
 	assert.NilError(t, err)
 
 	otherImagesToBeRemoved := []string{
@@ -253,13 +264,20 @@ func TestDownRemoveImages(t *testing.T) {
 
 	t.Log("-> docker compose down --rmi=all")
 	opts.Images = "all"
-	err = tested.Down(context.Background(), strings.ToLower(testProject), opts)
+	err = tested.Down(context.Background(), p, opts)
 	assert.NilError(t, err)
 }
 
 func TestDownRemoveImages_NoLabel(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+
+	p := &types.Project{
+		Name: strings.ToLower(testProject),
+		Services: types.Services{
+			{Name: "service1"},
+		},
+	}
 
 	api := mocks.NewMockAPIClient(mockCtrl)
 	cli := mocks.NewMockCli(mockCtrl)
@@ -272,13 +290,6 @@ func TestDownRemoveImages_NoLabel(t *testing.T) {
 
 	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt(false)).Return(
 		[]moby.Container{container}, nil)
-
-	api.EXPECT().VolumeList(gomock.Any(), filters.NewArgs(projectFilter(strings.ToLower(testProject)))).
-		Return(volume.VolumeListOKBody{
-			Volumes: []*moby.Volume{{Name: "myProject_volume"}},
-		}, nil)
-	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).
-		Return(nil, nil)
 
 	// ImageList returns no images for the project since they were unlabeled
 	// (created by an older version of Compose)
@@ -297,6 +308,6 @@ func TestDownRemoveImages_NoLabel(t *testing.T) {
 
 	api.EXPECT().ImageRemove(gomock.Any(), "testproject-service1:latest", moby.ImageRemoveOptions{}).Return(nil, nil)
 
-	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{Images: "local"})
+	err := tested.Down(context.Background(), p, compose.DownOptions{Images: "local"})
 	assert.NilError(t, err)
 }

--- a/pkg/mocks/mock_docker_compose_api.go
+++ b/pkg/mocks/mock_docker_compose_api.go
@@ -94,17 +94,17 @@ func (mr *MockServiceMockRecorder) Create(ctx, project, options interface{}) *go
 }
 
 // Down mocks base method.
-func (m *MockService) Down(ctx context.Context, projectName string, options api.DownOptions) error {
+func (m *MockService) Down(ctx context.Context, project *types.Project, options api.DownOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Down", ctx, projectName, options)
+	ret := m.ctrl.Call(m, "Down", ctx, project, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Down indicates an expected call of Down.
-func (mr *MockServiceMockRecorder) Down(ctx, projectName, options interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) Down(ctx, project, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Down", reflect.TypeOf((*MockService)(nil).Down), ctx, projectName, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Down", reflect.TypeOf((*MockService)(nil).Down), ctx, project, options)
 }
 
 // Events mocks base method.
@@ -405,15 +405,15 @@ func (m *MockLogConsumer) EXPECT() *MockLogConsumerMockRecorder {
 }
 
 // Log mocks base method.
-func (m *MockLogConsumer) Log(service, container, message string) {
+func (m *MockLogConsumer) Log(containerName, service, message string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Log", service, container, message)
+	m.ctrl.Call(m, "Log", containerName, service, message)
 }
 
 // Log indicates an expected call of Log.
-func (mr *MockLogConsumerMockRecorder) Log(service, container, message interface{}) *gomock.Call {
+func (mr *MockLogConsumerMockRecorder) Log(containerName, service, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockLogConsumer)(nil).Log), service, container, message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockLogConsumer)(nil).Log), containerName, service, message)
 }
 
 // Register mocks base method.


### PR DESCRIPTION
**What I did**

With -p option, only resources from config files are are stopped and removed by `down` command.
Use a project from `p.WithServices` instead of `getProjectWithResources`.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Fixes #9918 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![IMG_1373](https://user-images.githubusercontent.com/32049413/195997682-3c9c2c4c-ee74-4bb1-b585-ce562e9d6d08.png)

