### PR TITLE
Dry run kill support

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -338,7 +338,12 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 			if parallel > 0 {
 				backend.MaxConcurrency(parallel)
 			}
-			return backend.DryRunMode(dryRun)
+			ctx, err := backend.DryRunMode(cmd.Context(), dryRun)
+			if err != nil {
+				return err
+			}
+			cmd.SetContext(ctx)
+			return nil
 		},
 	}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -78,7 +78,7 @@ type Service interface {
 	// MaxConcurrency defines upper limit for concurrent operations against engine API
 	MaxConcurrency(parallel int)
 	// DryRunMode defines if dry run applies to the command
-	DryRunMode(dryRun bool) error
+	DryRunMode(ctx context.Context, dryRun bool) (context.Context, error)
 	// Watch services' development context and sync/notify/rebuild/restart on changes
 	Watch(ctx context.Context, project *types.Project, services []string, options WatchOptions) error
 }

--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -37,6 +37,8 @@ import (
 
 var _ client.APIClient = &DryRunClient{}
 
+type DryRunKey struct{}
+
 // DryRunClient implements APIClient by delegating to implementation functions. This allows lazy init and per-method overrides
 type DryRunClient struct {
 	apiClient client.APIClient

--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -63,7 +63,7 @@ func (d *DryRunClient) ContainerCreate(ctx context.Context, config *containerTyp
 }
 
 func (d *DryRunClient) ContainerKill(ctx context.Context, container, signal string) error {
-	return ErrNotImplemented
+	return nil
 }
 
 func (d *DryRunClient) ContainerPause(ctx context.Context, container string) error {

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -52,7 +52,7 @@ type ServiceProxy struct {
 	ImagesFn             func(ctx context.Context, projectName string, options ImagesOptions) ([]ImageSummary, error)
 	WatchFn              func(ctx context.Context, project *types.Project, services []string, options WatchOptions) error
 	MaxConcurrencyFn     func(parallel int)
-	DryRunModeFn         func(dryRun bool) error
+	DryRunModeFn         func(ctx context.Context, dryRun bool) (context.Context, error)
 	interceptors         []Interceptor
 }
 
@@ -327,6 +327,6 @@ func (s *ServiceProxy) MaxConcurrency(i int) {
 	s.MaxConcurrencyFn(i)
 }
 
-func (s *ServiceProxy) DryRunMode(dryRun bool) error {
-	return s.DryRunModeFn(dryRun)
+func (s *ServiceProxy) DryRunMode(ctx context.Context, dryRun bool) (context.Context, error) {
+	return s.DryRunModeFn(ctx, dryRun)
 }

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -66,22 +66,22 @@ func (s *composeService) MaxConcurrency(i int) {
 	s.maxConcurrency = i
 }
 
-func (s *composeService) DryRunMode(dryRun bool) error {
+func (s *composeService) DryRunMode(ctx context.Context, dryRun bool) (context.Context, error) {
 	if dryRun {
 		cli, err := command.NewDockerCli()
 		if err != nil {
-			return err
+			return ctx, err
 		}
 		err = cli.Initialize(flags.NewClientOptions(), command.WithInitializeClient(func(cli *command.DockerCli) (client.APIClient, error) {
 			dryRunClient := api.NewDryRunClient(s.apiClient())
 			return dryRunClient, nil
 		}))
 		if err != nil {
-			return err
+			return ctx, err
 		}
 		s.dockerCli = cli
 	}
-	return nil
+	return context.WithValue(ctx, api.DryRunKey{}, dryRun), nil
 }
 
 func (s *composeService) stdout() *streams.Out {

--- a/pkg/mocks/mock_docker_compose_api.go
+++ b/pkg/mocks/mock_docker_compose_api.go
@@ -108,17 +108,18 @@ func (mr *MockServiceMockRecorder) Down(ctx, projectName, options interface{}) *
 }
 
 // DryRunMode mocks base method.
-func (m *MockService) DryRunMode(dryRun bool) error {
+func (m *MockService) DryRunMode(ctx context.Context, dryRun bool) (context.Context, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DryRunMode", dryRun)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "DryRunMode", ctx, dryRun)
+	ret0, _ := ret[0].(context.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DryRunMode indicates an expected call of DryRunMode.
-func (mr *MockServiceMockRecorder) DryRunMode(dryRun interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) DryRunMode(ctx, dryRun interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DryRunMode", reflect.TypeOf((*MockService)(nil).DryRunMode), dryRun)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DryRunMode", reflect.TypeOf((*MockService)(nil).DryRunMode), ctx, dryRun)
 }
 
 // Events mocks base method.

--- a/pkg/progress/plain.go
+++ b/pkg/progress/plain.go
@@ -23,8 +23,9 @@ import (
 )
 
 type plainWriter struct {
-	out  io.Writer
-	done chan bool
+	out    io.Writer
+	done   chan bool
+	dryRun bool
 }
 
 func (p *plainWriter) Start(ctx context.Context) error {
@@ -37,7 +38,11 @@ func (p *plainWriter) Start(ctx context.Context) error {
 }
 
 func (p *plainWriter) Event(e Event) {
-	fmt.Fprintln(p.out, e.ID, e.Text, e.StatusText)
+	prefix := ""
+	if p.dryRun {
+		prefix = "DRY RUN MODE - "
+	}
+	fmt.Fprintln(p.out, prefix, e.ID, e.Text, e.StatusText)
 }
 
 func (p *plainWriter) Events(events []Event) {
@@ -47,7 +52,11 @@ func (p *plainWriter) Events(events []Event) {
 }
 
 func (p *plainWriter) TailMsgf(m string, args ...interface{}) {
-	fmt.Fprintln(p.out, append([]interface{}{m}, args...)...)
+	prefix := ""
+	if p.dryRun {
+		prefix = DRYRUN_PREFIX
+	}
+	fmt.Fprintln(p.out, append([]interface{}{prefix, m}, args...)...)
 }
 
 func (p *plainWriter) Stop() {

--- a/pkg/progress/tty_test.go
+++ b/pkg/progress/tty_test.go
@@ -41,22 +41,22 @@ func TestLineText(t *testing.T) {
 
 	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
 
-	out := lineText(ev, "", 50, lineWidth, true)
+	out := lineText(ev, "", 50, lineWidth, true, false)
 	assert.Equal(t, out, "\x1b[37m . id Text Status                            0.0s\n\x1b[0m")
 
-	out = lineText(ev, "", 50, lineWidth, false)
+	out = lineText(ev, "", 50, lineWidth, false, false)
 	assert.Equal(t, out, " . id Text Status                            0.0s\n")
 
 	ev.Status = Done
-	out = lineText(ev, "", 50, lineWidth, true)
+	out = lineText(ev, "", 50, lineWidth, true, false)
 	assert.Equal(t, out, "\x1b[34m . id Text Status                            0.0s\n\x1b[0m")
 
 	ev.Status = Error
-	out = lineText(ev, "", 50, lineWidth, true)
+	out = lineText(ev, "", 50, lineWidth, true, false)
 	assert.Equal(t, out, "\x1b[31m . id Text Status                            0.0s\n\x1b[0m")
 
 	ev.Status = Warning
-	out = lineText(ev, "", 50, lineWidth, true)
+	out = lineText(ev, "", 50, lineWidth, true, false)
 	assert.Equal(t, out, "\x1b[33m . id Text Status                            0.0s\n\x1b[0m")
 }
 
@@ -75,7 +75,7 @@ func TestLineTextSingleEvent(t *testing.T) {
 
 	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
 
-	out := lineText(ev, "", 50, lineWidth, true)
+	out := lineText(ev, "", 50, lineWidth, true, false)
 	assert.Equal(t, out, "\x1b[34m . id Text Status                            0.0s\n\x1b[0m")
 }
 


### PR DESCRIPTION
**What I did**
Update Compose internal writers to display correctly dry run message in TTY and plain text mode.
Add support for of dry-run for the `kill` command

**Related issue**
[<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->](https://docker.atlassian.net/browse/ENV-54)

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/215128940-6f16d1e9-0750-4bfc-ab5e-92df411bf1e3.png)
