### PR TITLE
Add Cucumber GHA workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
         mode:
           - plugin
           - standalone
+          - cucumber
     steps:
       -
         name: Checkout
@@ -186,6 +187,11 @@ jobs:
           rm -f /usr/local/bin/docker-compose
           cp bin/build/docker-compose /usr/local/bin
           make e2e-compose-standalone
+      -
+        name: Run cucumber tests
+        if: ${{ matrix.mode == 'cucumber'}}
+        run: |
+          make test-cucumber
 
   release:
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ e2e-compose: ## Run end to end local tests in plugin mode. Set E2E_TEST=TestName
 e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test
 	go test $(TEST_FLAGS) -v -count=1 -parallel=1 --tags=standalone ./pkg/e2e
 
+.PHONY: test-cucumber
+test-cucumber:
+	go test $(TEST_FLAGS) -v -count=1 -parallel=1 ./e2e
+
 .PHONY: build-and-e2e-compose
 build-and-e2e-compose: build e2e-compose ## Compile the compose cli-plugin and run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
 


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Add GHA workflow to run 🥒 tests

Check [my fork](https://github.com/laurazard/compose/actions/runs/3892462324/jobs/6643901571) for an example run of this workflow

**⚠️  [DNM until [this PR](https://github.com/docker/compose/pull/10124)] fixing the 🥒 tests is merged.**

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="582" alt="image" src="https://user-images.githubusercontent.com/70572044/211798464-908d013b-a647-4874-b11a-8dc5045622d2.png">
