### PR TITLE
bump buildx and use confutil.ConfigDir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/containerd v1.6.21
 	github.com/cucumber/godog v0.0.0-00010101000000-000000000000 // replaced; see replace for the actual version used
 	github.com/distribution/distribution/v3 v3.0.0-20230327091844-0c958010ace2
-	github.com/docker/buildx v0.10.4
+	github.com/docker/buildx v0.10.5
 	github.com/docker/cli v23.0.6+incompatible
 	github.com/docker/cli-docs-tool v0.5.1
 	github.com/docker/docker v23.0.6+incompatible
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/moby/buildkit v0.11.6
+	github.com/moby/buildkit v0.11.7-0.20230519102302-348e79dfed17
 	github.com/moby/term v0.5.0
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zA
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/distribution/distribution/v3 v3.0.0-20230327091844-0c958010ace2 h1:KTYNpKuqtdZJOobHigxfdikPdsBwddmzeRn3UMocznM=
 github.com/distribution/distribution/v3 v3.0.0-20230327091844-0c958010ace2/go.mod h1:r5XLH1cp+Wau2jxdptkYsFvvvzPPQTIe8eUuQ0vq30Q=
-github.com/docker/buildx v0.10.4 h1:qsHwlUZaLu7UQkDhJDSRQ+jrvWf6mqwwtY+gWO3rzuA=
-github.com/docker/buildx v0.10.4/go.mod h1:2mHDjD0QevclBGYIXDOWY/ZU71JAzx7w4CfgroYbHQw=
+github.com/docker/buildx v0.10.5 h1:0GRS8TugOQUU3ja17VgMGgkEVR+qbWt8HhpTupCRu74=
+github.com/docker/buildx v0.10.5/go.mod h1:UV+XfFFlBuOd6G2Ge8I6w8+u9FB9R2zpiKyf2TFEw+k=
 github.com/docker/cli v23.0.6+incompatible h1:CScadyCJ2ZKUDpAMZta6vK8I+6/m60VIjGIV7Wg/Eu4=
 github.com/docker/cli v23.0.6+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.5.1 h1:jIk/cCZurZERhALPVKhqlNxTQGxn2kcI+56gE57PQXg=
@@ -523,8 +523,8 @@ github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/moby/buildkit v0.11.6 h1:VYNdoKk5TVxN7k4RvZgdeM4GOyRvIi4Z8MXOY7xvyUs=
-github.com/moby/buildkit v0.11.6/go.mod h1:GCqKfHhz+pddzfgaR7WmHVEE3nKKZMMDPpK8mh3ZLv4=
+github.com/moby/buildkit v0.11.7-0.20230519102302-348e79dfed17 h1:asvsqGToDMMsf5LOXiZxjKeHokXLF2FdYHzQVKympL8=
+github.com/moby/buildkit v0.11.7-0.20230519102302-348e79dfed17/go.mod h1:GCqKfHhz+pddzfgaR7WmHVEE3nKKZMMDPpK8mh3ZLv4=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -112,11 +112,11 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		}
 		buildOptions.BuildArgs = mergeArgs(buildOptions.BuildArgs, flatten(args))
 
-		ids, err := s.doBuildBuildkit(ctx, service.Name, buildOptions, w)
+		digest, err := s.doBuildBuildkit(ctx, service.Name, buildOptions, w)
 		if err != nil {
 			return err
 		}
-		builtIDs[idx] = ids[service.Name]
+		builtIDs[idx] = digest
 
 		return nil
 	}, func(traversal *graphTraversal) {

--- a/pkg/compose/build_buildkit.go
+++ b/pkg/compose/build_buildkit.go
@@ -20,44 +20,46 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
-	"path/filepath"
 
+	"github.com/docker/buildx/build"
+	"github.com/docker/buildx/builder"
 	_ "github.com/docker/buildx/driver/docker"           //nolint:blank-imports
 	_ "github.com/docker/buildx/driver/docker-container" //nolint:blank-imports
 	_ "github.com/docker/buildx/driver/kubernetes"       //nolint:blank-imports
 	_ "github.com/docker/buildx/driver/remote"           //nolint:blank-imports
-	buildx "github.com/docker/buildx/util/progress"
-	"github.com/moby/buildkit/client"
-
-	"github.com/docker/buildx/build"
-	"github.com/docker/buildx/builder"
+	"github.com/docker/buildx/util/confutil"
 	"github.com/docker/buildx/util/dockerutil"
+	buildx "github.com/docker/buildx/util/progress"
 	"github.com/docker/compose/v2/pkg/progress"
+	"github.com/moby/buildkit/client"
 )
 
-func (s *composeService) doBuildBuildkit(ctx context.Context, service string, opts build.Options, p *buildx.Printer) (map[string]string, error) {
+func (s *composeService) doBuildBuildkit(ctx context.Context, service string, opts build.Options, p *buildx.Printer) (string, error) {
 	b, err := builder.New(s.dockerCli)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	nodes, err := b.LoadNodes(ctx, false)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	var response map[string]*client.SolveResponse
 	if s.dryRun {
 		response = s.dryRunBuildResponse(ctx, service, opts)
 	} else {
-		response, err = build.Build(ctx, nodes, map[string]build.Options{service: opts}, dockerutil.NewClient(s.dockerCli), filepath.Dir(s.configFile().Filename), buildx.WithPrefix(p, service, true))
+		response, err = build.Build(ctx, nodes,
+			map[string]build.Options{service: opts},
+			dockerutil.NewClient(s.dockerCli),
+			confutil.ConfigDir(s.dockerCli),
+			buildx.WithPrefix(p, service, true))
 		if err != nil {
-			return nil, WrapCategorisedComposeError(err, BuildFailure)
+			return "", WrapCategorisedComposeError(err, BuildFailure)
 		}
 	}
 
-	imagesBuilt := map[string]string{}
-	for name, img := range response {
+	for _, img := range response {
 		if img == nil || len(img.ExporterResponse) == 0 {
 			continue
 		}
@@ -65,10 +67,10 @@ func (s *composeService) doBuildBuildkit(ctx context.Context, service string, op
 		if !ok {
 			continue
 		}
-		imagesBuilt[name] = digest
+		return digest, nil
 	}
 
-	return imagesBuilt, err
+	return "", fmt.Errorf("buildkit response is missing expected result for %s", service)
 }
 
 func (s composeService) dryRunBuildResponse(ctx context.Context, name string, options build.Options) map[string]*client.SolveResponse {


### PR DESCRIPTION
**What I did**
bump buildx to latest release
use `confutil.ConfigDir` to better align with buildx codebase
only return digest for (single) image we have built (multi-value return is a legacy from the time we ran buildx for all images at once)

