### PR TITLE
Flush splitWriter buffer on dettach to capture last line of logs

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -524,6 +524,9 @@ type LogConsumer interface {
 // ContainerEventListener is a callback to process ContainerEvent from services
 type ContainerEventListener func(event ContainerEvent)
 
+// ContainerDetachFn detach from container stream and return the remaining logs from buffers
+type ContainerDetachFn func() (string, string)
+
 // ContainerEvent notify an event has been collected on source container implementing Service
 type ContainerEvent struct {
 	Type int
@@ -538,6 +541,7 @@ type ContainerEvent struct {
 	// ContainerEventExit only
 	ExitCode   int
 	Restarting bool
+	Detach     ContainerDetachFn
 }
 
 const (

--- a/pkg/utils/writer.go
+++ b/pkg/utils/writer.go
@@ -21,8 +21,13 @@ import (
 	"io"
 )
 
+type Writer interface {
+	io.Writer
+	Flush() string
+}
+
 // GetWriter creates a io.Writer that will actually split by line and format by LogConsumer
-func GetWriter(consumer func(string)) io.WriteCloser {
+func GetWriter(consumer func(string)) Writer {
 	return &splitWriter{
 		buffer:   bytes.Buffer{},
 		consumer: consumer,
@@ -58,11 +63,10 @@ func (s *splitWriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
-func (s *splitWriter) Close() error {
+func (s *splitWriter) Flush() string {
 	b := s.buffer.Bytes()
 	if len(b) == 0 {
-		return nil
+		return ""
 	}
-	s.consumer(string(b))
-	return nil
+	return string(b)
 }


### PR DESCRIPTION
**What I did**
This is a fix for https://github.com/docker/compose/issues/10658 which doesn't rely on assumption we receive container logs as a plain line. Some stacks don't buffer stdout and we actually receive logs char by char

`attach` event get a new callback attribute so that, as we detach on exit, we can flush buffers to collect the remaining logs

**Related issue**
fixes https://github.com/docker/compose/issues/10779
https://docker.atlassian.net/browse/ENV-246

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
