### PR TITLE
fix: remove invalid cache-from registry entries

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -72,12 +72,6 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		if err != nil {
 			return err
 		}
-		for _, image := range service.Build.CacheFrom {
-			buildOptions.CacheFrom = append(buildOptions.CacheFrom, bclient.CacheOptionsEntry{
-				Type:  "registry",
-				Attrs: map[string]string{"ref": image},
-			})
-		}
 		buildOptions.Exports = []bclient.ExportEntry{{
 			Type: "docker",
 			Attrs: map[string]string{


### PR DESCRIPTION
**What I did**

When specifying:

```
cache_from:
  - type=gha
```

docker compose currently translates this into `--cache-from type=gha --cache-from type=registry,ref=type=gha`, which causes a warning.

This PR removes the explicit addition of `type=registry`, which shouldn't be necessary as the cache flag parsing handles this case already https://github.com/docker/buildx/blob/25ceb9067893be764f9ab439722835eece2fe169/util/buildflags/cache.go#L22

This code was originally added in https://github.com/docker/compose/commit/70694e12a2f266d6122e90bea4299c08eec003be, but I couldn't find any mention why it would be necessary.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://user-images.githubusercontent.com/864578/210334867-871127b8-cc76-4f57-891e-201c5f778597.png)
