### PR TITLE
remove --timeout=0 flag to cleanup function of watch e2e test

### DIFF
--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -84,7 +84,7 @@ func doTest(t *testing.T, svcName string, tarSync bool) {
 
 	// important that --rmi is used to prune the images and ensure that watch builds on launch
 	cleanup := func() {
-		cli.RunDockerComposeCmd(t, "down", svcName, "--timeout=0", "--remove-orphans", "--volumes", "--rmi=local")
+		cli.RunDockerComposeCmd(t, "down", svcName, "--remove-orphans", "--volumes", "--rmi=local")
 	}
 	cleanup()
 	t.Cleanup(cleanup)


### PR DESCRIPTION
compose down command need the watch process to be killed to succeed

**What I did**
Fix the watch e2e tests which fails during the cleanup stage

**Related issue**
https://github.com/docker/compose/actions/runs/6240098754/job/16939441138

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/11e3ef2c-69a5-48c1-b67d-5a938b6b74e3)
