### PR TITLE
progress: minor correctness fixes

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -324,7 +324,11 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 			ticker := time.NewTicker(500 * time.Millisecond)
 			defer ticker.Stop()
 			for {
-				<-ticker.C
+				select {
+				case <-ticker.C:
+				case <-ctx.Done():
+					return nil
+				}
 				switch config.Condition {
 				case ServiceConditionRunningOrHealthy:
 					healthy, err := s.isServiceHealthy(ctx, waitingFor, true)


### PR DESCRIPTION
**What I did**
* When waiting for dependencies, `select` on the context as well as the ticker
* Write multiple progress events "transactionally" (i.e. hold the lock for the duration to avoid other events being interleaved)
* Do not change "finished" steps back to "in progress" to prevent flickering

There are some bigger issues here I want to address, but these are a few quick fixes.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![lynx](https://github.com/docker/compose/assets/841263/c43844fa-6b7e-4dcb-b28d-c235d553931d)