### PR TITLE
one off container name use configured Separator for naming

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -62,7 +62,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 
 	slug := stringid.GenerateRandomID()
 	if service.ContainerName == "" {
-		service.ContainerName = fmt.Sprintf("%s_%s_run_%s", project.Name, service.Name, stringid.TruncateID(slug))
+		service.ContainerName = fmt.Sprintf("%[1]s%[4]s%[2]s%[4]srun%[4]s%[3]s", project.Name, service.Name, stringid.TruncateID(slug), api.Separator)
 	}
 	service.Scale = 1
 	service.Restart = ""

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -48,11 +48,11 @@ func TestLocalComposeRun(t *testing.T) {
 		for _, line := range lines {
 			fields := strings.Fields(line)
 			containerID := fields[len(fields)-1]
-			assert.Assert(t, !strings.HasPrefix(containerID, "run-test_front"))
-			if strings.HasPrefix(containerID, "run-test_back") {
+			assert.Assert(t, !strings.HasPrefix(containerID, "run-test-front"))
+			if strings.HasPrefix(containerID, "run-test-back") {
 				// only the one-off container for back service
-				assert.Assert(t, strings.HasPrefix(containerID, "run-test_back_run_"), containerID)
-				truncatedSlug = strings.Replace(containerID, "run-test_back_run_", "", 1)
+				assert.Assert(t, strings.HasPrefix(containerID, "run-test-back-run-"), containerID)
+				truncatedSlug = strings.Replace(containerID, "run-test-back-run-", "", 1)
 				runContainerID = containerID
 			}
 			if strings.HasPrefix(containerID, "run-test-db-1") {
@@ -75,7 +75,7 @@ func TestLocalComposeRun(t *testing.T) {
 		assert.Equal(t, lines[len(lines)-1], "Hello again", res.Stdout())
 
 		res = c.RunDockerCmd(t, "ps", "--all")
-		assert.Assert(t, strings.Contains(res.Stdout(), "run-test_back"), res.Stdout())
+		assert.Assert(t, strings.Contains(res.Stdout(), "run-test-back"), res.Stdout())
 	})
 
 	t.Run("down", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestLocalComposeRun(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: "compose_run_test.go"})
 
 		res = c.RunDockerCmd(t, "ps", "--all")
-		assert.Assert(t, strings.Contains(res.Stdout(), "run-test_back"), res.Stdout())
+		assert.Assert(t, strings.Contains(res.Stdout(), "run-test-back"), res.Stdout())
 	})
 
 	t.Run("compose run --publish", func(t *testing.T) {

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -143,31 +143,31 @@ func TestStartStopWithOneOffs(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
-		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-run"), res.Combined())
 	})
 
 	t.Run("stop (not one-off containers)", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "stop")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
-		assert.Assert(t, !strings.Contains(res.Combined(), "e2e_start_stop_with_oneoffs_bar_run"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e_start_stop_with_oneoffs-bar-run"), res.Combined())
 
 		res = c.RunDockerComposeCmd(t, "--project-name", projectName, "ps", "-a", "--status", "running")
-		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-run"), res.Combined())
 	})
 
 	t.Run("start (not one-off containers)", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "start")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
-		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-run"), res.Combined())
 	})
 
 	t.Run("restart (not one-off containers)", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "--project-name", projectName, "restart")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-foo-1"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-1"), res.Combined())
-		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs_bar_run"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "e2e-start-stop-with-oneoffs-bar-run"), res.Combined())
 	})
 
 	t.Run("down", func(t *testing.T) {


### PR DESCRIPTION
**What I did**
use configured name separator to define oneoff container name

**Related issue**
closes https://github.com/docker/compose/issues/10354
