### PR TITLE
introduce support for custom build outputs

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -254,7 +254,7 @@ func RunningAsStandalone() bool {
 }
 
 // RootCommand returns the compose command with its child commands
-func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //nolint:gocyclo
+func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command { //nolint:gocyclo
 	// filter out useless commandConn.CloseWrite warning message that can occur
 	// when using a remote context that is unreachable: "commandConn.CloseWrite: commandconn: failed to wait: signal: killed"
 	// https://github.com/docker/cli/blob/e1f24d3c93df6752d3c27c8d61d18260f141310c/cli/connhelper/commandconn/commandconn.go#L203-L215
@@ -285,7 +285,7 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 				return cmd.Help()
 			}
 			if version {
-				return versionCommand(streams).Execute()
+				return versionCommand(dockerCli).Execute()
 			}
 			_ = cmd.Help()
 			return dockercli.StatusError{
@@ -323,11 +323,11 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 				ansi = v
 			}
 
-			formatter.SetANSIMode(streams, ansi)
+			formatter.SetANSIMode(dockerCli, ansi)
 
 			if noColor, ok := os.LookupEnv("NO_COLOR"); ok && noColor != "" {
 				progress.NoColor()
-				formatter.SetANSIMode(streams, formatter.Never)
+				formatter.SetANSIMode(dockerCli, formatter.Never)
 			}
 
 			switch ansi {
@@ -384,27 +384,27 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 	}
 
 	c.AddCommand(
-		upCommand(&opts, streams, backend),
+		upCommand(&opts, dockerCli, backend),
 		downCommand(&opts, backend),
 		startCommand(&opts, backend),
 		restartCommand(&opts, backend),
 		stopCommand(&opts, backend),
-		psCommand(&opts, streams, backend),
-		listCommand(streams, backend),
-		logsCommand(&opts, streams, backend),
-		configCommand(&opts, streams, backend),
+		psCommand(&opts, dockerCli, backend),
+		listCommand(dockerCli, backend),
+		logsCommand(&opts, dockerCli, backend),
+		configCommand(&opts, dockerCli, backend),
 		killCommand(&opts, backend),
-		runCommand(&opts, streams, backend),
+		runCommand(&opts, dockerCli, backend),
 		removeCommand(&opts, backend),
-		execCommand(&opts, streams, backend),
+		execCommand(&opts, dockerCli, backend),
 		pauseCommand(&opts, backend),
 		unpauseCommand(&opts, backend),
-		topCommand(&opts, streams, backend),
-		eventsCommand(&opts, streams, backend),
-		portCommand(&opts, streams, backend),
-		imagesCommand(&opts, streams, backend),
-		versionCommand(streams),
-		buildCommand(&opts, backend),
+		topCommand(&opts, dockerCli, backend),
+		eventsCommand(&opts, dockerCli, backend),
+		portCommand(&opts, dockerCli, backend),
+		imagesCommand(&opts, dockerCli, backend),
+		versionCommand(dockerCli),
+		buildCommand(&opts, dockerCli, backend),
 		pushCommand(&opts, backend),
 		pullCommand(&opts, backend),
 		createCommand(&opts, backend),

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -11,6 +11,7 @@ Build or rebuild services
 | `--dry-run`      |               |         | Execute command in dry run mode                                                                             |
 | `-m`, `--memory` | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
 | `--no-cache`     |               |         | Do not use cache when building the image                                                                    |
+| `--output`       | `stringArray` |         | Output destination (format: "type=local,dest=path")                                                         |
 | `--progress`     | `string`      | `auto`  | Set type of progress output (auto, tty, plain, quiet)                                                       |
 | `--pull`         |               |         | Always attempt to pull a newer version of the image.                                                        |
 | `--push`         |               |         | Push service images.                                                                                        |

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -77,6 +77,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: output
+      value_type: stringArray
+      default_value: '[]'
+      description: 'Output destination (format: "type=local,dest=path")'
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: parallel
       value_type: bool
       default_value: "true"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -121,6 +121,8 @@ type BuildOptions struct {
 	SSHs []types.SSHKey
 	// Memory limit for the build container
 	Memory int64
+	// Outputs define custom output. format: "type=local,dest=path"
+	Outputs []string
 }
 
 // Apply mutates project according to build options

--- a/pkg/compose/build_buildkit.go
+++ b/pkg/compose/build_buildkit.go
@@ -70,7 +70,7 @@ func (s *composeService) doBuildBuildkit(ctx context.Context, service string, op
 		return digest, nil
 	}
 
-	return "", fmt.Errorf("buildkit response is missing expected result for %s", service)
+	return "", nil
 }
 
 func (s composeService) dryRunBuildResponse(ctx context.Context, name string, options build.Options) map[string]*client.SolveResponse {


### PR DESCRIPTION
**What I did**
introduce `--output` flag on `build` command to export built artifact with alternate exporter.
AFAICT having this as part of the compose.yaml service definition doesn't make much sense as `compose up` scenario require image to be exported to container runtime local store. On the other hand, maybe there's room for new use-cases?

**Related issue**
fixes https://github.com/docker/compose/issues/9586

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
