### PR TITLE
inject secrets using docker cp

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -49,6 +49,12 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	if err := prepareVolumes(project); err != nil { // all dependencies already checked, but might miss service img
 		return "", err
 	}
+
+	err := prepareSecrets(project)
+	if err != nil {
+		return "", err
+	}
+
 	service, err := project.GetService(opts.Service)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What I did**
replace use of bind mounts to create secrets with `cp`, the same way we do for environment-based secrets
this allows to set UID/GID on secret according to configuration

As a side-effect, changes made to a secret file won't get reflected in container immediately, so `compose up` force secrets to be refreshed, in the philosophy or "convergence" to enforce desired state is reflected in actual resources. I can expect some users to consider this a bug, but if they heavily rely on this, they can just declare a bind mount.

Unfortunately, we can't use this for secret _folders_, as `cp` doesn't offer any option to fully override target folder. So those get converted into (bind) `volumes`

**Related issue**
closes https://github.com/docker/compose/issues/9648

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
