### PR TITLE
update the watch warning message when no services with a develop section

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -149,7 +149,7 @@ func (s *composeService) Watch(ctx context.Context, project *types.Project, serv
 	}
 
 	if !watching {
-		return fmt.Errorf("none of the selected services is configured for watch, consider setting an 'x-develop' section")
+		return fmt.Errorf("none of the selected services is configured for watch, consider setting an 'develop' section")
 	}
 
 	return eg.Wait()


### PR DESCRIPTION
**What I did**
Fix the warning message of `watch` mode when no service defines a `develop` section.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/d79ee783-acb4-4f64-97da-5d5ef651f33a)
