### PR TITLE
restore support for `--memory`

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -374,7 +374,7 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 		portCommand(&opts, streams, backend),
 		imagesCommand(&opts, streams, backend),
 		versionCommand(streams),
-		buildCommand(&opts, streams, backend),
+		buildCommand(&opts, backend),
 		pushCommand(&opts, backend),
 		pullCommand(&opts, backend),
 		createCommand(&opts, backend),

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -5,15 +5,16 @@ Build or rebuild services
 
 ### Options
 
-| Name            | Type          | Default | Description                                                                                                 |
-|:----------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
-| `--build-arg`   | `stringArray` |         | Set build-time variables for services.                                                                      |
-| `--no-cache`    |               |         | Do not use cache when building the image                                                                    |
-| `--progress`    | `string`      | `auto`  | Set type of progress output (auto, tty, plain, quiet)                                                       |
-| `--pull`        |               |         | Always attempt to pull a newer version of the image.                                                        |
-| `--push`        |               |         | Push service images.                                                                                        |
-| `-q`, `--quiet` |               |         | Don't print anything to STDOUT                                                                              |
-| `--ssh`         | `string`      |         | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
+| Name             | Type          | Default | Description                                                                                                 |
+|:-----------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
+| `--build-arg`    | `stringArray` |         | Set build-time variables for services.                                                                      |
+| `-m`, `--memory` | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
+| `--no-cache`     |               |         | Do not use cache when building the image                                                                    |
+| `--progress`     | `string`      | `auto`  | Set type of progress output (auto, tty, plain, quiet)                                                       |
+| `--pull`         |               |         | Always attempt to pull a newer version of the image.                                                        |
+| `--push`         |               |         | Push service images.                                                                                        |
+| `-q`, `--quiet`  |               |         | Don't print anything to STDOUT                                                                              |
+| `--ssh`          | `string`      |         | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -46,11 +46,12 @@ options:
       swarm: false
     - option: memory
       shorthand: m
-      value_type: string
+      value_type: bytes
+      default_value: "0"
       description: |
-        Set memory limit for the build container. Not supported on buildkit yet.
+        Set memory limit for the build container. Not supported by BuildKit.
       deprecated: false
-      hidden: true
+      hidden: false
       experimental: false
       experimentalcli: false
       kubernetes: false

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -119,6 +119,8 @@ type BuildOptions struct {
 	Services []string
 	// Ssh authentications passed in the command line
 	SSHs []types.SSHKey
+	// Memory limit for the build container
+	Memory int64
 }
 
 // Apply mutates project according to build options

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -91,7 +91,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 				} else {
 					service.Build.Args = service.Build.Args.OverrideBy(args)
 				}
-				id, err := s.doBuildClassic(ctx, service)
+				id, err := s.doBuildClassic(ctx, service, options)
 				if err != nil {
 					return err
 				}
@@ -102,6 +102,11 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 				}
 				return nil
 			}
+
+			if options.Memory != 0 {
+				fmt.Fprintln(s.stderr(), "WARNING: --memory is not supported by BuildKit and will be ignored.")
+			}
+
 			buildOptions, err := s.toBuildOptions(project, service, options)
 			if err != nil {
 				return err

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -43,7 +43,7 @@ import (
 )
 
 //nolint:gocyclo
-func (s *composeService) doBuildClassic(ctx context.Context, service types.ServiceConfig) (string, error) {
+func (s *composeService) doBuildClassic(ctx context.Context, service types.ServiceConfig, options api.BuildOptions) (string, error) {
 	var (
 		buildCtx      io.ReadCloser
 		dockerfileCtx io.ReadCloser
@@ -161,6 +161,7 @@ func (s *composeService) doBuildClassic(ctx context.Context, service types.Servi
 	buildOptions.Tags = append(buildOptions.Tags, service.Image)
 	buildOptions.Dockerfile = relDockerfile
 	buildOptions.AuthConfigs = authConfigs
+	buildOptions.Memory = options.Memory
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
**What I did**

restore support for `build --memory` on classic builder.
This flag was hidden as initial design only supported buildkit, but as we introduced support for classic builder, there's no reason not so enable use of this flag

```
$ DOCKER_BUILDKIT=0 docker compose build --memory 6M 
Sending build context to Docker daemon  37.85kB
Step 1/3 : FROM ubuntu
 ---> bab8ce5c00ca
...
Successfully built 9c5ac36ea508
Successfully tagged truc-test:latest

$ DOCKER_BUILDKIT=1 docker compose build --memory 6M 
WARNING --memory is ignored as not supported in buildkit.
[+] Building 0.3s (6/6) FINISHED     
```

**Related issue**
closes https://github.com/docker/compose/issues/10488

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
