### PR TITLE
update README and CI workflows to match main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - 'v2'
+      - 'main'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - 'v2'
+      - 'main'
     tags:
       - 'v*'
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '44 9 * * 4'
   push:
-    branches: [ "v2" ]
+    branches: [ "main" ]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
     + [Linux](#linux)
 - [Quick Start](#quick-start)
 - [Contributing](#contributing)
+- [Legacy](#legacy)
 # Docker Compose v2
 
 [![GitHub release](https://img.shields.io/github/release/docker/compose.svg?style=flat-square)](https://github.com/docker/compose/releases/latest)
 [![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?style=flat-square&logo=go&logoColor=white)](https://pkg.go.dev/github.com/docker/compose/v2)
-[![Build Status](https://img.shields.io/github/workflow/status/docker/compose/ci?label=ci&logo=github&style=flat-square)](https://github.com/docker/compose/actions?query=workflow%3Aci)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/docker/compose/ci.yml?label=ci&logo=github&style=flat-square)](https://github.com/docker/compose/actions?query=workflow%3Aci)
 [![Go Report Card](https://goreportcard.com/badge/github.com/docker/compose/v2?style=flat-square)](https://goreportcard.com/report/github.com/docker/compose/v2)
-[![Codecov](https://codecov.io/gh/docker/compose/branch/master/graph/badge.svg?token=HP3K4Y4ctu)](https://codecov.io/gh/docker/compose)
+[![Codecov](https://codecov.io/gh/docker/compose/branch/main/graph/badge.svg?token=HP3K4Y4ctu)](https://codecov.io/gh/docker/compose)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/docker/compose/badge)](https://api.securityscorecards.dev/projects/github.com/docker/compose)
 ![Docker Compose](logo.png?raw=true "Docker Compose Logo")
 
@@ -22,12 +23,6 @@ A Compose file is used to define how one or more containers that make up
 your application are configured.
 Once you have a Compose file, you can create and start your application with a
 single command: `docker compose up`.
-
-# About update and backward compatibility
-
-Docker Compose V2 is a major version bump release of Docker Compose. It has been completely rewritten from scratch in Golang (V1 was in Python). The installation instructions for Compose V2 differ from V1. V2 is not a standalone binary anymore, and installation scripts will have to be adjusted. Some commands are different.
-
-For a smooth transition from legacy docker-compose 1.xx, please consider installing [compose-switch](https://github.com/docker/compose-switch) to translate `docker-compose ...` commands into Compose V2's `docker compose .... `. Also check V2's `--compatibility` flag.
 
 # Where to get Docker Compose
 
@@ -85,3 +80,8 @@ Want to help develop Docker Compose? Check out our
 
 If you find an issue, please report it on the
 [issue tracker](https://github.com/docker/compose/issues/new/choose).
+
+Legacy
+-------------
+
+The Python version of Compose is available under the `v1` [branch](https://github.com/docker/compose/tree/v1)


### PR DESCRIPTION
**What I did**
Update CI workflows to target `main` branch instead of `v2`
Update README.md to remove compatibility section and add a legacy one

**Related issue**
https://docker.atlassian.net/browse/ENV-243

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/ec35e5cb-b9b3-4bd3-832a-8ee824d5bd5b)
