### PR TITLE
Revert "Fix Goroutine leak in v2/command/formatter"

### DIFF
--- a/cmd/formatter/colors.go
+++ b/cmd/formatter/colors.go
@@ -92,14 +92,8 @@ func rainbowColor() colorFunc {
 }
 
 var loop = make(chan colorFunc)
-var quitChan = make(chan bool)
-
-func cleanInfiniteGoroutine() {
-	quitChan <- true
-}
 
 func init() {
-	defer cleanInfiniteGoroutine()
 	colors := map[string]colorFunc{}
 	for i, name := range names {
 		colors[name] = makeColorFunc(strconv.Itoa(30 + i))
@@ -122,14 +116,8 @@ func init() {
 		}
 
 		for {
-			select {
-			case <-quitChan:
-				return
-			default:
-				loop <- rainbow[i]
-				i = (i + 1) % len(rainbow)
-			}
+			loop <- rainbow[i]
+			i = (i + 1) % len(rainbow)
 		}
 	}()
-
 }

--- a/cmd/formatter/formatter_test.go
+++ b/cmd/formatter/formatter_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"testing"
 
-	"go.uber.org/goleak"
 	"gotest.tools/v3/assert"
 )
 
@@ -71,9 +70,4 @@ func TestPrint(t *testing.T) {
 	assert.Equal(t, json, `{"Name":"myName1","Status":"myStatus1"}
 {"Name":"myName2","Status":"myStatus2"}
 `)
-}
-
-// Test the absence of unexpected goroutines.
-func TestColorsGoroutinesLeak(t *testing.T) {
-	goleak.VerifyNone(t)
 }

--- a/go.mod
+++ b/go.mod
@@ -150,8 +150,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-require go.uber.org/goleak v1.1.12
-
 replace (
 	// Override for e2e tests
 	github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7

--- a/go.sum
+++ b/go.sum
@@ -770,7 +770,6 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -979,7 +978,6 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Reverts docker/compose#10192
this break compose up, as `defer cleanInfiniteGoroutine()` takes place immediately after `init` execution and prevent use of colors