### PR TITLE
Make hashes between `up` and `configure` consistent

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -186,6 +186,10 @@ func runHash(ctx context.Context, dockerCli command.Cli, opts configOptions) err
 		return err
 	}
 
+	if err := applyPlatforms(project, true); err != nil {
+		return err
+	}
+
 	if len(services) > 0 {
 		err = project.ForServices(services, types.IgnoreDependencies)
 		if err != nil {

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -190,20 +190,19 @@ func runHash(ctx context.Context, dockerCli command.Cli, opts configOptions) err
 		return err
 	}
 
-	if len(services) > 0 {
-		err = project.ForServices(services, types.IgnoreDependencies)
+	sorted := services
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
+	})
+
+	for _, name := range sorted {
+		s, err := project.GetService(name)
 		if err != nil {
 			return err
 		}
-	}
 
-	sorted := project.Services
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Name < sorted[j].Name
-	})
-
-	for _, s := range sorted {
 		hash, err := compose.ServiceHash(s)
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What I did**
Currently, when `docker compose config --hash [service]` computes a hash for the service, it deletes all other services before computing the hash. That means if a service depends on another service, the `DependsOn` field gets deleted, causing the hash to be different than when `docker up` creates the labels.

I prevented the dependencies from getting deleted before hash computation to fix this.

I also noticed that `docker up` does some modification to the platform of the image **before** doing the hash (I.e. if no platform was specified in the yaml file, the default one is set). `docker config` doesn't do this at all. So I modified `docker config` to apply these modifications before computing the hash. 

It could be argued that `config` shouldn't call `applyPlatform`. Take the scenario where a compose file contains services that don't have a platform specified. If that same file is run on two different machines with different default platforms, the hashes will be different. Personally, I think the hashes for the identical files should be different because they'll run on different platforms, but would love to get some feedback on that.

**Related issue**
Fixes #10907 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/24998201/75f20382-9968-457d-b572-6549faa4911c)

