### PR TITLE
Fix replacing "service:x" with "container:y"

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -126,17 +126,22 @@ func updateServices(service *types.ServiceConfig, cnts Containers) {
 	if len(cnts) == 0 {
 		return
 	}
-	cnt := cnts[0]
-	serviceName := cnt.Labels[api.ServiceLabel]
+	serviceName2containerID := make(map[string]string)
+	for _, cnt := range cnts {
+		serviceName := cnt.Labels[api.ServiceLabel]
+		if _, exists := serviceName2containerID[serviceName]; !exists {
+			serviceName2containerID[serviceName] = cnt.ID
+		}
+	}
 
-	if d := getDependentServiceFromMode(service.NetworkMode); d == serviceName {
-		service.NetworkMode = types.NetworkModeContainerPrefix + cnt.ID
+	if id, found := serviceName2containerID[getDependentServiceFromMode(service.NetworkMode)]; found {
+		service.NetworkMode = types.NetworkModeContainerPrefix + id
 	}
-	if d := getDependentServiceFromMode(service.Ipc); d == serviceName {
-		service.Ipc = types.NetworkModeContainerPrefix + cnt.ID
+	if id, found := serviceName2containerID[getDependentServiceFromMode(service.Ipc)]; found {
+		service.Ipc = types.NetworkModeContainerPrefix + id
 	}
-	if d := getDependentServiceFromMode(service.Pid); d == serviceName {
-		service.Pid = types.NetworkModeContainerPrefix + cnt.ID
+	if id, found := serviceName2containerID[getDependentServiceFromMode(service.Pid)]; found {
+		service.Pid = types.NetworkModeContainerPrefix + id
 	}
 	var links []string
 	for _, serviceLink := range service.Links {


### PR DESCRIPTION
**What I did**
As mentioned in https://github.com/docker/compose/issues/9055#issuecomment-1333848036 and https://github.com/docker/compose/issues/9055#issuecomment-1333862905,  `updateServices()` gets called from `prepareRun()` with an array of _all_ containers belonging to the project and taking only first one of them is wrong in general case. For this use case we should construct a `map` from service name to ID of the first container belonging to that service. This `map` is then used ro replace `service:x` with `container:y` in `network_mode:`, `ipc:` and `pid:`. This change should not break the second use case of `updateServices()` when it is called from `updateProject()` with an array of containers already filtered by service (as pointed out in https://github.com/docker/compose/issues/9055#issuecomment-1333861996). In this case `map` will contain only one pair and code will behave exactly like before - only replacing mentions of one particular service and leaving all other `service:x` intact.

**Related issue**
Fixes #9055.