### PR TITLE
fix typo

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -331,7 +331,7 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 					if exited {
 						w.Events(containerEvents(containers, progress.Exited))
 						if code != 0 {
-							return fmt.Errorf("service %q didn't completed successfully: exit %d", dep, code)
+							return fmt.Errorf("service %q didn't complete successfully: exit %d", dep, code)
 						}
 						return nil
 					}


### PR DESCRIPTION
**What I did**

Tiny PR to fix a typo in the CLI which alerts when a container hasn't exited successfully and you have other containers waiting for it to do so.

**Related issue**
None raised - this is a single character change

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/38299499/211064080-50c4f7e1-6c66-4712-91ab-c9746f0e720f.png)

