### PR TITLE
alias -n for --tail to align with docker CLI

### DIFF
--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -56,7 +56,7 @@ func logsCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *c
 	flags.BoolVar(&opts.noColor, "no-color", false, "Produce monochrome output.")
 	flags.BoolVar(&opts.noPrefix, "no-log-prefix", false, "Don't print prefix in logs.")
 	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps.")
-	flags.StringVar(&opts.tail, "tail", "all", "Number of lines to show from the end of the logs for each container.")
+	flags.StringVarP(&opts.tail, "tail", "n", "all", "Number of lines to show from the end of the logs for each container.")
 	return logsCmd
 }
 

--- a/docs/reference/compose_logs.md
+++ b/docs/reference/compose_logs.md
@@ -11,7 +11,7 @@ View output from containers
 | `--no-color`         |          |         | Produce monochrome output.                                                                     |
 | `--no-log-prefix`    |          |         | Don't print prefix in logs.                                                                    |
 | `--since`            | `string` |         | Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)    |
-| `--tail`             | `string` | `all`   | Number of lines to show from the end of the logs for each container.                           |
+| `-n`, `--tail`       | `string` | `all`   | Number of lines to show from the end of the logs for each container.                           |
 | `-t`, `--timestamps` |          |         | Show timestamps.                                                                               |
 | `--until`            | `string` |         | Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes) |
 

--- a/docs/reference/docker_compose_logs.yaml
+++ b/docs/reference/docker_compose_logs.yaml
@@ -47,6 +47,7 @@ options:
       kubernetes: false
       swarm: false
     - option: tail
+      shorthand: "n"
       value_type: string
       default_value: all
       description: |


### PR DESCRIPTION
**What I did**
created `-n` alias for `compose logs --tail` to align with `docker logs` UX

**Related issue**
closes https://github.com/docker/compose/issues/10199

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
