### PR TITLE
only list running containers when --all=false

### DIFF
--- a/pkg/compose/ps.go
+++ b/pkg/compose/ps.go
@@ -32,7 +32,7 @@ func (s *composeService) Ps(ctx context.Context, projectName string, options api
 	if options.All {
 		oneOff = oneOffInclude
 	}
-	containers, err := s.getContainers(ctx, projectName, oneOff, true, options.Services...)
+	containers, err := s.getContainers(ctx, projectName, oneOff, options.All, options.Services...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compose/ps_test.go
+++ b/pkg/compose/ps_test.go
@@ -46,7 +46,7 @@ func TestPs(t *testing.T) {
 	ctx := context.Background()
 	args := filters.NewArgs(projectFilter(strings.ToLower(testProject)))
 	args.Add("label", "com.docker.compose.oneoff=False")
-	listOpts := moby.ContainerListOptions{Filters: args, All: true}
+	listOpts := moby.ContainerListOptions{Filters: args, All: false}
 	c1, inspect1 := containerDetails("service1", "123", "running", "healthy", 0)
 	c2, inspect2 := containerDetails("service1", "456", "running", "", 0)
 	c2.Ports = []moby.Port{{PublicPort: 80, PrivatePort: 90, IP: "localhost"}}

--- a/pkg/e2e/ps_test.go
+++ b/pkg/e2e/ps_test.go
@@ -94,4 +94,18 @@ func TestPs(t *testing.T) {
 		}
 		assert.Equal(t, 2, count, "Did not match both services:\n"+res.Combined())
 	})
+
+	t.Run("ps --all", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "stop")
+		assert.NoError(t, res.Error)
+
+		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps")
+		lines := strings.Split(res.Stdout(), "\n")
+		assert.Equal(t, 2, len(lines))
+
+		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps", "--all")
+		lines = strings.Split(res.Stdout(), "\n")
+		assert.Equal(t, 4, len(lines))
+	})
+
 }


### PR DESCRIPTION
**What I did**
List containers according to `docker compose ps --all=?` flag to exclude non-running ones by default

**Related issue**
closes https://github.com/docker/compose/issues/10085

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/208052527-4b116cca-1b5a-46de-9b86-e6b46e5b750f.png)

