### PR TITLE
Fix Goroutine leak in v2/command/formatter

### DIFF
--- a/cmd/formatter/colors.go
+++ b/cmd/formatter/colors.go
@@ -99,6 +99,7 @@ func cleanInfiniteGoroutine() {
 }
 
 func init() {
+	defer cleanInfiniteGoroutine()
 	colors := map[string]colorFunc{}
 	for i, name := range names {
 		colors[name] = makeColorFunc(strconv.Itoa(30 + i))
@@ -131,5 +132,4 @@ func init() {
 		}
 	}()
 
-	defer cleanInfiniteGoroutine()
 }

--- a/cmd/formatter/colors.go
+++ b/cmd/formatter/colors.go
@@ -92,6 +92,11 @@ func rainbowColor() colorFunc {
 }
 
 var loop = make(chan colorFunc)
+var quitChan = make(chan bool)
+
+func cleanInfiniteGoroutine() {
+	quitChan <- true
+}
 
 func init() {
 	colors := map[string]colorFunc{}
@@ -116,8 +121,15 @@ func init() {
 		}
 
 		for {
-			loop <- rainbow[i]
-			i = (i + 1) % len(rainbow)
+			select {
+			case <-quitChan:
+				return
+			default:
+				loop <- rainbow[i]
+				i = (i + 1) % len(rainbow)
+			}
 		}
 	}()
+
+	defer cleanInfiniteGoroutine()
 }

--- a/cmd/formatter/formatter_test.go
+++ b/cmd/formatter/formatter_test.go
@@ -75,5 +75,5 @@ func TestPrint(t *testing.T) {
 
 // Test the absence of unexpected goroutines.
 func TestColorsGoroutinesLeak(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	goleak.VerifyNone(t)
 }

--- a/cmd/formatter/formatter_test.go
+++ b/cmd/formatter/formatter_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"testing"
 
+	"go.uber.org/goleak"
 	"gotest.tools/v3/assert"
 )
 
@@ -70,4 +71,9 @@ func TestPrint(t *testing.T) {
 	assert.Equal(t, json, `{"Name":"myName1","Status":"myStatus1"}
 {"Name":"myName2","Status":"myStatus2"}
 `)
+}
+
+// Test the absence of unexpected goroutines.
+func TestColorsGoroutinesLeak(t *testing.T) {
+	defer goleak.VerifyNone(t)
 }

--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,8 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
+require go.uber.org/goleak v1.1.12
+
 replace (
 	// Override for e2e tests
 	github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7

--- a/go.sum
+++ b/go.sum
@@ -770,6 +770,7 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -978,6 +979,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
**What I did**
In this PR, I fixed the Goroutine leak in the `v2/command/formatter` init function. The problem that we had previously, is known as The Forgotten Sender.
To fix the issue, we should simply quit the infinite loop in the Goroutine, by sending a single that indicates that the main thread finished its execution. It's done using `defer()` and the `quitChan` channel.
A test of the Goroutine leak was added to the unit tests to make sure that the fix is working properly.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Fixes #10157.