### PR TITLE
prevent assignment to entry in nil map

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -303,10 +303,10 @@ func (s *composeService) toBuildOptions(project *types.Project, service types.Se
 }
 
 func flatten(in types.MappingWithEquals) types.Mapping {
-	if len(in) == 0 {
-		return nil
-	}
 	out := types.Mapping{}
+	if len(in) == 0 {
+		return out
+	}
 	for k, v := range in {
 		if v == nil {
 			continue


### PR DESCRIPTION
**What I did**
have `flatten` always return non-nil `Mapping` to prevent risk for assignment to entry in nil map.

**Related issue**
closes https://github.com/docker/compose/issues/10244

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
