### PR TITLE
sort containers by creation date to scale down the older ones

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -172,6 +173,9 @@ func (c *convergence) ensureService(ctx context.Context, project *types.Project,
 
 	eg, _ := errgroup.WithContext(ctx)
 
+	sort.Slice(containers, func(i, j int) bool {
+		return containers[i].Created < containers[j].Created
+	})
 	for i, container := range containers {
 		if i >= expected {
 			// Scale Down


### PR DESCRIPTION
**What I did**
sort service containers by creation date, so that scaling down will remove the older ones. This makes "down scale" more deterministic.

This allows to better support no-downtime container replacement by running:
```
docker compose up --scale x=2 --no-recreate -d  # creates a 2nd container for service, maybe with up-to-date image
docker compose up --scale x=1 --no-recreate -d  # remove older container
```

**Related issue**
fixes https://github.com/docker/compose/issues/10569

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
