### PR TITLE
fix local image removal when `compose down` is ran with `--project-name`

### DIFF
--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -223,6 +223,7 @@ func TestDownRemoveImages(t *testing.T) {
 
 	localImagesToBeRemoved := []string{
 		"testproject-local-anonymous:latest",
+		"local-named-image:latest",
 	}
 	for _, img := range localImagesToBeRemoved {
 		// test calls down --rmi=local then down --rmi=all, so local images
@@ -238,7 +239,6 @@ func TestDownRemoveImages(t *testing.T) {
 	assert.NilError(t, err)
 
 	otherImagesToBeRemoved := []string{
-		"local-named-image:latest",
 		"remote-image:latest",
 		"registry.example.com/remote-image-tagged:v1.0",
 	}

--- a/pkg/compose/image_pruner.go
+++ b/pkg/compose/image_pruner.go
@@ -107,14 +107,8 @@ func (p *ImagePruner) ImagesToPrune(ctx context.Context, opts ImagePruneOptions)
 			// removed from YAML)
 			shouldPrune = true
 		} else {
-			// only prune the image if it belongs to a known service for the
-			// project AND is either an implicitly-named, locally-built image
-			// or `--rmi=all` has been specified.
-			// TODO(milas): now that Compose labels the images it builds, this
-			// makes less sense; arguably, locally-built but explicitly-named
-			// images should be removed with `--rmi=local` as well.
-			service, err := p.project.GetService(img.Labels[api.ServiceLabel])
-			if err == nil && (opts.Mode == ImagePruneAll || service.Image == "") {
+			// only prune the image if it belongs to a known service for the project.
+			if _, err := p.project.GetService(img.Labels[api.ServiceLabel]); err == nil {
 				shouldPrune = true
 			}
 		}


### PR DESCRIPTION
**What I did**
As previously noted in comment, with built image being tagged to make listing more deterministic, we don't need anymore to check service.image being set. Running with `--project-name` this attribute is always set, whenever it might not have been in the initial compose.yaml file.

**Related issue**
closes https://github.com/docker/compose/issues/9914

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
