### PR TITLE
Preserve symbol table in binaries for static analysis (`govulncheck`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 PKG := github.com/docker/compose/v2
 VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 
-GO_LDFLAGS ?= -s -w -X ${PKG}/internal.Version=${VERSION}
+GO_LDFLAGS ?= -w -X ${PKG}/internal.Version=${VERSION}
 GO_BUILDTAGS ?= e2e
 
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
While this stripping does decrease the binary size by some amount, it also removes the ability for `govulncheck` (https://go.dev/blog/vuln) to scan the binary for actual uses of vulnerable functions, requiring the user to clone the code locally and hope they're testing against the same version of the stdlib, etc that the binary was built with.  If we stop passing `-s`, then we can then run `govulncheck` on the binary directly (making it easier to flag both false positives in CVE scans _and_ actual issues worth looking into).

Here's an example of the output on a freshly built binary with this change:

```console
$ govulncheck ./bin/build/docker-compose
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Using govulncheck@v0.0.0 with
vulnerability data from https://vuln.go.dev (last modified 27 Feb 23 16:29 UTC).

Scanning your binary for known vulnerabilities...
No vulnerabilities found.
```

Compared to the 1.16.0 release binary:

```console
$ govulncheck ./docker-compose
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Using govulncheck@v0.0.0 with
vulnerability data from https://vuln.go.dev (last modified 27 Feb 23 16:29 UTC).

Scanning your binary for known vulnerabilities...
govulncheck: vulncheck.Binary: reading go:func.*: no symbol "go:func.*"
```

It's not 100% apples-to-apples, but the size difference between these binaries is ~46MiB for the 1.16.0 release and ~52MiB for the binary I built from this commit.