### PR TITLE
fix(secrets): file permission value does not comply with spec

### DIFF
--- a/pkg/compose/secrets.go
+++ b/pkg/compose/secrets.go
@@ -58,7 +58,7 @@ func createTar(env string, config types.ServiceSecretConfig) (bytes.Buffer, erro
 	value := []byte(env)
 	b := bytes.Buffer{}
 	tarWriter := tar.NewWriter(&b)
-	mode := uint32(0o400)
+	mode := uint32(0o444)
 	if config.Mode != nil {
 		mode = *config.Mode
 	}


### PR DESCRIPTION
Compose Spec mentions that default values for secrets is `0444` aka. world-readable permissions. However, the value was previously set to `0400`.

**What I did**
Fix the file permission mode value from previously set `0400` to `0444` in order to comply with the Compose Specifications where Secrets should be defaulted to world-readable permissions unless not explicitly mentioned via Long Syntax.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
closes #10783

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
