### PR TITLE
use containers we expect to start for wait condition

### DIFF
--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -229,7 +229,7 @@ func TestWaitDependencies(t *testing.T) {
 			"db":    {Condition: ServiceConditionRunningOrHealthy},
 			"redis": {Condition: ServiceConditionRunningOrHealthy},
 		}
-		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies))
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies, nil))
 	})
 	t.Run("should skip dependencies with condition service_started", func(t *testing.T) {
 		dbService := types.ServiceConfig{Name: "db", Scale: 1}
@@ -239,6 +239,6 @@ func TestWaitDependencies(t *testing.T) {
 			"db":    {Condition: types.ServiceConditionStarted},
 			"redis": {Condition: types.ServiceConditionStarted},
 		}
-		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies))
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies, nil))
 	})
 }

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -76,11 +76,6 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	if err := s.ensureImagesExists(ctx, project, opts.QuietPull); err != nil { // all dependencies already checked, but might miss service img
 		return "", err
 	}
-	if !opts.NoDeps {
-		if err := s.waitDependencies(ctx, project, service.DependsOn); err != nil {
-			return "", err
-		}
-	}
 
 	observedState, err := s.getContainers(ctx, project.Name, oneOffInclude, true)
 	if err != nil {
@@ -88,6 +83,11 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	}
 	updateServices(&service, observedState)
 
+	if !opts.NoDeps {
+		if err := s.waitDependencies(ctx, project, service.DependsOn, observedState); err != nil {
+			return "", err
+		}
+	}
 	created, err := s.createContainer(ctx, project, service, service.ContainerName, 1,
 		opts.AutoRemove, opts.UseNetworkAliases, opts.Interactive)
 	if err != nil {

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -18,18 +18,18 @@ package compose
 
 import (
 	"context"
-	"github.com/docker/docker/api/types/filters"
 	"strings"
 	"time"
 
-	"github.com/compose-spec/compose-go/types"
-	"github.com/docker/compose/v2/pkg/utils"
-	moby "github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
+	"github.com/docker/compose/v2/pkg/utils"
+
+	"github.com/compose-spec/compose-go/types"
+	moby "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 func (s *composeService) Start(ctx context.Context, projectName string, options api.StartOptions) error {
@@ -94,7 +94,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 			return err
 		}
 
-		return s.startService(ctx, project, service, containers.filter(isService(service.Name)))
+		return s.startService(ctx, project, service, containers)
 	})
 	if err != nil {
 		return err

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -38,7 +38,7 @@ func TestUpServiceUnhealthy(t *testing.T) {
 	const projectName = "e2e-start-fail"
 
 	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/start-fail/compose.yaml", "--project-name", projectName, "up", "-d")
-	res.Assert(t, icmd.Expected{ExitCode: 1, Err: `container for service "fail" is unhealthy`})
+	res.Assert(t, icmd.Expected{ExitCode: 1, Err: `container e2e-start-fail-fail-1 is unhealthy`})
 
 	c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
 }
@@ -135,6 +135,6 @@ func TestUpWithDependencyExit(t *testing.T) {
 			c.RunDockerComposeCmd(t, "--project-name", "dependencies", "down")
 		})
 
-		res.Assert(t, icmd.Expected{ExitCode: 1, Err: "dependency failed to start: container for service \"db\" exited (1)"})
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: "dependency failed to start: container dependencies-db-1 exited (1)"})
 	})
 }


### PR DESCRIPTION
as we check dependency service is running/healthy, use containers we created for the service so that we can detect failure to start, and not wait with no end for a dead service to become healthy.

**Related issue**
closes https://github.com/docker/compose/issues/10200

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/214881523-f7ed6245-186b-46d9-b47a-8f3b7144a3d7.png)
