### PR TITLE
use `build` as common API for build scenarios

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/compose/v2/pkg/utils"
 )
 
 // Service manages a compose project
@@ -105,6 +106,38 @@ type BuildOptions struct {
 	Services []string
 	// Ssh authentications passed in the command line
 	SSHs []types.SSHKey
+}
+
+// Apply mutates project according to build options
+func (o BuildOptions) Apply(project *types.Project) error {
+	platform := project.Environment["DOCKER_DEFAULT_PLATFORM"]
+	for i, service := range project.Services {
+		if service.Image == "" && service.Build == nil {
+			return fmt.Errorf("invalid service %q. Must specify either image or build", service.Name)
+		}
+
+		if service.Build == nil {
+			continue
+		}
+		service.Image = GetImageNameOrDefault(service, project.Name)
+		if platform != "" {
+			if len(service.Build.Platforms) > 0 && !utils.StringContains(service.Build.Platforms, platform) {
+				return fmt.Errorf("service %q build.platforms does not support value set by DOCKER_DEFAULT_PLATFORM: %s", service.Name, platform)
+			}
+			service.Platform = platform
+		}
+		if service.Platform != "" {
+			if len(service.Build.Platforms) > 0 && !utils.StringContains(service.Build.Platforms, service.Platform) {
+				return fmt.Errorf("service %q build configuration does not support platform: %s", service.Name, service.Platform)
+			}
+		}
+
+		service.Build.Pull = service.Build.Pull || o.Pull
+		service.Build.NoCache = service.Build.NoCache || o.NoCache
+
+		project.Services[i] = service
+	}
+	return nil
 }
 
 // CreateOptions group options of the Create API

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -27,55 +27,23 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/types"
-	buildx "github.com/docker/buildx/build"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command/image/build"
-	"github.com/docker/compose/v2/pkg/utils"
 	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder/remotecontext/urlutil"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/hashicorp/go-multierror"
-	"github.com/moby/buildkit/util/entitlements"
 	"github.com/pkg/errors"
 
 	"github.com/docker/compose/v2/pkg/api"
 )
 
