### PR TITLE
distinguish stdout and stderr in `up` logs

### DIFF
--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -67,7 +67,7 @@ func runLogs(ctx context.Context, backend api.Service, opts logsOptions, service
 	if err != nil {
 		return err
 	}
-	consumer := formatter.NewLogConsumer(ctx, os.Stdout, !opts.noColor, !opts.noPrefix)
+	consumer := formatter.NewLogConsumer(ctx, os.Stdout, os.Stderr, !opts.noColor, !opts.noPrefix)
 	return backend.Logs(ctx, name, consumer, api.LogOptions{
 		Project:    project,
 		Services:   services,

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -176,7 +176,7 @@ func runUp(ctx context.Context, backend api.Service, createOptions createOptions
 
 	var consumer api.LogConsumer
 	if !upOptions.Detach {
-		consumer = formatter.NewLogConsumer(ctx, os.Stdout, !upOptions.noColor, !upOptions.noPrefix)
+		consumer = formatter.NewLogConsumer(ctx, os.Stdout, os.Stderr, !upOptions.noColor, !upOptions.noPrefix)
 	}
 
 	attachTo := services

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -437,7 +437,8 @@ type Stack struct {
 
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
-	Log(containerName, service, message string)
+	Log(containerName, message string)
+	Err(containerName, message string)
 	Status(container, msg string)
 	Register(container string)
 }
@@ -461,8 +462,10 @@ type ContainerEvent struct {
 }
 
 const (
-	// ContainerEventLog is a ContainerEvent of type log. Line is set
+	// ContainerEventLog is a ContainerEvent of type log on stdout. Line is set
 	ContainerEventLog = iota
+	// ContainerEventErr is a ContainerEvent of type log on stderr. Line is set
+	ContainerEventErr
 	// ContainerEventAttach is a ContainerEvent of type attach. First event sent about a container
 	ContainerEventAttach
 	// ContainerEventStopped is a ContainerEvent of type stopped.

--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -69,9 +69,17 @@ func (s *composeService) attachContainer(ctx context.Context, container moby.Con
 		Service:   serviceName,
 	})
 
-	w := utils.GetWriter(func(line string) {
+	wOut := utils.GetWriter(func(line string) {
 		listener(api.ContainerEvent{
 			Type:      api.ContainerEventLog,
+			Container: containerName,
+			Service:   serviceName,
+			Line:      line,
+		})
+	})
+	wErr := utils.GetWriter(func(line string) {
+		listener(api.ContainerEvent{
+			Type:      api.ContainerEventErr,
 			Container: containerName,
 			Service:   serviceName,
 			Line:      line,
@@ -83,7 +91,7 @@ func (s *composeService) attachContainer(ctx context.Context, container moby.Con
 		return err
 	}
 
-	_, _, err = s.attachContainerStreams(ctx, container.ID, inspect.Config.Tty, nil, w, w)
+	_, _, err = s.attachContainerStreams(ctx, container.ID, inspect.Config.Tty, nil, wOut, wErr)
 	return err
 }
 

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -99,7 +99,6 @@ func (s *composeService) logContainers(ctx context.Context, consumer api.LogCons
 		return err
 	}
 
-	service := c.Labels[api.ServiceLabel]
 	r, err := s.apiClient().ContainerLogs(ctx, cnt.ID, types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
@@ -116,7 +115,7 @@ func (s *composeService) logContainers(ctx context.Context, consumer api.LogCons
 
 	name := getContainerNameWithoutProject(c)
 	w := utils.GetWriter(func(line string) {
-		consumer.Log(name, service, line)
+		consumer.Log(name, line)
 	})
 	if cnt.Config.Tty {
 		_, err = io.Copy(w, r)

--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -118,7 +118,11 @@ func (p *printer) Run(ctx context.Context, cascadeStop bool, exitCodeFrom string
 				}
 			case api.ContainerEventLog:
 				if !aborting {
-					p.consumer.Log(container, event.Service, event.Line)
+					p.consumer.Log(container, event.Line)
+				}
+			case api.ContainerEventErr:
+				if !aborting {
+					p.consumer.Err(container, event.Line)
 				}
 			}
 		}

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -66,3 +66,13 @@ func TestPortRange(t *testing.T) {
 
 	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
 }
+
+func TestStdoutStderr(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-stdout-stderr"
+
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/stdout-stderr/compose.yaml", "--project-name", projectName, "up")
+	res.Assert(t, icmd.Expected{Out: "log to stdout", Err: "log to stderr"})
+
+	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
+}

--- a/pkg/e2e/fixtures/stdout-stderr/compose.yaml
+++ b/pkg/e2e/fixtures/stdout-stderr/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  stderr:
+    image: alpine
+    command: /bin/ash /log_to_stderr.sh
+    volumes:
+           - ./log_to_stderr.sh:/log_to_stderr.sh

--- a/pkg/e2e/fixtures/stdout-stderr/log_to_stderr.sh
+++ b/pkg/e2e/fixtures/stdout-stderr/log_to_stderr.sh
@@ -1,0 +1,16 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+>&2 echo "log to stderr"
+echo "log to stdout"

--- a/pkg/mocks/mock_docker_compose_api.go
+++ b/pkg/mocks/mock_docker_compose_api.go
@@ -416,16 +416,28 @@ func (m *MockLogConsumer) EXPECT() *MockLogConsumerMockRecorder {
 	return m.recorder
 }
 
-// Log mocks base method.
-func (m *MockLogConsumer) Log(containerName, service, message string) {
+// Err mocks base method.
+func (m *MockLogConsumer) Err(containerName, message string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Log", containerName, service, message)
+	m.ctrl.Call(m, "Err", containerName, message)
+}
+
+// Err indicates an expected call of Err.
+func (mr *MockLogConsumerMockRecorder) Err(containerName, message interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockLogConsumer)(nil).Err), containerName, message)
+}
+
+// Log mocks base method.
+func (m *MockLogConsumer) Log(containerName, message string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Log", containerName, message)
 }
 
 // Log indicates an expected call of Log.
-func (mr *MockLogConsumerMockRecorder) Log(containerName, service, message interface{}) *gomock.Call {
+func (mr *MockLogConsumerMockRecorder) Log(containerName, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockLogConsumer)(nil).Log), containerName, service, message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Log", reflect.TypeOf((*MockLogConsumer)(nil).Log), containerName, message)
 }
 
 // Register mocks base method.


### PR DESCRIPTION
**What I did**
As we attach to containers to collect log, distinguish Stdout and Stderr, and print logs on os.Stdout/Stderr accordingly

**Related issue**
#fixes https://github.com/docker/compose/issues/8098

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/207259187-0ee695fd-0884-47b7-b0d6-c1be07787085.png)
