### PR TITLE
Enable service explicitly requested to be restarted

### DIFF
--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v2/pkg/api"
@@ -61,22 +60,23 @@ func runRestart(ctx context.Context, backend api.Service, opts restartOptions, s
 		return err
 	}
 
+	if project != nil && len(services) > 0 {
+		err := project.EnableServices(services...)
+		if err != nil {
+			return err
+		}
+	}
+
 	var timeout *time.Duration
 	if opts.timeChanged {
 		timeoutValue := time.Duration(opts.timeout) * time.Second
 		timeout = &timeoutValue
 	}
 
-	if opts.noDeps {
-		err := project.ForServices(services, types.IgnoreDependencies)
-		if err != nil {
-			return err
-		}
-	}
-
 	return backend.Restart(ctx, name, api.RestartOptions{
 		Timeout:  timeout,
 		Services: services,
 		Project:  project,
+		NoDeps:   opts.noDeps,
 	})
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -213,6 +213,8 @@ type RestartOptions struct {
 	Timeout *time.Duration
 	// Services passed in the command line to be restarted
 	Services []string
+	// NoDeps ignores services dependencies
+	NoDeps bool
 }
 
 // StopOptions group options of the Stop API

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -48,6 +48,13 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 		}
 	}
 
+	if options.NoDeps {
+		err := project.ForServices(options.Services, types.IgnoreDependencies)
+		if err != nil {
+			return err
+		}
+	}
+
 	// ignore depends_on relations which are not impacted by restarting service or not required
 	for i, service := range project.Services {
 		for name, r := range service.DependsOn {

--- a/pkg/e2e/fixtures/restart-test/compose.yaml
+++ b/pkg/e2e/fixtures/restart-test/compose.yaml
@@ -3,3 +3,10 @@ services:
     image: alpine
     init: true
     command: ash -c "if [[ -f /tmp/restart.lock ]] ; then sleep infinity; else touch /tmp/restart.lock; fi"
+
+  test:
+    profiles:
+      - test
+    image: alpine
+    init: true
+    command: ash -c "if [[ -f /tmp/restart.lock ]] ; then sleep infinity; else touch /tmp/restart.lock; fi"

--- a/pkg/e2e/restart_test.go
+++ b/pkg/e2e/restart_test.go
@@ -84,3 +84,19 @@ func TestRestartWithDependencies(t *testing.T) {
 	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf("Container e2e-restart-deps-%s-1  Started", depWithRestart)), res.Combined())
 	assert.Assert(t, !strings.Contains(res.Combined(), depNoRestart), res.Combined())
 }
+
+func TestRestartWithProfiles(t *testing.T) {
+	c := NewParallelCLI(t, WithEnv(
+		"COMPOSE_PROJECT_NAME=e2e-restart-profiles",
+	))
+
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "down", "--remove-orphans")
+	})
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/restart-test/compose.yaml", "--profile", "test", "up", "-d")
+
+	res := c.RunDockerComposeCmd(t, "restart", "test")
+	fmt.Println(res.Combined())
+	assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-restart-profiles-test-1  Started"), res.Combined())
+}


### PR DESCRIPTION
**What I did**
loading local compose.yaml file, if service(s) are explicitly set by command args, automagically enable profiles
also moved "no deps" logic to backend code otherwise running without a project cause a nil pointer panic.

**Related issue**
fixes https://github.com/docker/compose/issues/10948

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
