### PR TITLE
introduce ConvergenceResult and use it to also stop dependencies

### DIFF
--- a/pkg/compose/convergenceResult.go
+++ b/pkg/compose/convergenceResult.go
@@ -1,0 +1,70 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"github.com/docker/compose/v2/pkg/api"
+	"github.com/docker/compose/v2/pkg/utils"
+	"github.com/docker/docker/api/types"
+)
+
+// ConvergenceResult tracks operations applied to containers during a convergence execution
+type ConvergenceResult struct {
+	containers Containers
+	operations map[string]int
+}
+
+const (
+	containerCreated = iota
+	containerRecreated
+	containerStarted
+	containerRemoved
+)
+
+func newConvergenceResult() *ConvergenceResult {
+	return &ConvergenceResult{
+		operations: map[string]int{},
+	}
+}
+
+func (r *ConvergenceResult) add(c types.Container, op int) {
+	r.containers = append(r.containers, c)
+	r.operations[c.ID] = op
+}
+
+func (r *ConvergenceResult) addAll(o *ConvergenceResult) {
+	for _, c := range o.containers {
+		r.containers = append(r.containers, c)
+		r.operations[c.ID] = o.operations[c.ID]
+	}
+}
+
+// upServices collects services which have been started or created (i.e switched from "down" to "up" state)
+// this excludes services which where already running, even if those have been updated/scaled
+func (r *ConvergenceResult) upServices() []string {
+	created := utils.Set[string]{}
+	for _, container := range r.containers {
+		op := r.operations[container.ID]
+		switch op {
+		case containerCreated, containerStarted:
+			created.Add(container.Labels[api.ServiceLabel])
+		case containerRecreated:
+			created.Remove(container.Labels[api.ServiceLabel])
+		}
+	}
+	return created.Values()
+}

--- a/pkg/e2e/fixtures/abort/compose.yaml
+++ b/pkg/e2e/fixtures/abort/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  backend:
+    image: nginx:alpine
+
+  test:
+    image: alpine
+    command: /bin/true
+    links:
+      - backend

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -138,3 +138,19 @@ func TestUpWithDependencyExit(t *testing.T) {
 		res.Assert(t, icmd.Expected{ExitCode: 1, Err: "dependency failed to start: container for service \"db\" exited (1)"})
 	})
 }
+
+func TestExitRemovesDependencies(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-removes-dependencies"
+
+	t.Run("up with dependency to remove dependencies on exit", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "fixtures/abort/compose.yaml", "--project-name", projectName,
+			"up", "--abort-on-container-exit", "test")
+
+		t.Cleanup(func() {
+			c.RunDockerComposeCmd(t, "--project-name", "dependencies", "down")
+		})
+
+		res.Assert(t, icmd.Expected{Err: "Container e2e-removes-dependencies-test-1  Stopped"})
+	})
+}

--- a/pkg/utils/set.go
+++ b/pkg/utils/set.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+type Set[T comparable] map[T]struct{}
+
+func (s Set[T]) Add(t T) {
+	s[t] = struct{}{}
+}
+
+func (s Set[T]) Remove(t T) {
+	delete(s, t)
+}
+
+func (s Set[T]) Values() []T {
+	v := make([]T, 0, len(s))
+	for k := range s {
+		v = append(v, k)
+	}
+	return v
+}

--- a/pkg/utils/slices.go
+++ b/pkg/utils/slices.go
@@ -29,6 +29,14 @@ func Contains[T any](origin []T, element T) bool {
 	return false
 }
 
+// Append adds element to a slice if not already present
+func Append[T any](origin []T, element T) []T {
+	if !Contains(origin, element) {
+		origin = append(origin, element)
+	}
+	return origin
+}
+
 // RemoveAll removes all elements from origin slice
 func RemoveAll[T any](origin []T, elements []T) []T {
 	var filtered []T


### PR DESCRIPTION
**What I did**
introduced `ConvergenceResult` to track all operations we applied on containers during convergence
This allows to track services we started by dependency, and should be stopped when we abort the app

**Related issue**
closes https://github.com/docker/compose/issues/3909

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/210751459-79e4cf6b-44a5-4cd1-a285-8220987f8abf.png)
