### PR TITLE
mark alpha command as experimental

### DIFF
--- a/cmd/compose/alpha.go
+++ b/cmd/compose/alpha.go
@@ -25,6 +25,9 @@ func alphaCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 		Short:  "Experimental commands",
 		Use:    "alpha [COMMAND]",
 		Hidden: true,
+		Annotations: map[string]string{
+			"experimentalCLI": "true",
+		},
 	}
 	cmd.AddCommand(watchCommand(p, backend))
 	return cmd

--- a/docs/reference/docker_compose_alpha.yaml
+++ b/docs/reference/docker_compose_alpha.yaml
@@ -9,7 +9,7 @@ clink:
     - docker_compose_alpha_watch.yaml
 deprecated: false
 experimental: false
-experimentalcli: false
+experimentalcli: true
 kubernetes: false
 swarm: false
 

--- a/docs/reference/docker_compose_alpha_watch.yaml
+++ b/docs/reference/docker_compose_alpha_watch.yaml
@@ -19,7 +19,7 @@ options:
       swarm: false
 deprecated: false
 experimental: false
-experimentalcli: false
+experimentalcli: true
 kubernetes: false
 swarm: false
 


### PR DESCRIPTION
Mark experimental CLI commands with annotation so docs will reflect it
based on @thaJeztah comment https://github.com/docker/compose/pull/10163#pullrequestreview-1245295414