### PR TITLE
Fix collection of built image IDs

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -57,14 +57,15 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 	}
 
 	return api.BuildOptions{
-		Pull:     opts.pull,
-		Push:     opts.push,
-		Progress: opts.progress,
-		Args:     types.NewMappingWithEquals(opts.args),
-		NoCache:  opts.noCache,
-		Quiet:    opts.quiet,
-		Services: services,
-		SSHs:     SSHKeys,
+		Pull:         opts.pull,
+		Push:         opts.push,
+		Progress:     opts.progress,
+		Args:         types.NewMappingWithEquals(opts.args),
+		NoCache:      opts.noCache,
+		Quiet:        opts.quiet,
+		Services:     services,
+		SSHs:         SSHKeys,
+		AllPlatforms: true,
 	}, nil
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -105,6 +105,8 @@ type BuildOptions struct {
 	Services []string
 	// Ssh authentications passed in the command line
 	SSHs []types.SSHKey
+	// AllPlatforms build for all configured platforms
+	AllPlatforms bool
 }
 
 // CreateOptions group options of the Create API

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -186,7 +186,7 @@ func loadDevelopmentConfig(service types.ServiceConfig, project *types.Project) 
 func (s *composeService) makeRebuildFn(ctx context.Context, project *types.Project) func(services []string) {
 	return func(services []string) {
 		fmt.Fprintf(s.stderr(), "Updating %s after changes were detected\n", strings.Join(services, ", "))
-		imageIds, err := s.build(ctx, project, api.BuildOptions{
+		imageIds, err := s.build(ctx, project, nil, api.BuildOptions{
 			Services: services,
 		})
 		if err != nil {

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -265,7 +265,11 @@ func TestBuildImageDependencies(t *testing.T) {
 	})
 
 	t.Run("BuildKit", func(t *testing.T) {
-		t.Skip("See https://github.com/docker/compose/issues/9232")
+		cli := NewParallelCLI(t, WithEnv(
+			"DOCKER_BUILDKIT=1",
+			"COMPOSE_FILE=./fixtures/build-dependencies/compose.yaml",
+		))
+		doTest(t, cli)
 	})
 }
 


### PR DESCRIPTION
**What I did**
Fix collection of built image IDs. We used a map[string]string to be [overridden by subsequent calls to `s.doBuild`](https://github.com/docker/compose/blob/v2/pkg/compose/build.go#L101), so loosing earlier results (wonder this didn't resulted in some bugs...). Replaced by a pre-allocated `[]string` using service index from `project.Services` to record IDs collected by goroutines.

Earlier bypass to `doBuildClassic` when buildkit is disabled: Don't convert build configuration into buildx `build.Options` before passing to `doBuildClassic` so that it can just use the plain `types.BuildConfig`
