### PR TITLE
Do not set a default timeout of 10 seconds when restarting / stopping…

### DIFF
--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -63,7 +63,7 @@ func downCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	flags := downCmd.Flags()
 	removeOrphans := utils.StringToBool(os.Getenv(ComposeRemoveOrphans))
 	flags.BoolVar(&opts.removeOrphans, "remove-orphans", removeOrphans, "Remove containers for services not defined in the Compose file.")
-	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")
+	flags.IntVarP(&opts.timeout, "timeout", "t", 0, "Specify a shutdown timeout in seconds")
 	flags.BoolVarP(&opts.volumes, "volumes", "v", false, `Remove named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers.`)
 	flags.StringVar(&opts.images, "rmi", "", `Remove images used by services. "local" remove only images that don't have a custom tag ("local"|"all")`)
 	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {

--- a/cmd/compose/stop.go
+++ b/cmd/compose/stop.go
@@ -47,7 +47,7 @@ func stopCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 		ValidArgsFunction: completeServiceNames(p),
 	}
 	flags := cmd.Flags()
-	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")
+	flags.IntVarP(&opts.timeout, "timeout", "t", 0, "Specify a shutdown timeout in seconds")
 
 	return cmd
 }

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -78,7 +78,7 @@ func upCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *cob
 		Short: "Create and start containers",
 		PreRunE: AdaptCmd(func(ctx context.Context, cmd *cobra.Command, args []string) error {
 			create.pullChanged = cmd.Flags().Changed("pull")
-			create.timeChanged = cmd.Flags().Changed("waitTimeout")
+			create.timeChanged = cmd.Flags().Changed("timeout")
 			return validateFlags(&up, &create)
 		}),
 		RunE: p.WithServices(func(ctx context.Context, project *types.Project, services []string) error {
@@ -104,7 +104,7 @@ func upCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *cob
 	flags.BoolVar(&up.noStart, "no-start", false, "Don't start the services after creating them.")
 	flags.BoolVar(&up.cascadeStop, "abort-on-container-exit", false, "Stops all containers if any container was stopped. Incompatible with -d")
 	flags.StringVar(&up.exitCodeFrom, "exit-code-from", "", "Return the exit code of the selected service container. Implies --abort-on-container-exit")
-	flags.IntVarP(&create.timeout, "timeout", "t", 10, "Use this timeout in seconds for container shutdown when attached or when containers are already running.")
+	flags.IntVarP(&create.timeout, "timeout", "t", 0, "Use this timeout in seconds for container shutdown when attached or when containers are already running.")
 	flags.BoolVar(&up.timestamp, "timestamps", false, "Show timestamps.")
 	flags.BoolVar(&up.noDeps, "no-deps", false, "Don't start linked services.")
 	flags.BoolVar(&create.recreateDeps, "always-recreate-deps", false, "Recreate dependent containers. Incompatible with --no-recreate.")

--- a/docs/reference/compose_down.md
+++ b/docs/reference/compose_down.md
@@ -10,7 +10,7 @@ Stop and remove containers, networks
 | `--dry-run`        |          |         | Execute command in dry run mode                                                                                          |
 | `--remove-orphans` |          |         | Remove containers for services not defined in the Compose file.                                                          |
 | `--rmi`            | `string` |         | Remove images used by services. "local" remove only images that don't have a custom tag ("local"\|"all")                 |
-| `-t`, `--timeout`  | `int`    | `10`    | Specify a shutdown timeout in seconds                                                                                    |
+| `-t`, `--timeout`  | `int`    | `0`     | Specify a shutdown timeout in seconds                                                                                    |
 | `-v`, `--volumes`  |          |         | Remove named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers. |
 
 

--- a/docs/reference/compose_restart.md
+++ b/docs/reference/compose_restart.md
@@ -9,7 +9,7 @@ Restart service containers
 |:------------------|:------|:--------|:--------------------------------------|
 | `--dry-run`       |       |         | Execute command in dry run mode       |
 | `--no-deps`       |       |         | Don't restart dependent services.     |
-| `-t`, `--timeout` | `int` | `10`    | Specify a shutdown timeout in seconds |
+| `-t`, `--timeout` | `int` | `0`     | Specify a shutdown timeout in seconds |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_stop.md
+++ b/docs/reference/compose_stop.md
@@ -8,7 +8,7 @@ Stop services
 | Name              | Type  | Default | Description                           |
 |:------------------|:------|:--------|:--------------------------------------|
 | `--dry-run`       |       |         | Execute command in dry run mode       |
-| `-t`, `--timeout` | `int` | `10`    | Specify a shutdown timeout in seconds |
+| `-t`, `--timeout` | `int` | `0`     | Specify a shutdown timeout in seconds |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -28,7 +28,7 @@ Create and start containers
 | `--remove-orphans`           |               |           | Remove containers for services not defined in the Compose file.                                          |
 | `-V`, `--renew-anon-volumes` |               |           | Recreate anonymous volumes instead of retrieving data from the previous containers.                      |
 | `--scale`                    | `stringArray` |           | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.            |
-| `-t`, `--timeout`            | `int`         | `10`      | Use this timeout in seconds for container shutdown when attached or when containers are already running. |
+| `-t`, `--timeout`            | `int`         | `0`       | Use this timeout in seconds for container shutdown when attached or when containers are already running. |
 | `--timestamps`               |               |           | Show timestamps.                                                                                         |
 | `--wait`                     |               |           | Wait for services to be running\|healthy. Implies detached mode.                                         |
 | `--wait-timeout`             | `int`         | `0`       | timeout waiting for application to be running\|healthy.                                                  |

--- a/docs/reference/docker_compose_down.yaml
+++ b/docs/reference/docker_compose_down.yaml
@@ -41,7 +41,7 @@ options:
     - option: timeout
       shorthand: t
       value_type: int
-      default_value: "10"
+      default_value: "0"
       description: Specify a shutdown timeout in seconds
       deprecated: false
       hidden: false

--- a/docs/reference/docker_compose_restart.yaml
+++ b/docs/reference/docker_compose_restart.yaml
@@ -28,7 +28,7 @@ options:
     - option: timeout
       shorthand: t
       value_type: int
-      default_value: "10"
+      default_value: "0"
       description: Specify a shutdown timeout in seconds
       deprecated: false
       hidden: false

--- a/docs/reference/docker_compose_stop.yaml
+++ b/docs/reference/docker_compose_stop.yaml
@@ -9,7 +9,7 @@ options:
     - option: timeout
       shorthand: t
       value_type: int
-      default_value: "10"
+      default_value: "0"
       description: Specify a shutdown timeout in seconds
       deprecated: false
       hidden: false

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -234,7 +234,7 @@ options:
     - option: timeout
       shorthand: t
       value_type: int
-      default_value: "10"
+      default_value: "0"
       description: |
         Use this timeout in seconds for container shutdown when attached or when containers are already running.
       deprecated: false


### PR DESCRIPTION
… but use the container StopTimeout (defaults to 10 seconds)

Also fixed custom timeout not used when invoking `up`

**What I did**
The default timeout value of 10 seconds when using stop / restart was removed.
This now defaults to the container `StopTimeout` which can be set using `stop_grace_period` and defaults to 10 seconds.
Also fixed custom timeout value not being used when calling `docker compose up`

**Related issue**
fixes #10670

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![](https://scontent-ams4-1.cdninstagram.com/v/t51.2885-19/282199929_331823422412433_231397151518294681_n.jpg?stp=dst-jpg_s320x320&_nc_ht=scontent-ams4-1.cdninstagram.com&_nc_cat=109&_nc_ohc=ZvnMagVwMW0AX9_NQ4W&edm=AOQ1c0wBAAAA&ccb=7-5&oh=00_AfAla4Nj43OQA89Dlr_oUltNb4gHUHggBgCLFHxXmPpPmA&oe=64875467&_nc_sid=f70a57)
