### PR TITLE
test: fix e2e commands on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,11 @@ jobs:
         name: Test plugin mode
         if: ${{ matrix.mode == 'plugin' }}
         run: |
-          make e2e-compose
+          rm -rf ./covdatafiles
+          mkdir ./covdatafiles
+          make e2e-compose GOCOVERDIR=covdatafiles
+          go tool covdata textfmt -i=covdatafiles -o=coverage.out
+
       -
         name: Test standalone mode
         if: ${{ matrix.mode == 'standalone' }}

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ ifeq ($(OS),Windows_NT)
 else
     DETECTED_OS = $(shell uname -s)
 endif
+
 ifeq ($(DETECTED_OS),Linux)
 	MOBY_DOCKER=/usr/bin/docker
 endif
@@ -71,10 +72,7 @@ install: binary
 
 .PHONY: e2e-compose
 e2e-compose: ## Run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
-	rm -rf covdatafiles
-	mkdir covdatafiles
-	GOCOVERDIR=covdatafiles go test $(TEST_FLAGS) -count=1 ./pkg/e2e
-	go tool covdata textfmt -i=covdatafiles -o=coverage.out
+	go test $(TEST_FLAGS) -count=1 ./pkg/e2e
 
 .PHONY: e2e-compose-standalone
 e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test


### PR DESCRIPTION
**What I did**
Ensure `make e2e-compose` works on Windows/PowerShell.

Instead of trying to make this work nicely cross-platform, just push the Coverage logic into the GitHub Actions job, as that's really where we care about it.

(It's surprisingly difficult to make this nicely portable; to make PowerShell not error out if the path does not exist you have to ignore ALL errors and the way that env vars are passed to processes is not the same.)

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![a seal looking confused](https://user-images.githubusercontent.com/841263/227576473-2b023b63-3939-495c-92b6-46f0ba382aa7.png)
