### PR TITLE
watch: data race / segfault fixes

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -455,6 +455,9 @@ func (s *composeService) recreateContainer(ctx context.Context, project *types.P
 
 // setDependentLifecycle define the Lifecycle strategy for all services to depend on specified service
 func setDependentLifecycle(project *types.Project, service string, strategy string) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	for i, s := range project.Services {
 		if utils.StringContains(s.GetDependencies(), service) {
 			if s.Extensions == nil {

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -25,9 +25,7 @@ package watch
 // there or aren't in the right places.
 //
 // https://app.clubhouse.io/windmill/story/691/filter-out-ephemeral-file-changes
-var EphemeralPathMatcher = initEphemeralPathMatcher()
-
-func initEphemeralPathMatcher() PathMatcher {
+func EphemeralPathMatcher() PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
 	emacsPatterns := []string{"**/.#*", "**/#*#"}
 	// if .swp is taken (presumably because multiple vims are running in that dir),

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -24,7 +24,8 @@ package watch
 // stop-gap so they don't have a terrible experience if those files aren't
 // there or aren't in the right places.
 //
-// https://app.clubhouse.io/windmill/story/691/filter-out-ephemeral-file-changes
+// NOTE: The underlying `patternmatcher` is NOT always Goroutine-safe, so
+// this is not a singleton; we create an instance for each watcher currently.
 func EphemeralPathMatcher() PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
 	emacsPatterns := []string{"**/.#*", "**/#*#"}

--- a/pkg/watch/ephemeral_test.go
+++ b/pkg/watch/ephemeral_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 Docker Compose CLI authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package watch_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/compose/v2/pkg/watch"
+)
+
+func TestEphemeralPathMatcher(t *testing.T) {
+	ignored := []string{
+		".file.txt.swp",
+		"/path/file.txt~",
+		"/home/moby/proj/.idea/modules.xml",
+		".#file.txt",
+		"#file.txt#",
+		"/dir/.file.txt.kate-swp",
+		"/go/app/1234-go-tmp-umask",
+	}
+	matcher := watch.EphemeralPathMatcher()
+	for _, p := range ignored {
+		ok, err := matcher.Matches(p)
+		if assert.NoErrorf(t, err, "Matching %s", p) {
+			assert.Truef(t, ok, "Path %s should have matched", p)
+		}
+	}
+
+	const includedPath = "normal.txt"
+	ok, err := matcher.Matches(includedPath)
+	if assert.NoErrorf(t, err, "Matching %s", includedPath) {
+		assert.Falsef(t, ok, "Path %s should NOT have matched", includedPath)
+	}
+}


### PR DESCRIPTION
**What I did**
Was getting segfaults with multiple services using `x-develop` and `watch` at the same time. Turns out the Moby path matcher lazily initializes the regex pattern internally the first time it's used, so it's not goroutine-safe.

Change here is to not use a global instance for the ephemeral path matcher, but a per-watcher instance.

Additionally, the data race detector caught a couple other issues that were easy enough to fix:
 * Use the lock that's used elsewhere for convergence before manipulating
 * Eliminate concurrent map access when triggering rebuilds

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![bear prying open a trash can](https://user-images.githubusercontent.com/841263/227050477-b1beae72-ebc3-4dee-9488-c28e5177b639.png)
