### PR TITLE
pkg/api: replace uuid for basic random id

### DIFF
--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -19,6 +19,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,8 +32,6 @@ import (
 	"github.com/docker/buildx/builder"
 	"github.com/docker/buildx/util/imagetools"
 	"github.com/docker/cli/cli/command"
-
-	"github.com/distribution/distribution/v3/uuid"
 	moby "github.com/docker/docker/api/types"
 	containerType "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -298,7 +297,9 @@ func (d *DryRunClient) VolumeRemove(ctx context.Context, volumeID string, force 
 }
 
 func (d *DryRunClient) ContainerExecCreate(ctx context.Context, container string, config moby.ExecConfig) (moby.IDResponse, error) {
-	id := uuid.Generate().String()
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	id := fmt.Sprintf("%x", b)
 	d.execs.Store(id, execDetails{
 		container: container,
 		command:   config.Cmd,

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -17,6 +17,7 @@
 package e2e
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/distribution/distribution/v3/uuid"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
@@ -127,7 +127,9 @@ func doTest(t *testing.T, svcName string, tarSync bool) {
 	}
 
 	waitForFlush := func() {
-		sentinelVal := uuid.Generate().String()
+		b := make([]byte, 32)
+		_, _ = rand.Read(b)
+		sentinelVal := fmt.Sprintf("%x", b)
 		writeDataFile("wait.txt", sentinelVal)
 		poll.WaitOn(t, checkFileContents("/app/data/wait.txt", sentinelVal))
 	}


### PR DESCRIPTION
The uuid package in distribution was created as a utility for the distribution project itself, to cut down external dependencies (see [1][1]).

For compose, this has the reverse effect, as it now brings all the dependencies of the distribution module with it.

This patch switches to the uuid generation to crypto/rand to produce a random id. I was considering using a different uuid implementation, or docker's "stringid.GenerateRandomID", but all of those are doing more than needed, so keep it simple.

Currently, this change has little effect, because compose also uses the distribution module for other purposes, but the distribution project is in the process of moving the "reference" package to a separate module, in which case we don't want to depend on the distribution module only for the uuid package.

[1]: https://github.com/distribution/distribution/commit/36e34a55ad127a80d008813cd25133a4e0ba5fb3

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
