### PR TITLE
add support of --builder and BUILDX_BUILDER

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -43,6 +43,7 @@ type buildOptions struct {
 	noCache bool
 	memory  cliopts.MemBytes
 	ssh     string
+	builder string
 }
 
 func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions, error) {
@@ -54,6 +55,10 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 			return api.BuildOptions{}, err
 		}
 	}
+	builderName := opts.builder
+	if builderName == "" {
+		builderName = os.Getenv("BUILDX_BUILDER")
+	}
 
 	return api.BuildOptions{
 		Pull:     opts.pull,
@@ -64,6 +69,7 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 		Quiet:    opts.quiet,
 		Services: services,
 		SSHs:     SSHKeys,
+		Builder:  builderName,
 	}, nil
 }
 
@@ -101,6 +107,7 @@ func buildCommand(p *ProjectOptions, progress *string, backend api.Service) *cob
 	cmd.Flags().BoolVar(&opts.pull, "pull", false, "Always attempt to pull a newer version of the image.")
 	cmd.Flags().StringArrayVar(&opts.args, "build-arg", []string{}, "Set build-time variables for services.")
 	cmd.Flags().StringVar(&opts.ssh, "ssh", "", "Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)")
+	cmd.Flags().StringVar(&opts.builder, "builder", "", "Set builder to use.")
 	cmd.Flags().Bool("parallel", true, "Build images in parallel. DEPRECATED")
 	cmd.Flags().MarkHidden("parallel") //nolint:errcheck
 	cmd.Flags().Bool("compress", true, "Compress the build context using gzip. DEPRECATED")

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -8,6 +8,7 @@ Build or rebuild services
 | Name             | Type          | Default | Description                                                                                                 |
 |:-----------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
 | `--build-arg`    | `stringArray` |         | Set build-time variables for services.                                                                      |
+| `--builder`      | `string`      |         | Set builder to use.                                                                                         |
 | `--dry-run`      |               |         | Execute command in dry run mode                                                                             |
 | `-m`, `--memory` | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
 | `--no-cache`     |               |         | Do not use cache when building the image                                                                    |

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -24,6 +24,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: builder
+      value_type: string
+      description: Set builder to use.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: compress
       value_type: bool
       default_value: "true"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -130,6 +130,8 @@ type BuildOptions struct {
 	SSHs []types.SSHKey
 	// Memory limit for the build container
 	Memory int64
+	// Builder name passed in the command line
+	Builder string
 }
 
 // Apply mutates project according to build options

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -116,7 +116,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		}
 		buildOptions.BuildArgs = mergeArgs(buildOptions.BuildArgs, flatten(args))
 
-		digest, err := s.doBuildBuildkit(ctx, service.Name, buildOptions, w)
+		digest, err := s.doBuildBuildkit(ctx, service.Name, buildOptions, w, options.Builder)
 		if err != nil {
 			return err
 		}

--- a/pkg/compose/build_buildkit.go
+++ b/pkg/compose/build_buildkit.go
@@ -34,8 +34,8 @@ import (
 	"github.com/moby/buildkit/client"
 )
 
-func (s *composeService) doBuildBuildkit(ctx context.Context, service string, opts build.Options, p *buildx.Printer) (string, error) {
-	b, err := builder.New(s.dockerCli)
+func (s *composeService) doBuildBuildkit(ctx context.Context, service string, opts build.Options, p *buildx.Printer, builderName string) (string, error) {
+	b, err := builder.New(s.dockerCli, builder.WithName(builderName))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What I did**
Add `--builder` flag to `build` command and support of the `BUILDX_BUILDER` env variable to support choose dedicated builder.

Should address #10664 until a proposal is discussed in the Compose specification

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/4df2fb19-792f-4787-bb43-0f72c88e579e)
