### PR TITLE
add support of privileged attribut in service.build section

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -30,6 +30,7 @@ import (
 	buildx "github.com/docker/buildx/build"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command/image/build"
+	"github.com/docker/compose/v2/pkg/utils"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder/remotecontext/urlutil"
 	"github.com/docker/docker/pkg/archive"
@@ -38,6 +39,7 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/hashicorp/go-multierror"
+	"github.com/moby/buildkit/util/entitlements"
 	"github.com/pkg/errors"
 
 	"github.com/docker/compose/v2/pkg/api"
@@ -91,6 +93,9 @@ func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options 
 
 	if len(options.Platforms) > 1 {
 		return "", errors.Errorf("this builder doesn't support multi-arch build, set DOCKER_BUILDKIT=1 to use multi-arch builder")
+	}
+	if utils.Contains(options.Allow, entitlements.EntitlementSecurityInsecure) {
+		return "", errors.Errorf("this builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use builder supporting privileged mode")
 	}
 
 	if options.Labels == nil {

--- a/pkg/e2e/fixtures/build-test/privileged/Dockerfile
+++ b/pkg/e2e/fixtures/build-test/privileged/Dockerfile
@@ -1,0 +1,19 @@
+# syntax = docker/dockerfile:experimental
+
+
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM alpine
+RUN --security=insecure cat /proc/self/status | grep CapEff

--- a/pkg/e2e/fixtures/build-test/privileged/compose.yaml
+++ b/pkg/e2e/fixtures/build-test/privileged/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  privileged-service:
+    build:
+      context: .
+      privileged: true


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Add support of `service.build.privileged` attribut recently added in Compose Specification

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/208869657-d97cc7d8-4667-4a07-b632-87bb7640bcfd.png)
