### PR TITLE
compute service hash with a default DeployConfig

### DIFF
--- a/pkg/compose/hash.go
+++ b/pkg/compose/hash.go
@@ -28,11 +28,12 @@ func ServiceHash(o types.ServiceConfig) (string, error) {
 	// remove the Build config when generating the service hash
 	o.Build = nil
 	o.PullPolicy = ""
-	o.Scale = 1
-	if o.Deploy != nil {
-		var one uint64 = 1
-		o.Deploy.Replicas = &one
+	if o.Deploy == nil {
+		o.Deploy = &types.DeployConfig{}
 	}
+	o.Scale = 1
+	var one uint64 = 1
+	o.Deploy.Replicas = &one
 	bytes, err := json.Marshal(o)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What I did**
as we compute service hash to compare actual vs expected state, always consider a default `DeployConfig` as passing `--scale service=N` will create one, even if the compose.yaml config doesn't define such a section

how to test:
```yaml
services:
  test:
    image: alpine
    command: ping localhost
```


```
 $ docker compose up -d
[+] Building 0.0s (0/0)                                                                                                                                
[+] Running 1/1
 ✔ Container truc-test-1  Started                                                                                                                 0.2s 
 $ docker compose up --scale test=2 -d
[+] Building 0.0s (0/0)                                                                                                                                
[+] Running 2/2
 ✔ Container truc-test-1  Recreated                                                                                                             10.2s 
 ✔ Container truc-test-2  Started 
```
container test-1 MUST not be re-created

with this PR:
```
 $ docker compose up -d
[+] Building 0.0s (0/0)                                                                                                                                
[+] Running 1/1
 ✔ Container truc-test-1  Started                                                                                                                 0.2s 
 $ docker compose up --scale test=2 -d
[+] Building 0.0s (0/0)                                                                                                                                
[+] Running 2/2
 ✔ Container truc-test-1  Running                                                                                                                0.0s 
 ✔ Container truc-test-2  Started 
```