### PR TITLE
otel: fix initialization / error-handling

### DIFF
--- a/internal/tracing/docker_context.go
+++ b/internal/tracing/docker_context.go
@@ -94,6 +94,10 @@ func ConfigFromDockerContext(st store.Store, name string) (OTLPConfig, error) {
 	case map[string]interface{}:
 		otelCfg = m[otelConfigFieldName]
 	}
+	if otelCfg == nil {
+		return OTLPConfig{}, nil
+	}
+
 	otelMap, ok := otelCfg.(map[string]interface{})
 	if !ok {
 		return OTLPConfig{}, fmt.Errorf(

--- a/internal/tracing/mux.go
+++ b/internal/tracing/mux.go
@@ -18,7 +18,6 @@ package tracing
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/go-multierror"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -36,10 +35,7 @@ func (m MuxExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 			return exporter.ExportSpans(ctx, spans)
 		})
 	}
-	if err := eg.Wait(); err != nil {
-		log.Fatal(err)
-	}
-	return nil
+	return eg.Wait()
 }
 
 func (m MuxExporter) Shutdown(ctx context.Context) error {


### PR DESCRIPTION
**What I did**
* If there's no `otel` key (or the value is `null`) in the config, don't return an error
* Propagate error from the exporter instead of panicking

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![baby mountain lion cubs](https://github.com/docker/compose/assets/841263/c10aaa24-97ac-4b63-a00b-77e07b40de58)
