### PR TITLE
watch: ignore ephemeral files & minor output tweaks

### DIFF
--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -14,7 +14,7 @@ import (
 // there or aren't in the right places.
 //
 // https://app.clubhouse.io/windmill/story/691/filter-out-ephemeral-file-changes
-var ephemeralPathMatcher = initEphemeralPathMatcher()
+var EphemeralPathMatcher = initEphemeralPathMatcher()
 
 func initEphemeralPathMatcher() model.PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -1,9 +1,20 @@
-package ignore
+/*
+   Copyright 2020 Docker Compose CLI authors
 
-import (
-	"github.com/tilt-dev/tilt/internal/dockerignore"
-	"github.com/tilt-dev/tilt/pkg/model"
-)
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package watch
 
 // EphemeralPathMatcher filters out spurious changes that we don't want to
 // rebuild on, like IDE temp/lock files.
@@ -16,7 +27,7 @@ import (
 // https://app.clubhouse.io/windmill/story/691/filter-out-ephemeral-file-changes
 var EphemeralPathMatcher = initEphemeralPathMatcher()
 
-func initEphemeralPathMatcher() model.PathMatcher {
+func initEphemeralPathMatcher() PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
 	emacsPatterns := []string{"**/.#*", "**/#*#"}
 	// if .swp is taken (presumably because multiple vims are running in that dir),
@@ -34,14 +45,14 @@ func initEphemeralPathMatcher() model.PathMatcher {
 	// https://github.com/golang/go/blob/0b5218cf4e3e5c17344ea113af346e8e0836f6c4/src/cmd/go/internal/work/exec.go#L1764
 	goPatterns := []string{"**/*-go-tmp-umask"}
 
-	allPatterns := []string{}
+	var allPatterns []string
 	allPatterns = append(allPatterns, golandPatterns...)
 	allPatterns = append(allPatterns, emacsPatterns...)
 	allPatterns = append(allPatterns, vimPatterns...)
 	allPatterns = append(allPatterns, katePatterns...)
 	allPatterns = append(allPatterns, goPatterns...)
 
-	matcher, err := dockerignore.NewDockerPatternMatcher("/", allPatterns)
+	matcher, err := NewDockerPatternMatcher("/", allPatterns)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -18,7 +18,7 @@ var EphemeralPathMatcher = initEphemeralPathMatcher()
 
 func initEphemeralPathMatcher() model.PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
-	emacsPatterns := []string{"**/.#*"}
+	emacsPatterns := []string{"**/.#*", "**/#*#"}
 	// if .swp is taken (presumably because multiple vims are running in that dir),
 	// vim will go with .swo, .swn, etc, and then even .svz, .svy!
 	// https://github.com/vim/vim/blob/ea781459b9617aa47335061fcc78403495260315/src/memline.c#L5076

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -5,8 +5,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-// Filter out spurious changes that we don't want to rebuild on, like IDE
-// temp/lock files.
+// EphemeralPathMatcher filters out spurious changes that we don't want to
+// rebuild on, like IDE temp/lock files.
 //
 // This isn't an ideal solution. In an ideal world, the user would put
 // everything to ignore in their tiltignore/dockerignore files. This is a
@@ -29,12 +29,17 @@ func initEphemeralPathMatcher() model.PathMatcher {
 	// files, but it doesn't have the "incrememnting" character problem mentioned
 	// above
 	katePatterns := []string{"**/.*.kate-swp"}
+	// go stdlib creates tmpfiles to determine umask for setting permissions
+	// during file creation; they are then immediately deleted
+	// https://github.com/golang/go/blob/0b5218cf4e3e5c17344ea113af346e8e0836f6c4/src/cmd/go/internal/work/exec.go#L1764
+	goPatterns := []string{"**/*-go-tmp-umask"}
 
 	allPatterns := []string{}
 	allPatterns = append(allPatterns, golandPatterns...)
 	allPatterns = append(allPatterns, emacsPatterns...)
 	allPatterns = append(allPatterns, vimPatterns...)
 	allPatterns = append(allPatterns, katePatterns...)
+	allPatterns = append(allPatterns, goPatterns...)
 
 	matcher, err := dockerignore.NewDockerPatternMatcher("/", allPatterns)
 	if err != nil {

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -17,7 +17,7 @@ import (
 var ephemeralPathMatcher = initEphemeralPathMatcher()
 
 func initEphemeralPathMatcher() model.PathMatcher {
-	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___"}
+	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
 	emacsPatterns := []string{"**/.#*"}
 	vimPatterns := []string{"**/4913", "**/*~", "**/.*.swp", "**/.*.swx"}
 

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -19,7 +19,12 @@ var ephemeralPathMatcher = initEphemeralPathMatcher()
 func initEphemeralPathMatcher() model.PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
 	emacsPatterns := []string{"**/.#*"}
-	vimPatterns := []string{"**/4913", "**/*~", "**/.*.swp", "**/.*.swx"}
+	// if .swp is taken (presumably because multiple vims are running in that dir),
+	// vim will go with .swo, .swn, etc, and then even .svz, .svy!
+	// https://github.com/vim/vim/blob/ea781459b9617aa47335061fcc78403495260315/src/memline.c#L5076
+	// ignoring .sw? seems dangerous, since things like .swf or .swi exist, but ignoring the first few
+	// seems safe and should catch most cases
+	vimPatterns := []string{"**/4913", "**/*~", "**/.*.swp", "**/.*.swx", "**/.*.swo", "**/.*.swn"}
 
 	allPatterns := []string{}
 	allPatterns = append(allPatterns, golandPatterns...)

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -1,8 +1,8 @@
 package ignore
 
 import (
-	"github.com/windmilleng/tilt/internal/dockerignore"
-	"github.com/windmilleng/tilt/pkg/model"
+	"github.com/tilt-dev/tilt/internal/dockerignore"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 // Filter out spurious changes that we don't want to rebuild on, like IDE

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -25,11 +25,16 @@ func initEphemeralPathMatcher() model.PathMatcher {
 	// ignoring .sw? seems dangerous, since things like .swf or .swi exist, but ignoring the first few
 	// seems safe and should catch most cases
 	vimPatterns := []string{"**/4913", "**/*~", "**/.*.swp", "**/.*.swx", "**/.*.swo", "**/.*.swn"}
+	// kate (the default text editor for KDE) uses a file similar to Vim's .swp
+	// files, but it doesn't have the "incrememnting" character problem mentioned
+	// above
+	katePatterns := []string{"**/.*.kate-swp"}
 
 	allPatterns := []string{}
 	allPatterns = append(allPatterns, golandPatterns...)
 	allPatterns = append(allPatterns, emacsPatterns...)
 	allPatterns = append(allPatterns, vimPatterns...)
+	allPatterns = append(allPatterns, katePatterns...)
 
 	matcher, err := dockerignore.NewDockerPatternMatcher("/", allPatterns)
 	if err != nil {

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -1,0 +1,34 @@
+package ignore
+
+import (
+	"github.com/windmilleng/tilt/internal/dockerignore"
+	"github.com/windmilleng/tilt/internal/model"
+)
+
+// Filter out spurious changes that we don't want to rebuild on, like IDE
+// temp/lock files.
+//
+// This isn't an ideal solution. In an ideal world, the user would put
+// everything to ignore in their tiltignore/dockerignore files. This is a
+// stop-gap so they don't have a terrible experience if those files aren't
+// there or aren't in the right places.
+//
+// https://app.clubhouse.io/windmill/story/691/filter-out-ephemeral-file-changes
+var ephemeralPathMatcher = initEphemeralPathMatcher()
+
+func initEphemeralPathMatcher() model.PathMatcher {
+	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___"}
+	emacsPatterns := []string{"**/.#*"}
+	vimPatterns := []string{"**/4913", "**/*~", "**/.*.swp", "**/.*.swx"}
+
+	allPatterns := []string{}
+	allPatterns = append(allPatterns, golandPatterns...)
+	allPatterns = append(allPatterns, emacsPatterns...)
+	allPatterns = append(allPatterns, vimPatterns...)
+
+	matcher, err := dockerignore.NewDockerPatternMatcher("/", allPatterns)
+	if err != nil {
+		panic(err)
+	}
+	return matcher
+}

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -2,7 +2,7 @@ package ignore
 
 import (
 	"github.com/windmilleng/tilt/internal/dockerignore"
-	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/pkg/model"
 )
 
 // Filter out spurious changes that we don't want to rebuild on, like IDE

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -20,7 +20,6 @@
 package watch
 
 import (
-	"fmt"
 	"path/filepath"
 	"time"
 
@@ -53,7 +52,6 @@ func (d *fseventNotify) loop() {
 			}
 
 			for _, e := range events {
-				fmt.Println(e)
 				e.Path = filepath.Join("/", e.Path)
 
 				_, isPathWereWatching := d.pathsWereWatching[e.Path]
@@ -67,6 +65,7 @@ func (d *fseventNotify) loop() {
 				if err != nil {
 					logrus.Infof("Error matching path %q: %v", e.Path, err)
 				} else if ignore {
+					logrus.Tracef("Ignoring event for path: %v", e.Path)
 					continue
 				}
 

--- a/pkg/watch/watcher_naive.go
+++ b/pkg/watch/watcher_naive.go
@@ -129,6 +129,7 @@ func (d *naiveNotify) watchRecursively(dir string) error {
 		}
 
 		if shouldSkipDir {
+			logrus.Debugf("Ignoring directory and its contents (recursively): %s", path)
 			return filepath.SkipDir
 		}
 
@@ -234,6 +235,7 @@ func (d *naiveNotify) shouldNotify(path string) bool {
 	if err != nil {
 		logrus.Infof("Error matching path %q: %v", path, err)
 	} else if ignore {
+		logrus.Tracef("Ignoring event for path: %v", path)
 		return false
 	}
 


### PR DESCRIPTION
**What I did**
Big change here is to import the ephemeral ignore set from Tilt.

The `.git` directory is also ignored for now: this restriction
should probably be lifted and made configurable in the future,
but it's not generally important to watch and triggers a LOT of
events (e.g. Git creates `index.lock` files that will appear and
disappear rapidly as terminals/IDEs/etc interact with Git, even
for read-only operations).

The Tilt-provided ephemeral file set has been slowly devised over
time based on temporary files that can cause trouble. We can also
look at a more robust/configurable solution here in the future,
but thse provide a reasonable out-of-the-box configuration for
the moment.

There's also some small tweaks to the output to add missing
newlines in a few edge cases and such.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![Eurasian red squirrel](https://user-images.githubusercontent.com/841263/221231868-268c3291-da3e-47e1-b3b3-6a77c912863f.png)
