### PR TITLE
detect dependency failed to start

### DIFF
--- a/pkg/e2e/fixtures/dependencies/dependency-exit.yaml
+++ b/pkg/e2e/fixtures/dependencies/dependency-exit.yaml
@@ -1,0 +1,10 @@
+services:
+  web:
+    image: nginx:alpine
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: alpine
+    command: sh -c "exit 1"
+

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -123,3 +123,18 @@ func TestUpWithBuildDependencies(t *testing.T) {
 		res.Assert(t, icmd.Success)
 	})
 }
+
+func TestUpWithDependencyExit(t *testing.T) {
+	c := NewParallelCLI(t)
+
+	t.Run("up with dependency to exit before being healthy", func(t *testing.T) {
+		res := c.RunDockerComposeCmdNoCheck(t, "--project-directory", "fixtures/dependencies",
+			"-f", "fixtures/dependencies/dependency-exit.yaml", "up", "-d")
+
+		t.Cleanup(func() {
+			c.RunDockerComposeCmd(t, "--project-name", "dependencies", "down")
+		})
+
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: "dependency failed to start: container for service \"db\" exited (1)"})
+	})
+}


### PR DESCRIPTION
**What I did**
detect dependent service failed to start (container exited) and exit with error.
note: this doesn't cover scenarios like replicated service with one container to exit but the other eventually becoming healthy, container to restart after an initial failure, etc...

**Related issue**
closes https://github.com/docker/compose/issues/9732

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/208450669-70f97bd2-1dd6-4227-b485-d78aea65306d.png)
