### PR TITLE
use directly DOCKERDESKTOP_APP_ID without env. prefix

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -131,7 +131,7 @@ jobs:
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ env.DOCKERDESKTOP_APP_ID }}
+          app_id: ${{ DOCKERDESKTOP_APP_ID }}
           private_key: ${{ secrets.DOCKERDESKTOP_APP_PRIVATEKEY }}
       -
         name: Trigger Docker Desktop e2e with edge version


### PR DESCRIPTION
**What I did**
Use environment variable directly without `env.` prefix
**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
