### PR TITLE
detect terminal is not a `console.File` to avoid a panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/bugsnag/bugsnag-go v1.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/cloudflare/cfssl v1.4.1 // indirect
+	github.com/cloudflare/cfssl v1.4.1
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/containerd/ttrpc v1.1.1 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect


### PR DESCRIPTION
**What I did**
check conversion to console.File is successful, otherwise fallback to plain text output

**Related issue**
see https://github.com/docker/compose/issues/10560

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
