### PR TITLE
Add remove-orphans functionality to run

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -162,7 +162,7 @@ func runCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *co
 	flags.BoolVar(&opts.servicePorts, "service-ports", false, "Run command with the service's ports enabled and mapped to the host.")
 	flags.BoolVar(&opts.quietPull, "quiet-pull", false, "Pull without printing progress information.")
 	flags.BoolVar(&createOpts.Build, "build", false, "Build image before starting container.")
-	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
+	flags.BoolVar(&createOpts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
 
 	cmd.Flags().BoolVarP(&opts.interactive, "interactive", "i", true, "Keep STDIN open even if not attached.")
 	cmd.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY.")

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -162,6 +162,7 @@ func runCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *co
 	flags.BoolVar(&opts.servicePorts, "service-ports", false, "Run command with the service's ports enabled and mapped to the host.")
 	flags.BoolVar(&opts.quietPull, "quiet-pull", false, "Pull without printing progress information.")
 	flags.BoolVar(&createOpts.Build, "build", false, "Build image before starting container.")
+	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
 
 	cmd.Flags().BoolVarP(&opts.interactive, "interactive", "i", true, "Keep STDIN open even if not attached.")
 	cmd.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY.")

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -24,6 +24,7 @@ Run a one-off command on a service.
 | `-u`, `--user`        | `string`      |         | Run as specified username or uid                                                  |
 | `-v`, `--volume`      | `stringArray` |         | Bind mount a volume.                                                              |
 | `-w`, `--workdir`     | `string`      |         | Working directory inside the container                                            |
+| `--remove-orphans`    |               |         | Remove containers for services not defined in the Compose file.                   |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -18,13 +18,13 @@ Run a one-off command on a service.
 | `--no-deps`           |               |         | Don't start linked services.                                                      |
 | `-p`, `--publish`     | `stringArray` |         | Publish a container's port(s) to the host.                                        |
 | `--quiet-pull`        |               |         | Pull without printing progress information.                                       |
+| `--remove-orphans`    |               |         | Remove containers for services not defined in the Compose file.                   |
 | `--rm`                |               |         | Automatically remove the container when it exits                                  |
 | `--service-ports`     |               |         | Run command with the service's ports enabled and mapped to the host.              |
 | `--use-aliases`       |               |         | Use the service's network useAliases in the network(s) the container connects to. |
 | `-u`, `--user`        | `string`      |         | Run as specified username or uid                                                  |
 | `-v`, `--volume`      | `stringArray` |         | Bind mount a volume.                                                              |
 | `-w`, `--workdir`     | `string`      |         | Working directory inside the container                                            |
-| `--remove-orphans`    |               |         | Remove containers for services not defined in the Compose file.                   |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -172,6 +172,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: remove-orphans
+      value_type: bool
+      default_value: "false"
+      description: Remove containers for services not defined in the Compose file.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: rm
       value_type: bool
       default_value: "false"
@@ -240,16 +250,6 @@ options:
       shorthand: w
       value_type: string
       description: Working directory inside the container
-      deprecated: false
-      hidden: false
-      experimental: false
-      experimentalcli: false
-      kubernetes: false
-      swarm: false
-    - option: remove-orphans
-      value_type: bool
-      default_value: "false"
-      description: Remove containers for services not defined in the Compose file.
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -261,3 +261,4 @@ experimental: false
 experimentalcli: false
 kubernetes: false
 swarm: false
+

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -246,9 +246,18 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: remove-orphans
+      value_type: bool
+      default_value: "false"
+      description: Remove containers for services not defined in the Compose file.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false
 kubernetes: false
 swarm: false
-


### PR DESCRIPTION
**What I did**

Naively followed @ndeloof's example in https://github.com/docker/compose/pull/10160 to add support for the `--remove-orphans` flag on `docker compose run`, since that command recommends the flag on certain errors/warnings, but doesn't support it yet.

**Related issue**

Related to https://github.com/docker/compose/issues/9718#issuecomment-1209448445, though that issue has already been closed. I can open a new one specific to `run` if that's desired.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

This is Czernobog, who was adopted off the street as an orphan. We will **not**, however, be supplying the `--remove-orphans` flag to remove her.

![image](https://user-images.githubusercontent.com/4631191/211845440-dd418148-b32c-4e30-9c33-2224ab30e613.png)

