### PR TITLE
prevent panic using classic builder

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -75,7 +75,11 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 			}
 
 			if !buildkitEnabled {
-				service.Build.Args = service.Build.Args.OverrideBy(args)
+				if service.Build.Args == nil {
+					service.Build.Args = args
+				} else {
+					service.Build.Args = service.Build.Args.OverrideBy(args)
+				}
 				id, err := s.doBuildClassic(ctx, service)
 				if err != nil {
 					return err


### PR DESCRIPTION
**What I did**
prevent panic accessing nil map, also see https://github.com/compose-spec/compose-go/pull/381
configure build tests to run both on classic builder and buildkit

**Related issue**
closes https://github.com/docker/compose/issues/10412

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/229090051-d53738c5-f72e-4ccb-8abc-1d0262429d2e.png)
