### PR TITLE
with compose v1, -H can be set after command

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -62,6 +62,19 @@ func Convert(args []string) []string {
 			continue
 		}
 		if len(arg) > 0 && arg[0] != '-' {
+
+			for j := i + 1; j < l-1; j++ {
+				// with compose V1, -H can be passed after command
+				if args[j] == "-H" || args[j] == "--host" {
+					rootFlags = append(rootFlags, args[j], args[j+1])
+					if l > j+2 {
+						args = append(args[0:j], args[j+2:]...)
+					} else {
+						args = args[0:j]
+					}
+				}
+			}
+
 			// not a top-level flag anymore, keep the rest of the command unmodified
 			if arg == compose.PluginName {
 				i++

--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -44,6 +44,11 @@ func Test_convert(t *testing.T) {
 			want: []string{"--host", "tcp://1.2.3.4", "compose", "up"},
 		},
 		{
+			name: "with H",
+			args: []string{"up", "-H", "tcp://1.2.3.4"},
+			want: []string{"-H", "tcp://1.2.3.4", "compose", "up"},
+		},
+		{
 			name: "compose --verbose",
 			args: []string{"--verbose"},
 			want: []string{"--debug", "compose"},


### PR DESCRIPTION
**What I did**
To offer better backward compatibility with Compose v1, also search for `-H`/`--host` after command

**Related issue**
closes https://github.com/docker/compose/issues/8801

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/211290401-95f8c72c-4218-4709-b2a2-e4b82593adb4.png)
