### PR TITLE
Ignore not only auto-removed containers but also "removal in progress" for orphan containers

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -274,7 +274,7 @@ func (s *composeService) removeContainers(ctx context.Context, w progress.Writer
 				Force:         true,
 				RemoveVolumes: volumes,
 			})
-			if err != nil && !errdefs.IsNotFound(err) {
+			if err != nil && !errdefs.IsNotFound(err) && !errdefs.IsConflict(err) {
 				w.Event(progress.ErrorMessageEvent(eventName, "Error while Removing"))
 				return err
 			}


### PR DESCRIPTION


Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

Ignore not only "not found" errors but also "conflict" raised when a removal is already in progress (cf https://github.com/moby/moby/blob/master/errdefs/helpers.go#L62)

I came across this race condition with an extension that creates several orphan containers in a compose stack, some where happily removed (removal happened before compose tried to delete them), some failed (not always the same ones) with `Error while Removing Error response from daemon: removal of container e7618297f985543d4df534179a843a9aa474645d6b7d6f436ce3568c592692bc is already in progress`

**Related issue**
This should improve https://github.com/docker/compose/pull/9896
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://c4.wallpaperflare.com/wallpaper/272/612/999/snail-race-wallpaper-preview.jpg)