### PR TITLE
Use `DOCKER_DEFAULT_PLATFORM` to determine platform when creating container

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -479,10 +479,14 @@ func (s *composeService) createMobyContainer(ctx context.Context, project *types
 	if err != nil {
 		return created, err
 	}
+	platform := service.Platform
+	if platform == "" {
+		platform = project.Environment["DOCKER_DEFAULT_PLATFORM"]
+	}
 	var plat *specs.Platform
-	if service.Platform != "" {
+	if platform != "" {
 		var p specs.Platform
-		p, err = platforms.Parse(service.Platform)
+		p, err = platforms.Parse(platform)
 		if err != nil {
 			return created, err
 		}


### PR DESCRIPTION


Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Previously we were only using `DOCKER_DEFAULT_PLATFORM` to determine the default platform to use during pull. For consistency, we should apply the same logic when creating the container.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

fixes https://github.com/docker/compose/issues/10041

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![IMG_5229](https://user-images.githubusercontent.com/70572044/208422008-75e30e25-3aad-4501-ae80-0801c578056e.jpg)
