### PR TITLE
Improve shell completion for `--project-directory`

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -443,6 +443,12 @@ func RootCommand(streams command.Cli, backend api.Service) *cobra.Command { //no
 		completeProjectNames(backend),
 	)
 	c.RegisterFlagCompletionFunc( //nolint:errcheck
+		"project-directory",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{}, cobra.ShellCompDirectiveFilterDirs
+		},
+	)
+	c.RegisterFlagCompletionFunc( //nolint:errcheck
 		"file",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt


### PR DESCRIPTION
Currently `docker compose --project-directory <tab>` completes file names as well even though this option is invalid.
Restrict `--project-directory` completion to offer directory names only.