### PR TITLE
Dry run `stop` and `rm` support

### DIFF
--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -79,5 +79,6 @@ func runRemove(ctx context.Context, backend api.Service, opts removeOptions, ser
 		Force:    opts.force,
 		Volumes:  opts.volumes,
 		Project:  project,
+		Stop:     opts.stop,
 	})
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -229,8 +229,8 @@ type KillOptions struct {
 type RemoveOptions struct {
 	// Project is the compose project used to define this app. Might be nil if user ran command just with project name
 	Project *types.Project
-	// DryRun just list removable resources
-	DryRun bool
+	// Stop option passed in the command line
+	Stop bool
 	// Volumes remove anonymous volumes
 	Volumes bool
 	// Force don't ask to confirm removal

--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -77,7 +77,7 @@ func (d *DryRunClient) ContainerPause(ctx context.Context, container string) err
 }
 
 func (d *DryRunClient) ContainerRemove(ctx context.Context, container string, options moby.ContainerRemoveOptions) error {
-	return ErrNotImplemented
+	return nil
 }
 
 func (d *DryRunClient) ContainerRename(ctx context.Context, container, newContainerName string) error {

--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -93,7 +93,7 @@ func (d *DryRunClient) ContainerStart(ctx context.Context, container string, opt
 }
 
 func (d *DryRunClient) ContainerStop(ctx context.Context, container string, options containerType.StopOptions) error {
-	return ErrNotImplemented
+	return nil
 }
 
 func (d *DryRunClient) ContainerUnpause(ctx context.Context, container string) error {

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -45,7 +45,7 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 	}
 
 	stoppedContainers := containers.filter(func(c moby.Container) bool {
-		return c.State != ContainerRunning
+		return c.State != ContainerRunning || (options.Stop && s.dryRun)
 	})
 
 	var names []string


### PR DESCRIPTION
**What I did**
Add Dry Run support for `stop` and `rm` commands

**Related issue**
https://docker.atlassian.net/browse/ENV-64
https://docker.atlassian.net/browse/ENV-68

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/217661028-5d3117ad-5a21-473f-90e5-e148a848c6d5.png)
