### PR TITLE
use main branch of Docker Desktop repo to trigger remote workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -144,7 +144,7 @@ jobs:
               owner: 'docker',
               repo: '${{ secrets.DOCKERDESKTOP_REPO }}',
               workflow_id: 'compose-edge-integration.yml',
-              ref: 'compose-edge-integration',
+              ref: 'main',
               inputs: {
                 "image-tag": "${{ needs.bin-image.outputs.digest }}"
               }


### PR DESCRIPTION
**What I did**
Dispatch workflow will only be done if the main branch is targeted ([see GH docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch))

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/be2f8efe-1c44-4480-9bd5-1c259e0182f7)
