### PR TITLE
move dry-run support from alpha to main command

### DIFF
--- a/cmd/compose/alpha.go
+++ b/cmd/compose/alpha.go
@@ -15,8 +15,6 @@
 package compose
 
 import (
-	"context"
-
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/spf13/cobra"
 )
@@ -33,26 +31,7 @@ func alphaCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	}
 	cmd.AddCommand(
 		watchCommand(p, backend),
-		dryRunRedirectCommand(p),
 		vizCommand(p, backend),
 	)
-	return cmd
-}
-
-// Temporary alpha command as the dry-run will be implemented with a flag
-func dryRunRedirectCommand(p *ProjectOptions) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "dry-run -- [COMMAND...]",
-		Short: "EXPERIMENTAL - Dry run command allow you to test a command without applying changes",
-		PreRunE: Adapt(func(ctx context.Context, args []string) error {
-			return nil
-		}),
-		RunE: AdaptCmd(func(ctx context.Context, cmd *cobra.Command, args []string) error {
-			rootCmd := cmd.Root()
-			rootCmd.SetArgs(append([]string{"compose", "--dry-run"}, args...))
-			return rootCmd.Execute()
-		}),
-		ValidArgsFunction: completeServiceNames(p),
-	}
 	return cmd
 }

--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -398,13 +398,12 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 	c.Flags().StringVar(&ansi, "ansi", "auto", `Control when to print ANSI control characters ("never"|"always"|"auto")`)
 	c.Flags().IntVar(&parallel, "parallel", -1, `Control max parallelism, -1 for unlimited`)
 	c.Flags().BoolVarP(&version, "version", "v", false, "Show the Docker Compose version information")
+	c.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Execute command in dry run mode")
 	c.Flags().MarkHidden("version") //nolint:errcheck
 	c.Flags().BoolVar(&noAnsi, "no-ansi", false, `Do not print ANSI control characters (DEPRECATED)`)
 	c.Flags().MarkHidden("no-ansi") //nolint:errcheck
 	c.Flags().BoolVar(&verbose, "verbose", false, "Show more output")
 	c.Flags().MarkHidden("verbose") //nolint:errcheck
-	c.Flags().BoolVar(&dryRun, "dry-run", false, "Execute command in dry run mode")
-	c.Flags().MarkHidden("dry-run") //nolint:errcheck
 	return c
 }
 

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -175,7 +175,7 @@ containers for the project.
 ### Use Dry Run mode to test your command
 
 Use `--dry-run` flag to test a command without changing your application stack state.
-Dry Run mode will show you all the steps Compose will apply by executing the command, for example:
+Dry Run mode shows you all the steps Compose applies when executing a command, for example:
 ```console
 $ docker compose --dry-run up --build -d
 [+] Pulling 1/1
@@ -192,10 +192,10 @@ $ docker compose --dry-run up --build -d
  ✔ DRY-RUN MODE -  Container nginx-golang-mysql-backend-1                                Started                                                                                                                                           0.0s
  ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-1                                  Started                                     Started
 ```
-You could see that the first step will be to pull the image defined by `db` service, then build the `backend` service.  
-After that, containers will be created, the `db` service started and the `backend` and `proxy` will wait until `db` service is healthy to start.
+From the example above, you can see that the first step is to pull the image defined by `db` service, then build the `backend` service.  
+Next, the containers are created. The `db` service is started, and the `backend` and `proxy` wait until the `db` service is healthy before starting.
 
-The Dry Run mode is not supported by all commands, especially by the command which doesn't change the state of a Compose stack
+Dry Run mode does not currently work with all commands. In particular, you cannot use Dry Run mode with a command that doesn't change the state of a Compose stack
 such as `ps`, `ls`, `logs` for example.  
 
 Here the list of commands supporting `--dry-run` flag:

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -41,6 +41,7 @@ Docker Compose
 |:-----------------------|:--------------|:--------|:----------------------------------------------------------------------------------------------------|
 | `--ansi`               | `string`      | `auto`  | Control when to print ANSI control characters ("never"\|"always"\|"auto")                           |
 | `--compatibility`      |               |         | Run compose in backward compatibility mode                                                          |
