### PR TITLE
escape containerimage.digest attribute in merge.yml GHA worlflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -77,7 +77,7 @@ jobs:
   bin-image:
     runs-on: ubuntu-22.04
     outputs:
-      digest: ${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}
+      digest: ${{ fromJSON(steps.bake.outputs.metadata).image-cross['containerimage.digest'] }}
     steps:
       -
         name: Checkout

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -77,7 +77,7 @@ jobs:
   bin-image:
     runs-on: ubuntu-22.04
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+      digest: ${{ fromJSON(steps.bake.outputs.metadata).image['containerimage.digest'] }}
     steps:
       -
         name: Checkout
@@ -145,6 +145,6 @@ jobs:
               workflow_id: 'compose-edge-integration.yml',
               ref: 'compose-edge-integration'
               inputs: {
-                "image-tag": '${{ fromJSON(needs.bin-image.bake.outputs.metadata).image-cross["containerimage.digest"] }}'
+                "image-tag": "${{ needs.bin-image.outputs.digest }}"
               }
             })


### PR DESCRIPTION
**What I did**
Fix the issue to get the `containerimage.digest` from the `bake` steps during the `Trigger Docker Desktop e2e with edge version` step of the `desktop-edge-test` job

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/a5301ecb-4cf4-4ca1-be13-8f8b87c1f3a5)
