### PR TITLE
Update 🥒 tests to use `dockerfile_inline`

### DIFF
--- a/e2e/cucumber-features/build-contexts.feature
+++ b/e2e/cucumber-features/build-contexts.feature
@@ -7,14 +7,12 @@ Background:
           a:
             build:
                 context: .
+                dockerfile_inline: |
+                    # syntax=docker/dockerfile:1
+                    FROM alpine:latest
+                    COPY --from=dep /etc/hostname /
                 additional_contexts:
                   - dep=docker-image://ubuntu:latest
-        """
-    And a dockerfile
-        """
-        # syntax=docker/dockerfile:1
-        FROM alpine:latest
-        COPY --from=dep /etc/hostname /
         """
 
 Scenario: Build w/ build context


### PR DESCRIPTION
**What I did**

Update Cucumber tests to use `dockerfile_inline` when appropriate, for clarity (and coverage).

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://user-images.githubusercontent.com/70572044/235159885-6bbee3d0-b811-46b6-a7e3-98b78f703df7.png)
