### PR TITLE
limit build concurrency according to --parallel

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -323,6 +324,13 @@ func RootCommand(streams api.Streams, backend api.Service) *cobra.Command { //no
 				if err != nil {
 					return err
 				}
+			}
+			if v, ok := os.LookupEnv("COMPOSE_PARALLEL_LIMIT"); ok && !cmd.Flags().Changed("parallel") {
+				i, err := strconv.Atoi(v)
+				if err != nil {
+					return fmt.Errorf("COMPOSE_PARALLEL_LIMIT must be an integer (found: %q)", v)
+				}
+				parallel = i
 			}
 			if parallel > 0 {
 				backend.MaxConcurrency(parallel)


### PR DESCRIPTION
**What I did**
This run the image build process on a per-service basis with concurrency constrained according to `--parallel` flag
- this allows to limit concurrent builds (https://github.com/docker/compose/issues/9091)
- this allow to control build oder based on `depends_on` directive - could be interesting to investigate a new depends_on condition `build` to offer fine tuning for this use-case. Can be used to offer a workaround on https://github.com/docker/compose/issues/8538

**Related issue**
closes https://github.com/docker/compose/issues/9091

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/210328323-67510b1f-ee90-4aae-9f56-aca535995110.png)
