### PR TITLE
test: speed up the e2e test suite

### DIFF
--- a/pkg/e2e/compose_exec_test.go
+++ b/pkg/e2e/compose_exec_test.go
@@ -35,6 +35,12 @@ func TestLocalComposeExec(t *testing.T) {
 		return ret
 	}
 
+	cleanup := func() {
+		c.RunDockerComposeCmd(t, cmdArgs("down", "--timeout=0")...)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
 	c.RunDockerComposeCmd(t, cmdArgs("up", "-d")...)
 
 	t.Run("exec true", func(t *testing.T) {

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -281,8 +281,12 @@ func TestStopWithDependenciesAttached(t *testing.T) {
 	const projectName = "compose-e2e-stop-with-deps"
 	c := NewParallelCLI(t, WithEnv("COMMAND=echo hello"))
 
-	t.Run("up", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/compose.yaml", "-p", projectName, "up", "--attach-dependencies", "foo")
-		res.Assert(t, icmd.Expected{Out: "exited with code 0"})
-	})
+	cleanup := func() {
+		c.RunDockerComposeCmd(t, "-p", projectName, "down", "--remove-orphans", "--timeout=0")
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/compose.yaml", "-p", projectName, "up", "--attach-dependencies", "foo")
+	res.Assert(t, icmd.Expected{Out: "exited with code 0"})
 }

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -51,8 +51,18 @@ func TestUpExitCodeFrom(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "e2e-exit-code-from"
 
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/start-fail/start-depends_on-long-lived.yaml", "--project-name", projectName, "up", "--exit-code-from=failure", "failure")
+	res.Assert(t, icmd.Expected{ExitCode: 42})
+
+	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
+}
+
+func TestUpExitCodeFromContainerKilled(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-exit-code-from-kill"
+
 	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/start-fail/start-depends_on-long-lived.yaml", "--project-name", projectName, "up", "--exit-code-from=test")
-	res.Assert(t, icmd.Expected{ExitCode: 137})
+	res.Assert(t, icmd.Expected{ExitCode: 143})
 
 	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
 }

--- a/pkg/e2e/fixtures/build-dependencies/compose.yaml
+++ b/pkg/e2e/fixtures/build-dependencies/compose.yaml
@@ -1,10 +1,12 @@
 services:
   base:
     image: base
+    init: true
     build:
       context: .
       dockerfile: base.dockerfile
   service:
+    init: true
     depends_on:
       - base
     build:

--- a/pkg/e2e/fixtures/dependencies/deps-completed-successfully.yaml
+++ b/pkg/e2e/fixtures/dependencies/deps-completed-successfully.yaml
@@ -4,6 +4,7 @@ services:
     command: echo 'hello world'
   longrunning:
     image: alpine
+    init: true
     depends_on:
       oneshot:
         condition: service_completed_successfully

--- a/pkg/e2e/fixtures/dependencies/recreate-no-deps.yaml
+++ b/pkg/e2e/fixtures/dependencies/recreate-no-deps.yaml
@@ -3,6 +3,7 @@ services:
   my-service:
     image: alpine
     command: tail -f /dev/null
+    init: true
     depends_on:
       nginx: {condition: service_healthy}
 

--- a/pkg/e2e/fixtures/ipam/compose.yaml
+++ b/pkg/e2e/fixtures/ipam/compose.yaml
@@ -1,6 +1,7 @@
 services:
   foo:
     image: alpine
+    init: true
     entrypoint: ["sleep", "600"]
     networks:
       default:

--- a/pkg/e2e/fixtures/logs-test/compose.yaml
+++ b/pkg/e2e/fixtures/logs-test/compose.yaml
@@ -1,6 +1,7 @@
 services:
   ping:
     image: alpine
+    init: true
     command: ping localhost -c ${REPEAT:-1}
   hello:
     image: alpine

--- a/pkg/e2e/fixtures/network-test/compose.yaml
+++ b/pkg/e2e/fixtures/network-test/compose.yaml
@@ -6,12 +6,14 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
   db:
     image: gtardif/sentences-db
+    init: true
     networks:
       - dbnet
       - closesnetworkname1
       - closesnetworkname2
   words:
     image: gtardif/sentences-api
+    init: true
     ports:
       - "8080:8080"
     networks:
@@ -19,6 +21,7 @@ services:
       - servicenet
   web:
     image: gtardif/sentences-web
+    init: true
     ports:
       - "80:80"
     labels:

--- a/pkg/e2e/fixtures/restart-test/compose-depends-on.yaml
+++ b/pkg/e2e/fixtures/restart-test/compose-depends-on.yaml
@@ -1,12 +1,14 @@
 services:
   with-restart:
     image: alpine
+    init: true
     command: tail -f /dev/null
     depends_on:
       nginx: {condition: service_healthy, restart: true}
 
   no-restart:
     image: alpine
+    init: true
     command: tail -f /dev/null
     depends_on:
       nginx: { condition: service_healthy }

--- a/pkg/e2e/fixtures/restart-test/compose.yaml
+++ b/pkg/e2e/fixtures/restart-test/compose.yaml
@@ -1,4 +1,5 @@
 services:
   restart:
     image: alpine
+    init: true
     command: ash -c "if [[ -f /tmp/restart.lock ]] ; then sleep infinity; else touch /tmp/restart.lock; fi"

--- a/pkg/e2e/fixtures/sentences/compose.yaml
+++ b/pkg/e2e/fixtures/sentences/compose.yaml
@@ -1,12 +1,15 @@
 services:
   db:
     image: gtardif/sentences-db
+    init: true
   words:
     image: gtardif/sentences-api
+    init: true
     ports:
       - "95:8080"
   web:
     image: gtardif/sentences-web
+    init: true
     ports:
       - "90:80"
     labels:

--- a/pkg/e2e/fixtures/start-fail/compose.yaml
+++ b/pkg/e2e/fixtures/start-fail/compose.yaml
@@ -1,6 +1,7 @@
 services:
   fail:
     image: alpine
+    init: true
     command: sleep infinity
     healthcheck:
       test: "false"
@@ -8,6 +9,7 @@ services:
       retries: 3
   depends:
     image: alpine
+    init: true
     command: sleep infinity
     depends_on:
       fail:

--- a/pkg/e2e/fixtures/start-fail/start-depends_on-long-lived.yaml
+++ b/pkg/e2e/fixtures/start-fail/start-depends_on-long-lived.yaml
@@ -1,11 +1,14 @@
 services:
   safe:
     image: 'alpine'
+    init: true
     command: ['/bin/sh', '-c', 'sleep infinity']  # never exiting
   failure:
     image: 'alpine'
-    command: ['/bin/sh', '-c', 'sleep 2 ; echo "exiting" ; exit 42']
+    init: true
+    command: ['/bin/sh', '-c', 'sleep 1 ; echo "exiting with error" ; exit 42']
   test:
     image: 'alpine'
+    init: true
     command: ['/bin/sh', '-c', 'sleep 99999 ; echo "tests are OK"']  # very long job
     depends_on: [safe]

--- a/pkg/e2e/fixtures/stdout-stderr/compose.yaml
+++ b/pkg/e2e/fixtures/stdout-stderr/compose.yaml
@@ -1,6 +1,7 @@
 services:
   stderr:
     image: alpine
+    init: true
     command: /bin/ash /log_to_stderr.sh
     volumes:
            - ./log_to_stderr.sh:/log_to_stderr.sh


### PR DESCRIPTION
**What I did**
Lots of our phony Compose files launch pointless long-lived processes so we can assert on state. However, this means they often don't respond well to signals on their own, requiring Compose to timeout and kill them when doing a `down`.

Add in lots of `init: true` where appropriate so that we don't block for no reason while running E2E tests all over the place.

Additionally, a couple tests have gotten a cleanup so they don't leave behind containers. I still want to build this into the framework in the future, but this is easier for the moment and won't cause any trouble in the future.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![flying squirrel mid-air](https://github.com/docker/compose/assets/841263/c19c51a4-d544-44cd-a5f8-6094bf559ad5)
