### PR TITLE
add buildx plugin to e2e configuration directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq ($(DETECTED_OS),Windows)
 endif
 
 TEST_COVERAGE_FLAGS = -race -coverprofile=coverage.out -covermode=atomic
-TEST_FLAGS?= -timeout 15m
+TEST_FLAGS?=
 E2E_TEST?=
 ifeq ($(E2E_TEST),)
 else

--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,10 @@ install: binary
 
 .PHONY: e2e-compose
 e2e-compose: ## Run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
-	docker compose version
 	go test $(TEST_FLAGS) $(TEST_COVERAGE_FLAGS) -count=1 ./pkg/e2e
 
 .PHONY: e2e-compose-standalone
 e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test
-	docker-compose version
 	go test $(TEST_FLAGS) -v -count=1 -parallel=1 --tags=standalone ./pkg/e2e
 
 .PHONY: build-and-e2e-compose

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -134,8 +134,8 @@ func initializePlugins(t testing.TB, configDir string) {
 	require.NoError(t, os.MkdirAll(filepath.Join(configDir, "cli-plugins"), 0o755),
 		"Failed to create cli-plugins directory")
 	composePlugin, err := findExecutable(DockerComposeExecutableName)
-	if os.IsNotExist(err) {
-		t.Logf("WARNING: docker-compose cli-plugin not found")
+	if err != nil {
+		t.Errorf("WARNING: docker-compose cli-plugin not found %s", err.Error())
 	}
 	buildxPlugin, err := findPluginExecutable(DockerBuildxExecutableName)
 	if os.IsNotExist(err) {
@@ -159,8 +159,11 @@ func dirContents(dir string) []string {
 }
 
 func findExecutable(executableName string) (string, error) {
-	_, filename, _, _ := runtime.Caller(0)
-	root := filepath.Join(filepath.Dir(filename), "..", "..")
+	filename, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	root := filepath.Join(filepath.Dir(filename), "..")
 	buildPath := filepath.Join(root, "bin", "build")
 
 	bin, err := filepath.Abs(filepath.Join(buildPath, executableName))

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -103,7 +103,7 @@ func NewCLI(t testing.TB, opts ...CLIOption) *CLI {
 	for _, opt := range opts {
 		opt(c)
 	}
-
+	t.Log(c.RunDockerComposeCmdNoCheck(t, "version").Combined())
 	return c
 }
 


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
We can't run locally e2e tests which need to configure buildx builder. I added a function to copy a specific CLI plugin to the e2e configuration directory and be sure the plugin will be available to run tests

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/208927455-5a70e08f-04d7-4eff-bc75-5b5fb195345d.png)
