### PR TITLE
trace: do not block connecting to OTLP endpoint

### DIFF
--- a/internal/tracing/docker_context.go
+++ b/internal/tracing/docker_context.go
@@ -69,7 +69,6 @@ func traceClientFromDockerContext(dockerCli command.Cli, otelEnv envMap) (otlptr
 		cfg.Endpoint,
 		grpc.WithContextDialer(DialInMemory),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("initializing otel connection from docker context metadata: %v", err)


### PR DESCRIPTION
**What I did**
Remove the call to enable blocking when doing the gRPC dial for OTel.

This was left over from debugging, but we should not block. OTel will handle the connection in the background.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![a bunch of buffalo blocking a car from moving](https://github.com/docker/compose/assets/841263/27baf13c-3c4d-4738-91bc-07944588e74c)
