### PR TITLE
exclude issues with the `kind/feature` label from stale bot process

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,7 +12,7 @@ onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
-  - "enhancement ✨"
+  - "kind/feature"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Add an exemption from stale bot for issue having the `kind/feature` label 

**Related issue**
fixes #9988 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/201644075-bf6c9556-3a68-4e38-b788-7d9eb442a38e.png)
