### PR TITLE
introduce COMPOSE_ANSI to define --ansi default value

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -306,6 +306,10 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 				logrus.SetLevel(logrus.TraceLevel)
 			}
 
+			if v, ok := os.LookupEnv("COMPOSE_ANSI"); ok && !cmd.Flags().Changed("ansi") {
+				ansi = v
+			}
+
 			formatter.SetANSIMode(streams, ansi)
 
 			if noColor, ok := os.LookupEnv("NO_COLOR"); ok && noColor != "" {


### PR DESCRIPTION
**What I did**
introduce COMPOSE_ANSI to define --ansi default value

**Related issue**
closes https://github.com/docker/compose/issues/9604

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
