### PR TITLE
use `--progress` to configure progress UI style

### DIFF
--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -46,6 +46,7 @@ Define and run multi-container applications with Docker.
 | `-f`, `--file`         | `stringArray` |         | Compose configuration files                                                                         |
 | `--parallel`           | `int`         | `-1`    | Control max parallelism, -1 for unlimited                                                           |
 | `--profile`            | `stringArray` |         | Specify a profile to enable                                                                         |
+| `--progress`           | `string`      | `auto`  | Set type of progress output (auto, tty, plain, quiet)                                               |
 | `--project-directory`  | `string`      |         | Specify an alternate working directory<br>(default: the path of the, first specified, Compose file) |
 | `-p`, `--project-name` | `string`      |         | Project name                                                                                        |
 

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -11,7 +11,6 @@ Build or rebuild services
 | `--dry-run`      |               |         | Execute command in dry run mode                                                                             |
 | `-m`, `--memory` | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
 | `--no-cache`     |               |         | Do not use cache when building the image                                                                    |
-| `--progress`     | `string`      | `auto`  | Set type of progress output (auto, tty, plain, quiet)                                                       |
 | `--pull`         |               |         | Always attempt to pull a newer version of the image.                                                        |
 | `--push`         |               |         | Push service images.                                                                                        |
 | `-q`, `--quiet`  |               |         | Don't print anything to STDOUT                                                                              |

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -280,6 +280,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: progress
+      value_type: string
+      default_value: auto
+      description: Set type of progress output (auto, tty, plain, quiet)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: project-directory
       value_type: string
       description: |-

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -90,9 +90,9 @@ options:
     - option: progress
       value_type: string
       default_value: auto
-      description: Set type of progress output (auto, tty, plain, quiet)
+      description: Set type of ui output (auto, tty, plain, quiet)
       deprecated: false
-      hidden: false
+      hidden: true
       experimental: false
       experimentalcli: false
       kubernetes: false

--- a/pkg/progress/quiet.go
+++ b/pkg/progress/quiet.go
@@ -1,0 +1,37 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package progress
+
+import "context"
+
+type quiet struct{}
+
+func (q quiet) Start(_ context.Context) error {
+	return nil
+}
+
+func (q quiet) Stop() {
+}
+
+func (q quiet) Event(_ Event) {
+}
+
+func (q quiet) Events(_ []Event) {
+}
+
+func (q quiet) TailMsgf(_ string, _ ...interface{}) {
+}

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -107,6 +107,8 @@ const (
 	ModeTTY = "tty"
 	// ModePlain dump raw events to output
 	ModePlain = "plain"
+	// ModeQuiet don't display events
+	ModeQuiet = "quiet"
 )
 
 // Mode define how progress should be rendered, either as ModePlain or ModeTTY
@@ -118,6 +120,9 @@ func NewWriter(ctx context.Context, out io.Writer, progressTitle string) (Writer
 	dryRun, ok := ctx.Value(api.DryRunKey{}).(bool)
 	if !ok {
 		dryRun = false
+	}
+	if Mode == ModeQuiet {
+		return quiet{}, nil
 	}
 	f, isConsole := out.(console.File) // see https://github.com/docker/compose/issues/10560
 	if Mode == ModeAuto && isTerminal && isConsole {


### PR DESCRIPTION
**What I did**
Introduce `--progress` top-level flag to configure progress UI as auto|tty|plain|quiet|none

This allows to have explicit control on the progress UI without using `--ansi` flag which also has impact on logs rendering

`build` already declared this flag. It is now redundant and kept for backward compatibility but marked hidden

**Related issue**
see https://github.com/docker/compose/issues/10686

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
