### PR TITLE
add --no-consistency flag to convert command

### DIFF
--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -51,6 +51,7 @@ type convertOptions struct {
 	profiles            bool
 	images              bool
 	hash                string
+	noConsistency       bool
 }
 
 func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
@@ -101,6 +102,7 @@ func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only validate the configuration, don't print anything.")
 	flags.BoolVar(&opts.noInterpolate, "no-interpolate", false, "Don't interpolate environment variables.")
 	flags.BoolVar(&opts.noNormalize, "no-normalize", false, "Don't normalize compose model.")
+	flags.BoolVar(&opts.noConsistency, "no-consistency", false, "Don't check model consistency - warning: may produce invalid Compose output")
 
 	flags.BoolVar(&opts.services, "services", false, "Print the service names, one per line.")
 	flags.BoolVar(&opts.volumes, "volumes", false, "Print the volume names, one per line.")
@@ -118,6 +120,7 @@ func runConvert(ctx context.Context, backend api.Service, opts convertOptions, s
 		cli.WithInterpolation(!opts.noInterpolate),
 		cli.WithResolvedPaths(true),
 		cli.WithNormalization(!opts.noNormalize),
+		cli.WithConsistency(!opts.noConsistency),
 		cli.WithDiscardEnvFile)
 
 	if err != nil {

--- a/docs/reference/compose_convert.md
+++ b/docs/reference/compose_convert.md
@@ -14,6 +14,7 @@ Converts the compose file to platform's canonical format
 | `--format` | `string` | `yaml` | Format the output. Values: [yaml \| json] |
 | `--hash` | `string` |  | Print the service config hash, one per line. |
 | `--images` |  |  | Print the image names, one per line. |
+| `--no-consistency` |  |  | Don't check model consistency - warning: may produce invalid Compose output |
 | `--no-interpolate` |  |  | Don't interpolate environment variables. |
 | `--no-normalize` |  |  | Don't normalize compose model. |
 | `-o`, `--output` | `string` |  | Save to file (default to stdout) |

--- a/docs/reference/docker_compose_convert.yaml
+++ b/docs/reference/docker_compose_convert.yaml
@@ -40,6 +40,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: no-consistency
+      value_type: bool
+      default_value: "false"
+      description: |
+        Don't check model consistency - warning: may produce invalid Compose output
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: no-interpolate
       value_type: bool
       default_value: "false"


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Add a `--no-consistency` flag to `config`/`convert` command which allows user to explicitly by pass the model consistency check. Usage of this flag may generate an invalid model regarding the Compose specification.


**Related issue**
fixes #9963 

depends on https://github.com/compose-spec/compose-go/pull/318

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/200087248-5ee910b8-cbc1-4ad6-bbca-655c1141ef40.png)
