### PR TITLE
introduce `--remove-orphans` in `compose create` command

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -78,6 +78,7 @@ func createCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	flags.StringVar(&opts.Pull, "pull", "missing", `Pull image before running ("always"|"missing"|"never")`)
 	flags.BoolVar(&opts.forceRecreate, "force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
 	flags.BoolVar(&opts.noRecreate, "no-recreate", false, "If containers already exist, don't recreate them. Incompatible with --force-recreate.")
+	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
 	return cmd
 }
 

--- a/docs/reference/compose_create.md
+++ b/docs/reference/compose_create.md
@@ -12,6 +12,7 @@ Creates containers for a service.
 | `--no-build`       |          |           | Don't build an image, even if it's missing.                                           |
 | `--no-recreate`    |          |           | If containers already exist, don't recreate them. Incompatible with --force-recreate. |
 | `--pull`           | `string` | `missing` | Pull image before running ("always"\|"missing"\|"never")                              |
+| `--remove-orphans` |          |           | Remove containers for services not defined in the Compose file.                       |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_create.yaml
+++ b/docs/reference/docker_compose_create.yaml
@@ -57,6 +57,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: remove-orphans
+      value_type: bool
+      default_value: "false"
+      description: Remove containers for services not defined in the Compose file.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false


### PR DESCRIPTION
**What I did**
introduce `--remove-orphans` in `compose create` command to align with `compose up` and make orphan warning suggestion relevant

**Related issue**
closes https://github.com/docker/compose/issues/9718

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
