### PR TITLE
allow a TTY to be allocated with -t

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -42,6 +42,7 @@ type runOptions struct {
 	Detach        bool
 	Remove        bool
 	noTty         bool
+	tty           bool
 	interactive   bool
 	user          string
 	workdir       string
@@ -133,6 +134,13 @@ func runCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *co
 				}
 				opts.entrypointCmd = command
 			}
+			if cmd.Flags().Changed("tty") {
+				if cmd.Flags().Changed("no-TTY") {
+					return fmt.Errorf("--tty and --no-TTY can't be used together")
+				} else {
+					opts.noTty = !opts.tty
+				}
+			}
 			return nil
 		}),
 		RunE: Adapt(func(ctx context.Context, args []string) error {
@@ -165,7 +173,7 @@ func runCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *co
 	flags.BoolVar(&createOpts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
 
 	cmd.Flags().BoolVarP(&opts.interactive, "interactive", "i", true, "Keep STDIN open even if not attached.")
-	cmd.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY.")
+	cmd.Flags().BoolVarP(&opts.tty, "tty", "t", true, "Allocate a pseudo-TTY.")
 	cmd.Flags().MarkHidden("tty") //nolint:errcheck
 
 	flags.SetNormalizeFunc(normalizeRunFlags)


### PR DESCRIPTION
**What I did**
Allow user to force a TTY to be allocated for container started by `compose run`. This allows to pipe compose output to another process but still get ANSI color support. `-it` flags were initially introduced to align with `docker run` considering this was a no-op flag as being default behavior by Docker Compose. But with terminal capability detection this is not the case and `-T` is enabled automatically.

**Related issue**
closes #10161

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
