### PR TITLE
use StringToBool to detect COMPOSE_IGNORE_ORPHANS

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -32,6 +32,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
+	"github.com/docker/compose/v2/pkg/utils"
 )
 
 type runOptions struct {
@@ -140,8 +141,7 @@ func runCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *
 			if err != nil {
 				return err
 			}
-			ignore := project.Environment["COMPOSE_IGNORE_ORPHANS"]
-			opts.ignoreOrphans = strings.ToLower(ignore) == "true"
+			opts.ignoreOrphans = utils.StringToBool(project.Environment["COMPOSE_IGNORE_ORPHANS"])
 			return runRun(ctx, backend, project, opts, createOpts)
 		}),
 		ValidArgsFunction: completeServiceNames(p),


### PR DESCRIPTION
**What I did**
COMPOSE_IGNORE_ORPHANS can be enabled by being set to `true` but also `t` or `1`.


**Related issue**
close https://github.com/docker/compose/issues/9323

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
