### PR TITLE
Fix Makefile target `validate-go-mod`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,6 @@ go-mod-tidy: ## Run go mod tidy in a container and output resulting go.mod and g
 .PHONY: validate-go-mod
 validate-go-mod: ## Validate go.mod and go.sum are up-to-date
 	$(BUILDX_CMD) bake vendor-validate
-	$(BUILDX_CMD) bake modules-validate
 
 .PHONY: validate-modules
 validate-modules: ## Validate root and e2e go.mod are synced


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**
`validate-go-mod` now only runs it's correct target

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![IMG_2259](https://user-images.githubusercontent.com/70572044/196450657-c2c79b9a-2c13-406d-ab51-997ae9a5368a.jpg)