-func (s *composeService) doBuildClassic(ctx context.Context, project *types.Project, opts map[string]buildx.Options) (map[string]string, error) {
-	nameDigests := make(map[string]string)
-	var errs error
-	err := project.WithServices(nil, func(service types.ServiceConfig) error {
-		imageName := api.GetImageNameOrDefault(service, project.Name)
-		o, ok := opts[imageName]
-		if !ok {
-			return nil
-		}
-		digest, err := s.doBuildClassicSimpleImage(ctx, o)
-		if err != nil {
-			errs = multierror.Append(errs, err).ErrorOrNil()
-		}
-		nameDigests[imageName] = digest
-		if errs != nil {
-			return nil
-		}
-		if len(o.Exports) != 0 && o.Exports[0].Attrs["push"] == "true" {
-			return s.push(ctx, project, api.PushOptions{})
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return nameDigests, errs
-}
-
 //nolint:gocyclo
-func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options buildx.Options) (string, error) {
+func (s *composeService) doBuildClassic(ctx context.Context, service types.ServiceConfig) (string, error) {
 	var (
 		buildCtx      io.ReadCloser
 		dockerfileCtx io.ReadCloser
@@ -86,31 +54,31 @@ func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options 
 		err error
 	)
 
-	dockerfileName := options.Inputs.DockerfilePath
-	specifiedContext := options.Inputs.ContextPath
+	dockerfileName := dockerFilePath(service.Build.Context, service.Build.Dockerfile)
+	specifiedContext := service.Build.Context
 	progBuff := s.stdout()
 	buildBuff := s.stdout()
-	if options.ImageIDFile != "" {
-		// Avoid leaving a stale file if we eventually fail
-		if err := os.Remove(options.ImageIDFile); err != nil && !os.IsNotExist(err) {
-			return "", errors.Wrap(err, "removing image ID file")
-		}
+
+	if len(service.Build.Platforms) > 1 {
+		return "", errors.Errorf("the classic builder doesn't support multi-arch build, set DOCKER_BUILDKIT=1 to use BuildKit")
+	}
+	if service.Build.Privileged {
+		return "", errors.Errorf("the classic builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use BuildKit")
+	}
+	if len(service.Build.AdditionalContexts) > 0 {
+		return "", errors.Errorf("the classic builder doesn't support additional contexts, set DOCKER_BUILDKIT=1 to use BuildKit")
+	}
+	if len(service.Build.SSH) > 0 {
+		return "", errors.Errorf("the classic builder doesn't support SSH keys, set DOCKER_BUILDKIT=1 to use BuildKit")
+	}
+	if len(service.Build.Secrets) > 0 {
+		return "", errors.Errorf("the classic builder doesn't support secrets, set DOCKER_BUILDKIT=1 to use BuildKit")
 	}
 
-	if len(options.Platforms) > 1 {
-		return "", errors.Errorf("this builder doesn't support multi-arch build, set DOCKER_BUILDKIT=1 to use multi-arch builder")
+	if service.Build.Labels == nil {
+		service.Build.Labels = make(map[string]string)
 	}
-	if utils.Contains(options.Allow, entitlements.EntitlementSecurityInsecure) {
-		return "", errors.Errorf("this builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use builder supporting privileged mode")
-	}
-	if len(options.Inputs.NamedContexts) > 0 {
-		return "", errors.Errorf("this builder doesn't support additional contexts, set DOCKER_BUILDKIT=1 to use BuildKit which does")
-	}
-
-	if options.Labels == nil {
-		options.Labels = make(map[string]string)
-	}
-	options.Labels[api.ImageBuilderLabel] = "classic"
+	service.Build.Labels[api.ImageBuilderLabel] = "classic"
 
 	switch {
 	case isLocalDir(specifiedContext):
@@ -189,8 +157,8 @@ func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options 
 	for k, auth := range creds {
 		authConfigs[k] = dockertypes.AuthConfig(auth)
 	}
-	buildOptions := imageBuildOptions(options)
-	buildOptions.Version = dockertypes.BuilderV1
+	buildOptions := imageBuildOptions(service.Build)
+	buildOptions.Tags = append(buildOptions.Tags, service.Image)
 	buildOptions.Dockerfile = relDockerfile
 	buildOptions.AuthConfigs = authConfigs
 
@@ -235,15 +203,6 @@ func (s *composeService) doBuildClassicSimpleImage(ctx context.Context, options 
 			"files and directories.")
 	}
 
-	if options.ImageIDFile != "" {
-		if imageID == "" {
-			return "", errors.Errorf("Server did not provide an image ID. Cannot write %s", options.ImageIDFile)
-		}
-		if err := os.WriteFile(options.ImageIDFile, []byte(imageID), 0o666); err != nil {
-			return "", err
-		}
-	}
-
 	return imageID, nil
 }
 
@@ -252,25 +211,18 @@ func isLocalDir(c string) bool {
 	return err == nil
 }
 
-func imageBuildOptions(options buildx.Options) dockertypes.ImageBuildOptions {
+func imageBuildOptions(config *types.BuildConfig) dockertypes.ImageBuildOptions {
 	return dockertypes.ImageBuildOptions{
-		Tags:        options.Tags,
-		NoCache:     options.NoCache,
+		Version:     dockertypes.BuilderV1,
+		Tags:        config.Tags,
+		NoCache:     config.NoCache,
 		Remove:      true,
-		PullParent:  options.Pull,
-		BuildArgs:   toMapStringStringPtr(options.BuildArgs),
-		Labels:      options.Labels,
-		NetworkMode: options.NetworkMode,
-		ExtraHosts:  options.ExtraHosts,
-		Target:      options.Target,
+		PullParent:  config.Pull,
+		BuildArgs:   config.Args,
+		Labels:      config.Labels,
+		NetworkMode: config.Network,
+		ExtraHosts:  config.ExtraHosts.AsList(),
+		Target:      config.Target,
+		Isolation:   container.Isolation(config.Isolation),
 	}
-}
-
-func toMapStringStringPtr(source map[string]string) map[string]*string {
-	dest := make(map[string]*string)
-	for k, v := range source {
-		v := v
-		dest[k] = &v
-	}
-	return dest
 }

--- a/pkg/compose/build_test.go
+++ b/pkg/compose/build_test.go
@@ -1,0 +1,121 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestPrepareProjectForBuild(t *testing.T) {
+	t.Run("build service platform", func(t *testing.T) {
+		project := types.Project{
+			Services: []types.ServiceConfig{
+				{
+					Name:  "test",
+					Image: "foo",
+					Build: &types.BuildConfig{
+						Context: ".",
+						Platforms: []string{
+							"linux/amd64",
+							"linux/arm64",
+							"alice/32",
+						},
+					},
+					Platform: "alice/32",
+				},
+			},
+		}
+
+		s := &composeService{}
+		err := s.prepareProjectForBuild(&project, nil)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, project.Services[0].Build.Platforms, types.StringList{"alice/32"})
+	})
+
+	t.Run("build DOCKER_DEFAULT_PLATFORM", func(t *testing.T) {
+		project := types.Project{
+			Environment: map[string]string{
+				"DOCKER_DEFAULT_PLATFORM": "linux/amd64",
+			},
+			Services: []types.ServiceConfig{
+				{
+					Name:  "test",
+					Image: "foo",
+					Build: &types.BuildConfig{
+						Context: ".",
+						Platforms: []string{
+							"linux/amd64",
+							"linux/arm64",
+						},
+					},
+				},
+			},
+		}
+
+		s := &composeService{}
+		err := s.prepareProjectForBuild(&project, nil)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, project.Services[0].Build.Platforms, types.StringList{"linux/amd64"})
+	})
+
+	t.Run("skip existing image", func(t *testing.T) {
+		project := types.Project{
+			Services: []types.ServiceConfig{
+				{
+					Name:  "test",
+					Image: "foo",
+					Build: &types.BuildConfig{
+						Context: ".",
+					},
+				},
+			},
+		}
+
+		s := &composeService{}
+		err := s.prepareProjectForBuild(&project, map[string]string{"foo": "exists"})
+		assert.NilError(t, err)
+		assert.Check(t, project.Services[0].Build == nil)
+	})
+
+	t.Run("unsupported build platform", func(t *testing.T) {
+		project := types.Project{
+			Environment: map[string]string{
+				"DOCKER_DEFAULT_PLATFORM": "commodore/64",
+			},
+			Services: []types.ServiceConfig{
+				{
+					Name:  "test",
+					Image: "foo",
+					Build: &types.BuildConfig{
+						Context: ".",
+						Platforms: []string{
+							"linux/amd64",
+							"linux/arm64",
+						},
+					},
+				},
+			},
+		}
+
+		s := &composeService{}
+		err := s.prepareProjectForBuild(&project, nil)
+		assert.Check(t, err != nil)
+	})
+}

--- a/pkg/compose/dependencies_test.go
+++ b/pkg/compose/dependencies_test.go
@@ -27,24 +27,26 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-var project = types.Project{
-	Services: []types.ServiceConfig{
-		{
-			Name: "test1",
-			DependsOn: map[string]types.ServiceDependency{
-				"test2": {},
+func createTestProject() *types.Project {
+	return &types.Project{
+		Services: []types.ServiceConfig{
+			{
+				Name: "test1",
+				DependsOn: map[string]types.ServiceDependency{
+					"test2": {},
+				},
+			},
+			{
+				Name: "test2",
+				DependsOn: map[string]types.ServiceDependency{
+					"test3": {},
+				},
+			},
+			{
+				Name: "test3",
 			},
 		},
-		{
-			Name: "test2",
-			DependsOn: map[string]types.ServiceDependency{
-				"test3": {},
-			},
-		},
-		{
-			Name: "test3",
-		},
-	},
+	}
 }
 
 func TestTraversalWithMultipleParents(t *testing.T) {
@@ -97,7 +99,7 @@ func TestInDependencyUpCommandOrder(t *testing.T) {
 	t.Cleanup(cancel)
 
 	var order []string
-	err := InDependencyOrder(ctx, &project, func(ctx context.Context, service string) error {
+	err := InDependencyOrder(ctx, createTestProject(), func(ctx context.Context, service string) error {
 		order = append(order, service)
 		return nil
 	})
@@ -110,7 +112,7 @@ func TestInDependencyReverseDownCommandOrder(t *testing.T) {
 	t.Cleanup(cancel)
 
 	var order []string
-	err := InReverseDependencyOrder(ctx, &project, func(ctx context.Context, service string) error {
+	err := InReverseDependencyOrder(ctx, createTestProject(), func(ctx context.Context, service string) error {
 		order = append(order, service)
 		return nil
 	})

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -54,6 +54,11 @@ func (s *composeService) Watch(ctx context.Context, project *types.Project, serv
 	needRebuild := make(chan string)
 	needSync := make(chan api.CopyOptions, 5)
 
+	err := s.prepareProjectForBuild(project, nil)
+	if err != nil {
+		return err
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		clock := clockwork.NewRealClock()

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -265,7 +265,11 @@ func TestBuildImageDependencies(t *testing.T) {
 	})
 
 	t.Run("BuildKit", func(t *testing.T) {
-		t.Skip("See https://github.com/docker/compose/issues/9232")
+		cli := NewParallelCLI(t, WithEnv(
+			"DOCKER_BUILDKIT=1",
+			"COMPOSE_FILE=./fixtures/build-dependencies/compose.yaml",
+		))
+		doTest(t, cli)
 	})
 }
 

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -374,7 +374,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 		})
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      "this builder doesn't support multi-arch build, set DOCKER_BUILDKIT=1 to use multi-arch builder",
+			Err:      "the classic builder doesn't support multi-arch build, set DOCKER_BUILDKIT=1 to use BuildKit",
 		})
 	})
 
@@ -391,7 +391,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 			"-f", "fixtures/build-test/platforms/compose-service-platform-not-in-build-platforms.yaml", "build")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      `service.platform "linux/riscv64" should be part of the service.build.platforms: ["linux/amd64" "linux/arm64"]`,
+			Err:      `service "platforms" build configuration does not support platform: linux/riscv64`,
 		})
 	})
 
@@ -402,7 +402,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 		})
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      `DOCKER_DEFAULT_PLATFORM "windows/amd64" value should be part of the service.build.platforms: ["linux/amd64" "linux/arm64"]`,
+			Err:      `service "platforms" build.platforms does not support value set by DOCKER_DEFAULT_PLATFORM: windows/amd64`,
 		})
 	})
 
