### PR TITLE
warn user secret uid/gid/mode is not supported

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -867,6 +867,10 @@ func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount
 			target = configsBaseDir + config.Target
 		}
 
+		if config.UID != "" || config.GID != "" || config.Mode != nil {
+			logrus.Warn("config `uid`, `gid` and `mode` are not supported, they will be ignored")
+		}
+
 		definedConfig := p.Configs[config.Source]
 		if definedConfig.External.External {
 			return nil, fmt.Errorf("unsupported external config %s", definedConfig.Name)
@@ -900,6 +904,10 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 			target = secretsDir + secret.Source
 		} else if !isAbsTarget(secret.Target) {
 			target = secretsDir + secret.Target
+		}
+
+		if secret.UID != "" || secret.GID != "" || secret.Mode != nil {
+			logrus.Warn("secrets `uid`, `gid` and `mode` are not supported, they will be ignored")
 		}
 
 		definedSecret := p.Secrets[secret.Source]


### PR DESCRIPTION
**What I did**
warn user who configured secret/config uid|gid|mode that this isn't supported and won't apply to bind-mounted file

**Related issue**
closes https://github.com/docker/compose/issues/10903
(not actually a fix, but we already have https://github.com/docker/compose/issues/9648 to track this missing feature)

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
