### PR TITLE
detect active endpoint trying to remove network and skip with a warning

### DIFF
--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -79,6 +79,8 @@ func TestDown(t *testing.T) {
 		{ID: "abc123", Name: "myProject_default"},
 		{ID: "def456", Name: "myProject_default"},
 	}, nil)
+	api.EXPECT().NetworkInspect(gomock.Any(), "abc123", gomock.Any()).Return(moby.NetworkResource{ID: "abc123"}, nil)
+	api.EXPECT().NetworkInspect(gomock.Any(), "def456", gomock.Any()).Return(moby.NetworkResource{ID: "def456"}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "abc123").Return(nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "def456").Return(nil)
 
@@ -118,6 +120,7 @@ func TestDownRemoveOrphans(t *testing.T) {
 	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", "myProject_default")),
 	}).Return([]moby.NetworkResource{{ID: "abc123", Name: "myProject_default"}}, nil)
+	api.EXPECT().NetworkInspect(gomock.Any(), "abc123", gomock.Any()).Return(moby.NetworkResource{ID: "abc123"}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "abc123").Return(nil)
 
 	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{RemoveOrphans: true})


### PR DESCRIPTION
**What I did**
Running `compose down` with a partial project, attempt to remove network fails with `error while removing network: network xxx has active endpoints`. With proposed changes, compose list active endpoints and skip network removal with a warning. `down` command then complete successfully.

```
$ docker compose down
[+] Running 2/1
 ✔ Container truc-server-1  Removed                                                     0.4s 
 ! Network truc_default     Resource is still in use                                    0.0s 
```

see https://github.com/docker/compose/issues/10295
