### PR TITLE
Fix empty file when using compose config in case of smaller source files

### DIFF
--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -17,11 +17,9 @@
 package compose
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"sort"
 	"strings"
@@ -139,15 +137,10 @@ func runConvert(ctx context.Context, streams api.Streams, backend api.Service, o
 		return nil
 	}
 
-	var out io.Writer = streams.Out()
 	if opts.Output != "" && len(content) > 0 {
-		file, err := os.Create(opts.Output)
-		if err != nil {
-			return err
-		}
-		out = bufio.NewWriter(file)
+		return os.WriteFile(opts.Output, content, 0o666)
 	}
-	_, err = fmt.Fprint(out, string(content))
+	_, err = fmt.Fprint(streams.Out(), string(content))
 	return err
 }
 


### PR DESCRIPTION
"docker compose config --output out.yml" resulted an empty file when the generated output was smaller than 4097 bytes. bufio.Writer doesn't seem necessary since only one write operation will happen. This way there is no need for a new bufio.Writer that could be flushed.

**What I did**

First I replaced `bufio.NewWriter(file)` with `io.Writer(file)`, then based on suggestion of @thaJeztah I replaced the whole conditional file writing with a simple `io.WriteFile`.  See the related issue for my previous ideas.

**Related issue**
closes https://github.com/docker/compose/issues/10121

