### PR TITLE
containerd-enabled engine return "Exists" status for already present layers

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -330,6 +330,7 @@ const (
 	ExtractingPhase        = "Extracting"
 	VerifyingChecksumPhase = "Verifying Checksum"
 	AlreadyExistsPhase     = "Already exists"
+	ExistsPhase            = "Exists"
 	PullCompletePhase      = "Pull complete"
 )
 
@@ -359,7 +360,7 @@ func toPullProgressEvent(parent string, jm jsonmessage.JSONMessage, w progress.W
 				percent = int(jm.Progress.Current * 100 / jm.Progress.Total)
 			}
 		}
-	case DownloadCompletePhase, AlreadyExistsPhase, PullCompletePhase:
+	case DownloadCompletePhase, AlreadyExistsPhase, ExistsPhase, PullCompletePhase:
 		status = progress.Done
 		percent = 100
 	}


### PR DESCRIPTION
**What I did**
Accept "Exists" as a pull JSONMessage.Status for already pulled layer. This is what we get with containerd-enabled docker engine

**How to test it**

enable container image store in Docker Desktop
then run `docker compose pull` (twice). Progress UI should show completion state