### PR TITLE
Cuke tests for port conflicts

### DIFF
--- a/e2e/cucumber-features/port-conflict.feature
+++ b/e2e/cucumber-features/port-conflict.feature
@@ -1,0 +1,28 @@
+Feature: Report port conflicts
+
+Background:
+    Given a compose file
+        """
+        services:
+          web:
+            image: nginx
+            ports:
+            - 31415:80
+        """
+    And I run "docker rm -f nginx-pi-31415"
+
+Scenario: Reports a port allocation conflict with another container
+    Given I run "docker run -d -p 31415:80 --name nginx-pi-31415 nginx"
+    When I run "compose up -d"
+    Then the output contains "port is already allocated"
+    And the exit code is 1
+
+Scenario: Reports a port conflict with some other process
+    Given a process listening on port 31415
+    When I run "compose up -d"
+    Then the output contains "address already in use"
+    And the exit code is 1
+
+Scenario: Cleanup
+    Given I run "docker rm -f nginx-pi-31415"
+

--- a/e2e/cucumber-features/ps.feature
+++ b/e2e/cucumber-features/ps.feature
@@ -16,6 +16,7 @@ Background:
         """
         FROM golang:1.19-alpine
         """
+    And I run "docker rm -f external-test"
 
 Scenario: external container from compose image exists
     When I run "compose build"
@@ -24,4 +25,5 @@ Scenario: external container from compose image exists
     Then the exit code is 0
     And I run "compose ps -a"
     Then the output does not contain "external-test"
+    And I run "docker rm -f external-test"
 

--- a/e2e/cucumber_test.go
+++ b/e2e/cucumber_test.go
@@ -19,6 +19,7 @@ package cucumber
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -87,6 +88,7 @@ func setup(s *godog.ScenarioContext) {
 	s.Step(`output contains "(.*)"$`, th.outputContains(true))
 	s.Step(`output does not contain "(.*)"$`, th.outputContains(false))
 	s.Step(`exit code is (\d+)$`, th.exitCodeIs)
+	s.Step(`a process listening on port (\d+)$`, th.listenerOnPort)
 }
 
 type testHelper struct {
@@ -172,5 +174,18 @@ func (th *testHelper) setDockerfile(dockerfileString string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (th *testHelper) listenerOnPort(port int) error {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return err
+	}
+
+	th.T.Cleanup(func() {
+		_ = l.Close()
+	})
+
 	return nil
 }


### PR DESCRIPTION
**What I did**

Add a cuke feature to test compose errors with port conflicts. I was trying to reproduce an error I was seeing in a different project, but these tests behaved as expected. Want some free tests?

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
