### PR TITLE
Don't share the options map

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -48,7 +48,6 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 }
 
 func (s *composeService) build(ctx context.Context, project *types.Project, options api.BuildOptions) error {
-	opts := map[string]build.Options{}
 	args := flatten(options.Args.Resolve(envResolver(project.Environment)))
 
 	return InDependencyOrder(ctx, project, func(ctx context.Context, name string) error {
@@ -92,7 +91,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 				Attrs: map[string]string{},
 			}}
 		}
-		opts[imageName] = buildOptions
+		opts := map[string]build.Options{imageName: buildOptions}
 		_, err = s.doBuild(ctx, project, opts, options.Progress)
 		return err
 	}, func(traversal *graphTraversal) {


### PR DESCRIPTION
**What I did**

docker-compose build

Without this, I get an exception when building multiple images in my compose run.

```
fatal error: concurrent map writes

goroutine 16 [running]:
github.com/docker/compose/v2/pkg/compose.(*composeService).build.func1({0x2cba4e0, 0xc00019b2c0}, {0xc000233150?, 0xd?})
        github.com/docker/compose/v2/pkg/compose/build.go:95 +0x652
github.com/docker/compose/v2/pkg/compose.(*graphTraversal).run.func1()
        github.com/docker/compose/v2/pkg/compose/dependencies.go:127 +0x63
golang.org/x/sync/errgroup.(*Group).Go.func1()
        golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
        golang.org/x/sync@v0.1.0/errgroup/errgroup.go:72 +0xa5
...
```

I'm not sure why the map is currently shared, but with this patch applied my docker-compose build run works.

```
$ docker version
Client: Docker Engine - Community
 Version:           20.10.22
 API version:       1.41
 Go version:        go1.19.4
 Git commit:        3a2c30b63a
 Built:             Thu Dec 15 15:37:38 2022
 OS/Arch:           darwin/amd64
 Context:           colima
 Experimental:      true

Server:
 Engine:
  Version:          20.10.20
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.7
  Git commit:       03df974ae9e6c219862907efdd76ec2e77ec930b
  Built:            Wed Oct 19 02:58:31 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.6.8
  GitCommit:        9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
 runc:
  Version:          1.1.4
  GitCommit:        5fd4c4d144137e991c4acebb2146ab1483a97925
 docker-init:
  Version:          0.19.0
  GitCommit:

$ docker context inspect colima
[
    {
        "Name": "colima",
        "Metadata": {
            "Description": "colima"
        },
        "Endpoints": {
            "docker": {
                "Host": "unix:///Users/emuller/.colima/default/docker.sock",
                "SkipTLSVerify": false
            }
        },
        "TLSMaterial": {},
        "Storage": {
            "MetadataPath": "/Users/emuller/.docker/contexts/meta/f24fd3749c1368328e2b149bec149cb6795619f244c5b584e844961215dadd16",
            "TLSPath": "/Users/emuller/.docker/contexts/tls/f24fd3749c1368328e2b149bec149cb6795619f244c5b584e844961215dadd16"
        }
    }
]

$ docker info
Client:
 Context:    colima
 Debug Mode: false
 Plugins:
  compose: Docker Compose (Docker Inc., 2.15.0)
WARNING: Plugin "/Users/emuller/.docker/cli-plugins/docker-buildx" is not valid: failed to fetch metadata: fork/exec /Users/emuller/.docker/cli-plugins/docker-buildx: no such file or directory
WARNING: Plugin "/Users/emuller/.docker/cli-plugins/docker-dev" is not valid: failed to fetch metadata: fork/exec /Users/emuller/.docker/cli-plugins/docker-dev: no such file or directory
WARNING: Plugin "/Users/emuller/.docker/cli-plugins/docker-sbom" is not valid: failed to fetch metadata: fork/exec /Users/emuller/.docker/cli-plugins/docker-sbom: no such file or directory
WARNING: Plugin "/Users/emuller/.docker/cli-plugins/docker-scan" is not valid: failed to fetch metadata: fork/exec /Users/emuller/.docker/cli-plugins/docker-scan: no such file or directory

Server:
 Containers: 12
  Running: 7
  Paused: 0
  Stopped: 5
 Images: 14
 Server Version: 20.10.20
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Cgroup Version: 1
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: runc io.containerd.runc.v2 io.containerd.runtime.v1.linux
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
 runc version: 5fd4c4d144137e991c4acebb2146ab1483a97925
 init version:
 Security Options:
  seccomp
   Profile: default
 Kernel Version: 5.15.82-0-virt
 Operating System: Alpine Linux v3.16
 OSType: linux
 Architecture: x86_64
 CPUs: 4
 Total Memory: 11.7GiB
 Name: colima
 ID: UJJH:MFKT:KZUZ:PMIZ:7MFA:2XYY:VMAH:7UKP:VRFR:ETM5:ES3Y:5D5N
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
```