### PR TITLE
useDockerDefaultOrServicePlatform fct should return service.platform if defined

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -415,8 +415,8 @@ func useDockerDefaultOrServicePlatform(project *types.Project, service types.Ser
 		return plats, err
 	}
 
-	if service.Platform != "" && !utils.StringContains(service.Build.Platforms, service.Platform) {
-		if len(service.Build.Platforms) > 0 {
+	if service.Platform != "" {
+		if len(service.Build.Platforms) > 0 && !utils.StringContains(service.Build.Platforms, service.Platform) {
 			return nil, fmt.Errorf("service.platform %q should be part of the service.build.platforms: %q", service.Platform, service.Build.Platforms)
 		}
 		// User defined a service platform and no build platforms, so we should keep the one define on the service level


### PR DESCRIPTION
and present in the build.platforms list (or if the list is empty)

Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Move the check of the `service.platform` presence inside the `service.build.platforms` list with the test of the list size, to be sure we always return the `service.plaform` value when present in the build platforms list or when this list is empty


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/203650444-d664f19a-b257-46a3-83f6-68b20863cbb8.png)

