### PR TITLE
Set `pullChanged` when setting `--pull` on `compose up`

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -93,6 +93,7 @@ func upCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *cob
 		Use:   "up [OPTIONS] [SERVICE...]",
 		Short: "Create and start containers",
 		PreRunE: AdaptCmd(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+			create.pullChanged = cmd.Flags().Changed("pull")
 			create.timeChanged = cmd.Flags().Changed("timeout")
 			return validateFlags(&up, &create)
 		}),

--- a/e2e/cucumber-features/up.feature
+++ b/e2e/cucumber-features/up.feature
@@ -1,0 +1,15 @@
+Feature: Up
+
+Background:
+    Given a compose file
+        """
+        services:
+          simple:
+            image: alpine
+            command: top
+        """
+
+Scenario: --pull always
+    When I run "compose up --pull=always -d"
+    Then the output contains "simple Pulled"
+


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Fixed issue where setting `--pull=always|never|missing` on `compose up` had no effect due to the changed flag not being set.

Also added e2e tests for this scenario.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

fixes https://github.com/docker/compose/issues/10125

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![360_F_203318225_LfINEv5hni0kUNGWeus9VBrxg4Eg21dD](https://user-images.githubusercontent.com/70572044/209958989-ebd7b6b0-aec6-4d13-b327-18a2107f5538.jpg)
