### PR TITLE
revisit the build UX by parsing buildkit solve events on our own

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -101,9 +101,8 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 				return err
 			}
 			buildOptions.BuildArgs = mergeArgs(buildOptions.BuildArgs, flatten(args))
-			opts := map[string]build.Options{service.Name: buildOptions}
 
-			ids, err := s.doBuildBuildkit(ctx, opts, options.Progress)
+			ids, err := s.doBuildBuildkit(ctx, service.Name, buildOptions, options.Progress)
 			if err != nil {
 				return err
 			}

--- a/pkg/progress/colors.go
+++ b/pkg/progress/colors.go
@@ -27,7 +27,7 @@ var (
 		return s
 	}
 
-	DoneColor    colorFunc = aec.BlueF.Apply
+	DoneColor    colorFunc = aec.CyanF.Apply
 	TimerColor   colorFunc = aec.BlueF.Apply
 	CountColor   colorFunc = aec.YellowF.Apply
 	WarningColor colorFunc = aec.YellowF.With(aec.Bold).Apply

--- a/pkg/progress/event.go
+++ b/pkg/progress/event.go
@@ -26,6 +26,8 @@ type EventStatus int
 func (s EventStatus) colorFn() colorFunc {
 	switch s {
 	case Done:
+		return DoneColor
+	case Success:
 		return SuccessColor
 	case Warning:
 		return WarningColor
@@ -41,10 +43,14 @@ const (
 	Working EventStatus = iota
 	// Done means that the current task is done
 	Done
+	// Done means that the current task is done
+	Success
 	// Warning means that the current task has warning
 	Warning
 	// Error means that the current task has errored
 	Error
+
+	Log
 )
 
 // Event represents a progress event.
@@ -95,7 +101,7 @@ func Waiting(id string) Event {
 
 // Healthy creates a new healthy event
 func Healthy(id string) Event {
-	return NewEvent(id, Done, "Healthy")
+	return NewEvent(id, Success, "Healthy")
 }
 
 // Exited creates a new exited event
@@ -110,17 +116,17 @@ func RestartingEvent(id string) Event {
 
 // RestartedEvent creates a new Restarted in progress Event
 func RestartedEvent(id string) Event {
-	return NewEvent(id, Done, "Restarted")
+	return NewEvent(id, Success, "Restarted")
 }
 
 // RunningEvent creates a new Running in progress Event
 func RunningEvent(id string) Event {
-	return NewEvent(id, Done, "Running")
+	return NewEvent(id, Success, "Running")
 }
 
 // CreatedEvent creates a new Created (done) Event
 func CreatedEvent(id string) Event {
-	return NewEvent(id, Done, "Created")
+	return NewEvent(id, Success, "Created")
 }
 
 // StoppingEvent creates a new Stopping in progress Event
@@ -130,7 +136,7 @@ func StoppingEvent(id string) Event {
 
 // StoppedEvent creates a new Stopping in progress Event
 func StoppedEvent(id string) Event {
-	return NewEvent(id, Done, "Stopped")
+	return NewEvent(id, Success, "Stopped")
 }
 
 // KillingEvent creates a new Killing in progress Event
@@ -140,7 +146,7 @@ func KillingEvent(id string) Event {
 
 // KilledEvent creates a new Killed in progress Event
 func KilledEvent(id string) Event {
-	return NewEvent(id, Done, "Killed")
+	return NewEvent(id, Success, "Killed")
 }
 
 // RemovingEvent creates a new Removing in progress Event
@@ -150,7 +156,7 @@ func RemovingEvent(id string) Event {
 
 // RemovedEvent creates a new removed (done) Event
 func RemovedEvent(id string) Event {
-	return NewEvent(id, Done, "Removed")
+	return NewEvent(id, Success, "Removed")
 }
 
 // NewEvent new event
@@ -171,16 +177,21 @@ var (
 	spinnerDone    = "✔"
 	spinnerWarning = "!"
 	spinnerError   = "✘"
+	spinnerLog     = "|"
 )
 
 func (e *Event) Spinner() any {
 	switch e.Status {
 	case Done:
 		return SuccessColor(spinnerDone)
+	case Success:
+		return SuccessColor(spinnerDone)
 	case Warning:
 		return WarningColor(spinnerWarning)
 	case Error:
 		return ErrorColor(spinnerError)
+	case Log:
+		return TimerColor(spinnerLog)
 	default:
 		return e.spinner.String()
 	}

--- a/pkg/progress/tty_test.go
+++ b/pkg/progress/tty_test.go
@@ -41,19 +41,19 @@ func TestLineText(t *testing.T) {
 
 	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
 
-	out := tty().lineText(ev, "", 50, lineWidth, false)
+	out := tty().lineText(ev, true, "", 50, lineWidth, false)
 	assert.Equal(t, out, " . id Text Status                            \x1b[34m0.0s \x1b[0m\n")
 
 	ev.Status = Done
-	out = tty().lineText(ev, "", 50, lineWidth, false)
-	assert.Equal(t, out, " \x1b[32m✔\x1b[0m id Text \x1b[32mStatus\x1b[0m                            \x1b[34m0.0s \x1b[0m\n")
+	out = tty().lineText(ev, true, "", 50, lineWidth, false)
+	assert.Equal(t, out, " \x1b[32m✔\x1b[0m id Text \x1b[36mStatus\x1b[0m                            \x1b[34m0.0s \x1b[0m\n")
 
 	ev.Status = Error
-	out = tty().lineText(ev, "", 50, lineWidth, false)
+	out = tty().lineText(ev, true, "", 50, lineWidth, false)
 	assert.Equal(t, out, " \x1b[31m\x1b[1m✘\x1b[0m id Text \x1b[31m\x1b[1mStatus\x1b[0m                            \x1b[34m0.0s \x1b[0m\n")
 
 	ev.Status = Warning
-	out = tty().lineText(ev, "", 50, lineWidth, false)
+	out = tty().lineText(ev, true, "", 50, lineWidth, false)
 	assert.Equal(t, out, " \x1b[33m\x1b[1m!\x1b[0m id Text \x1b[33m\x1b[1mStatus\x1b[0m                            \x1b[34m0.0s \x1b[0m\n")
 }
 
@@ -72,7 +72,7 @@ func TestLineTextSingleEvent(t *testing.T) {
 
 	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
 
-	out := tty().lineText(ev, "", 50, lineWidth, false)
+	out := tty().lineText(ev, true, "", 50, lineWidth, false)
 	assert.Equal(t, out, " \x1b[32m✔\x1b[0m id Text \x1b[32mStatus\x1b[0m                            \x1b[34m0.0s \x1b[0m\n")
 }
 


### PR DESCRIPTION
**What I did**
`compose build` output is broken as we get multiple buildkit sessions concurrently trying to update the terminal.
This PR changes our build integration by passing a custom `progress.Writer` to collect buildkit's SolveStatus event, and format them for output with our own progress implementation. This isn't perfect either, but at least avoids console to flash with random lines

[![demo](https://asciinema.org/a/lPPd5eqqVFLrnmWEB2FTZ6GII.svg)](https://asciinema.org/a/lPPd5eqqVFLrnmWEB2FTZ6GII?autoplay=1)


**Related issue**
fixes https://github.com/docker/compose/issues/10528

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
