### PR TITLE
Report error if project name is empty after normalization

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -189,6 +189,10 @@ func (o *ProjectOptions) ToProject(services []string, po ...cli.ProjectOptionsFn
 		return nil, compose.WrapComposeError(err)
 	}
 
+	if project.Name == "" {
+		return nil, errors.New("project name can't be empty. Use `--project-name` to set a valid name")
+	}
+
 	for i, s := range project.Services {
 		s.CustomLabels = map[string]string{
 			api.ProjectLabel:     project.Name,


### PR DESCRIPTION
**What I did**
Check project name is not empty after options have been applied.
This can happen as name is computed from parent directory

**Related issue**
see https://github.com/docker/compose/issues/10313

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
