### PR TITLE
introduce --no-attach to ignore some service output

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -48,6 +48,7 @@ type upOptions struct {
 	noPrefix           bool
 	attachDependencies bool
 	attach             []string
+	noAttach           []string
 	timestamp          bool
 	wait               bool
 }
@@ -128,6 +129,7 @@ func upCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *cob
 	flags.BoolVar(&up.attachDependencies, "attach-dependencies", false, "Attach to dependent containers.")
 	flags.BoolVar(&create.quietPull, "quiet-pull", false, "Pull without printing progress information.")
 	flags.StringArrayVar(&up.attach, "attach", []string{}, "Attach to service output.")
+	flags.StringArrayVar(&up.noAttach, "no-attach", []string{}, "Don't attach to specified service.")
 	flags.BoolVar(&up.wait, "wait", false, "Wait for services to be running|healthy. Implies detached mode.")
 
 	return upCmd
@@ -185,6 +187,7 @@ func runUp(ctx context.Context, streams api.Streams, backend api.Service, create
 	if len(attachTo) == 0 {
 		attachTo = project.ServiceNames()
 	}
+	attachTo = utils.RemoveAll(attachTo, upOptions.noAttach)
 
 	create := api.CreateOptions{
 		Services:             services,

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -15,6 +15,7 @@ Create and start containers
 | `-d`, `--detach`             |               |           | Detached mode: Run containers in the background                                                          |
 | `--exit-code-from`           | `string`      |           | Return the exit code of the selected service container. Implies --abort-on-container-exit                |
 | `--force-recreate`           |               |           | Recreate containers even if their configuration and image haven't changed.                               |
+| `--no-attach`                | `stringArray` |           | Don't attach to specified service.                                                                       |
 | `--no-build`                 |               |           | Don't build an image, even if it's missing.                                                              |
 | `--no-color`                 |               |           | Produce monochrome output.                                                                               |
 | `--no-deps`                  |               |           | Don't start linked services.                                                                             |
@@ -40,6 +41,9 @@ Builds, (re)creates, starts, and attaches to containers for a service.
 Unless they are already running, this command also starts any linked services.
 
 The `docker compose up` command aggregates the output of each container (like `docker compose logs --follow` does).
+One can optionally select a subset of services to attach to using `--attach` flag, or exclude some services using 
+`--no-attach` to prevent output to be flooded by some verbose services. 
+
 When the command exits, all containers are stopped. Running `docker compose up --detach` starts the containers in the
 background and leaves them running.
 

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -6,6 +6,9 @@ long: |-
     Unless they are already running, this command also starts any linked services.
 
     The `docker compose up` command aggregates the output of each container (like `docker compose logs --follow` does).
+    One can optionally select a subset of services to attach to using `--attach` flag, or exclude some services using
+    `--no-attach` to prevent output to be flooded by some verbose services.
+
     When the command exits, all containers are stopped. Running `docker compose up --detach` starts the containers in the
     background and leaves them running.
 
@@ -98,6 +101,16 @@ options:
       default_value: "false"
       description: |
         Recreate containers even if their configuration and image haven't changed.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: no-attach
+      value_type: stringArray
+      default_value: '[]'
+      description: Don't attach to specified service.
       deprecated: false
       hidden: false
       experimental: false

--- a/pkg/utils/slices.go
+++ b/pkg/utils/slices.go
@@ -28,3 +28,14 @@ func Contains[T any](origin []T, element T) bool {
 	}
 	return false
 }
+
+// RemoveAll removes all elements from origin slice
+func RemoveAll[T any](origin []T, elements []T) []T {
+	var filtered []T
+	for _, v := range origin {
+		if !Contains(elements, v) {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
**What I did**
complimentary to `up --attach` used to opt-in for services to collect output, introduce `--no-attach` to opt-out for verbose services user don't want to listen to

**Related issue**
closes https://github.com/docker/compose/issues/8546

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/210378466-e1e7ead6-6cff-4286-891a-0306b9b97a04.png)
