### PR TITLE
only set CopyUIDGID when secret is requested to set gid/uid

### DIFF
--- a/pkg/compose/secrets.go
+++ b/pkg/compose/secrets.go
@@ -45,7 +45,7 @@ func (s *composeService) injectSecrets(ctx context.Context, project *types.Proje
 		}
 
 		err = s.apiClient().CopyToContainer(ctx, id, "/", &b, moby.CopyToContainerOptions{
-			CopyUIDGID: true,
+			CopyUIDGID: config.UID != "" || config.GID != "",
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
**What I did**
only set CopyUIDGID when secret configuration explicitly requires to set uid/gid, otherwise we get hurt by https://github.com/moby/moby/issues/34142

**Related issue**
(partially) fixes https://github.com/docker/compose/issues/10595

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
