### PR TITLE
also restart dependent services after a service has been restarted

### DIFF
--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -28,6 +28,7 @@ import (
 type restartOptions struct {
 	*ProjectOptions
 	timeout int
+	noDeps  bool
 }
 
 func restartCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
@@ -44,6 +45,7 @@ func restartCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	}
 	flags := restartCmd.Flags()
 	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")
+	flags.BoolVar(&opts.noDeps, "no-deps", false, "Don't restart dependent services.")
 
 	return restartCmd
 }
@@ -52,6 +54,13 @@ func runRestart(ctx context.Context, backend api.Service, opts restartOptions, s
 	project, name, err := opts.projectOrName()
 	if err != nil {
 		return err
+	}
+
+	if opts.noDeps {
+		err := withSelectedServicesOnly(project, services)
+		if err != nil {
+			return err
+		}
 	}
 
 	timeout := time.Duration(opts.timeout) * time.Second

--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -49,7 +49,7 @@ func restartCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 }
 
 func runRestart(ctx context.Context, backend api.Service, opts restartOptions, services []string) error {
-	project, name, err := opts.projectOrName(services...)
+	project, name, err := opts.projectOrName()
 	if err != nil {
 		return err
 	}

--- a/docs/reference/compose_restart.md
+++ b/docs/reference/compose_restart.md
@@ -7,6 +7,7 @@ Restart service containers
 
 | Name              | Type  | Default | Description                           |
 |:------------------|:------|:--------|:--------------------------------------|
+| `--no-deps`       |       |         | Don't restart dependent services.     |
 | `-t`, `--timeout` | `int` | `10`    | Specify a shutdown timeout in seconds |
 
 

--- a/docs/reference/docker_compose_restart.yaml
+++ b/docs/reference/docker_compose_restart.yaml
@@ -15,6 +15,16 @@ usage: docker compose restart [OPTIONS] [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
+    - option: no-deps
+      value_type: bool
+      default_value: "false"
+      description: Don't restart dependent services.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: timeout
       shorthand: t
       value_type: int

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -48,14 +48,14 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 	}
 
 	if len(options.Services) == 0 {
-		options.Services = project.ServiceNames()
+		err = project.ForServices(options.Services)
+		if err != nil {
+			return err
+		}
 	}
 
 	w := progress.ContextWriter(ctx)
 	return InDependencyOrder(ctx, project, func(c context.Context, service string) error {
-		if !utils.StringContains(options.Services, service) {
-			return nil
-		}
 		eg, ctx := errgroup.WithContext(ctx)
 		for _, container := range containers.filter(isService(service)) {
 			container := container


### PR DESCRIPTION
**What I did**
As a service is restarted, restart dependent services to ensure they can access the restarted container, which is required when those are set to share namespaces.

Introduce `--no-deps` flag for those who prefer the legacy behavior, still disabled by default to enforce a predictable restart as side-effects of unshared namespaces is hard to diagnose.

**Related issue**
close https://github.com/docker/compose/issues/10263

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
