### PR TITLE
Update Config comment in API Service interface

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,7 +52,7 @@ type Service interface {
 	Ps(ctx context.Context, projectName string, options PsOptions) ([]ContainerSummary, error)
 	// List executes the equivalent to a `docker stack ls`
 	List(ctx context.Context, options ListOptions) ([]Stack, error)
-	// Convert translate compose model into backend's native format
+	// Config executes the equivalent to a `compose Config`
 	Config(ctx context.Context, project *types.Project, options ConfigOptions) ([]byte, error)
 	// Kill executes the equivalent to a `compose kill`
 	Kill(ctx context.Context, projectName string, options KillOptions) error

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,7 +52,7 @@ type Service interface {
 	Ps(ctx context.Context, projectName string, options PsOptions) ([]ContainerSummary, error)
 	// List executes the equivalent to a `docker stack ls`
 	List(ctx context.Context, options ListOptions) ([]Stack, error)
-	// Config executes the equivalent to a `compose Config`
+	// Config executes the equivalent to a `compose config`
 	Config(ctx context.Context, project *types.Project, options ConfigOptions) ([]byte, error)
 	// Kill executes the equivalent to a `compose kill`
 	Kill(ctx context.Context, projectName string, options KillOptions) error


### PR DESCRIPTION
**What I did**
Updated the outdated comment for Config method in Service interface for API package.
- Prev Comment - // Convert translate compose model into backend's native format
- Updated Comment - // Config executes the equivalent to a `compose config`
- Ref - https://docs.docker.com/engine/reference/commandline/compose_config/
- https://github.com/docker/compose/blob/8318f66330358988a058bf611a953f464ab7973f/cmd/compose/config.go#L123

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
closes #10839