### PR TITLE
when --index is not set select first service container

### DIFF
--- a/cmd/compose/cp.go
+++ b/cmd/compose/cp.go
@@ -64,10 +64,10 @@ func copyCommand(p *ProjectOptions, backend api.Service) *cobra.Command {
 	}
 
 	flags := copyCmd.Flags()
-	flags.IntVar(&opts.index, "index", 0, "Index of the container if there are multiple instances of a service .")
-	flags.BoolVar(&opts.all, "all", false, "Copy to all the containers of the service.")
+	flags.IntVar(&opts.index, "index", 0, "index of the container if service has multiple replicas")
+	flags.BoolVar(&opts.all, "all", false, "copy to all the containers of the service.")
 	flags.MarkHidden("all")                                                                                                      //nolint:errcheck
-	flags.MarkDeprecated("all", "By default all the containers of the service will get the source file/directory to be copied.") //nolint:errcheck
+	flags.MarkDeprecated("all", "by default all the containers of the service will get the source file/directory to be copied.") //nolint:errcheck
 	flags.BoolVarP(&opts.followLink, "follow-link", "L", false, "Always follow symbol link in SRC_PATH")
 	flags.BoolVarP(&opts.copyUIDGID, "archive", "a", false, "Archive mode (copy all uid/gid information)")
 

--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -65,7 +65,7 @@ func execCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *c
 
 	runCmd.Flags().BoolVarP(&opts.detach, "detach", "d", false, "Detached mode: Run command in the background.")
 	runCmd.Flags().StringArrayVarP(&opts.environment, "env", "e", []string{}, "Set environment variables")
-	runCmd.Flags().IntVar(&opts.index, "index", 1, "index of the container if there are multiple instances of a service [default: 1].")
+	runCmd.Flags().IntVar(&opts.index, "index", 0, "index of the container if service has multiple replicas")
 	runCmd.Flags().BoolVarP(&opts.privileged, "privileged", "", false, "Give extended privileges to the process.")
 	runCmd.Flags().StringVarP(&opts.user, "user", "u", "", "Run the command as this user.")
 	runCmd.Flags().BoolVarP(&opts.noTty, "no-TTY", "T", !streams.Out().IsTerminal(), "Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.")

--- a/cmd/compose/port.go
+++ b/cmd/compose/port.go
@@ -57,7 +57,7 @@ func portCommand(p *ProjectOptions, streams api.Streams, backend api.Service) *c
 		ValidArgsFunction: completeServiceNames(p),
 	}
 	cmd.Flags().StringVar(&opts.protocol, "protocol", "tcp", "tcp or udp")
-	cmd.Flags().IntVar(&opts.index, "index", 1, "index of the container if service has multiple replicas")
+	cmd.Flags().IntVar(&opts.index, "index", 0, "index of the container if service has multiple replicas")
 	return cmd
 }
 

--- a/docs/reference/compose_cp.md
+++ b/docs/reference/compose_cp.md
@@ -5,12 +5,12 @@ Copy files/folders between a service container and the local filesystem
 
 ### Options
 
-| Name                  | Type  | Default | Description                                                           |
-|:----------------------|:------|:--------|:----------------------------------------------------------------------|
-| `-a`, `--archive`     |       |         | Archive mode (copy all uid/gid information)                           |
-| `--dry-run`           |       |         | Execute command in dry run mode                                       |
-| `-L`, `--follow-link` |       |         | Always follow symbol link in SRC_PATH                                 |
-| `--index`             | `int` | `0`     | Index of the container if there are multiple instances of a service . |
+| Name                  | Type  | Default | Description                                             |
+|:----------------------|:------|:--------|:--------------------------------------------------------|
+| `-a`, `--archive`     |       |         | Archive mode (copy all uid/gid information)             |
+| `--dry-run`           |       |         | Execute command in dry run mode                         |
+| `-L`, `--follow-link` |       |         | Always follow symbol link in SRC_PATH                   |
+| `--index`             | `int` | `0`     | index of the container if service has multiple replicas |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_exec.md
+++ b/docs/reference/compose_exec.md
@@ -5,16 +5,16 @@ Execute a command in a running container.
 
 ### Options
 