+| `--dry-run`            |               |         | Execute command in dry run mode                                                                     |
 | `--env-file`           | `stringArray` |         | Specify an alternate environment file.                                                              |
 | `-f`, `--file`         | `stringArray` |         | Compose configuration files                                                                         |
 | `--parallel`           | `int`         | `-1`    | Control max parallelism, -1 for unlimited                                                           |
@@ -169,3 +170,49 @@ If flags are explicitly set on the command line, the associated environment vari
 
 Setting the `COMPOSE_IGNORE_ORPHANS` environment variable to `true` will stop docker compose from detecting orphaned
 containers for the project.
+
+
+### Use Dry Run mode to test your command
+
+Use `--dry-run` flag to test a command without changing your application stack state.
+Dry Run mode will show you all the steps Compose will apply by executing the command, for example:
+```console
+$ docker compose --dry-run up --build -d
+[+] Pulling 1/1
+ ✔ DRY-RUN MODE -  db Pulled                                                                                                                                                                                                               0.9s
+[+] Running 10/8
+ ✔ DRY-RUN MODE -    build service backend                                                                                                                                                                                                 0.0s
+ ✔ DRY-RUN MODE -  ==> ==> writing image dryRun-754a08ddf8bcb1cf22f310f09206dd783d42f7dd                                                                                                                                                   0.0s
+ ✔ DRY-RUN MODE -  ==> ==> naming to nginx-golang-mysql-backend                                                                                                                                                                            0.0s
+ ✔ DRY-RUN MODE -  Network nginx-golang-mysql_default                                    Created                                                                                                                                           0.0s
+ ✔ DRY-RUN MODE -  Container nginx-golang-mysql-db-1                                     Created                                                                                                                                           0.0s
+ ✔ DRY-RUN MODE -  Container nginx-golang-mysql-backend-1                                Created                                                                                                                                           0.0s
+ ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-1                                  Created                                                                                                                                           0.0s
+ ✔ DRY-RUN MODE -  Container nginx-golang-mysql-db-1                                     Healthy                                                                                                                                           0.5s
+ ✔ DRY-RUN MODE -  Container nginx-golang-mysql-backend-1                                Started                                                                                                                                           0.0s
+ ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-1                                  Started                                     Started
+```
+You could see that the first step will be to pull the image defined by `db` service, then build the `backend` service.  
+After that, containers will be created, the `db` service started and the `backend` and `proxy` will wait until `db` service is healthy to start.
+
+The Dry Run mode is not supported by all commands, especially by the command which doesn't change the state of a Compose stack
+such as `ps`, `ls`, `logs` for example.  
+
+Here the list of commands supporting `--dry-run` flag:
+* build
+* cp
+* create
+* down
+* exec
+* kill
+* pause
+* pull
+* push
+* remove
+* restart
+* run
+* start
+* stop
+* unpause
+* up
+

--- a/docs/reference/compose_alpha.md
+++ b/docs/reference/compose_alpha.md
@@ -5,11 +5,10 @@ Experimental commands
 
 ### Subcommands
 
-| Name                                  | Description                                                                                          |
-|:--------------------------------------|:-----------------------------------------------------------------------------------------------------|
-| [`dry-run`](compose_alpha_dry-run.md) | EXPERIMENTAL - Dry run command allow you to test a command without applying changes                  |
-| [`viz`](compose_alpha_viz.md)         | EXPERIMENTAL - Generate a graphviz graph from your compose file                                      |
-| [`watch`](compose_alpha_watch.md)     | EXPERIMENTAL - Watch build context for service and rebuild/refresh containers when files are updated |
+| Name                              | Description                                                                                          |
+|:----------------------------------|:-----------------------------------------------------------------------------------------------------|
+| [`viz`](compose_alpha_viz.md)     | EXPERIMENTAL - Generate a graphviz graph from your compose file                                      |
+| [`watch`](compose_alpha_watch.md) | EXPERIMENTAL - Watch build context for service and rebuild/refresh containers when files are updated |
 
 
 

--- a/docs/reference/compose_alpha.md
+++ b/docs/reference/compose_alpha.md
@@ -11,6 +11,12 @@ Experimental commands
 | [`watch`](compose_alpha_watch.md) | EXPERIMENTAL - Watch build context for service and rebuild/refresh containers when files are updated |
 
 
