### PR TITLE
do not render `Building` when no build is needed

### DIFF
--- a/pkg/compose/build_test.go
+++ b/pkg/compose/build_test.go
@@ -44,7 +44,7 @@ func TestPrepareProjectForBuild(t *testing.T) {
 		}
 
 		s := &composeService{}
-		err := s.prepareProjectForBuild(&project, nil)
+		_, err := s.prepareProjectForBuild(&project, nil)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, project.Services[0].Build.Platforms, types.StringList{"alice/32"})
 	})
@@ -70,7 +70,7 @@ func TestPrepareProjectForBuild(t *testing.T) {
 		}
 
 		s := &composeService{}
-		err := s.prepareProjectForBuild(&project, nil)
+		_, err := s.prepareProjectForBuild(&project, nil)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, project.Services[0].Build.Platforms, types.StringList{"linux/amd64"})
 	})
@@ -89,7 +89,7 @@ func TestPrepareProjectForBuild(t *testing.T) {
 		}
 
 		s := &composeService{}
-		err := s.prepareProjectForBuild(&project, map[string]string{"foo": "exists"})
+		_, err := s.prepareProjectForBuild(&project, map[string]string{"foo": "exists"})
 		assert.NilError(t, err)
 		assert.Check(t, project.Services[0].Build == nil)
 	})
@@ -115,7 +115,7 @@ func TestPrepareProjectForBuild(t *testing.T) {
 		}
 
 		s := &composeService{}
-		err := s.prepareProjectForBuild(&project, nil)
+		_, err := s.prepareProjectForBuild(&project, nil)
 		assert.Check(t, err != nil)
 	})
 }

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -79,7 +79,7 @@ func (s *composeService) Watch(ctx context.Context, project *types.Project, serv
 	needRebuild := make(chan fileMapping)
 	needSync := make(chan fileMapping)
 
-	err := s.prepareProjectForBuild(project, nil)
+	_, err := s.prepareProjectForBuild(project, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What I did**
Don't setup buildkit's progress printer is we have no build to run, to prevent `[+] Building 0/0` to be displayed.

`progress.Printer` doesn't offer an option to select the stream used to render status vs build logs

**Related issue**
fixes https://github.com/docker/compose/issues/10619

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
