### PR TITLE
use CGO to enable fsevent on OSX [ENV-37]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ all: build
 
 .PHONY: build ## Build the compose cli-plugin
 build:
-	CGO_ENABLED=0 GO111MODULE=on go build -trimpath -tags "$(GO_BUILDTAGS)" -ldflags "$(GO_LDFLAGS)" -o "$(DESTDIR)/docker-compose$(BINARY_EXT)" ./cmd
+	GO111MODULE=on go build -trimpath -tags "$(GO_BUILDTAGS)" -ldflags "$(GO_LDFLAGS)" -o "$(DESTDIR)/docker-compose$(BINARY_EXT)" ./cmd
 
 .PHONY: binary
 binary:

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/fsnotify/fsevents v0.1.1
 	github.com/fvbommel/sortorder v1.0.2 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+github.com/fsnotify/fsevents v0.1.1 h1:/125uxJvvoSDDBPen6yUZbil8J9ydKZnnl3TWWmvnkw=
+github.com/fsnotify/fsevents v0.1.1/go.mod h1:+d+hS27T6k5J8CRaPLKFgwKYcpS7GwW3Ule9+SC2ZRc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/pkg/watch/notify_test.go
+++ b/pkg/watch/notify_test.go
@@ -435,7 +435,7 @@ func TestWatchNonexistentDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// for directories that were the root of an Add, we don't report creation, cf. watcher_fsevent.go
+	// for directories that were the root of an Add, we don't report creation, cf. watcher_darwin.go
 	f.assertEvents()
 
 	f.events = nil

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -20,6 +20,7 @@
 package watch
 
 import (
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -52,18 +53,8 @@ func (d *fseventNotify) loop() {
 			}
 
 			for _, e := range events {
+				fmt.Println(e)
 				e.Path = filepath.Join("/", e.Path)
-
-				if e.Flags&fsevents.HistoryDone == fsevents.HistoryDone {
-					d.sawAnyHistoryDone = true
-					continue
-				}
-
-				// We wait until we've seen the HistoryDone event for this watcher before processing any events
-				// so that we skip all of the "spurious" events that precede it.
-				if !d.sawAnyHistoryDone {
-					continue
-				}
 
 				_, isPathWereWatching := d.pathsWereWatching[e.Path]
 				if e.Flags&fsevents.ItemIsDir == fsevents.ItemIsDir && e.Flags&fsevents.ItemCreated == fsevents.ItemCreated && isPathWereWatching {

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -19,9 +19,6 @@
 
 package watch
 
-/**
-FIXME this implementation requires CGO
-
 import (
 	"path/filepath"
 	"time"
@@ -130,7 +127,7 @@ func (d *fseventNotify) Errors() chan error {
 	return d.errors
 }
 
-func newFSEventWatcher(paths []string, ignore PathMatcher) (*fseventNotify, error) {
+func newWatcher(paths []string, ignore PathMatcher) (Notify, error) {
 	dw := &fseventNotify{
 		ignore: ignore,
 		stream: &fsevents.EventStream{
@@ -158,4 +155,3 @@ func newFSEventWatcher(paths []string, ignore PathMatcher) (*fseventNotify, erro
 }
 
 var _ Notify = &fseventNotify{}
-**/

--- a/pkg/watch/watcher_naive.go
+++ b/pkg/watch/watcher_naive.go
@@ -1,3 +1,6 @@
+//go:build !darwin
+// +build !darwin
+
 /*
    Copyright 2020 Docker Compose CLI authors
 
@@ -294,7 +297,7 @@ func (d *naiveNotify) add(path string) error {
 	return nil
 }
 
-func newWatcher(paths []string, ignore PathMatcher) (*naiveNotify, error) {
+func newWatcher(paths []string, ignore PathMatcher) (Notify, error) {
 	if ignore == nil {
 		return nil, fmt.Errorf("newWatcher: ignore is nil")
 	}


### PR DESCRIPTION
**What I did**
use CGO so we can rely on fsevent for `compose watch` on MacOS

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![Uploading image.png…]()
