### PR TITLE
watch: build & launch the project at start

### DIFF
--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -31,10 +31,14 @@ import (
 type watchOptions struct {
 	*ProjectOptions
 	quiet bool
+	noUp  bool
 }
 
 func watchCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
-	opts := watchOptions{
+	watchOpts := watchOptions{
+		ProjectOptions: p,
+	}
+	buildOpts := buildOptions{
 		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
@@ -44,22 +48,33 @@ func watchCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 			return nil
 		}),
 		RunE: Adapt(func(ctx context.Context, args []string) error {
-			return runWatch(ctx, dockerCli, backend, opts, args)
+			return runWatch(ctx, dockerCli, backend, watchOpts, buildOpts, args)
 		}),
 		ValidArgsFunction: completeServiceNames(dockerCli, p),
 	}
 
-	cmd.Flags().BoolVar(&opts.quiet, "quiet", false, "hide build output")
+	cmd.Flags().BoolVar(&watchOpts.quiet, "quiet", false, "hide build output")
+	cmd.Flags().BoolVar(&watchOpts.noUp, "no-up", false, "Do not build & start services before watching")
 	return cmd
 }
 
-func runWatch(ctx context.Context, dockerCli command.Cli, backend api.Service, opts watchOptions, services []string) error {
+func runWatch(ctx context.Context, dockerCli command.Cli, backend api.Service, watchOpts watchOptions, buildOpts buildOptions, services []string) error {
 	fmt.Fprintln(os.Stderr, "watch command is EXPERIMENTAL")
-	project, err := opts.ToProject(dockerCli, nil)
+	project, err := watchOpts.ToProject(dockerCli, nil)
 	if err != nil {
 		return err
 	}
 
+	if err := applyPlatforms(project, true); err != nil {
+		return err
+	}
+
+	build, err := buildOpts.toAPIBuildOptions(nil)
+	if err != nil {
+		return err
+	}
+
+	// validation done -- ensure we have the lockfile for this project before doing work
 	l, err := locker.NewPidfile(project.Name)
 	if err != nil {
 		return fmt.Errorf("cannot take exclusive lock for project %q: %v", project.Name, err)
@@ -68,5 +83,29 @@ func runWatch(ctx context.Context, dockerCli command.Cli, backend api.Service, o
 		return fmt.Errorf("cannot take exclusive lock for project %q: %v", project.Name, err)
 	}
 
-	return backend.Watch(ctx, project, services, api.WatchOptions{})
+	if !watchOpts.noUp {
+		upOpts := api.UpOptions{
+			Create: api.CreateOptions{
+				Build:                &build,
+				Services:             services,
+				RemoveOrphans:        false,
+				Recreate:             api.RecreateDiverged,
+				RecreateDependencies: api.RecreateNever,
+				Inherit:              true,
+				QuietPull:            watchOpts.quiet,
+			},
+			Start: api.StartOptions{
+				Project:     project,
+				Attach:      nil,
+				CascadeStop: false,
+				Services:    services,
+			},
+		}
+		if err := backend.Up(ctx, project, upOpts); err != nil {
+			return err
+		}
+	}
+	return backend.Watch(ctx, project, services, api.WatchOptions{
+		Build: build,
+	})
 }

--- a/docs/reference/compose_alpha_watch.md
+++ b/docs/reference/compose_alpha_watch.md
@@ -5,10 +5,11 @@ EXPERIMENTAL - Watch build context for service and rebuild/refresh containers wh
 
 ### Options
 
-| Name        | Type | Default | Description                     |
-|:------------|:-----|:--------|:--------------------------------|
-| `--dry-run` |      |         | Execute command in dry run mode |
-| `--quiet`   |      |         | hide build output               |
+| Name        | Type | Default | Description                                   |
+|:------------|:-----|:--------|:----------------------------------------------|
+| `--dry-run` |      |         | Execute command in dry run mode               |
+| `--no-up`   |      |         | Do not build & start services before watching |
+| `--quiet`   |      |         | hide build output                             |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_alpha_watch.yaml
+++ b/docs/reference/docker_compose_alpha_watch.yaml
@@ -7,6 +7,16 @@ usage: docker compose alpha watch [SERVICE...]
 pname: docker compose alpha
 plink: docker_compose_alpha.yaml
 options:
+    - option: no-up
+      value_type: bool
+      default_value: "false"
+      description: Do not build & start services before watching
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet
       value_type: bool
       default_value: "false"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -110,6 +110,7 @@ type VizOptions struct {
 
 // WatchOptions group options of the Watch API
 type WatchOptions struct {
+	Build BuildOptions
 }
 
 // BuildOptions group options of the Build API

--- a/pkg/compose/watch_test.go
+++ b/pkg/compose/watch_test.go
@@ -21,16 +21,14 @@ import (
 	"time"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/compose/v2/internal/sync"
+	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/mocks"
+	"github.com/docker/compose/v2/pkg/watch"
 	moby "github.com/docker/docker/api/types"
 	"github.com/golang/mock/gomock"
-
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/compose/v2/internal/sync"
-
-	"github.com/docker/compose/v2/pkg/watch"
 	"gotest.tools/v3/assert"
 )
 
@@ -126,7 +124,7 @@ func TestWatch_Sync(t *testing.T) {
 			dockerCli: cli,
 			clock:     clock,
 		}
-		err := service.watch(ctx, &proj, "test", watcher, syncer, []Trigger{
+		err := service.watch(ctx, &proj, "test", api.WatchOptions{}, watcher, syncer, []Trigger{
 			{
 				Path:   "/sync",
 				Action: "sync",

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -82,13 +82,12 @@ func doTest(t *testing.T, svcName string, tarSync bool) {
 
 	cli := NewCLI(t, WithEnv(env...))
 
+	// important that --rmi is used to prune the images and ensure that watch builds on launch
 	cleanup := func() {
-		cli.RunDockerComposeCmd(t, "down", svcName, "--timeout=0", "--remove-orphans", "--volumes")
+		cli.RunDockerComposeCmd(t, "down", svcName, "--timeout=0", "--remove-orphans", "--volumes", "--rmi=local")
 	}
 	cleanup()
 	t.Cleanup(cleanup)
-
-	cli.RunDockerComposeCmd(t, "up", svcName, "--wait", "--build")
 
 	cmd := cli.NewDockerComposeCmd(t, "--verbose", "alpha", "watch", svcName)
 	// stream output since watch runs in the background
@@ -161,14 +160,12 @@ func doTest(t *testing.T, svcName string, tarSync bool) {
 		Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "No such file or directory",
-		},
-		)
+		})
 	cli.RunDockerComposeCmdNoCheck(t, "exec", svcName, "stat", "/app/data/ignored").
 		Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "No such file or directory",
-		},
-		)
+		})
 
 	t.Logf("Creating subdirectory")
 	require.NoError(t, os.Mkdir(filepath.Join(dataDir, "subdir"), 0o700))
@@ -196,8 +193,7 @@ func doTest(t *testing.T, svcName string, tarSync bool) {
 		Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "No such file or directory",
-		},
-		)
+		})
 
 	testComplete.Store(true)
 }


### PR DESCRIPTION
**What I did**
The `alpha watch` command current "attaches" to an already-running Compose project, so it's necessary to run something like `docker compose up --wait` first.

Now, we'll do the equivalent of an `up --build` before starting the watch, so that we know the project is up-to-date and running.

Additionally, unlike an interactive `up`, the services are not stopped when `watch` exits (e.g. via `Ctrl-C`). This prevents the need to start from scratch each time the command is run - if some services are already running and up-to-date, they can be used as-is. A `down` can always be used to destroy everything, and we can consider introducing a flag like `--down-on-exit` to `watch` or changing the default.

NOTE: This requires #10956, so it won't even build until that's merged 😬 

**Related issue**
https://docker.atlassian.net/browse/ENV-286

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![lynx in the snow](https://github.com/docker/compose/assets/841263/0b373287-ec2d-461d-bdbd-c3c24c36dee5)