+### Options
+
+| Name        | Type | Default | Description                     |
+|:------------|:-----|:--------|:--------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode |
+
 
 <!---MARKER_GEN_END-->
 

--- a/docs/reference/compose_alpha_viz.md
+++ b/docs/reference/compose_alpha_viz.md
@@ -7,6 +7,7 @@ EXPERIMENTAL - Generate a graphviz graph from your compose file
 
 | Name                 | Type  | Default | Description                                                                                        |
 |:---------------------|:------|:--------|:---------------------------------------------------------------------------------------------------|
+| `--dry-run`          |       |         | Execute command in dry run mode                                                                    |
 | `--image`            |       |         | Include service's image name in output graph                                                       |
 | `--indentation-size` | `int` | `1`     | Number of tabs or spaces to use for indentation                                                    |
 | `--networks`         |       |         | Include service's attached networks in output graph                                                |

--- a/docs/reference/compose_alpha_watch.md
+++ b/docs/reference/compose_alpha_watch.md
@@ -5,9 +5,10 @@ EXPERIMENTAL - Watch build context for service and rebuild/refresh containers wh
 
 ### Options
 
-| Name      | Type | Default | Description       |
-|:----------|:-----|:--------|:------------------|
-| `--quiet` |      |         | hide build output |
+| Name        | Type | Default | Description                     |
+|:------------|:-----|:--------|:--------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode |
+| `--quiet`   |      |         | hide build output               |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -8,6 +8,7 @@ Build or rebuild services
 | Name             | Type          | Default | Description                                                                                                 |
 |:-----------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
 | `--build-arg`    | `stringArray` |         | Set build-time variables for services.                                                                      |
+| `--dry-run`      |               |         | Execute command in dry run mode                                                                             |
 | `-m`, `--memory` | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
 | `--no-cache`     |               |         | Do not use cache when building the image                                                                    |
 | `--progress`     | `string`      | `auto`  | Set type of progress output (auto, tty, plain, quiet)                                                       |

--- a/docs/reference/compose_config.md
+++ b/docs/reference/compose_config.md
@@ -11,6 +11,7 @@ Parse, resolve and render compose file in canonical format
 
 | Name                      | Type     | Default | Description                                                                 |
 |:--------------------------|:---------|:--------|:----------------------------------------------------------------------------|
+| `--dry-run`               |          |         | Execute command in dry run mode                                             |
 | `--format`                | `string` | `yaml`  | Format the output. Values: [yaml \| json]                                   |
 | `--hash`                  | `string` |         | Print the service config hash, one per line.                                |
 | `--images`                |          |         | Print the image names, one per line.                                        |

--- a/docs/reference/compose_cp.md
+++ b/docs/reference/compose_cp.md
@@ -8,6 +8,7 @@ Copy files/folders between a service container and the local filesystem
 | Name                  | Type  | Default | Description                                                           |
 |:----------------------|:------|:--------|:----------------------------------------------------------------------|
 | `-a`, `--archive`     |       |         | Archive mode (copy all uid/gid information)                           |
+| `--dry-run`           |       |         | Execute command in dry run mode                                       |
 | `-L`, `--follow-link` |       |         | Always follow symbol link in SRC_PATH                                 |
 | `--index`             | `int` | `0`     | Index of the container if there are multiple instances of a service . |
 

--- a/docs/reference/compose_create.md
+++ b/docs/reference/compose_create.md
@@ -8,6 +8,7 @@ Creates containers for a service.
 | Name               | Type          | Default   | Description                                                                                   |
 |:-------------------|:--------------|:----------|:----------------------------------------------------------------------------------------------|
 | `--build`          |               |           | Build images before starting containers.                                                      |
+| `--dry-run`        |               |           | Execute command in dry run mode                                                               |
 | `--force-recreate` |               |           | Recreate containers even if their configuration and image haven't changed.                    |
 | `--no-build`       |               |           | Don't build an image, even if it's missing.                                                   |
 | `--no-recreate`    |               |           | If containers already exist, don't recreate them. Incompatible with --force-recreate.         |

