### PR TITLE
fix `compose -p x logs -f` detect new services started after command

### DIFF
--- a/pkg/compose/events.go
+++ b/pkg/compose/events.go
@@ -25,7 +25,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 
 	"github.com/docker/compose/v2/pkg/api"
-
 	"github.com/docker/compose/v2/pkg/utils"
 )
 
@@ -67,8 +66,8 @@ func (s *composeService) Events(ctx context.Context, projectName string, options
 			err := options.Consumer(api.Event{
 				Timestamp:  timestamp,
 				Service:    service,
-				Container:  event.ID,
-				Status:     event.Status,
+				Container:  event.Actor.ID,
+				Status:     event.Action,
 				Attributes: attributes,
 			})
 			if err != nil {

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -51,13 +51,12 @@ func (s *composeService) Logs(
 		if err != nil {
 			return err
 		}
-	}
-
-	if len(options.Services) == 0 {
+	} else if len(options.Services) == 0 {
+		// we run with an explicit compose.yaml, so only consider services defined in this file
 		options.Services = project.ServiceNames()
+		containers = containers.filter(isService(options.Services...))
 	}
 
-	containers = containers.filter(isService(options.Services...))
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, c := range containers {
 		c := c

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -45,15 +45,9 @@ func (s *composeService) Logs(
 		return err
 	}
 
-	project := options.Project
-	if project == nil {
-		project, err = s.getProjectWithResources(ctx, containers, projectName)
-		if err != nil {
-			return err
-		}
-	} else if len(options.Services) == 0 {
+	if options.Project != nil && len(options.Services) == 0 {
 		// we run with an explicit compose.yaml, so only consider services defined in this file
-		options.Services = project.ServiceNames()
+		options.Services = options.Project.ServiceNames()
 		containers = containers.filter(isService(options.Services...))
 	}
 

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -155,13 +155,31 @@ func (s *composeService) watchContainers(ctx context.Context, //nolint:gocyclo
 		required = services
 	}
 
+	// predicate to tell if a container we receive event for should be considered or ignored
+	ofInterest := func(c moby.Container) bool {
+		if len(services) > 0 {
+			// we only watch some services
+			return utils.Contains(services, c.Labels[api.ServiceLabel])
+		}
+		return true
+	}
+
+	// predicate to tell if a container we receive event for should be watched until termination
+	isRequired := func(c moby.Container) bool {
+		if len(services) > 0 && len(required) > 0 {
+			// we only watch some services
+			return utils.Contains(required, c.Labels[api.ServiceLabel])
+		}
+		return true
+	}
+
 	var (
 		expected []string
 		watched  = map[string]int{}
 		replaced []string
 	)
 	for _, c := range containers {
-		if utils.Contains(required, c.Labels[api.ServiceLabel]) {
+		if isRequired(c) {
 			expected = append(expected, c.ID)
 		}
 		watched[c.ID] = 0
@@ -263,6 +281,11 @@ func (s *composeService) watchContainers(ctx context.Context, //nolint:gocyclo
 					}
 					watched[container.ID] = 1
 					if utils.Contains(expected, id) {
+						expected = append(expected, container.ID)
+					}
+				} else if ofInterest(container) {
+					watched[container.ID] = 1
+					if isRequired(container) {
 						expected = append(expected, container.ID)
 					}
 				}

--- a/pkg/e2e/fixtures/logs-test/compose.yaml
+++ b/pkg/e2e/fixtures/logs-test/compose.yaml
@@ -1,7 +1,7 @@
 services:
   ping:
     image: alpine
-    command: ping localhost -c 1
+    command: ping localhost -c ${REPEAT:-1}
   hello:
     image: alpine
     command: echo hello


### PR DESCRIPTION
when we run `compose --project-name logs` we SHOULD detect new services being started _after_ the initial model has been built from actual ressources. For this purpose, 
- options.Services filter is only set when project is not nil
- `create` events` adds container to the watched list

added an e2e test to check this behaves as expected

**Related issue**
fixes https://github.com/docker/compose/issues/10618

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
