### PR TITLE
go.mod: docker 5aac513617f072b15322b147052cbda0d451d389 / v22.06-dev

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -155,7 +155,7 @@ require (
 
 replace (
 	github.com/docker/cli => github.com/docker/cli v20.10.3-0.20221013132413-1d6c6e2367e2+incompatible // 22.06 master branch
-	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20221021122114-f9cb47a052be+incompatible // 22.06 branch
+	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20221021173910-5aac513617f0+incompatible // 22.06 branch
 	github.com/moby/buildkit => github.com/moby/buildkit v0.10.1-0.20220816171719-55ba9d14360a // same as buildx
 
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2 // Can be removed on next bump of containerd to > 1.6.4

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -149,8 +149,8 @@ github.com/docker/cli v20.10.3-0.20221013132413-1d6c6e2367e2+incompatible/go.mod
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.3-0.20221021122114-f9cb47a052be+incompatible h1:zB3HN4R9GYxPbd6UD9/+f3DvJCiqKBGKPxBSyjVx7Qo=
-github.com/docker/docker v20.10.3-0.20221021122114-f9cb47a052be+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.3-0.20221021173910-5aac513617f0+incompatible h1:s5C/kGjAucPHfx9nwIKZOCNvKOEiRUgJxQpwSmr2+RU=
+github.com/docker/docker v20.10.3-0.20221021173910-5aac513617f0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 
 replace (
 	github.com/docker/cli => github.com/docker/cli v20.10.3-0.20221013132413-1d6c6e2367e2+incompatible // 22.06 master branch
-	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20221021122114-f9cb47a052be+incompatible // 22.06 branch
+	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20221021173910-5aac513617f0+incompatible // 22.06 branch
 	github.com/moby/buildkit => github.com/moby/buildkit v0.10.1-0.20220816171719-55ba9d14360a // same as buildx
 
 	github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2 // Can be removed on next bump of containerd to > 1.6.4

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/docker/cli-docs-tool v0.5.0/go.mod h1:zMjqTFCU361PRh8apiXzeAZ1Q/xupbI
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.3-0.20221021122114-f9cb47a052be+incompatible h1:zB3HN4R9GYxPbd6UD9/+f3DvJCiqKBGKPxBSyjVx7Qo=
-github.com/docker/docker v20.10.3-0.20221021122114-f9cb47a052be+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.3-0.20221021173910-5aac513617f0+incompatible h1:s5C/kGjAucPHfx9nwIKZOCNvKOEiRUgJxQpwSmr2+RU=
+github.com/docker/docker v20.10.3-0.20221021173910-5aac513617f0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=


### PR DESCRIPTION
This restores compatibility with go1.18, which was broken since commit; https://github.com/moby/moby/commit/c062238ea4274e9af98cb96dcfe31a0dfc763440

cmd.Environ() is new in go1.19, and not needed for this specific case. Without this, trying to use this package in code that uses go1.18 will fail;

    builder/remotecontext/git/gitutils.go:216:23: cmd.Environ undefined (type *exec.Cmd has no field or method Environ)

Changing to use `os.Environ()` instead restores compatibility with go1.18

Full diff: https://github.com/docker/docker/compare/f9cb47a052be6a5f73e3077773ffa6ccbde1285d...5aac513617f072b15322b147052cbda0d451d389

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

- https://github.com/docker/compose/pull/9934
- https://github.com/docker/docker-ce-packaging/pull/775

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
