### PR TITLE
test: tweak pause test to try and prevent failures in Windows CI

### DIFF
--- a/pkg/e2e/fixtures/pause/compose.yaml
+++ b/pkg/e2e/fixtures/pause/compose.yaml
@@ -2,8 +2,16 @@ services:
   a:
     image:  nginx:alpine
     ports: [80]
+    healthcheck:
+      test: wget --spider -S -T1 http://localhost:80
+      interval: 1s
+      timeout: 1s
   b:
     image:  nginx:alpine
     ports: [80]
     depends_on:
       - a
+    healthcheck:
+      test: wget --spider -S -T1 http://localhost:80
+      interval: 1s
+      timeout: 1s

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -103,7 +103,7 @@ func NewCLI(t testing.TB, opts ...CLIOption) *CLI {
 	for _, opt := range opts {
 		opt(c)
 	}
-	t.Log(c.RunDockerComposeCmdNoCheck(t, "version").Combined())
+	c.RunDockerComposeCmdNoCheck(t, "version")
 	return c
 }
 
@@ -305,7 +305,10 @@ func (c *CLI) RunDockerComposeCmd(t testing.TB, args ...string) *icmd.Result {
 // RunDockerComposeCmdNoCheck runs a docker compose command, don't presume of any expectation and returns a result
 func (c *CLI) RunDockerComposeCmdNoCheck(t testing.TB, args ...string) *icmd.Result {
 	t.Helper()
-	return icmd.RunCmd(c.NewDockerComposeCmd(t, args...))
+	cmd := c.NewDockerComposeCmd(t, args...)
+	cmd.Stdout = os.Stdout
+	t.Logf("Running command: %s", strings.Join(cmd.Command, " "))
+	return icmd.RunCmd(cmd)
 }
 
 // NewDockerComposeCmd creates a command object for Compose, either in plugin

--- a/pkg/e2e/pause_test.go
+++ b/pkg/e2e/pause_test.go
@@ -101,7 +101,7 @@ func TestPauseServiceAlreadyPaused(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	// launch a and wait for it to come up
-	cli.RunDockerComposeCmd(t, "up", "-d", "a")
+	cli.RunDockerComposeCmd(t, "up", "--wait", "a")
 	HTTPGetWithRetry(t, urlForService(t, cli, "a", 80), http.StatusOK, 50*time.Millisecond, 10*time.Second)
 
 	// pause a twice - first time should pass, second time fail


### PR DESCRIPTION
This test keeps failing with a timeout in Windows. I don't actually think it should take that long to bring up an nginx container, so I'm guessing that there's something else going on that's causing trouble.

Increase the verbosity when running Compose commands: I think this will generally make E2E test failures easier to diagnose by always logging the full command that's going to be run and also capturing stdout.

Add a health check and use `--wait` when launching the fixture for the pause test. Combined with the verbosity increase, this should make it easier to understand what's going on here.