### PR TITLE
don't use unitialized cli to setup DryRunClient

### DIFF
--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -70,7 +70,7 @@ type execDetails struct {
 }
 
 // NewDryRunClient produces a DryRunClient
-func NewDryRunClient(apiClient client.APIClient, cli *command.DockerCli) (*DryRunClient, error) {
+func NewDryRunClient(apiClient client.APIClient, cli command.Cli) (*DryRunClient, error) {
 	b, err := builder.New(cli, builder.WithSkippedValidation())
 	if err != nil {
 		return nil, err

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -88,8 +88,11 @@ func (s *composeService) DryRunMode(ctx context.Context, dryRun bool) (context.C
 		if err != nil {
 			return ctx, err
 		}
-		err = cli.Initialize(flags.NewClientOptions(), command.WithInitializeClient(func(cli *command.DockerCli) (client.APIClient, error) {
-			return api.NewDryRunClient(s.apiClient(), cli)
+
+		options := flags.NewClientOptions()
+		options.Context = s.dockerCli.CurrentContext()
+		err = cli.Initialize(options, command.WithInitializeClient(func(cli *command.DockerCli) (client.APIClient, error) {
+			return api.NewDryRunClient(s.apiClient(), s.dockerCli)
 		}))
 		if err != nil {
 			return ctx, err


### PR DESCRIPTION
**What I did**
use the actual dockerCli to setup DryRunClient, otherwise we get a chicked/egg problem with buildx trying to guess the active context while we are still intializing

**Related issue**
fixes https://github.com/docker/compose/issues/10766

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/4125fb90-1141-484f-a295-aae7f9923965)

