### PR TITLE
up: handle various attach use cases better

### DIFF
--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -9,14 +9,14 @@ Create and start containers
 |:-----------------------------|:--------------|:----------|:---------------------------------------------------------------------------------------------------------|
 | `--abort-on-container-exit`  |               |           | Stops all containers if any container was stopped. Incompatible with -d                                  |
 | `--always-recreate-deps`     |               |           | Recreate dependent containers. Incompatible with --no-recreate.                                          |
-| `--attach`                   | `stringArray` |           | Attach to service output.                                                                                |
-| `--attach-dependencies`      |               |           | Attach to dependent containers.                                                                          |
+| `--attach`                   | `stringArray` |           | Restrict attaching to the specified services. Incompatible with --attach-dependencies.                   |
+| `--attach-dependencies`      |               |           | Automatically attach to log output of dependent services.                                                |
 | `--build`                    |               |           | Build images before starting containers.                                                                 |
 | `-d`, `--detach`             |               |           | Detached mode: Run containers in the background                                                          |
 | `--dry-run`                  |               |           | Execute command in dry run mode                                                                          |
 | `--exit-code-from`           | `string`      |           | Return the exit code of the selected service container. Implies --abort-on-container-exit                |
 | `--force-recreate`           |               |           | Recreate containers even if their configuration and image haven't changed.                               |
-| `--no-attach`                | `stringArray` |           | Don't attach to specified service.                                                                       |
+| `--no-attach`                | `stringArray` |           | Do not attach (stream logs) to the specified services.                                                   |
 | `--no-build`                 |               |           | Don't build an image, even if it's missing.                                                              |
 | `--no-color`                 |               |           | Produce monochrome output.                                                                               |
 | `--no-deps`                  |               |           | Don't start linked services.                                                                             |
@@ -31,7 +31,7 @@ Create and start containers
 | `-t`, `--timeout`            | `int`         | `0`       | Use this timeout in seconds for container shutdown when attached or when containers are already running. |
 | `--timestamps`               |               |           | Show timestamps.                                                                                         |
 | `--wait`                     |               |           | Wait for services to be running\|healthy. Implies detached mode.                                         |
-| `--wait-timeout`             | `int`         | `0`       | timeout waiting for application to be running\|healthy.                                                  |
+| `--wait-timeout`             | `int`         | `0`       | Maximum duration to wait for the project to be running\|healthy.                                         |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -48,7 +48,8 @@ options:
     - option: attach
       value_type: stringArray
       default_value: '[]'
-      description: Attach to service output.
+      description: |
+        Restrict attaching to the specified services. Incompatible with --attach-dependencies.
       deprecated: false
       hidden: false
       experimental: false
@@ -58,7 +59,7 @@ options:
     - option: attach-dependencies
       value_type: bool
       default_value: "false"
-      description: Attach to dependent containers.
+      description: Automatically attach to log output of dependent services.
       deprecated: false
       hidden: false
       experimental: false
@@ -110,7 +111,7 @@ options:
     - option: no-attach
       value_type: stringArray
       default_value: '[]'
-      description: Don't attach to specified service.
+      description: Do not attach (stream logs) to the specified services.
       deprecated: false
       hidden: false
       experimental: false
@@ -266,7 +267,7 @@ options:
     - option: wait-timeout
       value_type: int
       default_value: "0"
-      description: timeout waiting for application to be running|healthy.
+      description: Maximum duration to wait for the project to be running|healthy.
       deprecated: false
       hidden: false
       experimental: false

--- a/pkg/utils/set.go
+++ b/pkg/utils/set.go
@@ -16,6 +16,23 @@ package utils
 
 type Set[T comparable] map[T]struct{}
 
+func NewSet[T comparable](v ...T) Set[T] {
+	if len(v) == 0 {
+		return make(Set[T])
+	}
+
+	out := make(Set[T], len(v))
+	for i := range v {
+		out.Add(v[i])
+	}
+	return out
+}
+
+func (s Set[T]) Has(v T) bool {
+	_, ok := s[v]
+	return ok
+}
+
 func (s Set[T]) Add(v T) {
 	s[v] = struct{}{}
 }
@@ -52,4 +69,25 @@ func (s Set[T]) RemoveAll(elements ...T) {
 	for _, e := range elements {
 		s.Remove(e)
 	}
+}
+
+func (s Set[T]) Diff(other Set[T]) Set[T] {
+	out := make(Set[T])
+	for k := range s {
+		if _, ok := other[k]; !ok {
+			out[k] = struct{}{}
+		}
+	}
+	return out
+}
+
+func (s Set[T]) Union(other Set[T]) Set[T] {
+	out := make(Set[T])
+	for k := range s {
+		out[k] = struct{}{}
+	}
+	for k := range other {
+		out[k] = struct{}{}
+	}
+	return out
 }

--- a/pkg/utils/set_test.go
+++ b/pkg/utils/set_test.go
@@ -1,0 +1,41 @@
+/*
+   Copyright 2022 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSet_Has(t *testing.T) {
+	x := NewSet[string]("value")
+	require.True(t, x.Has("value"))
+	require.False(t, x.Has("VALUE"))
+}
+
+func TestSet_Diff(t *testing.T) {
+	a := NewSet[int](1, 2)
+	b := NewSet[int](2, 3)
+	require.ElementsMatch(t, []int{1}, a.Diff(b).Elements())
+	require.ElementsMatch(t, []int{3}, b.Diff(a).Elements())
+}
+
+func TestSet_Union(t *testing.T) {
+	a := NewSet[int](1, 2)
+	b := NewSet[int](2, 3)
+	require.ElementsMatch(t, []int{1, 2, 3}, a.Union(b).Elements())
+	require.ElementsMatch(t, []int{1, 2, 3}, b.Union(a).Elements())
+}


### PR DESCRIPTION
**What I did**
By default, `compose up` attaches to all services (i.e. shows log output from every associated container). If a service is specified, e.g. `compose up foo`, then only `foo`'s logs are tailed. The `--attach-dependencies` flag can also be used, so that if `foo` depended upon `bar`, then `bar`'s logs would also be followed. It's also possible to use `--no-attach` to filter out one or more services explicitly, e.g. `compose up --no-attach=noisy` would launch all services, including `noisy`, and would show log output from every service _except_ `noisy`. Lastly, it's possible to use `up --attach` to explicitly restrict to a subset of services (or their dependencies).

How these flags interact with each other is also worth thinking through.

There were a few different connected issues here, but the primary issue was that running `compose up foo` was always attaching dependencies regardless of `--attach-dependencies`.

The filtering logic here has been updated so that it behaves predictably both when launching all services (`compose up`) or a subset (`compose up foo`) as well as various flag combinations on top of those.

Notably, this required making some changes to how it watches containers. The logic here between attaching for logs and monitoring for lifecycle changes is
tightly coupled, so some changes were needed to ensure that the full set of services being `up`'d are _watched_ and the subset that should have logs shown are _attached_. (This does mean faking the attach with an event but not actually doing it.)

While handling that, I adjusted the context lifetimes here, which improves error handling that gets shown to the user and should help avoid potential leaks by getting rid of a `context.Background()`.

**Related issue**
Fixes:
 * #10909

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![spider monkey](https://github.com/docker/compose/assets/841263/8463c328-cde2-4f59-86c4-c605590aa22e)
