### PR TITLE
don't filter by services if no filter was set

### DIFF
--- a/pkg/compose/ps.go
+++ b/pkg/compose/ps.go
@@ -37,19 +37,9 @@ func (s *composeService) Ps(ctx context.Context, projectName string, options api
 		return nil, err
 	}
 
-	project := options.Project
-	if project == nil {
-		project, err = s.getProjectWithResources(ctx, containers, projectName)
-		if err != nil {
-			return nil, err
-		}
+	if len(options.Services) != 0 {
+		containers = containers.filter(isService(options.Services...))
 	}
-
-	if len(options.Services) == 0 {
-		options.Services = project.ServiceNames()
-	}
-
-	containers = containers.filter(isService(options.Services...))
 	summary := make([]api.ContainerSummary, len(containers))
 	eg, ctx := errgroup.WithContext(ctx)
 	for i, container := range containers {

--- a/pkg/compose/ps_test.go
+++ b/pkg/compose/ps_test.go
@@ -24,12 +24,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"gotest.tools/v3/assert"
 
-	moby "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/volume"
-
 	compose "github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/mocks"
+	moby "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 )
 
 func TestPs(t *testing.T) {
@@ -51,8 +49,6 @@ func TestPs(t *testing.T) {
 	c2, inspect2 := containerDetails("service1", "456", "running", "", 0)
 	c2.Ports = []moby.Port{{PublicPort: 80, PrivatePort: 90, IP: "localhost"}}
 	c3, inspect3 := containerDetails("service2", "789", "exited", "", 130)
-	api.EXPECT().VolumeList(ctx, gomock.Any()).Return(volume.ListResponse{}, nil)
-	api.EXPECT().NetworkList(ctx, gomock.Any()).Return([]moby.NetworkResource{}, nil)
 	api.EXPECT().ContainerList(ctx, listOpts).Return([]moby.Container{c1, c2, c3}, nil)
 	api.EXPECT().ContainerInspect(anyCancellableContext(), "123").Return(inspect1, nil)
 	api.EXPECT().ContainerInspect(anyCancellableContext(), "456").Return(inspect2, nil)


### PR DESCRIPTION
**What I did**
My assumption regarding https://github.com/docker/roadmap/issues/418 is that services have been created with some profiles enabled. Then as `compose ps` is executed, without profiles, we get a reduced compose model. As code used to assume no filter == filter by all project services, we actually filter out services launched previously

**Related issue**
closes https://github.com/docker/roadmap/issues/418

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/211044295-d44743be-fa58-4f16-8db0-1f680ea305fa.png)

