### PR TITLE
build: fix missing proxy build args for classic builder

### DIFF
--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -38,8 +38,8 @@ func TestLocalComposeBuild(t *testing.T) {
 
 		t.Run(env+" build named and unnamed images", func(t *testing.T) {
 			// ensure local test run does not reuse previously build image
-			c.RunDockerOrExitError(t, "rmi", "build-test-nginx")
-			c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "build-test-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "custom-nginx")
 
 			res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "build")
 
@@ -50,8 +50,8 @@ func TestLocalComposeBuild(t *testing.T) {
 
 		t.Run(env+" build with build-arg", func(t *testing.T) {
 			// ensure local test run does not reuse previously build image
-			c.RunDockerOrExitError(t, "rmi", "build-test-nginx")
-			c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "build-test-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "custom-nginx")
 
 			c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "build", "--build-arg", "FOO=BAR")
 
@@ -61,8 +61,8 @@ func TestLocalComposeBuild(t *testing.T) {
 
 		t.Run(env+" build with build-arg set by env", func(t *testing.T) {
 			// ensure local test run does not reuse previously build image
-			c.RunDockerOrExitError(t, "rmi", "build-test-nginx")
-			c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "build-test-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "custom-nginx")
 
 			icmd.RunCmd(c.NewDockerComposeCmd(t,
 				"--project-directory",
@@ -72,7 +72,7 @@ func TestLocalComposeBuild(t *testing.T) {
 				"FOO"),
 				func(cmd *icmd.Cmd) {
 					cmd.Env = append(cmd.Env, "FOO=BAR")
-				})
+				}).Assert(t, icmd.Success)
 
 			res := c.RunDockerCmd(t, "image", "inspect", "build-test-nginx")
 			res.Assert(t, icmd.Expected{Out: `"FOO": "BAR"`})
@@ -92,8 +92,9 @@ func TestLocalComposeBuild(t *testing.T) {
 		})
 
 		t.Run(env+" build as part of up", func(t *testing.T) {
-			c.RunDockerOrExitError(t, "rmi", "build-test-nginx")
-			c.RunDockerOrExitError(t, "rmi", "custom-nginx")
+			// ensure local test run does not reuse previously build image
+			c.RunDockerOrExitError(t, "rmi", "-f", "build-test-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "custom-nginx")
 
 			res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "up", "-d")
 			t.Cleanup(func() {
@@ -130,8 +131,8 @@ func TestLocalComposeBuild(t *testing.T) {
 
 		t.Run(env+" cleanup build project", func(t *testing.T) {
 			c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "down")
-			c.RunDockerCmd(t, "rmi", "build-test-nginx")
-			c.RunDockerCmd(t, "rmi", "custom-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "build-test-nginx")
+			c.RunDockerOrExitError(t, "rmi", "-f", "custom-nginx")
 		})
 	}
 


### PR DESCRIPTION
**What I did**
Refactor to use a consistent code path for determining the build args for a service image regardless of whether BuildKit or the classic builder is being used.

After recent changes, these code paths had diverged, so the classic builder was missing the proxy variables from the Docker client config.

**Related issue**
* #10803

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![a very cute weasel on a tree branch looking at the camera](https://github.com/docker/compose/assets/841263/4678a0c7-093e-4324-8c55-f0ba83b33832)
