### PR TITLE
introduce ability to select source for variable interpolation

### DIFF
--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -37,16 +37,17 @@ Define and run multi-container applications with Docker.
 
 ### Options
 
-| Name                   | Type          | Default | Description                                                                                         |
-|:-----------------------|:--------------|:--------|:----------------------------------------------------------------------------------------------------|
-| `--ansi`               | `string`      | `auto`  | Control when to print ANSI control characters ("never"\|"always"\|"auto")                           |
-| `--compatibility`      |               |         | Run compose in backward compatibility mode                                                          |
-| `--env-file`           | `stringArray` |         | Specify an alternate environment file.                                                              |
-| `-f`, `--file`         | `stringArray` |         | Compose configuration files                                                                         |
-| `--parallel`           | `int`         | `-1`    | Control max parallelism, -1 for unlimited                                                           |
-| `--profile`            | `stringArray` |         | Specify a profile to enable                                                                         |
-| `--project-directory`  | `string`      |         | Specify an alternate working directory<br>(default: the path of the, first specified, Compose file) |
-| `-p`, `--project-name` | `string`      |         | Project name                                                                                        |
+| Name                   | Type          | Default       | Description                                                                                         |
+|:-----------------------|:--------------|:--------------|:----------------------------------------------------------------------------------------------------|
+| `--ansi`               | `string`      | `auto`        | Control when to print ANSI control characters ("never"\|"always"\|"auto")                           |
+| `--compatibility`      |               |               | Run compose in backward compatibility mode                                                          |
+| `--env-file`           | `stringArray` |               | Specify an alternate environment file.                                                              |
+| `--env-from`           | `string`      | `os,env-file` | Specify sources to use for variables substitution.                                                  |
+| `-f`, `--file`         | `stringArray` |               | Compose configuration files                                                                         |
+| `--parallel`           | `int`         | `-1`          | Control max parallelism, -1 for unlimited                                                           |
+| `--profile`            | `stringArray` |               | Specify a profile to enable                                                                         |
+| `--project-directory`  | `string`      |               | Specify an alternate working directory<br>(default: the path of the, first specified, Compose file) |
+| `-p`, `--project-name` | `string`      |               | Project name                                                                                        |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -214,6 +214,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: env-from
+      value_type: string
+      default_value: os,env-file
+      description: Specify sources to use for variables substitution.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: file
       shorthand: f
       value_type: stringArray


### PR DESCRIPTION
**What I did**
Introduce `--env-from` so an advanced user can select the source for variable interpolation. Defaults to `os,env-file` to reflect the environment variable precedence as documented on https://docs.docker.com/compose/environment-variables/envvars-precedence/

Typical use cases are
- user want to disable `.env` file support.
- user want to prevent his local environment to _leak_ into application configuration and make it strictly reproducible

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
