### PR TITLE
test: e2e test reliability improvements

### DIFF
--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -71,10 +71,14 @@ func TestPortRange(t *testing.T) {
 	c := NewParallelCLI(t)
 	const projectName = "e2e-port-range"
 
+	reset := func() {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans", "--timeout=0")
+	}
+	reset()
+	t.Cleanup(reset)
+
 	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/port-range/compose.yaml", "--project-name", projectName, "up", "-d")
 	res.Assert(t, icmd.Success)
-
-	c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--remove-orphans")
 }
 
 func TestStdoutStderr(t *testing.T) {

--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -31,7 +31,7 @@ const (
 
 func TestExplicitProfileUsage(t *testing.T) {
 	c := NewParallelCLI(t)
-	const projectName = "compose-e2e-profiles"
+	const projectName = "compose-e2e-explicit-profiles"
 	const profileName = "test-profile"
 
 	t.Run("compose up with profile", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestNoProfileUsage(t *testing.T) {
 
 func TestActiveProfileViaTargetedService(t *testing.T) {
 	c := NewParallelCLI(t)
-	const projectName = "compose-e2e-profiles-via-target-service"
+	const projectName = "compose-e2e-via-target-service-profiles"
 	const profileName = "test-profile"
 
 	t.Run("compose up with service name", func(t *testing.T) {


### PR DESCRIPTION
**What I did**
* Use unique project name prefixes (some of these tests assert on output using the project name as a magic string, so could be impacted by other tests with the same project name prefix)
* Tear down port range project before starting to try and avoid race conditions with the engine and port assignment

**Related issue**
n/a

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![cat in a construction worker outfit on a work site](https://github.com/docker/compose/assets/841263/a51cd550-04af-4abc-946a-c10659d571fb)
