### PR TITLE
Fix Cucumber 🥒 tests

### DIFF
--- a/e2e/cucumber-features/simple.feature
+++ b/e2e/cucumber-features/simple.feature
@@ -12,4 +12,4 @@ Background:
 Scenario: compose up
     When I run "compose up -d"
     Then the output contains "simple-1  Started"
-    And service "simple" is "running"
+    And service "simple" is "Up"

--- a/e2e/cucumber-features/start.feature
+++ b/e2e/cucumber-features/start.feature
@@ -17,5 +17,5 @@ Scenario: Start single service
     Then the output contains "simple-1  Created"
     And the output contains "another-1  Created"
     Then I run "compose start another"
-    And service "another" is "running"
-    And service "simple" is "created"
+    And service "another" is "Up"
+    And service "simple" is "Created"


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Update Cucumber tests expected `compose ps` output to match new changes.

(fixing these so I can make a follow up PR to add a GHA for 🥒 tests)

Run them with `go test -v ./e2e`

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![maxresdefault](https://user-images.githubusercontent.com/70572044/209664624-068321e5-b2f3-49e4-a65d-e24909eb7d21.jpg)
