### PR TITLE
fix support for project name set by COMPOSE_PROJECT_NAME env var

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -175,7 +175,7 @@ func (o *ProjectOptions) toProjectName() (string, error) {
 		return o.ProjectName, nil
 	}
 
-	envProjectName := os.Getenv("ComposeProjectName")
+	envProjectName := os.Getenv(ComposeProjectName)
 	if envProjectName != "" {
 		return envProjectName, nil
 	}


### PR DESCRIPTION
**What I did**

**Related issue**
close https://github.com/docker/compose/issues/10593

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/c0d17095-0e69-453d-b2d1-76c8eb00b3c1)

