### PR TITLE
check service names based on project, not running containers

### DIFF
--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -96,6 +96,16 @@ func runPs(ctx context.Context, streams api.Streams, backend api.Service, servic
 	if err != nil {
 		return err
 	}
+
+	if project != nil && len(services) > 0 {
+		names := project.ServiceNames()
+		for _, service := range services {
+			if !utils.StringContains(names, service) {
+				return fmt.Errorf("no such service: %s", service)
+			}
+		}
+	}
+
 	containers, err := backend.Ps(ctx, name, api.PsOptions{
 		Project:  project,
 		All:      opts.All,
@@ -103,16 +113,6 @@ func runPs(ctx context.Context, streams api.Streams, backend api.Service, servic
 	})
 	if err != nil {
 		return err
-	}
-
-SERVICES:
-	for _, s := range services {
-		for _, c := range containers {
-			if c.Service == s {
-				continue SERVICES
-			}
-		}
-		return fmt.Errorf("no such service: %s", s)
 	}
 
 	if len(opts.Status) != 0 {

--- a/pkg/e2e/ps_test.go
+++ b/pkg/e2e/ps_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/icmd"
 
 	"github.com/docker/compose/v2/pkg/api"
 )
@@ -108,4 +109,14 @@ func TestPs(t *testing.T) {
 		assert.Equal(t, 4, len(lines))
 	})
 
+	t.Run("ps unknown", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "stop")
+		assert.NoError(t, res.Error)
+
+		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps", "nginx")
+		res.Assert(t, icmd.Success)
+
+		res = c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/ps-test/compose.yaml", "--project-name", projectName, "ps", "unknown")
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: "no such service: unknown"})
+	})
 }


### PR DESCRIPTION
**What I did**
listed container might not include the requested service. Then the error message "no such service" is wrong.

**Related issue**
closes https://github.com/docker/compose/issues/9951

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
