### PR TITLE
Add `--scale`  to `compose create`

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -197,7 +197,10 @@ func runRun(ctx context.Context, backend api.Service, project *types.Project, op
 		return err
 	}
 
-	createOpts.Apply(project)
+	err = createOpts.Apply(project)
+	if err != nil {
+		return err
+	}
 
 	err = progress.Run(ctx, func(ctx context.Context) error {
 		return startDependencies(ctx, backend, *project, opts.Service, opts.ignoreOrphans)

--- a/cmd/compose/up_test.go
+++ b/cmd/compose/up_test.go
@@ -34,8 +34,8 @@ func TestApplyScaleOpt(t *testing.T) {
 			},
 		},
 	}
-	opt := upOptions{scale: []string{"foo=2"}}
-	err := opt.apply(&p, nil)
+	opt := createOptions{scale: []string{"foo=2"}}
+	err := opt.Apply(&p)
 	assert.NilError(t, err)
 	foo, err := p.GetService("foo")
 	assert.NilError(t, err)

--- a/docs/reference/compose_create.md
+++ b/docs/reference/compose_create.md
@@ -5,14 +5,15 @@ Creates containers for a service.
 
 ### Options
 
-| Name               | Type     | Default   | Description                                                                           |
-|:-------------------|:---------|:----------|:--------------------------------------------------------------------------------------|
-| `--build`          |          |           | Build images before starting containers.                                              |
-| `--force-recreate` |          |           | Recreate containers even if their configuration and image haven't changed.            |
-| `--no-build`       |          |           | Don't build an image, even if it's missing.                                           |
-| `--no-recreate`    |          |           | If containers already exist, don't recreate them. Incompatible with --force-recreate. |
-| `--pull`           | `string` | `missing` | Pull image before running ("always"\|"missing"\|"never")                              |
-| `--remove-orphans` |          |           | Remove containers for services not defined in the Compose file.                       |
+| Name               | Type          | Default   | Description                                                                                   |
+|:-------------------|:--------------|:----------|:----------------------------------------------------------------------------------------------|
+| `--build`          |               |           | Build images before starting containers.                                                      |
+| `--force-recreate` |               |           | Recreate containers even if their configuration and image haven't changed.                    |
+| `--no-build`       |               |           | Don't build an image, even if it's missing.                                                   |
+| `--no-recreate`    |               |           | If containers already exist, don't recreate them. Incompatible with --force-recreate.         |
+| `--pull`           | `string`      | `missing` | Pull image before running ("always"\|"missing"\|"never")                                      |
+| `--remove-orphans` |               |           | Remove containers for services not defined in the Compose file.                               |
+| `--scale`          | `stringArray` |           | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present. |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_create.yaml
+++ b/docs/reference/docker_compose_create.yaml
@@ -67,6 +67,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: scale
+      value_type: stringArray
+      default_value: '[]'
+      description: |
+        Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

**What I did**

Added `--scale` argument to `compose create`, moved scale logic from `cmd/compose/up.go` into `cmd/compose/create.go`.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

fixes https://github.com/docker/compose/issues/10204

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="579" alt="image" src="https://user-images.githubusercontent.com/70572044/214829293-cd98161c-8a58-494c-a87d-57cd8248bdc9.png">