--- a/docs/reference/compose_down.md
+++ b/docs/reference/compose_down.md
@@ -7,6 +7,7 @@ Stop and remove containers, networks
 
 | Name               | Type     | Default | Description                                                                                                              |
 |:-------------------|:---------|:--------|:-------------------------------------------------------------------------------------------------------------------------|
+| `--dry-run`        |          |         | Execute command in dry run mode                                                                                          |
 | `--remove-orphans` |          |         | Remove containers for services not defined in the Compose file.                                                          |
 | `--rmi`            | `string` |         | Remove images used by services. "local" remove only images that don't have a custom tag ("local"\|"all")                 |
 | `-t`, `--timeout`  | `int`    | `10`    | Specify a shutdown timeout in seconds                                                                                    |

--- a/docs/reference/compose_events.md
+++ b/docs/reference/compose_events.md
@@ -5,9 +5,10 @@ Receive real time events from containers.
 
 ### Options
 
-| Name     | Type | Default | Description                               |
-|:---------|:-----|:--------|:------------------------------------------|
-| `--json` |      |         | Output events as a stream of json objects |
+| Name        | Type | Default | Description                               |
+|:------------|:-----|:--------|:------------------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode           |
+| `--json`    |      |         | Output events as a stream of json objects |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_exec.md
+++ b/docs/reference/compose_exec.md
@@ -8,6 +8,7 @@ Execute a command in a running container.
 | Name              | Type          | Default | Description                                                                       |
 |:------------------|:--------------|:--------|:----------------------------------------------------------------------------------|
 | `-d`, `--detach`  |               |         | Detached mode: Run command in the background.                                     |
+| `--dry-run`       |               |         | Execute command in dry run mode                                                   |
 | `-e`, `--env`     | `stringArray` |         | Set environment variables                                                         |
 | `--index`         | `int`         | `1`     | index of the container if there are multiple instances of a service [default: 1]. |
 | `-T`, `--no-TTY`  |               |         | Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.  |

--- a/docs/reference/compose_images.md
+++ b/docs/reference/compose_images.md
@@ -7,6 +7,7 @@ List images used by the created containers
 
 | Name            | Type     | Default | Description                                 |
 |:----------------|:---------|:--------|:--------------------------------------------|
+| `--dry-run`     |          |         | Execute command in dry run mode             |
 | `--format`      | `string` | `table` | Format the output. Values: [table \| json]. |
 | `-q`, `--quiet` |          |         | Only display IDs                            |
 

--- a/docs/reference/compose_kill.md
+++ b/docs/reference/compose_kill.md
@@ -7,6 +7,7 @@ Force stop service containers.
 
 | Name               | Type     | Default   | Description                                                     |
 |:-------------------|:---------|:----------|:----------------------------------------------------------------|
+| `--dry-run`        |          |           | Execute command in dry run mode                                 |
 | `--remove-orphans` |          |           | Remove containers for services not defined in the Compose file. |
 | `-s`, `--signal`   | `string` | `SIGKILL` | SIGNAL to send to the container.                                |
 

--- a/docs/reference/compose_logs.md
+++ b/docs/reference/compose_logs.md
@@ -7,6 +7,7 @@ View output from containers
 
 | Name                 | Type     | Default | Description                                                                                    |
 |:---------------------|:---------|:--------|:-----------------------------------------------------------------------------------------------|
+| `--dry-run`          |          |         | Execute command in dry run mode                                                                |
 | `-f`, `--follow`     |          |         | Follow log output.                                                                             |
 | `--no-color`         |          |         | Produce monochrome output.                                                                     |
 | `--no-log-prefix`    |          |         | Don't print prefix in logs.                                                                    |

--- a/docs/reference/compose_ls.md
+++ b/docs/reference/compose_ls.md
@@ -8,6 +8,7 @@ List running compose projects
 | Name            | Type     | Default | Description                                 |
 |:----------------|:---------|:--------|:--------------------------------------------|
 | `-a`, `--all`   |          |         | Show all stopped Compose projects           |
