### PR TITLE
set CPU quota

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -529,7 +529,8 @@ func getDeployResources(s types.ServiceConfig) container.Resources {
 		CPURealtimePeriod:  s.CPURTPeriod,
 		CPURealtimeRuntime: s.CPURTRuntime,
 		CPUShares:          s.CPUShares,
-		CPUPercent:         int64(s.CPUS * 100),
+		NanoCPUs:           int64(s.CPUS * 1e9),
+		CPUPercent:         int64(s.CPUPercent * 100),
 		CpusetCpus:         s.CPUSet,
 		DeviceCgroupRules:  s.DeviceCgroupRules,
 	}


### PR DESCRIPTION
**What I did**
fix set CPU quota on created containers
`CPUPercent` we used so far only applies to ... windows containers!

**Related issue**
fixes https://github.com/docker/compose/issues/10073
(this doesn't fix compose-go to replicate deploy.resources... to cpus)

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/208442981-70228910-e8d2-4e6b-87f3-572b8e64af1d.png)
