### PR TITLE
test: add a fully containerized (via Compose) e2e setup

### DIFF
--- a/dind.compose.yaml
+++ b/dind.compose.yaml
@@ -1,0 +1,55 @@
+services:
+  docker:
+    image: ${DIND_IMAGE:-docker.io/docker}:${DIND_TAG:-git}
+    privileged: true
+    environment:
+      DOCKER_TLS_CERTDIR: /certs
+    volumes:
+      - type: volume
+        source: dind-sock
+        target: /var/run
+      - type: volume
+        source: dind-certs-ca
+        target: /certs/ca
+      - type: volume
+        source: dind-certs-client
+        target: /certs/client
+    networks: [dind]
+    healthcheck:
+      test: ["CMD", "docker", "version", "--format='{{ .Server.Version }}'"]
+      interval: 1s
+      # start_interval: 1s
+      start_period: 15s
+      timeout: 5s
+
+  cli-sock:
+    image: ${DIND_IMAGE:-docker.io/docker}:${DIND_CLI_TAG:-cli}
+    command: ["docker", "version"]
+    volumes:
+      - type: volume
+        source: dind-sock
+        target: /var/run
+    depends_on:
+      docker:
+        condition: service_healthy
+  cli-tls:
+    image: ${DIND_IMAGE:-docker.io/docker}:${DIND_CLI_TAG:-cli}
+    environment:
+      DOCKER_TLS_CERTDIR: /certs
+    volumes:
+      - type: volume
+        source: dind-certs-client
+        target: /certs/client
+    command: [ "docker", "version" ]
+    depends_on:
+      docker:
+        condition: service_healthy
+    networks: [dind]
+
+volumes:
+  dind-certs-ca:
+  dind-certs-client:
+  dind-sock:
+
+networks:
+  dind:

--- a/e2e.compose.yaml
+++ b/e2e.compose.yaml
@@ -1,0 +1,17 @@
+include:
+  - ./dind.compose.yaml
+
+services:
+  e2e:
+    pull_policy: build
+    build:
+      context: .
+      target: e2e
+    volumes:
+      - type: volume
+        source: dind-sock
+        target: /var/run
+    network_mode: service:docker
+    depends_on:
+      docker:
+        condition: service_healthy


### PR DESCRIPTION
**What I did**
`dind.compose.yaml` has a Docker-in-Docker setup, which is then referenced via `include` in `e2e.compose.yaml`.

Not all tests currently pass, as some rely on bind mounts, for example.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![falcon](https://github.com/docker/compose/assets/841263/d8f797ea-df34-4330-a966-f928bd55b46f)
