### PR TITLE
Coverage unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    env:
-      DESTDIR: "./bin/build"
     strategy:
       fail-fast: false
       matrix:
@@ -185,7 +183,7 @@ jobs:
         if: ${{ matrix.mode == 'standalone' }}
         run: |
           rm -f /usr/local/bin/docker-compose
-          cp bin/build/docker-compose /usr/local/bin
+          cp ${{ env.DESTDIR }}/build/docker-compose /usr/local/bin
           make e2e-compose-standalone
 
   release:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,12 +26,9 @@ variable "DOCS_FORMATS" {
 
 # Defines the output folder
 variable "DESTDIR" {
-  default = ""
+  default = "./bin"
 }
-function "bindir" {
-  params = [defaultdir]
-  result = DESTDIR != "" ? DESTDIR : "./bin/${defaultdir}"
-}
+
 
 target "_common" {
   args = {
@@ -80,13 +77,13 @@ target "vendor-update" {
 target "test" {
   inherits = ["_common"]
   target = "test-coverage"
-  output = [bindir("coverage")]
+  output = ["${DESTDIR}/coverage"]
 }
 
 target "binary" {
   inherits = ["_common"]
   target = "binary"
-  output = [bindir("build")]
+  output = ["${DESTDIR}/build"]
   platforms = ["local"]
 }
 
@@ -110,7 +107,7 @@ target "binary-cross" {
 target "release" {
   inherits = ["binary-cross"]
   target = "release"
-  output = [bindir("release")]
+  output = ["${DESTDIR}/release"]
 }
 
 target "docs-validate" {


### PR DESCRIPTION
we can't mesure our test coverage with e2e tests as they're using a built Compose binary and not source code directly

Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
Attach code coverage report to our unit tests as we're using a Compose binary and not source when running e2e tests.
We're just monitoring `assert.go` and `framework.go` files 😞 

<img width="1602" alt="Screenshot 2022-12-22 at 11 12 47" src="https://user-images.githubusercontent.com/705411/209111484-a3d3dd63-7aea-46b4-920b-dc361082103a.png">


Changes have been done to be aligned with `buildx` CI

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/209111041-dfa10c67-fd15-4869-b0cd-e589f3cb1c06.png)
