### PR TITLE
don't fail `logs` when driver:none is set

### DIFF
--- a/pkg/e2e/fixtures/logs-test/restart.yaml
+++ b/pkg/e2e/fixtures/logs-test/restart.yaml
@@ -1,0 +1,5 @@
+services:
+  ping:
+    image: alpine
+    command: "sh -c 'ping -c 1 localhost && exit 1'"
+    restart: "on-failure:2"

--- a/pkg/e2e/logs_test.go
+++ b/pkg/e2e/logs_test.go
@@ -56,3 +56,22 @@ func TestLocalComposeLogs(t *testing.T) {
 		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 	})
 }
+
+func TestLocalComposeLogsFollow(t *testing.T) {
+	c := NewParallelCLI(t)
+
+	const projectName = "compose-e2e-logs-restart"
+
+	t.Run("up", func(t *testing.T) {
+		c.RunDockerComposeCmd(t, "-f", "./fixtures/logs-test/restart.yaml", "--project-name", projectName, "up", "-d")
+	})
+
+	t.Run("logs", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "logs", "--follow")
+		assert.Check(t, strings.Count(res.Combined(), "PING localhost (127.0.0.1)") == 2)
+	})
+
+	t.Run("down", func(t *testing.T) {
+		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	})
+}


### PR DESCRIPTION
**What I did**
detect engine response requesting container logs as `ErrNotImplemented` when logging driver is configured to `none`. This should not fail the command, just show a warning

bonus:
- configure `logContainers` to collect logs _after_ last watch event, so we don't get previous logs repeated after a container restart.
- detect container will restart using container inspect's `Restarting` attribute (not sure why we didn't used this before?)
- thanks to ^ `logs` can now detect container will not restart and then exits
- introduced an e2e test to cover `--follow`

**Related issue**
fixes: https://github.com/docker/compose/issues/9030

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/208683036-f478b140-bd2a-4db4-a1cd-95cf93b3c5a2.png)
