### PR TITLE
introduce `--ignore-buildable` to ignore buildable images on pull

### DIFF
--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -37,6 +37,7 @@ type pullOptions struct {
 	noParallel         bool
 	includeDeps        bool
 	ignorePullFailures bool
+	noBuildable        bool
 }
 
 func pullCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
@@ -58,13 +59,14 @@ func pullCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 		ValidArgsFunction: completeServiceNames(p),
 	}
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Pull without printing progress information")
-	cmd.Flags().BoolVar(&opts.includeDeps, "include-deps", false, "Also pull services declared as dependencies")
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Pull without printing progress information.")
+	cmd.Flags().BoolVar(&opts.includeDeps, "include-deps", false, "Also pull services declared as dependencies.")
 	cmd.Flags().BoolVar(&opts.parallel, "parallel", true, "DEPRECATED pull multiple images in parallel.")
 	flags.MarkHidden("parallel") //nolint:errcheck
 	cmd.Flags().BoolVar(&opts.parallel, "no-parallel", true, "DEPRECATED disable parallel pulling.")
 	flags.MarkHidden("no-parallel") //nolint:errcheck
-	cmd.Flags().BoolVar(&opts.ignorePullFailures, "ignore-pull-failures", false, "Pull what it can and ignores images with pull failures")
+	cmd.Flags().BoolVar(&opts.ignorePullFailures, "ignore-pull-failures", false, "Pull what it can and ignores images with pull failures.")
+	cmd.Flags().BoolVar(&opts.noBuildable, "ignore-buildable", false, "Ignore images that can be built.")
 	return cmd
 }
 
@@ -97,7 +99,8 @@ func runPull(ctx context.Context, backend api.Service, opts pullOptions, service
 	}
 
 	return backend.Pull(ctx, project, api.PullOptions{
-		Quiet:          opts.quiet,
-		IgnoreFailures: opts.ignorePullFailures,
+		Quiet:           opts.quiet,
+		IgnoreFailures:  opts.ignorePullFailures,
+		IgnoreBuildable: opts.noBuildable,
 	})
 }

--- a/docs/reference/compose_pull.md
+++ b/docs/reference/compose_pull.md
@@ -5,11 +5,12 @@ Pull service images
 
 ### Options
 
-| Name                     | Type | Default | Description                                            |
-|:-------------------------|:-----|:--------|:-------------------------------------------------------|
-| `--ignore-pull-failures` |      |         | Pull what it can and ignores images with pull failures |
-| `--include-deps`         |      |         | Also pull services declared as dependencies            |
-| `-q`, `--quiet`          |      |         | Pull without printing progress information             |
+| Name                     | Type | Default | Description                                             |
+|:-------------------------|:-----|:--------|:--------------------------------------------------------|
+| `--ignore-buildable`     |      |         | Ignore images that can be built.                        |
+| `--ignore-pull-failures` |      |         | Pull what it can and ignores images with pull failures. |
+| `--include-deps`         |      |         | Also pull services declared as dependencies.            |
+| `-q`, `--quiet`          |      |         | Pull without printing progress information.             |
 
 
 <!---MARKER_GEN_END-->
@@ -62,3 +63,6 @@ $ docker compose pull db
    ⠹ 77a0c198cde5 Waiting                                                  9.3s
    ⠹ c8752d5b785c Waiting                                                  9.3s
 ```
+
+`docker compose pull` will try to pull image for services with a build section. If pull fails, it will let
+user know this service image MUST be built. You can skip this by setting `--ignore-buildable` flag

--- a/docs/reference/docker_compose_pull.yaml
+++ b/docs/reference/docker_compose_pull.yaml
@@ -7,10 +7,20 @@ usage: docker compose pull [OPTIONS] [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
+    - option: ignore-buildable
+      value_type: bool
+      default_value: "false"
+      description: Ignore images that can be built.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: ignore-pull-failures
       value_type: bool
       default_value: "false"
-      description: Pull what it can and ignores images with pull failures
+      description: Pull what it can and ignores images with pull failures.
       deprecated: false
       hidden: false
       experimental: false
@@ -20,7 +30,7 @@ options:
     - option: include-deps
       value_type: bool
       default_value: "false"
-      description: Also pull services declared as dependencies
+      description: Also pull services declared as dependencies.
       deprecated: false
       hidden: false
       experimental: false
@@ -51,7 +61,7 @@ options:
       shorthand: q
       value_type: bool
       default_value: "false"
-      description: Pull without printing progress information
+      description: Pull without printing progress information.
       deprecated: false
       hidden: false
       experimental: false
@@ -99,6 +109,9 @@ examples: |-
        ⠹ 77a0c198cde5 Waiting                                                  9.3s
        ⠹ c8752d5b785c Waiting                                                  9.3s
     ```
+
+    `docker compose pull` will try to pull image for services with a build section. If pull fails, it will let
+    user know this service image MUST be built. You can skip this by setting `--ignore-buildable` flag
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -193,8 +193,9 @@ type PushOptions struct {
 
 // PullOptions group options of the Pull API
 type PullOptions struct {
-	Quiet          bool
-	IgnoreFailures bool
+	Quiet           bool
+	IgnoreFailures  bool
+	IgnoreBuildable bool
 }
 
 // ImagesOptions group options of the Images API

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -102,6 +102,15 @@ func (s *composeService) pull(ctx context.Context, project *types.Project, opts 
 			}
 		}
 
+		if service.Build != nil && opts.IgnoreBuildable {
+			w.Event(progress.Event{
+				ID:     service.Name,
+				Status: progress.Done,
+				Text:   "Skipped - Image can be built",
+			})
+			continue
+		}
+
 		if s, ok := imagesBeingPulled[service.Image]; ok {
 			w.Event(progress.Event{
 				ID:     service.Name,


### PR DESCRIPTION
**What I did**
`docker compose pull --ignore-buildable` will only pull images which have no `build` section.

**Related issue**
closes https://github.com/docker/compose/issues/8805

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/210334905-665bf506-a69f-4eab-8947-49226d9f3234.png)
