### PR TITLE
service hash MUST exclude replicas

### DIFF
--- a/pkg/compose/hash_test.go
+++ b/pkg/compose/hash_test.go
@@ -17,25 +17,27 @@
 package compose
 
 import (
-	"encoding/json"
+	"testing"
 
 	"github.com/compose-spec/compose-go/types"
-	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
 )
 
-// ServiceHash computes the configuration hash for a service.
-func ServiceHash(o types.ServiceConfig) (string, error) {
-	// remove the Build config when generating the service hash
-	o.Build = nil
-	o.PullPolicy = ""
-	o.Scale = 1
-	if o.Deploy != nil {
-		var one uint64 = 1
-		o.Deploy.Replicas = &one
+func TestServiceHash(t *testing.T) {
+	hash1, err := ServiceHash(serviceConfig(1))
+	assert.NilError(t, err)
+	hash2, err := ServiceHash(serviceConfig(2))
+	assert.NilError(t, err)
+	assert.Equal(t, hash1, hash2)
+}
+
+func serviceConfig(replicas uint64) types.ServiceConfig {
+	return types.ServiceConfig{
+		Scale: int(replicas),
+		Deploy: &types.DeployConfig{
+			Replicas: &replicas,
+		},
+		Name:  "foo",
+		Image: "bar",
 	}
-	bytes, err := json.Marshal(o)
-	if err != nil {
-		return "", err
-	}
-	return digest.SHA256.FromBytes(bytes).Encoded(), nil
 }

--- a/pkg/e2e/fixtures/logs-test/restart.yaml
+++ b/pkg/e2e/fixtures/logs-test/restart.yaml
@@ -1,5 +1,5 @@
 services:
   ping:
     image: alpine
-    command: "sh -c 'ping -c 1 localhost && exit 1'"
+    command: "sh -c 'ping -c 2 localhost && exit 1'"
     restart: "on-failure:2"

--- a/pkg/e2e/logs_test.go
+++ b/pkg/e2e/logs_test.go
@@ -56,22 +56,3 @@ func TestLocalComposeLogs(t *testing.T) {
 		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 	})
 }
-
-func TestLocalComposeLogsFollow(t *testing.T) {
-	c := NewParallelCLI(t)
-
-	const projectName = "compose-e2e-logs-restart"
-
-	t.Run("up", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/logs-test/restart.yaml", "--project-name", projectName, "up", "-d")
-	})
-
-	t.Run("logs", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "logs", "--follow")
-		assert.Check(t, strings.Count(res.Combined(), "PING localhost (127.0.0.1)") == 2, res.Combined())
-	})
-
-	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
-	})
-}


### PR DESCRIPTION
**What I did**
fix service hash computation to exclude deploy.replicas

**Related issue**
closes https://github.com/docker/compose/issues/10077

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/208729493-514d3b92-f0c7-4bba-9814-8e8022abce13.png)
