### PR TITLE
pass services list to projectOrName function to add profiles for targeted services

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -137,11 +137,11 @@ func (o *projectOptions) addProjectFlags(f *pflag.FlagSet) {
 	_ = f.MarkHidden("workdir")
 }
 
-func (o *projectOptions) projectOrName() (*types.Project, string, error) {
+func (o *projectOptions) projectOrName(services ...string) (*types.Project, string, error) {
 	name := o.ProjectName
 	var project *types.Project
 	if o.ProjectName == "" {
-		p, err := o.toProject(nil)
+		p, err := o.toProject(services)
 		if err != nil {
 			envProjectName := os.Getenv("COMPOSE_PROJECT_NAME")
 			if envProjectName != "" {

--- a/cmd/compose/kill.go
+++ b/cmd/compose/kill.go
@@ -54,7 +54,7 @@ func killCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runKill(ctx context.Context, backend api.Service, opts killOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -63,7 +63,7 @@ func logsCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runLogs(ctx context.Context, backend api.Service, opts logsOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/pause.go
+++ b/cmd/compose/pause.go
@@ -44,7 +44,7 @@ func pauseCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runPause(ctx context.Context, backend api.Service, opts pauseOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func unpauseCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runUnPause(ctx context.Context, backend api.Service, opts unpauseOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -91,7 +91,7 @@ func psCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runPs(ctx context.Context, backend api.Service, services []string, opts psOptions) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -59,7 +59,7 @@ Any data which is not in a volume will be lost.`,
 }
 
 func runRemove(ctx context.Context, backend api.Service, opts removeOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -49,7 +49,7 @@ func restartCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runRestart(ctx context.Context, backend api.Service, opts restartOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/start.go
+++ b/cmd/compose/start.go
@@ -43,7 +43,7 @@ func startCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runStart(ctx context.Context, backend api.Service, opts startOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/stop.go
+++ b/cmd/compose/stop.go
@@ -53,7 +53,7 @@ func stopCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runStop(ctx context.Context, backend api.Service, opts stopOptions, services []string) error {
-	project, name, err := opts.projectOrName()
+	project, name, err := opts.projectOrName(services...)
 	if err != nil {
 		return err
 	}

--- a/pkg/e2e/fixtures/profiles/compose.yaml
+++ b/pkg/e2e/fixtures/profiles/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  main:
+  regular-service:
     image: nginx:alpine
 
   profiled-service:

--- a/pkg/e2e/fixtures/profiles/compose.yaml
+++ b/pkg/e2e/fixtures/profiles/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  main:
+    image: nginx:alpine
+
+  profiled-service:
+    image: nginx:alpine
+    profiles:
+      - test-profile

--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -1,10 +1,32 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package e2e
 
 import (
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/icmd"
 	"strings"
 	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+)
+
+const (
+	profiledService = "profiled-service"
+	regularService  = "regular-service"
 )
 
 func TestExplicitProfileUsage(t *testing.T) {
@@ -17,8 +39,8 @@ func TestExplicitProfileUsage(t *testing.T) {
 			"-p", projectName, "--profile", profileName, "up", "-d")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps")
-		res.Assert(t, icmd.Expected{Out: "profiled-service"})
-		res.Assert(t, icmd.Expected{Out: "main"})
+		res.Assert(t, icmd.Expected{Out: regularService})
+		res.Assert(t, icmd.Expected{Out: profiledService})
 	})
 
 	t.Run("compose stop with profile", func(t *testing.T) {
@@ -26,8 +48,8 @@ func TestExplicitProfileUsage(t *testing.T) {
 			"-p", projectName, "--profile", profileName, "stop")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
-		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+		assert.Assert(t, !strings.Contains(res.Combined(), regularService))
+		assert.Assert(t, !strings.Contains(res.Combined(), profiledService))
 	})
 
 	t.Run("compose start with profile", func(t *testing.T) {
@@ -35,8 +57,8 @@ func TestExplicitProfileUsage(t *testing.T) {
 			"-p", projectName, "--profile", profileName, "start")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		res.Assert(t, icmd.Expected{Out: "profiled-service"})
-		res.Assert(t, icmd.Expected{Out: "main"})
+		res.Assert(t, icmd.Expected{Out: regularService})
+		res.Assert(t, icmd.Expected{Out: profiledService})
 	})
 
 	t.Run("compose restart with profile", func(t *testing.T) {
@@ -44,8 +66,8 @@ func TestExplicitProfileUsage(t *testing.T) {
 			"-p", projectName, "--profile", profileName, "restart")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		res.Assert(t, icmd.Expected{Out: "profiled-service"})
-		res.Assert(t, icmd.Expected{Out: "main"})
+		res.Assert(t, icmd.Expected{Out: regularService})
+		res.Assert(t, icmd.Expected{Out: profiledService})
 	})
 
 	t.Run("down", func(t *testing.T) {
@@ -67,8 +89,8 @@ func TestNoProfileUsage(t *testing.T) {
 			"-p", projectName, "up", "-d")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps")
-		res.Assert(t, icmd.Expected{Out: "main"})
-		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+		res.Assert(t, icmd.Expected{Out: regularService})
+		assert.Assert(t, !strings.Contains(res.Combined(), profiledService))
 	})
 
 	t.Run("compose stop without profile", func(t *testing.T) {
@@ -76,8 +98,8 @@ func TestNoProfileUsage(t *testing.T) {
 			"-p", projectName, "stop")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
-		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+		assert.Assert(t, !strings.Contains(res.Combined(), regularService))
+		assert.Assert(t, !strings.Contains(res.Combined(), profiledService))
 	})
 
 	t.Run("compose start without profile", func(t *testing.T) {
@@ -85,8 +107,8 @@ func TestNoProfileUsage(t *testing.T) {
 			"-p", projectName, "start")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		res.Assert(t, icmd.Expected{Out: "main"})
-		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+		res.Assert(t, icmd.Expected{Out: regularService})
+		assert.Assert(t, !strings.Contains(res.Combined(), profiledService))
 	})
 
 	t.Run("compose restart without profile", func(t *testing.T) {
@@ -94,8 +116,8 @@ func TestNoProfileUsage(t *testing.T) {
 			"-p", projectName, "restart")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		res.Assert(t, icmd.Expected{Out: "main"})
-		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+		res.Assert(t, icmd.Expected{Out: regularService})
+		assert.Assert(t, !strings.Contains(res.Combined(), profiledService))
 	})
 
 	t.Run("down", func(t *testing.T) {
@@ -112,38 +134,37 @@ func TestActiveProfileViaTargetedService(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "compose-e2e-profiles-via-target-service"
 	const profileName = "test-profile"
-	const targetedService = "profiled-service"
 
 	t.Run("compose up with service name", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
-			"-p", projectName, "up", targetedService, "-d")
+			"-p", projectName, "up", profiledService, "-d")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps")
-		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
-		res.Assert(t, icmd.Expected{Out: targetedService})
+		assert.Assert(t, !strings.Contains(res.Combined(), regularService))
+		res.Assert(t, icmd.Expected{Out: profiledService})
 
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "--profile", profileName, "ps")
-		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
-		res.Assert(t, icmd.Expected{Out: targetedService})
+		assert.Assert(t, !strings.Contains(res.Combined(), regularService))
+		res.Assert(t, icmd.Expected{Out: profiledService})
 	})
 
 	t.Run("compose stop with service name", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
-			"-p", projectName, "stop", targetedService)
+			"-p", projectName, "stop", profiledService)
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
-		assert.Assert(t, !strings.Contains(res.Combined(), targetedService))
+		assert.Assert(t, !strings.Contains(res.Combined(), regularService))
+		assert.Assert(t, !strings.Contains(res.Combined(), profiledService))
 	})
 
 	t.Run("compose start with service name", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
-			"-p", projectName, "start", targetedService)
+			"-p", projectName, "start", profiledService)
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
-		res.Assert(t, icmd.Expected{Out: targetedService})
+		assert.Assert(t, !strings.Contains(res.Combined(), regularService))
+		res.Assert(t, icmd.Expected{Out: profiledService})
 	})
 
 	t.Run("compose restart with service name", func(t *testing.T) {
@@ -151,8 +172,8 @@ func TestActiveProfileViaTargetedService(t *testing.T) {
 			"-p", projectName, "restart")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
 		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
-		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
-		res.Assert(t, icmd.Expected{Out: targetedService})
+		assert.Assert(t, !strings.Contains(res.Combined(), regularService))
+		res.Assert(t, icmd.Expected{Out: profiledService})
 	})
 
 	t.Run("down", func(t *testing.T) {

--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -1,0 +1,59 @@
+package e2e
+
+import (
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+	"strings"
+	"testing"
+)
+
+func TestExplicitProfileUsage(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "compose-e2e-profiles"
+	const profileName = "test-profile"
+
+	t.Run("compose up with profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "--profile", profileName, "up", "-d")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res.Assert(t, icmd.Expected{Out: "profiled-service"})
+		res.Assert(t, icmd.Expected{Out: "main"})
+	})
+
+	t.Run("compose stop with profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "--profile", profileName, "stop")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+	})
+
+	t.Run("compose start with profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "--profile", profileName, "start")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		res.Assert(t, icmd.Expected{Out: "profiled-service"})
+		res.Assert(t, icmd.Expected{Out: "main"})
+	})
+
+	t.Run("compose restart with profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "--profile", profileName, "restart")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		res.Assert(t, icmd.Expected{Out: "profiled-service"})
+		res.Assert(t, icmd.Expected{Out: "main"})
+	})
+
+	t.Run("down", func(t *testing.T) {
+		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	})
+
+	t.Run("check containers after down", func(t *testing.T) {
+		res := c.RunDockerCmd(t, "ps", "--all")
+		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
+	})
+}

--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -107,3 +107,60 @@ func TestNoProfileUsage(t *testing.T) {
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }
+
+func TestActiveProfileViaTargetedService(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "compose-e2e-profiles-via-target-service"
+	const profileName = "test-profile"
+	const targetedService = "profiled-service"
+
+	t.Run("compose up with service name", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "up", targetedService, "-d")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+		res.Assert(t, icmd.Expected{Out: targetedService})
+
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "--profile", profileName, "ps")
+		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+		res.Assert(t, icmd.Expected{Out: targetedService})
+	})
+
+	t.Run("compose stop with service name", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "stop", targetedService)
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+		assert.Assert(t, !strings.Contains(res.Combined(), targetedService))
+	})
+
+	t.Run("compose start with service name", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "start", targetedService)
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+		res.Assert(t, icmd.Expected{Out: targetedService})
+	})
+
+	t.Run("compose restart with service name", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "restart")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+		res.Assert(t, icmd.Expected{Out: targetedService})
+	})
+
+	t.Run("down", func(t *testing.T) {
+		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	})
+
+	t.Run("check containers after down", func(t *testing.T) {
+		res := c.RunDockerCmd(t, "ps", "--all")
+		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
+	})
+}

--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -57,3 +57,53 @@ func TestExplicitProfileUsage(t *testing.T) {
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }
+
+func TestNoProfileUsage(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "compose-e2e-no-profiles"
+
+	t.Run("compose up without profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "up", "-d")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res.Assert(t, icmd.Expected{Out: "main"})
+		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+	})
+
+	t.Run("compose stop without profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "stop")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+		assert.Assert(t, !strings.Contains(res.Combined(), "main"))
+	})
+
+	t.Run("compose start without profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "start")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		res.Assert(t, icmd.Expected{Out: "main"})
+		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+	})
+
+	t.Run("compose restart without profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"-p", projectName, "restart")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps", "--status", "running")
+		res.Assert(t, icmd.Expected{Out: "main"})
+		assert.Assert(t, !strings.Contains(res.Combined(), "profiled-service"))
+	})
+
+	t.Run("down", func(t *testing.T) {
+		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	})
+
+	t.Run("check containers after down", func(t *testing.T) {
+		res := c.RunDockerCmd(t, "ps", "--all")
+		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
+	})
+}


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Pass the list of targeted services to `projectOrName` to let  `compose-go` parsing add associated profiles and then follow the Compose specification:
>A service MUST be ignored by the Compose implementation when none of the listed profiles match the active ones, unless the service is explicitly targeted by a command. In that case its profiles MUST be added to the set of active profiles.  

**Related issue**
fixes #9986 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/204381699-68e8a8a6-ac70-4443-a939-183d66781690.png)
