### PR TITLE
Shorten tty output when terminal is too small

### DIFF
--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -157,6 +157,10 @@ func (w *ttyWriter) print() {
 		}
 	}
 
+	skipChildEvents := false
+	if len(w.eventIDs) > goterm.Height()-1 {
+		skipChildEvents = true
+	}
 	numLines := 0
 	for _, v := range w.eventIDs {
 		event := w.events[v]
@@ -169,6 +173,9 @@ func (w *ttyWriter) print() {
 		for _, v := range w.eventIDs {
 			ev := w.events[v]
 			if ev.ParentID == event.ID {
+				if skipChildEvents {
+					continue
+				}
 				line := lineText(ev, "  ", terminalWidth, statusPadding, runtime.GOOS != "windows")
 				fmt.Fprint(w.out, line)
 				numLines++


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

We've had lots of complaints about the new TUI breaking when output exceeds terminal height. Related discussion can be found in these issues:
- https://github.com/docker/compose/issues/9377
- https://github.com/docker/compose/issues/8800
- https://github.com/docker/compose/issues/8753
- https://github.com/docker/compose/issues/9500
- https://github.com/docker/compose/issues/9962

The issue was partly addressed by the changes to detect when multiple services use the same images in https://github.com/docker/compose/pull/9173, but the root issue persists. Whenever have more lines to write than the terminal height is, we're unable to scroll back far enough to rewrite the buffer, and leave dangling lines behind, filling up the terminal scrollback and resulting in bad UX.

**What I did**

Detect when the number of events we have to display is > than terminal height, and adjust the output to omit child events when that's the case. This isn't a perfect solution (if the number of services > terminal height we will still run into issues, and the shortened output isn't very explicit), but it only kicks in in cases where the output would otherwise be worse, so it's an improvement over the current situation.

**Before**:

https://user-images.githubusercontent.com/70572044/211946344-7a11e231-0087-4820-9caa-88c32a46d8b3.mov

After:

https://user-images.githubusercontent.com/70572044/211946808-780d8f8d-3194-459a-8c5b-3c45771c913f.mov

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![IMG_20221224_193236](https://user-images.githubusercontent.com/70572044/211920804-0d02782a-a3a9-426e-aae9-411e11254fbf.jpg)
