### PR TITLE
use a simpler prompt implementation when we lack a terminal

### DIFF
--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -61,7 +61,7 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 	if options.Force {
 		fmt.Fprintln(s.stdout(), msg)
 	} else {
-		confirm, err := prompt.User{}.Confirm(msg, false)
+		confirm, err := prompt.NewPrompt(s.stdin(), s.stdout()).Confirm(msg, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/utils/stringutils.go
+++ b/pkg/utils/stringutils.go
@@ -33,6 +33,10 @@ func StringContains(array []string, needle string) bool {
 
 // StringToBool converts a string to a boolean ignoring errors
 func StringToBool(s string) bool {
-	b, _ := strconv.ParseBool(strings.ToLower(strings.TrimSpace(s)))
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "y" {
+		return true
+	}
+	b, _ := strconv.ParseBool(s)
 	return b
 }


### PR DESCRIPTION
**What I did**
When stdin is not a terminal, use a simpler Prompt implementation to collect and parse user confirmation

make the survey implementation to rely on dockercli.In() on Out() streams - unfortunately, not using `Fd()` but `FD()` as func name, so need an adapter

**Related issue**
closes https://github.com/docker/compose/issues/9739

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/211018980-bba69b1e-816c-46ba-be9a-ffda52e7d608.png)
