### PR TITLE
update to go1.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.19.3
+ARG GO_VERSION=1.19.4
 ARG XX_VERSION=1.1.2
 ARG GOLANGCI_LINT_VERSION=v1.49.0
 ARG ADDLICENSE_VERSION=v1.0.0

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 variable "GO_VERSION" {
-  default = "1.19.3"
+  default = "1.19.4"
 }
 
 variable "BUILD_TAGS" {


### PR DESCRIPTION
Includes security fixes for net/http (CVE-2022-41717, CVE-2022-41720), and os (CVE-2022-41720).

These minor releases include 2 security fixes following the security policy:

- os, net/http: avoid escapes from os.DirFS and http.Dir on Windows

  The os.DirFS function and http.Dir type provide access to a tree of files rooted at a given directory. These functions permitted access to Windows device files under that root. For example, os.DirFS("C:/tmp").Open("COM1") would open the COM1 device. Both os.DirFS and http.Dir only provide read-only filesystem access.

  In addition, on Windows, an os.DirFS for the directory \(the root of the current drive) can permit a maliciously crafted path to escape from the drive and access any path on the system.

  The behavior of os.DirFS("") has changed. Previously, an empty root was treated equivalently to "/", so os.DirFS("").Open("tmp") would open the path "/tmp". This now returns an error.

  This is CVE-2022-41720 and Go issue https://go.dev/issue/56694.

- net/http: limit canonical header cache by bytes, not entries

  An attacker can cause excessive memory growth in a Go server accepting HTTP/2 requests.

  HTTP/2 server connections contain a cache of HTTP header keys sent by the client. While the total number of entries in this cache is capped, an attacker sending very large keys can cause the server to allocate approximately 64 MiB per open connection.

  This issue is also fixed in golang.org/x/net/http2 vX.Y.Z, for users manually configuring HTTP/2.

  Thanks to Josselin Costanzi for reporting this issue.

  This is CVE-2022-41717 and Go issue https://go.dev/issue/56350.

View the release notes for more information:
https://go.dev/doc/devel/release#go1.19.4

And the milestone on the issue tracker:
https://github.com/golang/go/issues?q=milestone%3AGo1.19.4+label%3ACherryPickApproved

Full diff: https://github.com/golang/go/compare/go1.19.3...go1.19.4

The golang.org/x/net fix is in https://github.com/golang/net/commit/1e63c2f08a10a150fa02c50ece89b340ae64efe4

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
