### PR TITLE
Apply profiles during model loading

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -54,10 +54,11 @@ func (o *configOptions) ToProject(services []string) (*types.Project, error) {
 		cli.WithResolvedPaths(true),
 		cli.WithNormalization(!o.noNormalize),
 		cli.WithConsistency(!o.noConsistency),
+		cli.WithProfiles(o.Profiles),
 		cli.WithDiscardEnvFile)
 }
 
-func convertCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *cobra.Command {
+func configCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *cobra.Command {
 	opts := configOptions{
 		ProjectOptions: p,
 	}

--- a/go.mod
+++ b/go.mod
@@ -177,6 +177,8 @@ require (
 )
 
 replace (
+	github.com/compose-spec/compose-go => github.com/ndeloof/compose-go v1.2.4-0.20230228082114-ffc730be6172
+
 	// Override for e2e tests
 	github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7
 

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,6 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/compose-spec/compose-go v1.11.0 h1:YLl0wf4YU9ZVei6mqLxAfI2gWOrqnTsPBAcIe9cO9Zk=
-github.com/compose-spec/compose-go v1.11.0/go.mod h1:huuiqxbQTZLkagcN9D/1tEKZwMXVetYeIWtjCAVsoXw=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
@@ -575,6 +573,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/ndeloof/compose-go v1.2.4-0.20230228082114-ffc730be6172 h1:ZAscYFwnsEQBH+0qyetFKvmd3LlpHF+Pw238jrEYe+g=
+github.com/ndeloof/compose-go v1.2.4-0.20230228082114-ffc730be6172/go.mod h1:0/X/dTehChV+KBB696nOOl+HYzKn+XaIm4i12phUB5U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
**What I did**
this demonstrates https://github.com/compose-spec/compose-go/pull/359

using:
```yaml
services:
  test:
    image: nginx
  truc:
    profiles: [dev]
    image: blah
    env_file:
      - none
```

`docker compose config` won't try to load `none` env file as service is disabled by inactive profile.

**Related issue**
closes https://github.com/docker/compose/issues/8713

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
