### PR TITLE
restore `--timeout` flag renamed by mistake

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -104,7 +104,7 @@ func upCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *cob
 	flags.BoolVar(&up.noStart, "no-start", false, "Don't start the services after creating them.")
 	flags.BoolVar(&up.cascadeStop, "abort-on-container-exit", false, "Stops all containers if any container was stopped. Incompatible with -d")
 	flags.StringVar(&up.exitCodeFrom, "exit-code-from", "", "Return the exit code of the selected service container. Implies --abort-on-container-exit")
-	flags.IntVarP(&create.timeout, "waitTimeout", "t", 10, "Use this waitTimeout in seconds for container shutdown when attached or when containers are already running.")
+	flags.IntVarP(&create.timeout, "timeout", "t", 10, "Use this timeout in seconds for container shutdown when attached or when containers are already running.")
 	flags.BoolVar(&up.timestamp, "timestamps", false, "Show timestamps.")
 	flags.BoolVar(&up.noDeps, "no-deps", false, "Don't start linked services.")
 	flags.BoolVar(&create.recreateDeps, "always-recreate-deps", false, "Recreate dependent containers. Incompatible with --no-recreate.")

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -5,32 +5,32 @@ Create and start containers
 
 ### Options
 
-| Name                         | Type          | Default   | Description                                                                                                  |
-|:-----------------------------|:--------------|:----------|:-------------------------------------------------------------------------------------------------------------|
-| `--abort-on-container-exit`  |               |           | Stops all containers if any container was stopped. Incompatible with -d                                      |
-| `--always-recreate-deps`     |               |           | Recreate dependent containers. Incompatible with --no-recreate.                                              |
-| `--attach`                   | `stringArray` |           | Attach to service output.                                                                                    |
-| `--attach-dependencies`      |               |           | Attach to dependent containers.                                                                              |
-| `--build`                    |               |           | Build images before starting containers.                                                                     |
-| `-d`, `--detach`             |               |           | Detached mode: Run containers in the background                                                              |
-| `--exit-code-from`           | `string`      |           | Return the exit code of the selected service container. Implies --abort-on-container-exit                    |
-| `--force-recreate`           |               |           | Recreate containers even if their configuration and image haven't changed.                                   |
-| `--no-attach`                | `stringArray` |           | Don't attach to specified service.                                                                           |
-| `--no-build`                 |               |           | Don't build an image, even if it's missing.                                                                  |
-| `--no-color`                 |               |           | Produce monochrome output.                                                                                   |
-| `--no-deps`                  |               |           | Don't start linked services.                                                                                 |
-| `--no-log-prefix`            |               |           | Don't print prefix in logs.                                                                                  |
-| `--no-recreate`              |               |           | If containers already exist, don't recreate them. Incompatible with --force-recreate.                        |
-| `--no-start`                 |               |           | Don't start the services after creating them.                                                                |
-| `--pull`                     | `string`      | `missing` | Pull image before running ("always"\|"missing"\|"never")                                                     |
-| `--quiet-pull`               |               |           | Pull without printing progress information.                                                                  |
-| `--remove-orphans`           |               |           | Remove containers for services not defined in the Compose file.                                              |
-| `-V`, `--renew-anon-volumes` |               |           | Recreate anonymous volumes instead of retrieving data from the previous containers.                          |
-| `--scale`                    | `stringArray` |           | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.                |
-| `--timestamps`               |               |           | Show timestamps.                                                                                             |
-| `--wait`                     |               |           | Wait for services to be running\|healthy. Implies detached mode.                                             |
-| `--wait-timeout`             | `int`         | `0`       | timeout waiting for application to be running\|healthy.                                                      |
-| `-t`, `--waitTimeout`        | `int`         | `10`      | Use this waitTimeout in seconds for container shutdown when attached or when containers are already running. |
+| Name                         | Type          | Default   | Description                                                                                              |
+|:-----------------------------|:--------------|:----------|:---------------------------------------------------------------------------------------------------------|
+| `--abort-on-container-exit`  |               |           | Stops all containers if any container was stopped. Incompatible with -d                                  |
+| `--always-recreate-deps`     |               |           | Recreate dependent containers. Incompatible with --no-recreate.                                          |
+| `--attach`                   | `stringArray` |           | Attach to service output.                                                                                |
+| `--attach-dependencies`      |               |           | Attach to dependent containers.                                                                          |
+| `--build`                    |               |           | Build images before starting containers.                                                                 |
+| `-d`, `--detach`             |               |           | Detached mode: Run containers in the background                                                          |
+| `--exit-code-from`           | `string`      |           | Return the exit code of the selected service container. Implies --abort-on-container-exit                |
+| `--force-recreate`           |               |           | Recreate containers even if their configuration and image haven't changed.                               |
+| `--no-attach`                | `stringArray` |           | Don't attach to specified service.                                                                       |
+| `--no-build`                 |               |           | Don't build an image, even if it's missing.                                                              |
+| `--no-color`                 |               |           | Produce monochrome output.                                                                               |
+| `--no-deps`                  |               |           | Don't start linked services.                                                                             |
+| `--no-log-prefix`            |               |           | Don't print prefix in logs.                                                                              |
+| `--no-recreate`              |               |           | If containers already exist, don't recreate them. Incompatible with --force-recreate.                    |
+| `--no-start`                 |               |           | Don't start the services after creating them.                                                            |
+| `--pull`                     | `string`      | `missing` | Pull image before running ("always"\|"missing"\|"never")                                                 |
+| `--quiet-pull`               |               |           | Pull without printing progress information.                                                              |
+| `--remove-orphans`           |               |           | Remove containers for services not defined in the Compose file.                                          |
+| `-V`, `--renew-anon-volumes` |               |           | Recreate anonymous volumes instead of retrieving data from the previous containers.                      |
+| `--scale`                    | `stringArray` |           | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.            |
+| `-t`, `--timeout`            | `int`         | `10`      | Use this timeout in seconds for container shutdown when attached or when containers are already running. |
+| `--timestamps`               |               |           | Show timestamps.                                                                                         |
+| `--wait`                     |               |           | Wait for services to be running\|healthy. Implies detached mode.                                         |
+| `--wait-timeout`             | `int`         | `0`       | timeout waiting for application to be running\|healthy.                                                  |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -231,6 +231,18 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: timeout
+      shorthand: t
+      value_type: int
+      default_value: "10"
+      description: |
+        Use this timeout in seconds for container shutdown when attached or when containers are already running.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: timestamps
       value_type: bool
       default_value: "false"