@@ -414,7 +414,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 		})
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      "this builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use builder supporting privileged mode",
+			Err:      "the classic builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use BuildKit",
 		})
 	})
 

--- a/pkg/e2e/fixtures/build-dependencies/service.dockerfile
+++ b/pkg/e2e/fixtures/build-dependencies/service.dockerfile
@@ -12,8 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM alpine
-
-COPY --from=base /hello.txt /hello.txt
+FROM base
 
 CMD [ "cat", "/hello.txt" ]


### PR DESCRIPTION
**What I did**
from various places we trigger builds (`build`,  `up` and `watch` commands), use `composeService#build` as the single entry point into the (complex) build logic. 

This allows to manage classic vs buildkit at early stage, and to pass the BuildConfig to classic builder, while we only get it converted into `buildx.Options` for buildkit builder

To get `up` to only build selected platform, `prepareProjectForBuild` mutate the `project` to remove unnecessary build config so that the exact same `build` function can be used both by `up` and `build`.
Added a test case to make it obvious about this mutation and prevent any regression next time we try to change this codebase :)

**Related issue**
see https://github.com/docker/compose/issues/10056 for illustration of the issue using `buildx.Options` to configure classic builder

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/225618253-808b5d92-bf18-4931-b52c-782ae5e463fd.png)


