### PR TITLE
watch: enable tar-based syncer by default

### DIFF
--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -73,9 +74,7 @@ func doTest(t *testing.T, svcName string, tarSync bool) {
 	env := []string{
 		"COMPOSE_FILE=" + composeFilePath,
 		"COMPOSE_PROJECT_NAME=" + projName,
-	}
-	if tarSync {
-		env = append(env, "COMPOSE_EXPERIMENTAL_WATCH_TAR=1")
+		"COMPOSE_EXPERIMENTAL_WATCH_TAR=" + strconv.FormatBool(tarSync),
 	}
 
 	cli := NewCLI(t, WithEnv(env...))


### PR DESCRIPTION
**What I did**
Swap the default implementation now that batching is merged. Keeping the `docker cp` based implementation around for the moment, but it needs to be _explicitly_ disabled now by setting `COMPOSE_EXPERIMENTAL_WATCH_TAR=0`.

After the next release, we should remove the `docker cp` implementation entirely.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![capybara in a hot tub](https://github.com/docker/compose/assets/841263/4c75dd27-ad90-442e-8467-1fecf8a050fd)
