### PR TITLE
exclude unstable labels from config hash

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -424,7 +424,7 @@ func (s *composeService) recreateContainer(ctx context.Context, project *types.P
 	}
 	name := getContainerName(project.Name, service, number)
 	tmpName := fmt.Sprintf("%s_%s", replaced.ID[:12], name)
-	service.Labels[api.ContainerReplaceLabel] = replaced.ID
+	service.CustomLabels[api.ContainerReplaceLabel] = replaced.ID
 	created, err = s.createMobyContainer(ctx, project, service, tmpName, number, inherited, false, true, false, w)
 	if err != nil {
 		return created, err


### PR DESCRIPTION
**What I did**
since 2.16.0 we introduced a `replace` label to track relationship between new container and the one it replaces
this label is transient, and MUST not be considered for config hash computation

**Related issue**
close https://github.com/docker/compose/issues/9600

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
