### PR TITLE
Fix typo in warning about existing volume

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1194,7 +1194,7 @@ func (s *composeService) ensureVolume(ctx context.Context, volume types.VolumeCo
 		logrus.Warnf("volume %q already exists but was not created by Docker Compose. Use `external: true` to use an existing volume", volume.Name)
 	}
 	if ok && p != project {
-		logrus.Warnf("volume %q already exists but was not created for project %q. Use `external: true` to use an existing volume", volume.Name, p)
+		logrus.Warnf("volume %q already exists but was created for project %q (expected %q). Use `external: true` to use an existing volume", volume.Name, p, project)
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, this was telling us "but was not created for project [project-it-was-created-for]", which is wrong. I opted to make the message super explicit and print both the actual project and the expected project.

**What I did**

**Related issue**
I couldn't find an existing issue for this.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

This surprised koala has been my phone background ever since I got my first smartphone:

![image](https://github.com/docker/compose/assets/277474/2a8a5e0d-a914-4fb0-b8d8-31dd8ff8a8c0)
