### PR TITLE
test: watch e2e reliability tweaks

### DIFF
--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -68,7 +68,7 @@ func doTest(t *testing.T, svcName string) {
 		"COMPOSE_PROJECT_NAME=" + projName,
 	}
 
-	cli := NewParallelCLI(t, WithEnv(env...))
+	cli := NewCLI(t, WithEnv(env...))
 
 	cleanup := func() {
 		cli.RunDockerComposeCmd(t, "down", svcName, "--timeout=0", "--remove-orphans", "--volumes")

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -33,6 +34,10 @@ import (
 )
 
 func TestWatch(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Test currently broken on macOS due to symlink issues (see compose-go#436)")
+	}
+
 	services := []string{"alpine", "busybox", "debian"}
 	for _, svcName := range services {
 		t.Run(svcName, func(t *testing.T) {


### PR DESCRIPTION
**What I did**
* Skip on macOS until upstream fix is merged
* Do not run in parallel to avoid trouble in CI

**Related issue**
* compose-spec/compose-go#436

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![racoon snout booping the camera](https://github.com/docker/compose/assets/841263/a04d2492-a3aa-417f-b4fc-6aff35c74e57)
