### PR TITLE
ContainerStart must run sequentially for engine to assing distinct ports within configured range

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -721,21 +721,17 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 	}
 
 	w := progress.ContextWriter(ctx)
-	eg, ctx := errgroup.WithContext(ctx)
 	for _, container := range containers {
 		if container.State == ContainerRunning {
 			continue
 		}
-		container := container
-		eg.Go(func() error {
-			eventName := getContainerProgressName(container)
-			w.Event(progress.StartingEvent(eventName))
-			err := s.apiClient().ContainerStart(ctx, container.ID, moby.ContainerStartOptions{})
-			if err == nil {
-				w.Event(progress.StartedEvent(eventName))
-			}
+		eventName := getContainerProgressName(container)
+		w.Event(progress.StartingEvent(eventName))
+		err := s.apiClient().ContainerStart(ctx, container.ID, moby.ContainerStartOptions{})
+		if err != nil {
 			return err
-		})
+		}
+		w.Event(progress.StartedEvent(eventName))
 	}
-	return eg.Wait()
+	return nil
 }

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -56,3 +56,13 @@ func TestUpExitCodeFrom(t *testing.T) {
 
 	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
 }
+
+func TestPortRange(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-port-range"
+
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/port-range/compose.yaml", "--project-name", projectName, "up", "-d")
+	res.Assert(t, icmd.Success)
+
+	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
+}

--- a/pkg/e2e/fixtures/port-range/compose.yaml
+++ b/pkg/e2e/fixtures/port-range/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  a:
+    image: nginx:alpine
+    scale: 5
+    ports:
+      - "6005-6015:80"


### PR DESCRIPTION
**What I did**
A service configured with `port: 6000-6010:80` will get a random port assigned within this range
As we invoke `ContainerStart`, engine select an available port within container's config port range.
If we invoke those concurrently for containers within same service, engine will fail to assign a distinct port. 
Arguably, engine _should_ manage concurrent access and prevent this to happen, but .. ¯\\_(ツ)_/

**Related issue**
fixes https://github.com/docker/compose/issues/8530

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/206998920-bf047c1d-c387-4630-8862-f9caa7519965.png)
