### PR TITLE
Fix concurrent map read/write when recreating containers

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -399,7 +399,8 @@ func (s *composeService) createContainer(ctx context.Context, project *types.Pro
 	w := progress.ContextWriter(ctx)
 	eventName := "Container " + name
 	w.Event(progress.CreatingEvent(eventName))
-	container, err = s.createMobyContainer(ctx, project, service, name, number, nil, autoRemove, useNetworkAliases, attachStdin, w)
+	container, err = s.createMobyContainer(ctx, project, service, name, number, nil,
+		autoRemove, useNetworkAliases, attachStdin, w, mergeLabels(service.Labels, service.CustomLabels))
 	if err != nil {
 		return
 	}
@@ -424,8 +425,9 @@ func (s *composeService) recreateContainer(ctx context.Context, project *types.P
 	}
 	name := getContainerName(project.Name, service, number)
 	tmpName := fmt.Sprintf("%s_%s", replaced.ID[:12], name)
-	service.CustomLabels[api.ContainerReplaceLabel] = replaced.ID
-	created, err = s.createMobyContainer(ctx, project, service, tmpName, number, inherited, false, true, false, w)
+	created, err = s.createMobyContainer(ctx, project, service, tmpName, number, inherited,
+		false, true, false, w,
+		mergeLabels(service.Labels, service.CustomLabels).Add(api.ContainerReplaceLabel, replaced.ID))
 	if err != nil {
 		return created, err
 	}
@@ -475,10 +477,19 @@ func (s *composeService) startContainer(ctx context.Context, container moby.Cont
 	return nil
 }
 
-func (s *composeService) createMobyContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,
-	name string, number int, inherit *moby.Container, autoRemove bool, useNetworkAliases bool, attachStdin bool, w progress.Writer) (moby.Container, error) {
+func (s *composeService) createMobyContainer(ctx context.Context,
+	project *types.Project,
+	service types.ServiceConfig,
+	name string,
+	number int,
+	inherit *moby.Container,
+	autoRemove, useNetworkAliases, attachStdin bool,
+	w progress.Writer,
+	labels types.Labels,
+) (moby.Container, error) {
 	var created moby.Container
-	containerConfig, hostConfig, networkingConfig, err := s.getCreateOptions(ctx, project, service, number, inherit, autoRemove, attachStdin)
+	containerConfig, hostConfig, networkingConfig, err := s.getCreateOptions(ctx, project, service, number, inherit,
+		autoRemove, attachStdin, labels)
 	if err != nil {
 		return created, err
 	}
@@ -724,4 +735,14 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 		w.Event(progress.StartedEvent(eventName))
 	}
 	return nil
+}
+
+func mergeLabels(ls ...types.Labels) types.Labels {
+	merged := types.Labels{}
+	for _, l := range ls {
+		for k, v := range l {
+			merged[k] = v
+		}
+	}
+	return merged
 }

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -236,10 +236,16 @@ func (s *composeService) ensureProjectVolumes(ctx context.Context, project *type
 	return nil
 }
 
-func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project, service types.ServiceConfig,
-	number int, inherit *moby.Container, autoRemove bool, attachStdin bool) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
+func (s *composeService) getCreateOptions(ctx context.Context,
+	p *types.Project,
+	service types.ServiceConfig,
+	number int,
+	inherit *moby.Container,
+	autoRemove, attachStdin bool,
+	labels types.Labels,
+) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
 
-	labels, err := s.prepareLabels(service, number)
+	labels, err := s.prepareLabels(labels, service, number)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -451,15 +457,7 @@ func parseSecurityOpts(p *types.Project, securityOpts []string) ([]string, bool,
 	return parsed, unconfined, nil
 }
 
-func (s *composeService) prepareLabels(service types.ServiceConfig, number int) (map[string]string, error) {
-	labels := map[string]string{}
-	for k, v := range service.Labels {
-		labels[k] = v
-	}
-	for k, v := range service.CustomLabels {
-		labels[k] = v
-	}
-
+func (s *composeService) prepareLabels(labels types.Labels, service types.ServiceConfig, number int) (map[string]string, error) {
 	hash, err := ServiceHash(service)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Why i did it**

`docker-compose.yaml`

```
services:
  agent:
    image: python:3.7
   command: echo "Luis"
```

`docker-compose -f docker-compose.yaml up --force-recreate --scale agent=500`

`fatal error: concurrent map iteration and map write`

**What I did**

For each container, the `CustomLabels` map was being filled out and used as a way to pass labels to lower levels of the stack while being concurrently read by other goroutines in the process of spinning other containers. A new `labels` argument was added and propagated down the stack thus avoiding the need to set the map.

**Related issue**

fixes #10319 


![IMG_20230309_195856](https://user-images.githubusercontent.com/639415/225874272-9ed065bc-0fe2-4a29-802e-03b7429b20b8.jpg)

I love it when a plan comes together