### PR TITLE
use compose service methods when exist instead of directly service.dockerCli

### DIFF
--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -86,7 +86,7 @@ func (s *composeService) attachContainer(ctx context.Context, container moby.Con
 		})
 	})
 
-	inspect, err := s.dockerCli.Client().ContainerInspect(ctx, container.ID)
+	inspect, err := s.apiClient().ContainerInspect(ctx, container.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -235,7 +235,7 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 		Text:   "Pulled",
 	})
 
-	inspected, _, err := s.dockerCli.Client().ImageInspectWithRaw(ctx, service.Image)
+	inspected, _, err := s.apiClient().ImageInspectWithRaw(ctx, service.Image)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -56,7 +56,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 
 	applyRunOptions(project, &service, opts)
 
-	if err := s.dockerCli.In().CheckTty(opts.Interactive, service.Tty); err != nil {
+	if err := s.stdin().CheckTty(opts.Interactive, service.Tty); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>

**What I did**
use internal functions of `composeService` struct when exist instead of accessing via the `composeService.dockerCli` attribute

**Related issue**
see discussions in #10173 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/212390331-bbedac02-58b4-44ba-a422-6bc14e83d340.png)