-| Name              | Type          | Default | Description                                                                       |
-|:------------------|:--------------|:--------|:----------------------------------------------------------------------------------|
-| `-d`, `--detach`  |               |         | Detached mode: Run command in the background.                                     |
-| `--dry-run`       |               |         | Execute command in dry run mode                                                   |
-| `-e`, `--env`     | `stringArray` |         | Set environment variables                                                         |
-| `--index`         | `int`         | `1`     | index of the container if there are multiple instances of a service [default: 1]. |
-| `-T`, `--no-TTY`  |               |         | Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.  |
-| `--privileged`    |               |         | Give extended privileges to the process.                                          |
-| `-u`, `--user`    | `string`      |         | Run the command as this user.                                                     |
-| `-w`, `--workdir` | `string`      |         | Path to workdir directory for this command.                                       |
+| Name              | Type          | Default | Description                                                                      |
+|:------------------|:--------------|:--------|:---------------------------------------------------------------------------------|
+| `-d`, `--detach`  |               |         | Detached mode: Run command in the background.                                    |
+| `--dry-run`       |               |         | Execute command in dry run mode                                                  |
+| `-e`, `--env`     | `stringArray` |         | Set environment variables                                                        |
+| `--index`         | `int`         | `0`     | index of the container if service has multiple replicas                          |
+| `-T`, `--no-TTY`  |               |         | Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY. |
+| `--privileged`    |               |         | Give extended privileges to the process.                                         |
+| `-u`, `--user`    | `string`      |         | Run the command as this user.                                                    |
+| `-w`, `--workdir` | `string`      |         | Path to workdir directory for this command.                                      |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_port.md
+++ b/docs/reference/compose_port.md
@@ -8,7 +8,7 @@ Print the public port for a port binding.
 | Name         | Type     | Default | Description                                             |
 |:-------------|:---------|:--------|:--------------------------------------------------------|
 | `--dry-run`  |          |         | Execute command in dry run mode                         |
-| `--index`    | `int`    | `1`     | index of the container if service has multiple replicas |
+| `--index`    | `int`    | `0`     | index of the container if service has multiple replicas |
 | `--protocol` | `string` | `tcp`   | tcp or udp                                              |
 
 

--- a/docs/reference/docker_compose_cp.yaml
+++ b/docs/reference/docker_compose_cp.yaml
@@ -10,7 +10,7 @@ options:
     - option: all
       value_type: bool
       default_value: "false"
-      description: Copy to all the containers of the service.
+      description: copy to all the containers of the service.
       deprecated: true
       hidden: true
       experimental: false
@@ -42,8 +42,7 @@ options:
     - option: index
       value_type: int
       default_value: "0"
-      description: |
-        Index of the container if there are multiple instances of a service .
+      description: index of the container if service has multiple replicas
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/reference/docker_compose_exec.yaml
+++ b/docs/reference/docker_compose_exec.yaml
@@ -33,9 +33,8 @@ options:
       swarm: false
     - option: index
       value_type: int
-      default_value: "1"
-      description: |
-        index of the container if there are multiple instances of a service [default: 1].
+      default_value: "0"
+      description: index of the container if service has multiple replicas
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/reference/docker_compose_port.yaml
+++ b/docs/reference/docker_compose_port.yaml
@@ -7,7 +7,7 @@ plink: docker_compose.yaml
 options:
     - option: index
       value_type: int
-      default_value: "1"
+      default_value: "0"
       description: index of the container if service has multiple replicas
       deprecated: false
       hidden: false


### PR DESCRIPTION
**What I did**
select replica with lowest container number (might not be "1") when `--index` has not been set by user.

Also use `getSpecifiedContainer` for `Port` to avoid duplicated logic for same feature

**Related issue**
fixes https://github.com/docker/compose/issues/10761

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
