### PR TITLE
fix race condition collecting pulled images IDs

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -294,14 +294,11 @@ func (s *composeService) pullRequiredImages(ctx context.Context, project *types.
 				return err
 			})
 		}
+		err := eg.Wait()
 		for i, service := range needPull {
 			if pulledImages[i] != "" {
 				images[service.Image] = pulledImages[i]
 			}
-		}
-		err := eg.Wait()
-		if err != nil {
-			return err
 		}
 		return err
 	})


### PR DESCRIPTION
**What I did**
fix race condition: we only can set images ID _after_ all pulls completed and we collected the digests.

**Related issue**
fixes https://github.com/docker/compose/issues/9897

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/206150855-ab3e7929-0a6f-442f-bdfb-ed8a6076265c.png)
