### PR TITLE
fix container being recreated while config has not changed

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -119,7 +119,7 @@ func (o *ProjectOptions) WithProject(fn ProjectFunc) func(cmd *cobra.Command, ar
 // WithServices creates a cobra run command from a ProjectFunc based on configured project options and selected services
 func (o *ProjectOptions) WithServices(fn ProjectServicesFunc) func(cmd *cobra.Command, args []string) error {
 	return Adapt(func(ctx context.Context, args []string) error {
-		project, err := o.ToProject(args, cli.WithResolvedPaths(true))
+		project, err := o.ToProject(args, cli.WithResolvedPaths(true), cli.WithDiscardEnvFile)
 		if err != nil {
 			return err
 		}
@@ -143,7 +143,7 @@ func (o *ProjectOptions) projectOrName(services ...string) (*types.Project, stri
 	name := o.ProjectName
 	var project *types.Project
 	if len(o.ConfigPaths) > 0 || o.ProjectName == "" {
-		p, err := o.ToProject(services)
+		p, err := o.ToProject(services, cli.WithDiscardEnvFile)
 		if err != nil {
 			envProjectName := os.Getenv("COMPOSE_PROJECT_NAME")
 			if envProjectName != "" {

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -142,7 +142,7 @@ func runCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *co
 			return nil
 		}),
 		RunE: Adapt(func(ctx context.Context, args []string) error {
-			project, err := p.ToProject([]string{opts.Service}, cgo.WithResolvedPaths(true))
+			project, err := p.ToProject([]string{opts.Service}, cgo.WithResolvedPaths(true), cgo.WithDiscardEnvFile)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**What I did**
As we don't load project `WithDiscardEnvFile` the config hash includes `env_file` attribute. But when selecting service(s) to be ran, compose-go `EnableService` always applies the discard option (this could be considered a bug, but that's another discussion :P)

**Related issue**
fixes https://github.com/docker/compose/issues/10068

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
