### PR TITLE
build(deps): upgrade to compose-go v1.18.3

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -262,7 +262,7 @@ func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 			cli.WithDotEnv,
 			cli.WithConfigFileEnv,
 			cli.WithDefaultConfigPath,
-			cli.WithProfiles(o.Profiles),
+			cli.WithDefaultProfiles(o.Profiles...),
 			cli.WithName(o.ProjectName))...)
 }
 

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -61,7 +61,7 @@ func (o *configOptions) ToProject(ctx context.Context, services []string) (*type
 		cli.WithResolvedPaths(!o.noResolvePath),
 		cli.WithNormalization(!o.noNormalize),
 		cli.WithConsistency(!o.noConsistency),
-		cli.WithProfiles(o.Profiles),
+		cli.WithDefaultProfiles(o.Profiles...),
 		cli.WithDiscardEnvFile,
 		cli.WithContext(ctx),
 		cli.WithResourceLoader(git))

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/adrg/xdg v0.4.0
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go v1.18.2
+	github.com/compose-spec/compose-go v1.18.3
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.3
 	github.com/cucumber/godog v0.0.0-00010101000000-000000000000 // replaced; see replace for the actual version used

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go v1.18.2 h1:ZxiSvB9K4coRs39wgGeWOwfjgziOpOQT+etJ4MB3PRA=
-github.com/compose-spec/compose-go v1.18.2/go.mod h1:zR2tP1+kZHi5vJz7PjpW6oMoDji/Js3GHjP+hfjf70Q=
+github.com/compose-spec/compose-go v1.18.3 h1:hiwTZ8ED1l+CB2G2G4LFv/bIaoUfG2ZBalz4S7MOy5w=
+github.com/compose-spec/compose-go v1.18.3/go.mod h1:zR2tP1+kZHi5vJz7PjpW6oMoDji/Js3GHjP+hfjf70Q=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=


### PR DESCRIPTION
**What I did**
Bump to [compose-go@v1.18.3](https://github.com/compose-spec/compose-go/releases/tag/v1.18.3)

**Related issue**
Fixes:
 * #10921 
 * #10913 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![a kangaroo with its baby in its pouch](https://github.com/docker/compose/assets/841263/be2200d8-ede3-4db1-9f56-18723fe2be78)
