### PR TITLE
only stop services started by `up` on interruption

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -62,11 +62,13 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 				<-signalChan
 				s.Kill(ctx, project.Name, api.KillOptions{ //nolint:errcheck
 					Services: options.Create.Services,
+					Project:  project,
 				})
 			}()
 
 			return s.Stop(ctx, project.Name, api.StopOptions{
 				Services: options.Create.Services,
+				Project:  project,
 			})
 		})
 	}


### PR DESCRIPTION
**What I did**
Pass `project` to stop command so that we only stop services created by `up` when interrupted

**Related issue**
close https://github.com/docker/compose/issues/10022

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/204549624-1a6be363-501b-4cfa-bf45-8a8c81c02eb8.png)
