### PR TITLE
introduce --timestamp option on compose up

### DIFF
--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/docker/compose/v2/cmd/formatter"
-
 	"github.com/spf13/cobra"
 
+	"github.com/docker/compose/v2/cmd/formatter"
 	"github.com/docker/compose/v2/pkg/api"
 )
 
@@ -67,7 +66,7 @@ func runLogs(ctx context.Context, backend api.Service, opts logsOptions, service
 	if err != nil {
 		return err
 	}
-	consumer := formatter.NewLogConsumer(ctx, os.Stdout, os.Stderr, !opts.noColor, !opts.noPrefix)
+	consumer := formatter.NewLogConsumer(ctx, os.Stdout, os.Stderr, !opts.noColor, !opts.noPrefix, false)
 	return backend.Logs(ctx, name, consumer, api.LogOptions{
 		Project:    project,
 		Services:   services,

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -49,6 +49,7 @@ type upOptions struct {
 	noPrefix           bool
 	attachDependencies bool
 	attach             []string
+	timestamp          bool
 	wait               bool
 }
 
@@ -126,6 +127,7 @@ func upCommand(p *projectOptions, backend api.Service) *cobra.Command {
 	flags.BoolVar(&up.cascadeStop, "abort-on-container-exit", false, "Stops all containers if any container was stopped. Incompatible with -d")
 	flags.StringVar(&up.exitCodeFrom, "exit-code-from", "", "Return the exit code of the selected service container. Implies --abort-on-container-exit")
 	flags.IntVarP(&create.timeout, "timeout", "t", 10, "Use this timeout in seconds for container shutdown when attached or when containers are already running.")
+	flags.BoolVar(&up.timestamp, "timestamps", false, "Show timestamps.")
 	flags.BoolVar(&up.noDeps, "no-deps", false, "Don't start linked services.")
 	flags.BoolVar(&create.recreateDeps, "always-recreate-deps", false, "Recreate dependent containers. Incompatible with --no-recreate.")
 	flags.BoolVarP(&create.noInherit, "renew-anon-volumes", "V", false, "Recreate anonymous volumes instead of retrieving data from the previous containers.")
@@ -176,7 +178,7 @@ func runUp(ctx context.Context, backend api.Service, createOptions createOptions
 
 	var consumer api.LogConsumer
 	if !upOptions.Detach {
-		consumer = formatter.NewLogConsumer(ctx, os.Stdout, os.Stderr, !upOptions.noColor, !upOptions.noPrefix)
+		consumer = formatter.NewLogConsumer(ctx, os.Stdout, os.Stderr, !upOptions.noColor, !upOptions.noPrefix, upOptions.timestamp)
 	}
 
 	attachTo := services

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -27,6 +27,7 @@ Create and start containers
 | `-V`, `--renew-anon-volumes` |  |  | Recreate anonymous volumes instead of retrieving data from the previous containers. |
 | `--scale` | `stringArray` |  | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present. |
 | `-t`, `--timeout` | `int` | `10` | Use this timeout in seconds for container shutdown when attached or when containers are already running. |
+| `--timestamps` |  |  | Show timestamps. |
 | `--wait` |  |  | Wait for services to be running\|healthy. Implies detached mode. |
 
 

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -230,6 +230,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: timestamps
+      value_type: bool
+      default_value: "false"
+      description: Show timestamps.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: wait
       value_type: bool
       default_value: "false"


### PR DESCRIPTION
**What I did**
Add support for `docker compose up --timestamp` to align with same option on `logs` command.

**Related issue**
close https://github.com/docker/compose/issues/5730

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/207410415-08960d00-3272-4e24-b58d-00b904d75e23.png)
