### PR TITLE
check only running containers in after down tests of profiles e2e tests

### DIFF
--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -75,7 +75,7 @@ func TestExplicitProfileUsage(t *testing.T) {
 	})
 
 	t.Run("check containers after down", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "ps", "--all")
+		res := c.RunDockerCmd(t, "ps")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }
@@ -125,7 +125,7 @@ func TestNoProfileUsage(t *testing.T) {
 	})
 
 	t.Run("check containers after down", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "ps", "--all")
+		res := c.RunDockerCmd(t, "ps")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }
@@ -181,7 +181,7 @@ func TestActiveProfileViaTargetedService(t *testing.T) {
 	})
 
 	t.Run("check containers after down", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "ps", "--all")
+		res := c.RunDockerCmd(t, "ps")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Fix flakyness of profiles e2e tests, we just need to check there is no more running containers associated to the project name, no need to list the exited ones

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
