### PR TITLE
update `projectOptions` to be public by renaming it to `ProjectOptions`

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -34,7 +34,7 @@ import (
 )
 
 type buildOptions struct {
-	*projectOptions
+	*ProjectOptions
 	composeOptions
 	quiet    bool
 	pull     bool
@@ -73,9 +73,9 @@ var printerModes = []string{
 	buildx.PrinterModeQuiet,
 }
 
-func buildCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func buildCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := buildOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "build [OPTIONS] [SERVICE...]",
@@ -129,7 +129,7 @@ func buildCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runBuild(ctx context.Context, backend api.Service, opts buildOptions, services []string) error {
-	project, err := opts.toProject(services, cli.WithResolvedPaths(true))
+	project, err := opts.ToProject(services, cli.WithResolvedPaths(true))
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/completion.go
+++ b/cmd/compose/completion.go
@@ -32,9 +32,9 @@ func noCompletion() validArgsFn {
 	}
 }
 
-func completeServiceNames(p *projectOptions) validArgsFn {
+func completeServiceNames(p *ProjectOptions) validArgsFn {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		project, err := p.toProject(nil)
+		project, err := p.ToProject(nil)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -35,7 +35,7 @@ import (
 )
 
 type convertOptions struct {
-	*projectOptions
+	*ProjectOptions
 	Format              string
 	Output              string
 	quiet               bool
@@ -50,9 +50,9 @@ type convertOptions struct {
 	noConsistency       bool
 }
 
-func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func convertCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := convertOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Aliases: []string{"config"},
@@ -112,13 +112,12 @@ func convertCommand(p *projectOptions, backend api.Service) *cobra.Command {
 
 func runConvert(ctx context.Context, backend api.Service, opts convertOptions, services []string) error {
 	var content []byte
-	project, err := opts.toProject(services,
+	project, err := opts.ToProject(services,
 		cli.WithInterpolation(!opts.noInterpolate),
 		cli.WithResolvedPaths(true),
 		cli.WithNormalization(!opts.noNormalize),
 		cli.WithConsistency(!opts.noConsistency),
 		cli.WithDiscardEnvFile)
-
 	if err != nil {
 		return err
 	}
@@ -153,7 +152,7 @@ func runConvert(ctx context.Context, backend api.Service, opts convertOptions, s
 }
 
 func runServices(opts convertOptions) error {
-	project, err := opts.toProject(nil)
+	project, err := opts.ToProject(nil)
 	if err != nil {
 		return err
 	}
@@ -164,7 +163,7 @@ func runServices(opts convertOptions) error {
 }
 
 func runVolumes(opts convertOptions) error {
-	project, err := opts.toProject(nil)
+	project, err := opts.ToProject(nil)
 	if err != nil {
 		return err
 	}
@@ -179,7 +178,7 @@ func runHash(opts convertOptions) error {
 	if opts.hash != "*" {
 		services = append(services, strings.Split(opts.hash, ",")...)
 	}
-	project, err := opts.toProject(services)
+	project, err := opts.ToProject(services)
 	if err != nil {
 		return err
 	}
@@ -195,7 +194,7 @@ func runHash(opts convertOptions) error {
 
 func runProfiles(opts convertOptions, services []string) error {
 	set := map[string]struct{}{}
-	project, err := opts.toProject(services)
+	project, err := opts.ToProject(services)
 	if err != nil {
 		return err
 	}
@@ -216,7 +215,7 @@ func runProfiles(opts convertOptions, services []string) error {
 }
 
 func runConfigImages(opts convertOptions, services []string) error {
-	project, err := opts.toProject(services)
+	project, err := opts.ToProject(services)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/cp.go
+++ b/cmd/compose/cp.go
@@ -27,7 +27,7 @@ import (
 )
 
 type copyOptions struct {
-	*projectOptions
+	*ProjectOptions
 
 	source      string
 	destination string
@@ -37,9 +37,9 @@ type copyOptions struct {
 	copyUIDGID  bool
 }
 
-func copyCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func copyCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := copyOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	copyCmd := &cobra.Command{
 		Use: `cp [OPTIONS] SERVICE:SRC_PATH DEST_PATH|-

--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -43,7 +43,7 @@ type createOptions struct {
 	quietPull     bool
 }
 
-func createCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func createCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := createOptions{}
 	cmd := &cobra.Command{
 		Use:   "create [OPTIONS] [SERVICE...]",

--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -31,7 +31,7 @@ import (
 )
 
 type downOptions struct {
-	*projectOptions
+	*ProjectOptions
 	removeOrphans bool
 	timeChanged   bool
 	timeout       int
@@ -39,9 +39,9 @@ type downOptions struct {
 	images        string
 }
 
-func downCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func downCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := downOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	downCmd := &cobra.Command{
 		Use:   "down [OPTIONS]",

--- a/cmd/compose/events.go
+++ b/cmd/compose/events.go
@@ -31,10 +31,10 @@ type eventsOpts struct {
 	json bool
 }
 
-func eventsCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func eventsCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := eventsOpts{
 		composeOptions: &composeOptions{
-			projectOptions: p,
+			ProjectOptions: p,
 		},
 	}
 	cmd := &cobra.Command{

--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -43,10 +43,10 @@ type execOpts struct {
 	interactive bool
 }
 
-func execCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+func execCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
 	opts := execOpts{
 		composeOptions: &composeOptions{
-			projectOptions: p,
+			ProjectOptions: p,
 		},
 	}
 	runCmd := &cobra.Command{

--- a/cmd/compose/images.go
+++ b/cmd/compose/images.go
@@ -34,14 +34,14 @@ import (
 )
 
 type imageOptions struct {
-	*projectOptions
+	*ProjectOptions
 	Quiet  bool
 	Format string
 }
 
-func imagesCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func imagesCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := imageOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	imgCmd := &cobra.Command{
 		Use:   "images [OPTIONS] [SERVICE...]",

--- a/cmd/compose/kill.go
+++ b/cmd/compose/kill.go
@@ -27,14 +27,14 @@ import (
 )
 
 type killOptions struct {
-	*projectOptions
+	*ProjectOptions
 	removeOrphans bool
 	signal        string
 }
 
-func killCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func killCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := killOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "kill [OPTIONS] [SERVICE...]",
@@ -65,5 +65,4 @@ func runKill(ctx context.Context, backend api.Service, opts killOptions, service
 		Services:      services,
 		Signal:        opts.signal,
 	})
-
 }

--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -27,7 +27,7 @@ import (
 )
 
 type logsOptions struct {
-	*projectOptions
+	*ProjectOptions
 	composeOptions
 	follow     bool
 	tail       string
@@ -38,9 +38,9 @@ type logsOptions struct {
 	timestamps bool
 }
 
-func logsCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func logsCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := logsOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	logsCmd := &cobra.Command{
 		Use:   "logs [OPTIONS] [SERVICE...]",

--- a/cmd/compose/pause.go
+++ b/cmd/compose/pause.go
@@ -25,12 +25,12 @@ import (
 )
 
 type pauseOptions struct {
-	*projectOptions
+	*ProjectOptions
 }
 
-func pauseCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func pauseCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := pauseOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "pause [SERVICE...]",
@@ -56,12 +56,12 @@ func runPause(ctx context.Context, backend api.Service, opts pauseOptions, servi
 }
 
 type unpauseOptions struct {
-	*projectOptions
+	*ProjectOptions
 }
 
-func unpauseCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func unpauseCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := unpauseOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "unpause [SERVICE...]",

--- a/cmd/compose/port.go
+++ b/cmd/compose/port.go
@@ -28,15 +28,15 @@ import (
 )
 
 type portOptions struct {
-	*projectOptions
+	*ProjectOptions
 	port     uint16
 	protocol string
 	index    int
 }
 
-func portCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func portCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := portOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "port [OPTIONS] SERVICE PRIVATE_PORT",

--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -39,7 +39,7 @@ import (
 )
 
 type psOptions struct {
-	*projectOptions
+	*ProjectOptions
 	Format   string
 	All      bool
 	Quiet    bool
@@ -67,9 +67,9 @@ func (p *psOptions) parseFilter() error {
 	return nil
 }
 
-func psCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func psCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := psOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	psCmd := &cobra.Command{
 		Use:   "ps [OPTIONS] [SERVICE...]",

--- a/cmd/compose/ps_test.go
+++ b/cmd/compose/ps_test.go
@@ -71,7 +71,7 @@ func TestPsTable(t *testing.T) {
 			}, nil
 		}).AnyTimes()
 
-	opts := psOptions{projectOptions: &projectOptions{ProjectName: "test"}}
+	opts := psOptions{ProjectOptions: &ProjectOptions{ProjectName: "test"}}
 	err = runPs(ctx, backend, nil, opts)
 	assert.NoError(t, err)
 

--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -30,7 +30,7 @@ import (
 )
 
 type pullOptions struct {
-	*projectOptions
+	*ProjectOptions
 	composeOptions
 	quiet              bool
 	parallel           bool
@@ -39,9 +39,9 @@ type pullOptions struct {
 	ignorePullFailures bool
 }
 
-func pullCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func pullCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := pullOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "pull [OPTIONS] [SERVICE...]",
@@ -84,7 +84,7 @@ func withSelectedServicesOnly(project *types.Project, services []string) error {
 }
 
 func runPull(ctx context.Context, backend api.Service, opts pullOptions, services []string) error {
-	project, err := opts.toProject(services)
+	project, err := opts.ToProject(services)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -25,16 +25,16 @@ import (
 )
 
 type pushOptions struct {
-	*projectOptions
+	*ProjectOptions
 	composeOptions
 	IncludeDeps    bool
 	Ignorefailures bool
 	Quiet          bool
 }
 
-func pushCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func pushCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := pushOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	pushCmd := &cobra.Command{
 		Use:   "push [OPTIONS] [SERVICE...]",
@@ -52,7 +52,7 @@ func pushCommand(p *projectOptions, backend api.Service) *cobra.Command {
 }
 
 func runPush(ctx context.Context, backend api.Service, opts pushOptions, services []string) error {
-	project, err := opts.toProject(services)
+	project, err := opts.ToProject(services)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -24,15 +24,15 @@ import (
 )
 
 type removeOptions struct {
-	*projectOptions
+	*ProjectOptions
 	force   bool
 	stop    bool
 	volumes bool
 }
 
-func removeCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func removeCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := removeOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "rm [OPTIONS] [SERVICE...]",

--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -26,13 +26,13 @@ import (
 )
 
 type restartOptions struct {
-	*projectOptions
+	*ProjectOptions
 	timeout int
 }
 
-func restartCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func restartCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := restartOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	restartCmd := &cobra.Command{
 		Use:   "restart [OPTIONS] [SERVICE...]",

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -108,10 +108,10 @@ func (opts runOptions) apply(project *types.Project) error {
 	return nil
 }
 
-func runCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+func runCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
 	opts := runOptions{
 		composeOptions: &composeOptions{
-			projectOptions: p,
+			ProjectOptions: p,
 		},
 	}
 	createOpts := createOptions{}
@@ -137,7 +137,7 @@ func runCommand(p *projectOptions, dockerCli command.Cli, backend api.Service) *
 			return nil
 		}),
 		RunE: Adapt(func(ctx context.Context, args []string) error {
-			project, err := p.toProject([]string{opts.Service}, cgo.WithResolvedPaths(true))
+			project, err := p.ToProject([]string{opts.Service}, cgo.WithResolvedPaths(true))
 			if err != nil {
 				return err
 			}

--- a/cmd/compose/start.go
+++ b/cmd/compose/start.go
@@ -24,12 +24,12 @@ import (
 )
 
 type startOptions struct {
-	*projectOptions
+	*ProjectOptions
 }
 
-func startCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func startCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := startOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	startCmd := &cobra.Command{
 		Use:   "start [SERVICE...]",

--- a/cmd/compose/stop.go
+++ b/cmd/compose/stop.go
@@ -26,14 +26,14 @@ import (
 )
 
 type stopOptions struct {
-	*projectOptions
+	*ProjectOptions
 	timeChanged bool
 	timeout     int
 }
 
-func stopCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func stopCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := stopOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "stop [OPTIONS] [SERVICE...]",

--- a/cmd/compose/top.go
+++ b/cmd/compose/top.go
@@ -31,12 +31,12 @@ import (
 )
 
 type topOptions struct {
-	*projectOptions
+	*ProjectOptions
 }
 
-func topCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func topCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	opts := topOptions{
-		projectOptions: p,
+		ProjectOptions: p,
 	}
 	topCmd := &cobra.Command{
 		Use:   "top [SERVICES...]",

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -34,7 +34,7 @@ import (
 
 // composeOptions hold options common to `up` and `run` to run compose project
 type composeOptions struct {
-	*projectOptions
+	*ProjectOptions
 }
 
 type upOptions struct {
@@ -87,7 +87,7 @@ func (opts upOptions) apply(project *types.Project, services []string) error {
 	return nil
 }
 
-func upCommand(p *projectOptions, backend api.Service) *cobra.Command {
+func upCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	up := upOptions{}
 	create := createOptions{}
 	upCmd := &cobra.Command{


### PR DESCRIPTION
Signed-off-by: Tiger Wang <tigerwang@outlook.com>

**What I did**

- updated `projectOptions` to be public by renaming it to `ProjectOptions`
- updated `toProject(...)` method of `projectOptions` to be public by renaming it to `ToProject(...)`
- tested all impacted code to make sure they are passing 

**Related issue**

- #10102 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![my cat](https://user-images.githubusercontent.com/7172560/208479067-f3149d22-296c-4f46-95f4-dd78ad3cf4fe.png)

This is my cat - she never shows up and always hide herself somewhere in the house.
