### PR TITLE
don't skip `compose` used as project name

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -62,10 +62,6 @@ func Convert(args []string) []string {
 			continue
 		}
 		if len(arg) > 0 && arg[0] != '-' {
-			// not a top-level flag anymore, keep the rest of the command unmodified
-			if arg == compose.PluginName {
-				i++
-			}
 			command = append(command, args[i:]...)
 			break
 		}

--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -83,6 +83,11 @@ func Test_convert(t *testing.T) {
 			args: []string{"--project-directory", "", "ps"},
 			want: []string{"compose", "--project-directory", "", "ps"},
 		},
+		{
+			name: "compose as project name",
+			args: []string{"--project-name", "compose", "down", "--remove-orphans"},
+			want: []string{"compose", "--project-name", "compose", "down", "--remove-orphans"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What I did**
fix support for converting `docker-compose --project-name compose` into a compose v2 command (`docker <space> compose`)
Tried to understand the fix in https://github.com/docker/compose/pull/8985 to skip `compose` argument but doesn't make any sense to me after 18 months. This code is only used if command is `docker-compose ..` but not when used as a CLI plugin with `docker compose ...`, maybe this wasn't the case earlier? @ulyssessouza do you remember?

**Related issue**
fixes https://github.com/docker/compose/issues/10647

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
