### PR TITLE
load project from files when explicitly set by user

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -140,7 +140,7 @@ func (o *projectOptions) addProjectFlags(f *pflag.FlagSet) {
 func (o *projectOptions) projectOrName(services ...string) (*types.Project, string, error) {
 	name := o.ProjectName
 	var project *types.Project
-	if o.ProjectName == "" {
+	if len(o.ConfigPaths) > 0 || o.ProjectName == "" {
 		p, err := o.toProject(services)
 		if err != nil {
 			envProjectName := os.Getenv("COMPOSE_PROJECT_NAME")


### PR DESCRIPTION
As a user run `docker compose --file foo.yaml --project-name bar ...`, parse the provided compose file as source of truth for the compose model the command will execute upon. Project should only be built from actual resources when there's no explicit compose file being set and we only rely on a project name.

**Related issue**
fixes https://github.com/docker/compose/issues/9554

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/206674696-ec6d7488-77d3-4989-a988-011d2bb2b6be.png)
