### PR TITLE
ci: speed up a couple Dockerfile targets w/ cache mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ FROM build-base AS lint
 ARG BUILD_TAGS
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg/mod \
     --mount=from=golangci-lint,source=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
     golangci-lint run --build-tags "$BUILD_TAGS" ./...
 
@@ -129,6 +130,7 @@ FROM base AS docsgen
 WORKDIR /src
 RUN --mount=target=. \
     --mount=target=/root/.cache,type=cache \
+    --mount=type=cache,target=/go/pkg/mod \
     go build -o /out/docsgen ./docs/yaml/main/generate.go
 
 FROM --platform=${BUILDPLATFORM} alpine AS docs-build


### PR DESCRIPTION
**What I did**
The local Go package module path was missing from a couple of jobs, which made them slower than needed since they were re-downloading a bunch of dependencies.

In particular, this makes `make lint` waaaay faster!

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![jumping ferret: https://www.flickr.com/photos/usfwsmtnprairie/5244105513](https://github.com/docker/compose/assets/841263/44be3f71-a0ff-43ea-b00f-19469e2b1f30)