+| `--dry-run`     |          |         | Execute command in dry run mode             |
 | `--filter`      | `filter` |         | Filter output based on conditions provided. |
 | `--format`      | `string` | `table` | Format the output. Values: [table \| json]. |
 | `-q`, `--quiet` |          |         | Only display IDs.                           |

--- a/docs/reference/compose_pause.md
+++ b/docs/reference/compose_pause.md
@@ -3,6 +3,12 @@
 <!---MARKER_GEN_START-->
 Pause services
 
+### Options
+
+| Name        | Type | Default | Description                     |
+|:------------|:-----|:--------|:--------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode |
+
 
 <!---MARKER_GEN_END-->
 

--- a/docs/reference/compose_port.md
+++ b/docs/reference/compose_port.md
@@ -7,6 +7,7 @@ Print the public port for a port binding.
 
 | Name         | Type     | Default | Description                                             |
 |:-------------|:---------|:--------|:--------------------------------------------------------|
+| `--dry-run`  |          |         | Execute command in dry run mode                         |
 | `--index`    | `int`    | `1`     | index of the container if service has multiple replicas |
 | `--protocol` | `string` | `tcp`   | tcp or udp                                              |
 

--- a/docs/reference/compose_ps.md
+++ b/docs/reference/compose_ps.md
@@ -8,6 +8,7 @@ List containers
 | Name                  | Type          | Default | Description                                                                                                   |
 |:----------------------|:--------------|:--------|:--------------------------------------------------------------------------------------------------------------|
 | `-a`, `--all`         |               |         | Show all stopped containers (including those created by the run command)                                      |
