### PR TITLE
cleanup framework.go from uncessary debug logs

### DIFF
--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -133,9 +133,9 @@ func initializePlugins(t testing.TB, configDir string) {
 
 	require.NoError(t, os.MkdirAll(filepath.Join(configDir, "cli-plugins"), 0o755),
 		"Failed to create cli-plugins directory")
-	composePlugin, err := findExecutable(t, DockerComposeExecutableName)
-	if err != nil {
-		t.Errorf("WARNING: docker-compose cli-plugin not found %s", err.Error())
+	composePlugin, err := findExecutable(DockerComposeExecutableName)
+	if os.IsNotExist(err) {
+		t.Logf("WARNING: docker-compose cli-plugin not found")
 	}
 
 	if err == nil {
@@ -160,24 +160,16 @@ func dirContents(dir string) []string {
 	return res
 }
 
-func findExecutable(t testing.TB, executableName string) (string, error) {
-	filename, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	t.Logf("Current dir %s", filename)
-	root := filepath.Join(filepath.Dir(filename), "..")
-	t.Logf("Root dir %s", root)
-
+func findExecutable(executableName string) (string, error) {
+	_, filename, _, _ := runtime.Caller(0)
+	root := filepath.Join(filepath.Dir(filename), "..", "..")
 	buildPath := filepath.Join(root, "bin", "build")
 
 	bin, err := filepath.Abs(filepath.Join(buildPath, executableName))
 	if err != nil {
-		t.Errorf("Error finding compose binary %s", err.Error())
 		return "", err
 	}
 
-	t.Logf("binary path %s", bin)
 	if _, err := os.Stat(bin); err == nil {
 		return bin, nil
 	}
@@ -204,28 +196,19 @@ func findPluginExecutable(pluginExecutableName string) (string, error) {
 // CopyFile copies a file from a sourceFile to a destinationFile setting permissions to 0755
 func CopyFile(t testing.TB, sourceFile string, destinationFile string) {
 	t.Helper()
-	t.Logf("copy %s to %s", sourceFile, destinationFile)
 
 	src, err := os.Open(sourceFile)
 	require.NoError(t, err, "Failed to open source file: %s")
 	//nolint:errcheck
 	defer src.Close()
-	t.Logf("Source file opened %s ", src.Name())
 
 	dst, err := os.OpenFile(destinationFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
 	require.NoError(t, err, "Failed to open destination file: %s", destinationFile)
 	//nolint:errcheck
 	defer dst.Close()
-	t.Logf("Destination file opened %s ", dst.Name())
 
 	_, err = io.Copy(dst, src)
 	require.NoError(t, err, "Failed to copy file: %s", sourceFile)
-	t.Logf("File copied?  %s ", err)
-	fileStat, err := dst.Stat()
-	if err != nil {
-		t.Logf("Can't get file stat %s ", err)
-	}
-	t.Logf("File stat: %+v", fileStat)
 }
 
 // BaseEnvironment provides the minimal environment variables used across all
@@ -346,7 +329,7 @@ func ComposeStandalonePath(t testing.TB) string {
 	if !composeStandaloneMode {
 		require.Fail(t, "Not running in standalone mode")
 	}
-	composeBinary, err := findExecutable(t, DockerComposeExecutableName)
+	composeBinary, err := findExecutable(DockerComposeExecutableName)
 	require.NoError(t, err, "Could not find standalone Compose binary (%q)",
 		DockerComposeExecutableName)
 	return composeBinary


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Clean my mess, I was debugging a previous PR and forgot that auto-merge was enabled

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/208996712-ea96d9e6-84ab-4e96-ad80-1e8b3054be2f.png)
