### PR TITLE
introduce run --cap-add to run maintenance commands using service image

### DIFF
--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -8,6 +8,8 @@ Run a one-off command on a service.
 | Name                  | Type          | Default | Description                                                                       |
 |:----------------------|:--------------|:--------|:----------------------------------------------------------------------------------|
 | `--build`             |               |         | Build image before starting container.                                            |
+| `--cap-add`           | `list`        |         | Add Linux capabilities                                                            |
+| `--cap-drop`          | `list`        |         | Drop Linux capabilities                                                           |
 | `-d`, `--detach`      |               |         | Run container in background and print container ID                                |
 | `--dry-run`           |               |         | Execute command in dry run mode                                                   |
 | `--entrypoint`        | `string`      |         | Override the entrypoint of the image                                              |

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -68,6 +68,24 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: cap-add
+      value_type: list
+      description: Add Linux capabilities
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: cap-drop
+      value_type: list
+      description: Drop Linux capabilities
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: detach
       shorthand: d
       value_type: bool

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -305,6 +305,8 @@ type RunOptions struct {
 	WorkingDir        string
 	User              string
 	Environment       []string
+	CapAdd            []string
+	CapDrop           []string
 	Labels            types.Labels
 	Privileged        bool
 	UseNetworkAliases bool

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/cli/cli"
 	cmd "github.com/docker/cli/cli/command/container"
 	"github.com/docker/compose/v2/pkg/api"
+	"github.com/docker/compose/v2/pkg/utils"
 	"github.com/docker/docker/pkg/stringid"
 )
 
@@ -116,6 +117,14 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 	}
 	if len(opts.User) > 0 {
 		service.User = opts.User
+	}
+	if len(opts.CapAdd) > 0 {
+		service.CapAdd = append(service.CapAdd, opts.CapAdd...)
+		service.CapDrop = utils.Remove(service.CapDrop, opts.CapAdd...)
+	}
+	if len(opts.CapDrop) > 0 {
+		service.CapDrop = append(service.CapDrop, opts.CapDrop...)
+		service.CapAdd = utils.Remove(service.CapAdd, opts.CapDrop...)
 	}
 	if len(opts.WorkingDir) > 0 {
 		service.WorkingDir = opts.WorkingDir


### PR DESCRIPTION
**What I did**
introduce `docker run --cap-add` flag so user can get extra privileges to run maintenance commands without the need for an init container (which doesn't yet have a user-friendly support in compose file format)

```yaml
services:
  test:
    image: alpine
    command: ls -al /volume
    user: "1001"
    volumes:
      - volume:/volume

volumes:
  volume: {}
```

```
 $ docker compose run --cap-add CAP_CHOWN --user root test chown 1001:1001 -R /volume
[+] Creating 2/0
 ✔ Network machin_default  Created                                         0.0s 
 ✔ Volume "machin_volume"  Created                                         0.0s 

$ docker compose up
[+] Running 1/0
 ✔ Container machin-test-1  Created                                        0.0s 
Attaching to machin-test-1
machin-test-1  | total 8
machin-test-1  | drwxr-xr-x    2 1001     1001          4096 Jun  8 09:26 .
machin-test-1  | drwxr-xr-x    1 root     root          4096 Jun  8 09:26 ..
machin-test-1 exited with code 0
```

**Related issue**
fixed https://github.com/docker/compose/issues/10655

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
