### PR TITLE
add dry-run support to down command

### DIFF
--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -210,7 +210,7 @@ func (d *DryRunClient) ImagePush(ctx context.Context, ref string, options moby.I
 }
 
 func (d *DryRunClient) ImageRemove(ctx context.Context, imageName string, options moby.ImageRemoveOptions) ([]moby.ImageDeleteResponseItem, error) {
-	return nil, ErrNotImplemented
+	return nil, nil
 }
 
 func (d *DryRunClient) NetworkConnect(ctx context.Context, networkName, container string, config *network.EndpointSettings) error {
@@ -229,7 +229,7 @@ func (d *DryRunClient) NetworkDisconnect(ctx context.Context, networkName, conta
 }
 
 func (d *DryRunClient) NetworkRemove(ctx context.Context, networkName string) error {
-	return ErrNotImplemented
+	return nil
 }
 
 func (d *DryRunClient) VolumeCreate(ctx context.Context, options volume.CreateOptions) (volume.Volume, error) {
@@ -237,7 +237,7 @@ func (d *DryRunClient) VolumeCreate(ctx context.Context, options volume.CreateOp
 }
 
 func (d *DryRunClient) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
-	return ErrNotImplemented
+	return nil
 }
 
 func (d *DryRunClient) ContainerExecCreate(ctx context.Context, container string, config moby.ExecConfig) (moby.IDResponse, error) {


### PR DESCRIPTION
**What I did**
Add dry-run support for `down` command
```shell
> docker compose -f /Users/glours/sources/awesome-compose/nginx-golang-mysql/compose.yaml alpha dry-run -- down --rmi all --remove-orphans -v
[+] Running 10/0
 ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-1                 Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-run-a63195491410  Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-run-7c913f2c92a3  Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Container nginx-golang-mysql-backend-1               Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Container nginx-golang-mysql-db-1                    Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Volume nginx-golang-mysql_db-data                    Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Image mariadb:10-focal                               Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Image nginx-golang-mysql-backend:latest              Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Image nginx:latest                                   Removed                                                                                                                                                    0.0s 
 ✔ DRY-RUN MODE -  Network nginx-golang-mysql_default                   Removed                                                                                                                                                    0.0s
```

**Related issue**
https://docker.atlassian.net/browse/ENV-60

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/230390406-2b477479-fe31-41a7-9913-aeb587255e9d.png)
