### PR TITLE
Include image name in error message

### DIFF
--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -90,7 +90,7 @@ func (s *composeService) getImages(ctx context.Context, images []string) (map[st
 				if errdefs.IsNotFound(err) {
 					return nil
 				}
-				return err
+				return fmt.Errorf("unable to get image '%s': %w", img, err)
 			}
 			tag := ""
 			repository := ""


### PR DESCRIPTION
**What I did**
Added a more descriptive error message for images with invalid reference formats

**Related issue**
Fixes #10795 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![Tortoise](https://github.com/docker/compose/assets/24998201/34ff9134-80fc-471b-8c03-b9a2d1a98978)

