### PR TITLE
map deploy.restart_policy.condition to engine values

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -488,11 +488,25 @@ func getRestartPolicy(service types.ServiceConfig) container.RestartPolicy {
 			attempts = int(*policy.MaxAttempts)
 		}
 		restart = container.RestartPolicy{
-			Name:              policy.Condition,
+			Name:              mapRestartPolicyCondition(policy.Condition),
 			MaximumRetryCount: attempts,
 		}
 	}
 	return restart
+}
+
+func mapRestartPolicyCondition(condition string) string {
+	// map definitions of deploy.restart_policy to engine definitions
+	switch condition {
+	case "none", "no":
+		return "no"
+	case "on-failure", "unless-stopped":
+		return condition
+	case "any", "always":
+		return "always"
+	default:
+		return condition
+	}
 }
 
 func getDeployResources(s types.ServiceConfig) container.Resources {


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Map the value of `deploy.restat_policy.condition` to values supported by the engine. Basically this map `none` to `no` and `any` to `always`

**Related issue**
fixes #8756 
https://github.com/docker/docs/pull/15936

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/197491060-f222bfb3-eed5-4c29-9eaf-80ef97778cfc.png)
