### PR TITLE
check secret target is an absolute windows path

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -863,7 +863,7 @@ func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount
 		target := config.Target
 		if config.Target == "" {
 			target = configsBaseDir + config.Source
-		} else if !isUnixAbs(config.Target) {
+		} else if !isAbsTarget(config.Target) {
 			target = configsBaseDir + config.Target
 		}
 
@@ -898,7 +898,7 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 		target := secret.Target
 		if secret.Target == "" {
 			target = secretsDir + secret.Source
-		} else if !isUnixAbs(secret.Target) {
+		} else if !isAbsTarget(secret.Target) {
 			target = secretsDir + secret.Target
 		}
 
@@ -929,8 +929,22 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 	return values, nil
 }
 
+func isAbsTarget(p string) bool {
+	return isUnixAbs(p) || isWindowsAbs(p)
+}
+
 func isUnixAbs(p string) bool {
 	return strings.HasPrefix(p, "/")
+}
+
+func isWindowsAbs(p string) bool {
+	if strings.HasPrefix(p, "\\\\") {
+		return true
+	}
+	if len(p) > 2 && p[1] == ':' {
+		return p[2] == '\\'
+	}
+	return false
 }
 
 func buildMount(project types.Project, volume types.ServiceVolumeConfig) (mount.Mount, error) {

--- a/pkg/compose/secrets.go
+++ b/pkg/compose/secrets.go
@@ -66,7 +66,7 @@ func createTar(env string, config types.ServiceSecretConfig) (bytes.Buffer, erro
 	target := config.Target
 	if config.Target == "" {
 		target = "/run/secrets/" + config.Source
-	} else if !isUnixAbs(config.Target) {
+	} else if !isAbsTarget(config.Target) {
 		target = "/run/secrets/" + config.Target
 	}
 


### PR DESCRIPTION
**What I did**
As we check secret target is absolute, we need to consider both unix and windows absolute path syntaxes
we _could_ be more deterministic relying on image platform to only run the relevant code, but doesn't seem there are major risks for confusion

**Related issue**
fixes https://github.com/docker/compose/issues/10817

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
