### PR TITLE
use StatusError from docker/cli, not "dockerd"

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	buildx "github.com/docker/buildx/build"
+	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command/image/build"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder/remotecontext/urlutil"
-	"github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/jsonmessage"


### PR DESCRIPTION
This package is a leftover from when the "docker" cli and the "dockerd" cli both lived in the same repository. The package in docker/docker will be (re)moved soon, so replace it with the implementation in docker/cli, which is the right one :)

I added a "depguard" for this package to prevent accidental imports.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**


![MF-woodchuck](https://user-images.githubusercontent.com/1804568/207568538-29f5d506-3a7b-4681-9cb7-3fa7559f303c.jpeg)
