### PR TITLE
fix race condition, waiting for containers when one exit

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -118,6 +118,7 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 	if len(opts.User) > 0 {
 		service.User = opts.User
 	}
+
 	if len(opts.CapAdd) > 0 {
 		service.CapAdd = append(service.CapAdd, opts.CapAdd...)
 		service.CapDrop = utils.Remove(service.CapDrop, opts.CapAdd...)


### PR DESCRIPTION
**What I did**
as a container exits with error, we must cancel but the goroutine waiting for expected container to be started used to get stuck waiting. Need to stop waiting when context is cancelled

**Related issue**
fixes https://github.com/docker/compose/issues/10707
fixes https://github.com/docker/compose/issues/10718

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
