### PR TITLE
build: do not attempt to push unnamed service images

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -233,11 +233,7 @@ func runConfigImages(streams api.Streams, opts configOptions, services []string)
 		return err
 	}
 	for _, s := range project.Services {
-		if s.Image != "" {
-			fmt.Fprintln(streams.Out(), s.Image)
-		} else {
-			fmt.Fprintf(streams.Out(), "%s%s%s\n", project.Name, api.Separator, s.Name)
-		}
+		fmt.Fprintln(streams.Out(), api.GetImageNameOrDefault(s, project.Name))
 	}
 	return nil
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -145,7 +145,6 @@ func (o BuildOptions) Apply(project *types.Project) error {
 		if service.Build == nil {
 			continue
 		}
-		service.Image = GetImageNameOrDefault(service, project.Name)
 		if platform != "" {
 			if len(service.Build.Platforms) > 0 && !utils.StringContains(service.Build.Platforms, platform) {
 				return fmt.Errorf("service %q build.platforms does not support value set by DOCKER_DEFAULT_PLATFORM: %s", service.Name, platform)

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -45,7 +45,7 @@ import (
 )
 
 //nolint:gocyclo
-func (s *composeService) doBuildClassic(ctx context.Context, service types.ServiceConfig, options api.BuildOptions) (string, error) {
+func (s *composeService) doBuildClassic(ctx context.Context, projectName string, service types.ServiceConfig, options api.BuildOptions) (string, error) {
 	var (
 		buildCtx      io.ReadCloser
 		dockerfileCtx io.ReadCloser
@@ -160,7 +160,8 @@ func (s *composeService) doBuildClassic(ctx context.Context, service types.Servi
 		authConfigs[k] = registry.AuthConfig(auth)
 	}
 	buildOptions := imageBuildOptions(service.Build)
-	buildOptions.Tags = append(buildOptions.Tags, service.Image)
+	imageName := api.GetImageNameOrDefault(service, projectName)
+	buildOptions.Tags = append(buildOptions.Tags, imageName)
 	buildOptions.Dockerfile = relDockerfile
 	buildOptions.AuthConfigs = authConfigs
 	buildOptions.Memory = options.Memory

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -313,8 +313,15 @@ func isServiceImageToBuild(service types.ServiceConfig, services []types.Service
 		return true
 	}
 
-	for _, depService := range services {
-		if depService.Image == service.Image && depService.Build != nil {
+	if service.Image == "" {
+		// N.B. this should be impossible as service must have either `build` or `image` (or both)
+		return false
+	}
+
+	// look through the other services to see if another has a build definition for the same
+	// image name
+	for _, svc := range services {
+		if svc.Image == service.Image && svc.Build != nil {
 			return true
 		}
 	}

--- a/pkg/compose/viz.go
+++ b/pkg/compose/viz.go
@@ -52,7 +52,7 @@ func (s *composeService) Viz(_ context.Context, project *types.Project, opts api
 	// dot is the perfect layout for this use case since graph is directed and hierarchical
 	graphBuilder.WriteString(opts.Indentation + "layout=dot;\n")
 
-	addNodes(&graphBuilder, graph, &opts)
+	addNodes(&graphBuilder, graph, project.Name, &opts)
 	graphBuilder.WriteByte('\n')
 
 	addEdges(&graphBuilder, graph, &opts)
@@ -63,7 +63,7 @@ func (s *composeService) Viz(_ context.Context, project *types.Project, opts api
 
 // addNodes adds the corresponding graphviz representation of all the nodes in the given graph to the graphBuilder
 // returns the same graphBuilder
-func addNodes(graphBuilder *strings.Builder, graph vizGraph, opts *api.VizOptions) *strings.Builder {
+func addNodes(graphBuilder *strings.Builder, graph vizGraph, projectName string, opts *api.VizOptions) *strings.Builder {
 	for serviceNode := range graph {
 		// write:
 		// "service name" [style="filled" label<<font point-size="15">service name</font>
@@ -107,7 +107,7 @@ func addNodes(graphBuilder *strings.Builder, graph vizGraph, opts *api.VizOption
 		if opts.IncludeImageName {
 			graphBuilder.WriteString("<font point-size=\"10\">")
 			graphBuilder.WriteString("<br/><br/><b>Image:</b><br/>")
-			graphBuilder.WriteString(serviceNode.Image)
+			graphBuilder.WriteString(api.GetImageNameOrDefault(*serviceNode, projectName))
 			graphBuilder.WriteString("</font>")
 		}
 

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -111,7 +111,7 @@ func TestLocalComposeBuild(t *testing.T) {
 		t.Run(env+" no rebuild when up again", func(t *testing.T) {
 			res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "up", "-d")
 
-			assert.Assert(t, !strings.Contains(res.Stdout(), "COPY static"), res.Stdout())
+			assert.Assert(t, !strings.Contains(res.Stdout(), "COPY static"))
 		})
 
 		t.Run(env+" rebuild when up --build", func(t *testing.T) {
@@ -119,6 +119,11 @@ func TestLocalComposeBuild(t *testing.T) {
 
 			res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
 			res.Assert(t, icmd.Expected{Out: "COPY static2 /usr/share/nginx/html"})
+		})
+
+		t.Run(env+" build --push ignored for unnamed images", func(t *testing.T) {
+			res := c.RunDockerComposeCmd(t, "--workdir", "fixtures/build-test", "build", "--push", "nginx")
+			assert.Assert(t, !strings.Contains(res.Stdout(), "failed to push"), res.Stdout())
 		})
 
 		t.Run(env+" cleanup build project", func(t *testing.T) {


### PR DESCRIPTION
**What I did**
When building, if images are being pushed, ensure that only named images (i.e. services with a populated `image` field) are attempted to be pushed.

Services without `image` get an auto-generated name, which will be a "Docker library" reference since they're in the format `$project-$service`, which is implicitly the same as `docker.io/library/$project-$service`. A push for that is never desirable / will always fail.

The key here is that we cannot overwrite the `<svc>.image` field when doing builds, as we need to be able to check for its presence to determine whether a push makes sense.

**Related issue**
* #10813

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![otters on a water slide](https://github.com/docker/compose/assets/841263/845163d2-b9ad-4376-811e-03f3e1f56263)
