### PR TITLE
configure buildx for plain output if --ansi=never has been set

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -26,6 +26,7 @@ import (
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
 	buildx "github.com/docker/buildx/util/progress"
+	"github.com/docker/compose/v2/pkg/progress"
 	"github.com/docker/compose/v2/pkg/utils"
 	"github.com/spf13/cobra"
 
@@ -99,6 +100,9 @@ func buildCommand(p *projectOptions, backend api.Service) *cobra.Command {
 		RunE: AdaptCmd(func(ctx context.Context, cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("ssh") && opts.ssh == "" {
 				opts.ssh = "default"
+			}
+			if progress.Mode == progress.ModePlain && !cmd.Flags().Changed("progress") {
+				opts.progress = buildx.PrinterModePlain
 			}
 			return runBuild(ctx, backend, opts, args)
 		}),


### PR DESCRIPTION
**What I did**
set builx progress=plain when compose is ran with ansi=never

**Related issue**
close https://github.com/docker/compose/issues/10013

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/203811154-d59acabd-33cd-4e1b-9c1f-8dc06d71d059.png)
