### PR TITLE
report external network not found when swarm is disabled

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1103,7 +1103,13 @@ func (s *composeService) ensureNetwork(ctx context.Context, n types.NetworkConfi
 				// Here we assume `driver` is relevant for a network we don't manage
 				// which is a non-sense, but this is our legacy ¯\(ツ)/¯
 				// networkAttach will later fail anyway if network actually doesn't exists
-				return nil
+				enabled, err := s.isSWarmEnabled(ctx)
+				if err != nil {
+					return err
+				}
+				if enabled {
+					return nil
+				}
 			}
 			return fmt.Errorf("network %s declared as external, but could not be found", n.Name)
 		}


### PR DESCRIPTION
**What I did**
Compose _should_ report an error when external network isn't found. This check can't be implemented when swarm mode is enabled for ... some reasons 😅  but we can detect swarm is disabled.

**Related issue**
fixes https://github.com/docker/compose/issues/9948

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
