### PR TITLE
Support `--build-context` in `compose build`

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -36,14 +36,15 @@ import (
 type buildOptions struct {
 	*ProjectOptions
 	composeOptions
-	quiet    bool
-	pull     bool
-	push     bool
-	progress string
-	args     []string
-	noCache  bool
-	memory   string
-	ssh      string
+	quiet         bool
+	pull          bool
+	push          bool
+	progress      string
+	args          []string
+	noCache       bool
+	memory        string
+	ssh           string
+	buildContexts []string
 }
 
 func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions, error) {
@@ -57,14 +58,15 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 	}
 
 	return api.BuildOptions{
-		Pull:     opts.pull,
-		Push:     opts.push,
-		Progress: opts.progress,
-		Args:     types.NewMappingWithEquals(opts.args),
-		NoCache:  opts.noCache,
-		Quiet:    opts.quiet,
-		Services: services,
-		SSHs:     SSHKeys,
+		BuildContexts: opts.buildContexts,
+		Pull:          opts.pull,
+		Push:          opts.push,
+		Progress:      opts.progress,
+		Args:          types.NewMappingWithEquals(opts.args),
+		NoCache:       opts.noCache,
+		Quiet:         opts.quiet,
+		Services:      services,
+		SSHs:          SSHKeys,
 	}, nil
 }
 
@@ -115,6 +117,7 @@ func buildCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *
 	cmd.Flags().BoolVar(&opts.pull, "pull", false, "Always attempt to pull a newer version of the image.")
 	cmd.Flags().StringVar(&opts.progress, "progress", buildx.PrinterModeAuto, fmt.Sprintf(`Set type of progress output (%s)`, strings.Join(printerModes, ", ")))
 	cmd.Flags().StringArrayVar(&opts.args, "build-arg", []string{}, "Set build-time variables for services.")
+	cmd.Flags().StringArrayVar(&opts.buildContexts, "build-context", []string{}, "Set additional build contexts.")
 	cmd.Flags().StringVar(&opts.ssh, "ssh", "", "Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)")
 	cmd.Flags().Bool("parallel", true, "Build images in parallel. DEPRECATED")
 	cmd.Flags().MarkHidden("parallel") //nolint:errcheck

--- a/e2e/cucumber-features/build-contexts.feature
+++ b/e2e/cucumber-features/build-contexts.feature
@@ -1,0 +1,21 @@
+Feature: Build Contexts
+
+Background:
+    Given a compose file
+        """
+        services:
+          a:
+            build:
+                context: .
+        """
+    And a dockerfile
+        """
+        # syntax=docker/dockerfile:1
+        FROM alpine:latest
+        COPY --from=dep /etc/hostname /
+        """
+
+Scenario: A scenario
+    When I run "compose build --build-context dep=docker-image://ubuntu:latest"
+    Then the exit code is 0
+

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -89,6 +89,8 @@ type WatchOptions struct {
 
 // BuildOptions group options of the Build API
 type BuildOptions struct {
+	// Additional build contexts passed in the command line
+	BuildContexts []string
 	// Pull always attempt to pull a newer version of the image
 	Pull bool
 	// Push pushes service images


### PR DESCRIPTION
**What I did**

Add `--build-context` to `compose build` to support passing additional build contexts.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

fixes https://github.com/docker/compose/issues/9961

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="483" alt="image" src="https://user-images.githubusercontent.com/70572044/219326420-3c650e6c-918d-4492-9448-954e92558e23.png">

