### PR TITLE
make progress title configurable

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -47,10 +47,10 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 	if err != nil {
 		return err
 	}
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		_, err := s.build(ctx, project, options)
 		return err
-	}, s.stderr())
+	}, s.stderr(), "Building")
 }
 
 //nolint:gocyclo

--- a/pkg/compose/cp.go
+++ b/pkg/compose/cp.go
@@ -44,9 +44,9 @@ const (
 )
 
 func (s *composeService) Copy(ctx context.Context, projectName string, options api.CopyOptions) error {
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.copy(ctx, projectName, options)
-	}, s.stderr())
+	}, s.stderr(), "Copying")
 }
 
 func (s *composeService) copy(ctx context.Context, projectName string, options api.CopyOptions) error {

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -49,9 +49,9 @@ import (
 )
 
 func (s *composeService) Create(ctx context.Context, project *types.Project, options api.CreateOptions) error {
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.create(ctx, project, options)
-	}, s.stderr())
+	}, s.stderr(), "Creating")
 }
 
 func (s *composeService) create(ctx context.Context, project *types.Project, options api.CreateOptions) error {

--- a/pkg/compose/kill.go
+++ b/pkg/compose/kill.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (s *composeService) Kill(ctx context.Context, projectName string, options api.KillOptions) error {
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.kill(ctx, strings.ToLower(projectName), options)
-	}, s.stderr())
+	}, s.stderr(), "Killing")
 }
 
 func (s *composeService) kill(ctx context.Context, projectName string, options api.KillOptions) error {

--- a/pkg/compose/pause.go
+++ b/pkg/compose/pause.go
@@ -28,9 +28,9 @@ import (
 )
 
 func (s *composeService) Pause(ctx context.Context, projectName string, options api.PauseOptions) error {
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.pause(ctx, strings.ToLower(projectName), options)
-	}, s.stderr())
+	}, s.stderr(), "Pausing")
 }
 
 func (s *composeService) pause(ctx context.Context, projectName string, options api.PauseOptions) error {

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -42,9 +42,9 @@ func (s *composeService) Pull(ctx context.Context, project *types.Project, optio
 	if options.Quiet {
 		return s.pull(ctx, project, options)
 	}
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.pull(ctx, project, options)
-	}, s.stderr())
+	}, s.stderr(), "Pulling")
 }
 
 func (s *composeService) pull(ctx context.Context, project *types.Project, opts api.PullOptions) error { //nolint:gocyclo

--- a/pkg/compose/push.go
+++ b/pkg/compose/push.go
@@ -40,9 +40,9 @@ func (s *composeService) Push(ctx context.Context, project *types.Project, optio
 	if options.Quiet {
 		return s.push(ctx, project, options)
 	}
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.push(ctx, project, options)
-	}, s.stderr())
+	}, s.stderr(), "Pushing")
 }
 
 func (s *composeService) push(ctx context.Context, project *types.Project, options api.PushOptions) error {

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -93,9 +93,9 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 			return nil
 		}
 	}
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.remove(ctx, stoppedContainers, options)
-	}, s.stderr())
+	}, s.stderr(), "Removing")
 }
 
 func (s *composeService) remove(ctx context.Context, containers Containers, options api.RemoveOptions) error {

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (s *composeService) Restart(ctx context.Context, projectName string, options api.RestartOptions) error {
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.restart(ctx, strings.ToLower(projectName), options)
-	}, s.stderr())
+	}, s.stderr(), "Restarting")
 }
 
 func (s *composeService) restart(ctx context.Context, projectName string, options api.RestartOptions) error {

--- a/pkg/compose/stop.go
+++ b/pkg/compose/stop.go
@@ -26,9 +26,9 @@ import (
 )
 
 func (s *composeService) Stop(ctx context.Context, projectName string, options api.StopOptions) error {
-	return progress.Run(ctx, func(ctx context.Context) error {
+	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.stop(ctx, strings.ToLower(projectName), options)
-	}, s.stderr())
+	}, s.stderr(), "Stopping")
 }
 
 func (s *composeService) stop(ctx context.Context, projectName string, options api.StopOptions) error {

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -43,6 +43,7 @@ type ttyWriter struct {
 	tailEvents      []string
 	dryRun          bool
 	skipChildEvents bool
+	progressTitle   string
 }
 
 func (w *ttyWriter) Start(ctx context.Context) error {
@@ -149,7 +150,7 @@ func (w *ttyWriter) print() { //nolint:gocyclo
 	fmt.Fprint(w.out, aec.Hide)
 	defer fmt.Fprint(w.out, aec.Show)
 
-	firstLine := fmt.Sprintf("[+] Running %d/%d", numDone(w.events), w.numLines)
+	firstLine := fmt.Sprintf("[+] %s %d/%d", w.progressTitle, numDone(w.events), w.numLines)
 	if w.numLines != 0 && numDone(w.events) == w.numLines {
 		firstLine = DoneColor(firstLine)
 	}


### PR DESCRIPTION
**What I did**
Add a progress section title to tty writer so we're able to show a more accurate state than `Running` in the console output.
![Screenshot 2023-04-28 at 12 15 39](https://user-images.githubusercontent.com/705411/235121260-e205b8db-474f-441e-b199-1849be4e11cd.png)

This changes will also  improve dry run output.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/235121561-44fba6c8-f0ec-4a61-be38-44ca4abe52c1.png)
