### PR TITLE
ci: use CGO for tests to enable race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install: binary
 
 .PHONY: e2e-compose
 e2e-compose: ## Run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
-	go test $(TEST_FLAGS) $(TEST_COVERAGE_FLAGS) -count=1 ./pkg/e2e
+	CGO_ENABLED=1 go test $(TEST_FLAGS) $(TEST_COVERAGE_FLAGS) -count=1 ./pkg/e2e
 
 .PHONY: e2e-compose-standalone
 e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test


### PR DESCRIPTION
**What I did**
Explicitly enable CGO for e2e tests to avoid errors:
```
go: -race requires cgo; enable cgo by setting CGO_ENABLED=1
```

We're explicitly using CGO on macOS now for FSEvents support and purposefully NOT using CGO on other platforms since we don't need it.

The race detector (`-race`) requires it, however, so for the e2e make task, it should alway be on.

**Related issue**
See sample failed run from `v2` on Windows: https://github.com/docker/compose/actions/runs/4136372230/jobs/7150139071

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![fisher cat](https://user-images.githubusercontent.com/841263/217904637-3e19aa81-7c3e-41e3-afd3-f461d712c429.png)