### PR TITLE
use env instead of variables prefix to use DOCKERDESKTOP_APPID

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -131,7 +131,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ variables.DOCKERDESKTOP_APPID }}
+          app_id: ${{ env.DOCKERDESKTOP_APPID }}
           private_key: ${{ secrets.DOCKERDESKTOP_APP_PRIVATEKEY }}
       -
         name: Trigger Docker Desktop e2e with edge version


### PR DESCRIPTION
**What I did**
Fix the `merge` workflow

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/dde82379-d6ae-4e08-ba16-be3d2b9f8d6c)
