### PR TITLE
fix builkit progressui integration

### DIFF
--- a/pkg/e2e/cancel_test.go
+++ b/pkg/e2e/cancel_test.go
@@ -59,8 +59,8 @@ func TestComposeCancel(t *testing.T) {
 		}, 30*time.Second, 1*time.Second)
 
 		err = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT) // simulate Ctrl-C : send signal to processGroup, children will have same groupId by default
-
 		assert.NilError(t, err)
+
 		c.WaitForCondition(t, func() (bool, string) {
 			out := stdout.String()
 			errors := stderr.String()


### PR DESCRIPTION
**What I did**
share progressui for all images being built, isolate concurrent image builds using `buildx.WithPrefix`

this is a simpler alternative to https://github.com/docker/compose/pull/10531, which we could include in a patch release

**Related issue**
fix https://github.com/docker/compose/issues/10528

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
