### PR TITLE
test: speed up Cucumber stop test

### DIFF
--- a/e2e/cucumber-features/stop.feature
+++ b/e2e/cucumber-features/stop.feature
@@ -10,6 +10,7 @@ Background:
           sleep: # will be killed
             image: alpine
             command: ping localhost
+            init: true
         """
 
 Scenario: Cascade stop
@@ -22,7 +23,7 @@ Scenario: Exit code from
     When I run "compose up --exit-code-from sleep"
     Then the output contains "should_fail-1 exited with code 1"
     And the output contains "Aborting on container exit..."
-    And the exit code is 137
+    And the exit code is 143
 
 Scenario: Exit code from unknown service
     When I run "compose up --exit-code-from unknown"


### PR DESCRIPTION
**What I did**
Evidently `ping` doesn't respond to `SIGTERM`, so use `init` to get Tini supervising it. This changes the exit code to 143 since it's not hitting the 10s timeout and getting a `SIGKILL` (137).

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![roadrunner bird with a lizard in its mouth](https://user-images.githubusercontent.com/841263/204895274-11988cf7-b88d-49af-aba8-cbb2ba9880dc.png)
