### PR TITLE
fix race condition on compose logs

### DIFF
--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -17,7 +17,6 @@
 package compose
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/docker/compose/v2/pkg/api"
@@ -26,7 +25,7 @@ import (
 // logPrinter watch application containers an collect their logs
 type logPrinter interface {
 	HandleEvent(event api.ContainerEvent)
-	Run(ctx context.Context, cascadeStop bool, exitCodeFrom string, stopFn func() error) (int, error)
+	Run(cascadeStop bool, exitCodeFrom string, stopFn func() error) (int, error)
 	Cancel()
 	Stop()
 }
@@ -64,7 +63,7 @@ func (p *printer) HandleEvent(event api.ContainerEvent) {
 }
 
 //nolint:gocyclo
-func (p *printer) Run(ctx context.Context, cascadeStop bool, exitCodeFrom string, stopFn func() error) (int, error) {
+func (p *printer) Run(cascadeStop bool, exitCodeFrom string, stopFn func() error) (int, error) {
 	var (
 		aborting bool
 		exitCode int
@@ -74,8 +73,6 @@ func (p *printer) Run(ctx context.Context, cascadeStop bool, exitCodeFrom string
 		select {
 		case <-p.stopCh:
 			return exitCode, nil
-		case <-ctx.Done():
-			return exitCode, ctx.Err()
 		case event := <-p.queue:
 			container := event.Container
 			switch event.Type {

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -81,7 +81,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	var exitCode int
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		code, err := printer.Run(context.Background(), options.Start.CascadeStop, options.Start.ExitCodeFrom, stopFunc)
+		code, err := printer.Run(options.Start.CascadeStop, options.Start.ExitCodeFrom, stopFunc)
 		exitCode = code
 		return err
 	})


### PR DESCRIPTION
**What I did**
- printer MUST run before it can handle `ContainerEventAttach` events. So we MUST start goroutine first
- prefer an explicit call to `printer.Stop()` to avoid potential race condition if another goroutine tries to send last log event to the printer after context has been canceled

**Related issue**
https://github.com/docker/compose/issues/8880 reported to not be fixed might be related

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/208618654-9688acbf-d4bb-4e1d-b03e-cc51195b5c6c.png)
