### PR TITLE
only consider containers with config_hash labels (i.e, created by compose)

### DIFF
--- a/pkg/compose/ls.go
+++ b/pkg/compose/ls.go
@@ -24,14 +24,14 @@ import (
 
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/utils"
-
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/sirupsen/logrus"
 )
 
 func (s *composeService) List(ctx context.Context, opts api.ListOptions) ([]api.Stack, error) {
 	list, err := s.apiClient().ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(hasProjectLabelFilter()),
+		Filters: filters.NewArgs(hasProjectLabelFilter(), hasConfigHashLabel()),
 		All:     opts.All,
 	})
 	if err != nil {
@@ -50,7 +50,8 @@ func containersToStacks(containers []moby.Container) ([]api.Stack, error) {
 	for _, project := range keys {
 		configFiles, err := combinedConfigFiles(containersByLabel[project])
 		if err != nil {
-			return nil, err
+			logrus.Warn(err.Error())
+			configFiles = "N/A"
 		}
 
 		projects = append(projects, api.Stack{


### PR DESCRIPTION
**What I did**
As `compose build` sets a few `com.docker.compose` labels we need to distinguish container created by compose and not by another command.

**Related issue**
close https://github.com/docker/compose/issues/10314

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
