### PR TITLE
fix display of volumes flag in down command help

### DIFF
--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -64,7 +64,7 @@ func downCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	removeOrphans := utils.StringToBool(os.Getenv(ComposeRemoveOrphans))
 	flags.BoolVar(&opts.removeOrphans, "remove-orphans", removeOrphans, "Remove containers for services not defined in the Compose file.")
 	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")
-	flags.BoolVarP(&opts.volumes, "volumes", "v", false, "Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.")
+	flags.BoolVarP(&opts.volumes, "volumes", "v", false, `Remove named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers.`)
 	flags.StringVar(&opts.images, "rmi", "", `Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")`)
 	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		if name == "volume" {

--- a/docs/reference/compose_down.md
+++ b/docs/reference/compose_down.md
@@ -11,7 +11,7 @@ Stop and remove containers, networks
 | `--remove-orphans` |          |         | Remove containers for services not defined in the Compose file.                                                          |
 | `--rmi`            | `string` |         | Remove images used by services. "local" remove only images that don't have a custom tag ("local"\|"all")                 |
 | `-t`, `--timeout`  | `int`    | `10`    | Specify a shutdown timeout in seconds                                                                                    |
-| `-v`, `--volumes`  |          |         | Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers. |
+| `-v`, `--volumes`  |          |         | Remove named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers. |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_down.yaml
+++ b/docs/reference/docker_compose_down.yaml
@@ -54,7 +54,7 @@ options:
       value_type: bool
       default_value: "false"
       description: |
-        Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.
+        Remove named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers.
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
**What I did**
I removed usage of ` in the flag description and replaced it by "

**Related issue**
#10610 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/1c7d1944-634b-44c8-bfa7-e976b3f26926)