@@ -255,18 +267,6 @@ options:
       value_type: int
       default_value: "0"
       description: timeout waiting for application to be running|healthy.
-      deprecated: false
-      hidden: false
-      experimental: false
-      experimentalcli: false
-      kubernetes: false
-      swarm: false
-    - option: waitTimeout
-      shorthand: t
-      value_type: int
-      default_value: "10"
-      description: |
-        Use this waitTimeout in seconds for container shutdown when attached or when containers are already running.
       deprecated: false
       hidden: false
       experimental: false

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -53,7 +53,7 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 	}, s.stderr())
 }
 
-func (s *composeService) build(ctx context.Context, project *types.Project, options api.BuildOptions) (map[string]string, error) {
+func (s *composeService) build(ctx context.Context, project *types.Project, options api.BuildOptions) (map[string]string, error) { //nolint:gocyclo
 	args := options.Args.Resolve(envResolver(project.Environment))
 
 	buildkitEnabled, err := s.dockerCli.BuildKitEnabled()


### PR DESCRIPTION
**What I did**
while introducing `--wai-timeout` renaming attribute did accidentally rename the existing `--timeout` flag (golang rename has been too efficient here) and this hasn't been caught during PR review

**Related issue**
https://github.com/docker/compose/issues/10269

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/132757/229704915-1606a506-f337-4672-be02-c8e5712f53fd.png)
