### PR TITLE
only check the platform of cached image if image found

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -251,6 +251,9 @@ func (s *composeService) getLocalImagesDigests(ctx context.Context, project *typ
 	for i, service := range project.Services {
 		imgName := api.GetImageNameOrDefault(service, project.Name)
 		digest, ok := images[imgName]
+		if !ok {
+			continue
+		}
 		if service.Platform != "" {
 			platform, err := platforms.Parse(service.Platform)
 			if err != nil {
@@ -271,9 +274,8 @@ func (s *composeService) getLocalImagesDigests(ctx context.Context, project *typ
 			}
 		}
 
-		if ok {
-			project.Services[i].CustomLabels.Add(api.ImageDigestLabel, digest)
-		}
+		project.Services[i].CustomLabels.Add(api.ImageDigestLabel, digest)
+
 	}
 
 	return images, nil


### PR DESCRIPTION
**What I did**
Fix build issue introduced in Compose `v2.18.0` when checking local cached image platform (see #10546)

**Related issue**
Fixes #10574

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