+| `--dry-run`           |               |         | Execute command in dry run mode                                                                               |
 | [`--filter`](#filter) | `string`      |         | Filter services by a property (supported filters: status).                                                    |
 | [`--format`](#format) | `string`      | `table` | Format the output. Values: [table \| json]                                                                    |
 | `-q`, `--quiet`       |               |         | Only display IDs                                                                                              |

--- a/docs/reference/compose_pull.md
+++ b/docs/reference/compose_pull.md
@@ -7,6 +7,7 @@ Pull service images
 
 | Name                     | Type | Default | Description                                             |
 |:-------------------------|:-----|:--------|:--------------------------------------------------------|
+| `--dry-run`              |      |         | Execute command in dry run mode                         |
 | `--ignore-buildable`     |      |         | Ignore images that can be built.                        |
 | `--ignore-pull-failures` |      |         | Pull what it can and ignores images with pull failures. |
 | `--include-deps`         |      |         | Also pull services declared as dependencies.            |

--- a/docs/reference/compose_push.md
+++ b/docs/reference/compose_push.md
@@ -7,6 +7,7 @@ Push service images
 
 | Name                     | Type | Default | Description                                            |
 |:-------------------------|:-----|:--------|:-------------------------------------------------------|
+| `--dry-run`              |      |         | Execute command in dry run mode                        |
 | `--ignore-push-failures` |      |         | Push what it can and ignores images with push failures |
 | `--include-deps`         |      |         | Also push images of services declared as dependencies  |
 | `-q`, `--quiet`          |      |         | Push without printing progress information             |

--- a/docs/reference/compose_restart.md
+++ b/docs/reference/compose_restart.md
@@ -7,6 +7,7 @@ Restart service containers
 
 | Name              | Type  | Default | Description                           |
 |:------------------|:------|:--------|:--------------------------------------|
+| `--dry-run`       |       |         | Execute command in dry run mode       |
 | `--no-deps`       |       |         | Don't restart dependent services.     |
 | `-t`, `--timeout` | `int` | `10`    | Specify a shutdown timeout in seconds |
 

--- a/docs/reference/compose_rm.md
+++ b/docs/reference/compose_rm.md
@@ -12,6 +12,7 @@ Any data which is not in a volume will be lost.
 
 | Name              | Type | Default | Description                                         |
 |:------------------|:-----|:--------|:----------------------------------------------------|
+| `--dry-run`       |      |         | Execute command in dry run mode                     |
 | `-f`, `--force`   |      |         | Don't ask to confirm removal                        |
 | `-s`, `--stop`    |      |         | Stop the containers, if required, before removing   |
 | `-v`, `--volumes` |      |         | Remove any anonymous volumes attached to containers |

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -9,6 +9,7 @@ Run a one-off command on a service.
 |:----------------------|:--------------|:--------|:----------------------------------------------------------------------------------|
 | `--build`             |               |         | Build image before starting container.                                            |
 | `-d`, `--detach`      |               |         | Run container in background and print container ID                                |
+| `--dry-run`           |               |         | Execute command in dry run mode                                                   |
 | `--entrypoint`        | `string`      |         | Override the entrypoint of the image                                              |
 | `-e`, `--env`         | `stringArray` |         | Set environment variables                                                         |
 | `-i`, `--interactive` |               |         | Keep STDIN open even if not attached.                                             |

--- a/docs/reference/compose_start.md
+++ b/docs/reference/compose_start.md
@@ -3,6 +3,12 @@
 <!---MARKER_GEN_START-->
 Start services
 
+### Options
+
+| Name        | Type | Default | Description                     |
+|:------------|:-----|:--------|:--------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode |
+
 
 <!---MARKER_GEN_END-->
 

--- a/docs/reference/compose_stop.md
+++ b/docs/reference/compose_stop.md
@@ -7,6 +7,7 @@ Stop services
 
 | Name              | Type  | Default | Description                           |
 |:------------------|:------|:--------|:--------------------------------------|
+| `--dry-run`       |       |         | Execute command in dry run mode       |
 | `-t`, `--timeout` | `int` | `10`    | Specify a shutdown timeout in seconds |
 
 

--- a/docs/reference/compose_top.md
+++ b/docs/reference/compose_top.md
@@ -3,6 +3,12 @@
 <!---MARKER_GEN_START-->
 Display the running processes
 
+### Options
+
+| Name        | Type | Default | Description                     |
+|:------------|:-----|:--------|:--------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode |
+
 
 <!---MARKER_GEN_END-->
 

--- a/docs/reference/compose_unpause.md
+++ b/docs/reference/compose_unpause.md
@@ -3,6 +3,12 @@
 <!---MARKER_GEN_START-->
 Unpause services
 
+### Options
+
+| Name        | Type | Default | Description                     |
+|:------------|:-----|:--------|:--------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode |
+
 
 <!---MARKER_GEN_END-->
 

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -13,6 +13,7 @@ Create and start containers
 | `--attach-dependencies`      |               |           | Attach to dependent containers.                                                                          |
 | `--build`                    |               |           | Build images before starting containers.                                                                 |
 | `-d`, `--detach`             |               |           | Detached mode: Run containers in the background                                                          |
+| `--dry-run`                  |               |           | Execute command in dry run mode                                                                          |
 | `--exit-code-from`           | `string`      |           | Return the exit code of the selected service container. Implies --abort-on-container-exit                |
 | `--force-recreate`           |               |           | Recreate containers even if their configuration and image haven't changed.                               |
 | `--no-attach`                | `stringArray` |           | Don't attach to specified service.                                                                       |

--- a/docs/reference/compose_version.md
+++ b/docs/reference/compose_version.md
@@ -7,6 +7,7 @@ Show the Docker Compose version information
 
 | Name             | Type     | Default | Description                                                    |
 |:-----------------|:---------|:--------|:---------------------------------------------------------------|
+| `--dry-run`      |          |         | Execute command in dry run mode                                |
 | `-f`, `--format` | `string` |         | Format the output. Values: [pretty \| json]. (Default: pretty) |
 | `--short`        |          |         | Shows only Compose's version number.                           |
 

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -117,6 +117,51 @@ long: |-
 
     Setting the `COMPOSE_IGNORE_ORPHANS` environment variable to `true` will stop docker compose from detecting orphaned
     containers for the project.
+
+
+    ### Use Dry Run mode to test your command
+
+    Use `--dry-run` flag to test a command without changing your application stack state.
+    Dry Run mode will show you all the steps Compose will apply by executing the command, for example:
+    ```console
+    $ docker compose --dry-run up --build -d
+    [+] Pulling 1/1
+     ✔ DRY-RUN MODE -  db Pulled                                                                                                                                                                                                               0.9s
+    [+] Running 10/8
+     ✔ DRY-RUN MODE -    build service backend                                                                                                                                                                                                 0.0s
+     ✔ DRY-RUN MODE -  ==> ==> writing image dryRun-754a08ddf8bcb1cf22f310f09206dd783d42f7dd                                                                                                                                                   0.0s
+     ✔ DRY-RUN MODE -  ==> ==> naming to nginx-golang-mysql-backend                                                                                                                                                                            0.0s
+     ✔ DRY-RUN MODE -  Network nginx-golang-mysql_default                                    Created                                                                                                                                           0.0s
+     ✔ DRY-RUN MODE -  Container nginx-golang-mysql-db-1                                     Created                                                                                                                                           0.0s
+     ✔ DRY-RUN MODE -  Container nginx-golang-mysql-backend-1                                Created                                                                                                                                           0.0s
+     ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-1                                  Created                                                                                                                                           0.0s
+     ✔ DRY-RUN MODE -  Container nginx-golang-mysql-db-1                                     Healthy                                                                                                                                           0.5s
+     ✔ DRY-RUN MODE -  Container nginx-golang-mysql-backend-1                                Started                                                                                                                                           0.0s
+     ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-1                                  Started                                     Started
+    ```
+    You could see that the first step will be to pull the image defined by `db` service, then build the `backend` service.
+    After that, containers will be created, the `db` service started and the `backend` and `proxy` will wait until `db` service is healthy to start.
+
+    The Dry Run mode is not supported by all commands, especially by the command which doesn't change the state of a Compose stack
+    such as `ps`, `ls`, `logs` for example.
+
+    Here the list of commands supporting `--dry-run` flag:
+    * build
+    * cp
+    * create
+    * down
+    * exec
+    * kill
+    * pause
+    * pull
+    * push
+    * remove
+    * restart
+    * run
+    * start
+    * stop
+    * unpause
+    * up
 usage: docker compose
 pname: docker
 plink: docker.yaml
@@ -199,7 +244,7 @@ options:
       default_value: "false"
       description: Execute command in dry run mode
       deprecated: false
-      hidden: true
+      hidden: false
       experimental: false
       experimentalcli: false
       kubernetes: false

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -122,7 +122,7 @@ long: |-
     ### Use Dry Run mode to test your command
 
     Use `--dry-run` flag to test a command without changing your application stack state.
-    Dry Run mode will show you all the steps Compose will apply by executing the command, for example:
+    Dry Run mode shows you all the steps Compose applies when executing a command, for example:
     ```console
     $ docker compose --dry-run up --build -d
     [+] Pulling 1/1
@@ -139,10 +139,10 @@ long: |-
      ✔ DRY-RUN MODE -  Container nginx-golang-mysql-backend-1                                Started                                                                                                                                           0.0s
      ✔ DRY-RUN MODE -  Container nginx-golang-mysql-proxy-1                                  Started                                     Started
     ```
-    You could see that the first step will be to pull the image defined by `db` service, then build the `backend` service.
-    After that, containers will be created, the `db` service started and the `backend` and `proxy` will wait until `db` service is healthy to start.
+    From the example above, you can see that the first step is to pull the image defined by `db` service, then build the `backend` service.
+    Next, the containers are created. The `db` service is started, and the `backend` and `proxy` wait until the `db` service is healthy before starting.
 
-    The Dry Run mode is not supported by all commands, especially by the command which doesn't change the state of a Compose stack
+    Dry Run mode does not currently work with all commands. In particular, you cannot use Dry Run mode with a command that doesn't change the state of a Compose stack
     such as `ps`, `ls`, `logs` for example.
 
     Here the list of commands supporting `--dry-run` flag:

--- a/docs/reference/docker_compose_alpha.yaml
+++ b/docs/reference/docker_compose_alpha.yaml
@@ -9,6 +9,17 @@ cname:
 clink:
     - docker_compose_alpha_viz.yaml
     - docker_compose_alpha_watch.yaml
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: true

--- a/docs/reference/docker_compose_alpha.yaml
+++ b/docs/reference/docker_compose_alpha.yaml
@@ -4,11 +4,9 @@ long: Experimental commands
 pname: docker compose
 plink: docker_compose.yaml
 cname:
-    - docker compose alpha dry-run
     - docker compose alpha viz
     - docker compose alpha watch
 clink:
-    - docker_compose_alpha_dry-run.yaml
     - docker_compose_alpha_viz.yaml
     - docker_compose_alpha_watch.yaml
 deprecated: false

--- a/docs/reference/docker_compose_alpha_viz.yaml
+++ b/docs/reference/docker_compose_alpha_viz.yaml
@@ -57,6 +57,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: true

--- a/docs/reference/docker_compose_alpha_watch.yaml
+++ b/docs/reference/docker_compose_alpha_watch.yaml
@@ -17,6 +17,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: true

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -138,6 +138,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_config.yaml
+++ b/docs/reference/docker_compose_config.yaml
@@ -130,6 +130,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_cp.yaml
+++ b/docs/reference/docker_compose_cp.yaml
@@ -50,6 +50,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_create.yaml
+++ b/docs/reference/docker_compose_create.yaml
@@ -78,6 +78,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_down.yaml
+++ b/docs/reference/docker_compose_down.yaml
@@ -61,6 +61,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_events.yaml
+++ b/docs/reference/docker_compose_events.yaml
@@ -34,6 +34,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_exec.yaml
+++ b/docs/reference/docker_compose_exec.yaml
@@ -106,6 +106,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_images.yaml
+++ b/docs/reference/docker_compose_images.yaml
@@ -26,6 +26,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_kill.yaml
+++ b/docs/reference/docker_compose_kill.yaml
@@ -31,6 +31,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_logs.yaml
+++ b/docs/reference/docker_compose_logs.yaml
@@ -79,6 +79,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_ls.yaml
+++ b/docs/reference/docker_compose_ls.yaml
@@ -46,6 +46,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_pause.yaml
+++ b/docs/reference/docker_compose_pause.yaml
@@ -5,6 +5,17 @@ long: |
 usage: docker compose pause [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_port.yaml
+++ b/docs/reference/docker_compose_port.yaml
@@ -25,6 +25,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_ps.yaml
+++ b/docs/reference/docker_compose_ps.yaml
@@ -87,6 +87,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 examples: |-
     ### Format the output (--format) {#format}
 

--- a/docs/reference/docker_compose_pull.yaml
+++ b/docs/reference/docker_compose_pull.yaml
@@ -68,6 +68,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 examples: |-
     suppose you have this `compose.yaml`:
 

--- a/docs/reference/docker_compose_push.yaml
+++ b/docs/reference/docker_compose_push.yaml
@@ -54,6 +54,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_restart.yaml
+++ b/docs/reference/docker_compose_restart.yaml
@@ -36,6 +36,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_rm.yaml
+++ b/docs/reference/docker_compose_rm.yaml
@@ -64,6 +64,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -256,6 +256,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_start.yaml
+++ b/docs/reference/docker_compose_start.yaml
@@ -4,6 +4,17 @@ long: Starts existing containers for a service.
 usage: docker compose start [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_stop.yaml
+++ b/docs/reference/docker_compose_stop.yaml
@@ -17,6 +17,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_top.yaml
+++ b/docs/reference/docker_compose_top.yaml
@@ -4,6 +4,17 @@ long: Displays the running processes.
 usage: docker compose top [SERVICES...]
 pname: docker compose
 plink: docker_compose.yaml
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 examples: |-
     ```console
     $ docker compose top

--- a/docs/reference/docker_compose_unpause.yaml
+++ b/docs/reference/docker_compose_unpause.yaml
@@ -4,6 +4,17 @@ long: Unpauses paused containers of a service.
 usage: docker compose unpause [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -273,6 +273,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/docs/reference/docker_compose_version.yaml
+++ b/docs/reference/docker_compose_version.yaml
@@ -25,6 +25,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false


### PR DESCRIPTION
**What I did**
Move alpha `dry-run` command to a global `--dry-run` flag of the main Compose command

**Related issue**
closes #1203 

https://docker.atlassian.net/browse/ENV-183

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://user-images.githubusercontent.com/705411/236416511-58f6727e-cc62-4418-a655-8ee0d6bcc3d7.png)
