### PR TITLE
change the default branch of the doc repository

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           token: ${{ secrets.GHPAT_DOCS_DISPATCH }}
           repository: docker/docs
-          ref: master
+          ref: main
       -
         name: Prepare
         run: |


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Switch the default branch of the doc github repository from `master` to `main`. Currently the workflow to automatically create the PR to update Compose documentation failed

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/203585465-3947a0d2-c891-41bb-a363-ba3100281cb2.png)
