### PR TITLE
Make tests verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install: binary
 
 .PHONY: e2e-compose
 e2e-compose: ## Run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
-	go test $(TEST_FLAGS) -count=1 ./pkg/e2e
+	go test -v $(TEST_FLAGS) -count=1 ./pkg/e2e
 
 .PHONY: e2e-compose-standalone
 e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test


### PR DESCRIPTION
**What I did**

Added the `-v` flag so that I can see the output of `make build-and-e2e-compose` as it's happening. 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
