### PR TITLE
introduce `restart` for depends_on

### DIFF
--- a/cmd/compose/compose_test.go
+++ b/cmd/compose/compose_test.go
@@ -31,8 +31,10 @@ func TestFilterServices(t *testing.T) {
 				Links: []string{"bar"},
 			},
 			{
-				Name:        "bar",
-				NetworkMode: types.NetworkModeServicePrefix + "zot",
+				Name: "bar",
+				DependsOn: map[string]types.ServiceDependency{
+					"zot": {},
+				},
 			},
 			{
 				Name: "zot",

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -41,7 +41,7 @@ Docker Compose
 |:-----------------------|:--------------|:--------|:----------------------------------------------------------------------------------------------------|
 | `--ansi`               | `string`      | `auto`  | Control when to print ANSI control characters ("never"\|"always"\|"auto")                           |
 | `--compatibility`      |               |         | Run compose in backward compatibility mode                                                          |
-| `--env-file`           | `string`      |         | Specify an alternate environment file.                                                              |
+| `--env-file`           | `stringArray` |         | Specify an alternate environment file.                                                              |
 | `-f`, `--file`         | `stringArray` |         | Compose configuration files                                                                         |
 | `--parallel`           | `int`         | `-1`    | Control max parallelism, -1 for unlimited                                                           |
 | `--profile`            | `stringArray` |         | Specify a profile to enable                                                                         |

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -198,7 +198,8 @@ options:
       kubernetes: false
       swarm: false
     - option: env-file
-      value_type: string
+      value_type: stringArray
+      default_value: '[]'
       description: Specify an alternate environment file.
       deprecated: false
       hidden: false

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go v1.10.0
+	github.com/compose-spec/compose-go v1.11.0
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.18
 	github.com/cucumber/godog v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/compose-spec/compose-go v1.10.0 h1:MGrEv+WyETQWB4ARKTHRTvoZ0CZGi8lyFlveGNMej40=
-github.com/compose-spec/compose-go v1.10.0/go.mod h1:Tb5Ae2PsYN3GTqYqzl2IRbTPiJtPZZjMw8UKUvmehFk=
+github.com/compose-spec/compose-go v1.11.0 h1:YLl0wf4YU9ZVei6mqLxAfI2gWOrqnTsPBAcIe9cO9Zk=
+github.com/compose-spec/compose-go v1.11.0/go.mod h1:huuiqxbQTZLkagcN9D/1tEKZwMXVetYeIWtjCAVsoXw=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -47,6 +47,16 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 		}
 	}
 
+	// ignore depends_on relations which are not impacted by restarting service
+	for i, service := range project.Services {
+		for name, r := range service.DependsOn {
+			if !r.Restart {
+				delete(service.DependsOn, name)
+			}
+		}
+		project.Services[i] = service
+	}
+
 	if len(options.Services) == 0 {
 		err = project.ForServices(options.Services)
 		if err != nil {


### PR DESCRIPTION
introduce support for `restart` on `depends_on`.
this allows to declare dependent service which, when restarted, need to also trigger configured service to be restarted. Typically applies to containers sharing namespaces.

updated compose-go to v1.11 where `Normalize` makes all dependencies explicit, we can filter dependencies and ignore those which are not impacted by dependencies to be restarted.

Also add support for repeated `--env-file` flag, as supported by compose-go v1.11