### PR TITLE
workaround race condition in ContainerList

### DIFF
--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -64,16 +64,6 @@ func runRemove(ctx context.Context, backend api.Service, opts removeOptions, ser
 		return err
 	}
 
-	if opts.stop {
-		err := backend.Stop(ctx, name, api.StopOptions{
-			Services: services,
-			Project:  project,
-		})
-		if err != nil {
-			return err
-		}
-	}
-
 	return backend.Remove(ctx, name, api.RemoveOptions{
 		Services: services,
 		Force:    opts.force,

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -169,21 +169,32 @@ func TestRm(t *testing.T) {
 		c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "up", "-d")
 	})
 
-	t.Run("rm -sf", func(t *testing.T) {
+	t.Run("rm --stop --force simple", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "rm",
-			"-sf", "simple")
+			"--stop", "--force", "simple")
 		res.Assert(t, icmd.Expected{Err: "Removed", ExitCode: 0})
 	})
 
-	t.Run("check containers after rm -sf", func(t *testing.T) {
+	t.Run("check containers after rm", func(t *testing.T) {
 		res := c.RunDockerCmd(t, "ps", "--all")
-		assert.Assert(t, !strings.Contains(res.Combined(), projectName+"_simple"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), projectName+"-simple"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), projectName+"-another"), res.Combined())
 	})
 
-	t.Run("rm -sf <none>", func(t *testing.T) {
+	t.Run("up (again)", func(t *testing.T) {
+		c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "up", "-d")
+	})
+
+	t.Run("rm ---stop --force <none>", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "-p", projectName, "rm",
-			"-sf", "simple")
+			"--stop", "--force")
 		res.Assert(t, icmd.Expected{ExitCode: 0})
+	})
+
+	t.Run("check containers after rm", func(t *testing.T) {
+		res := c.RunDockerCmd(t, "ps", "--all")
+		assert.Assert(t, !strings.Contains(res.Combined(), projectName+"-simple"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), projectName+"-another"), res.Combined())
 	})
 
 	t.Run("down", func(t *testing.T) {


### PR DESCRIPTION
**What I did**
workaround a race condition in moby `ContainerList` API to report container as `State=running` when called immediately after `ContainerStop`.

also fixed e2e test which _should_ have identified this bug already, but was relying on legacy `_` separator 😓

**Related issue**
closes https://github.com/docker/compose/issues/10408

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/228169191-833f5af2-3cd5-4f22-848a-dfce27db9326.png)

