### PR TITLE
Add --include-deps to push command

### DIFF
--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -68,7 +68,7 @@ func pullCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	return cmd
 }
 
-func FilterServices(project *types.Project, services []string) error {
+func withSelectedServicesOnly(project *types.Project, services []string) error {
 	enabled, err := project.GetServices(services...)
 	if err != nil {
 		return err
@@ -90,7 +90,10 @@ func runPull(ctx context.Context, backend api.Service, opts pullOptions, service
 	}
 
 	if !opts.includeDeps {
-		FilterServices(project, services)
+		err := withSelectedServicesOnly(project, services)
+		if err != nil {
+			return err
+		}
 	}
 
 	return backend.Pull(ctx, project, api.PullOptions{

--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -27,7 +27,7 @@ import (
 type pushOptions struct {
 	*projectOptions
 	composeOptions
-
+	IncludeDeps    bool
 	Ignorefailures bool
 	Quiet          bool
 }
@@ -45,6 +45,7 @@ func pushCommand(p *projectOptions, backend api.Service) *cobra.Command {
 		ValidArgsFunction: completeServiceNames(p),
 	}
 	pushCmd.Flags().BoolVar(&opts.Ignorefailures, "ignore-push-failures", false, "Push what it can and ignores images with push failures")
+	pushCmd.Flags().BoolVar(&opts.IncludeDeps, "include-deps", false, "Also push images of services declared as dependencies")
 	pushCmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Push without printing progress information")
 
 	return pushCmd
@@ -54,6 +55,10 @@ func runPush(ctx context.Context, backend api.Service, opts pushOptions, service
 	project, err := opts.toProject(services)
 	if err != nil {
 		return err
+	}
+
+	if !opts.IncludeDeps {
+		FilterServices(project, services)
 	}
 
 	return backend.Push(ctx, project, api.PushOptions{

--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -58,7 +58,10 @@ func runPush(ctx context.Context, backend api.Service, opts pushOptions, service
 	}
 
 	if !opts.IncludeDeps {
-		FilterServices(project, services)
+		err := withSelectedServicesOnly(project, services)
+		if err != nil {
+			return err
+		}
 	}
 
 	return backend.Push(ctx, project, api.PushOptions{

--- a/docs/reference/compose_push.md
+++ b/docs/reference/compose_push.md
@@ -8,6 +8,7 @@ Push service images
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--ignore-push-failures` |  |  | Push what it can and ignores images with push failures |
+| `--include-deps` |  |  | Also push images of services declared as dependencies |
 | `-q`, `--quiet` |  |  | Push without printing progress information |
 
 

--- a/docs/reference/docker_compose_push.yaml
+++ b/docs/reference/docker_compose_push.yaml
@@ -33,6 +33,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: include-deps
+      value_type: bool
+      default_value: "false"
+      description: Also push images of services declared as dependencies
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet
       shorthand: q
       value_type: bool


### PR DESCRIPTION
**What I did**

Add `--include-deps` to the `push` sub-command, similar to what `pull` can do. I believe the default behavior is a little bit weird since you can't explicitly push the built image of a service that has declared dependencies. That being said, this change will break backwards compatibility, so I feel like we could

_Cute animal tax_ - a photo of my containerized cat:

![PXL_20201120_110811709 PORTRAIT(2)](https://user-images.githubusercontent.com/420581/205866751-ad1da478-c55c-4141-bf4b-50d00f04ea7f.jpg)


