### PR TITLE
progress: remove errant import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/bugsnag/bugsnag-go v1.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/cloudflare/cfssl v1.4.1
+	github.com/cloudflare/cfssl v1.4.1 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/containerd/ttrpc v1.1.1 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -21,12 +21,12 @@ import (
 	"io"
 	"sync"
 
-	"github.com/cloudflare/cfssl/log"
-	"github.com/docker/compose/v2/pkg/api"
-
 	"github.com/containerd/console"
 	"github.com/moby/term"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v2/pkg/api"
 )
 
 // Writer can write multiple progress events
@@ -125,7 +125,7 @@ func NewWriter(ctx context.Context, out io.Writer, progressTitle string) (Writer
 	}
 	if Mode == ModeTTY {
 		if !isConsole {
-			log.Warning("Terminal is not a POSIX console")
+			logrus.Warn("Terminal is not a POSIX console")
 		} else {
 			return newTTYWriter(f, dryRun, progressTitle)
 		}


### PR DESCRIPTION
**What I did**
Just write the warning to the passed in writer. The function being used was coming from `cfssl`'s log package, which was presumably the result of auto-import being slightly too aggressive.

(Note: `cfssl` is still an indirect dependency after this.)

**Related issue**
n/a

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![cat in a husky outfit next to two huskies](https://github.com/docker/compose/assets/841263/d57103c7-841c-4fcf-a214-a7af21453336)
