### PR TITLE
update compose-go

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -193,6 +193,11 @@ func (o *ProjectOptions) ToProject(services []string, po ...cli.ProjectOptionsFn
 		return nil, errors.New("project name can't be empty. Use `--project-name` to set a valid name")
 	}
 
+	err = project.EnableServices(services...)
+	if err != nil {
+		return nil, err
+	}
+
 	for i, s := range project.Services {
 		s.CustomLabels = map[string]string{
 			api.ProjectLabel:     project.Name,
@@ -207,20 +212,6 @@ func (o *ProjectOptions) ToProject(services []string, po ...cli.ProjectOptionsFn
 		}
 		project.Services[i] = s
 	}
-
-	if profiles, ok := options.Environment["COMPOSE_PROFILES"]; ok && len(o.Profiles) == 0 {
-		o.Profiles = append(o.Profiles, strings.Split(profiles, ",")...)
-	}
-
-	if len(services) > 0 {
-		s, err := project.GetServices(services...)
-		if err != nil {
-			return nil, err
-		}
-		o.Profiles = append(o.Profiles, s.GetProfiles()...)
-	}
-
-	project.ApplyProfiles(o.Profiles)
 
 	project.WithoutUnnecessaryResources()
 
@@ -237,6 +228,7 @@ func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 			cli.WithDotEnv,
 			cli.WithConfigFileEnv,
 			cli.WithDefaultConfigPath,
+			cli.WithProfiles(o.Profiles),
 			cli.WithName(o.ProjectName))...)
 }
 

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -54,6 +54,7 @@ func (o *configOptions) ToProject(services []string) (*types.Project, error) {
 		cli.WithResolvedPaths(true),
 		cli.WithNormalization(!o.noNormalize),
 		cli.WithConsistency(!o.noConsistency),
+		cli.WithProfiles(o.Profiles),
 		cli.WithDiscardEnvFile)
 }
 
@@ -181,7 +182,7 @@ func runHash(streams api.Streams, opts configOptions) error {
 	}
 
 	if len(services) > 0 {
-		err = withSelectedServicesOnly(project, services)
+		err = project.ForServices(services, types.IgnoreDependencies)
 		if err != nil {
 			return err
 		}

--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v2/pkg/api"
-	"github.com/docker/compose/v2/pkg/utils"
 )
 
 type pullOptions struct {
@@ -70,21 +69,6 @@ func pullCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	return cmd
 }
 
-func withSelectedServicesOnly(project *types.Project, services []string) error {
-	enabled, err := project.GetServices(services...)
-	if err != nil {
-		return err
-	}
-	for _, s := range project.Services {
-		if !utils.StringContains(services, s.Name) {
-			project.DisabledServices = append(project.DisabledServices, s)
-		}
-	}
-	project.Services = enabled
-
-	return nil
-}
-
 func runPull(ctx context.Context, backend api.Service, opts pullOptions, services []string) error {
 	project, err := opts.ToProject(services)
 	if err != nil {
@@ -92,7 +76,7 @@ func runPull(ctx context.Context, backend api.Service, opts pullOptions, service
 	}
 
 	if !opts.includeDeps {
-		err := withSelectedServicesOnly(project, services)
+		err := project.ForServices(services, types.IgnoreDependencies)
 		if err != nil {
 			return err
 		}

--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v2/pkg/api"
@@ -58,7 +59,7 @@ func runPush(ctx context.Context, backend api.Service, opts pushOptions, service
 	}
 
 	if !opts.IncludeDeps {
-		err := withSelectedServicesOnly(project, services)
+		err := project.ForServices(services, types.IgnoreDependencies)
 		if err != nil {
 			return err
 		}

--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v2/pkg/api"
@@ -57,7 +58,7 @@ func runRestart(ctx context.Context, backend api.Service, opts restartOptions, s
 	}
 
 	if opts.noDeps {
-		err := withSelectedServicesOnly(project, services)
+		err := project.ForServices(services, types.IgnoreDependencies)
 		if err != nil {
 			return err
 		}

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -91,12 +91,10 @@ func (opts runOptions) apply(project *types.Project) error {
 	}
 
 	if opts.noDeps {
-		for _, s := range project.Services {
-			if s.Name != opts.Service {
-				project.DisabledServices = append(project.DisabledServices, s)
-			}
+		err := project.ForServices([]string{opts.Service}, types.IgnoreDependencies)
+		if err != nil {
+			return err
 		}
-		project.Services = types.Services{target}
 	}
 
 	for i, s := range project.Services {

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -54,7 +54,7 @@ type upOptions struct {
 
 func (opts upOptions) apply(project *types.Project, services []string) error {
 	if opts.noDeps {
-		err := withSelectedServicesOnly(project, services)
+		err := project.ForServices(services, types.IgnoreDependencies)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go v1.11.0
+	github.com/compose-spec/compose-go v1.12.0
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.19
 	github.com/cucumber/godog v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/compose-spec/compose-go v1.11.0 h1:YLl0wf4YU9ZVei6mqLxAfI2gWOrqnTsPBAcIe9cO9Zk=
-github.com/compose-spec/compose-go v1.11.0/go.mod h1:huuiqxbQTZLkagcN9D/1tEKZwMXVetYeIWtjCAVsoXw=
+github.com/compose-spec/compose-go v1.12.0 h1:MSyWW//yijispnqmTqJSMv1ptRTlKU1sLPHJdc2ACnA=
+github.com/compose-spec/compose-go v1.12.0/go.mod h1:0/X/dTehChV+KBB696nOOl+HYzKn+XaIm4i12phUB5U=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=


### PR DESCRIPTION
**What I did**
bump compose-go 
- use updated `ForServices` with options to implement `--no-deps` flag
- pass selected profiles to loader to avoid loading disabled services environment

#closes https://github.com/docker/compose/issues/8713

