### PR TITLE
Align OCI artifacts with upstream guidance

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -71,7 +71,7 @@ func (s *composeService) publish(ctx context.Context, project *types.Project, re
 			Digest:    digest.FromString(string(f)),
 			Size:      int64(len(f)),
 			Annotations: map[string]string{
-				"com.docker.compose": api.ComposeVersion,
+				"com.docker.compose.version": api.ComposeVersion,
 			},
 		}
 		layers = append(layers, layer)
@@ -98,12 +98,9 @@ func (s *composeService) publish(ctx context.Context, project *types.Project, re
 		return err
 	}
 	configDescriptor := v1.Descriptor{
-		MediaType: "application/vnd.docker.compose.project",
+		MediaType: "application/vnd.oci.empty.v1+json",
 		Digest:    digest.FromBytes(emptyConfig),
 		Size:      int64(len(emptyConfig)),
-		Annotations: map[string]string{
-			"com.docker.compose.version": api.ComposeVersion,
-		},
 	}
 	err = resolver.Push(ctx, named, configDescriptor, emptyConfig)
 	if err != nil {

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -118,8 +118,8 @@ func (g ociRemoteLoader) Load(ctx context.Context, path string) (string, error) 
 			return "", err
 		}
 
-		if manifest.Config.MediaType != "application/vnd.docker.compose.project" {
-			return "", fmt.Errorf("%s is not a compose project OCI artifact, but %s", ref.String(), manifest.Config.MediaType)
+		if manifest.ArtifactType != "application/vnd.docker.compose.project" {
+			return "", fmt.Errorf("%s is not a compose project OCI artifact, but %s", ref.String(), manifest.ArtifactType)
 		}
 
 		for i, layer := range manifest.Layers {

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -112,17 +112,17 @@ func (g ociRemoteLoader) Load(ctx context.Context, path string) (string, error) 
 		}
 		defer f.Close() //nolint:errcheck
 
-		var descriptor v1.Manifest
-		err = json.Unmarshal(content, &descriptor)
+		var manifest v1.Manifest
+		err = json.Unmarshal(content, &manifest)
 		if err != nil {
 			return "", err
 		}
 
-		if descriptor.Config.MediaType != "application/vnd.docker.compose.project" {
-			return "", fmt.Errorf("%s is not a compose project OCI artifact, but %s", ref.String(), descriptor.Config.MediaType)
+		if manifest.Config.MediaType != "application/vnd.docker.compose.project" {
+			return "", fmt.Errorf("%s is not a compose project OCI artifact, but %s", ref.String(), manifest.Config.MediaType)
 		}
 
-		for i, layer := range descriptor.Layers {
+		for i, layer := range manifest.Layers {
 			digested, err := reference.WithDigest(ref, layer.Digest)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
- Relates to https://github.com/docker/compose/pull/11008

**What I did**

Make some slight tweaks to the code that produces and consumes Compose files as OCI artifacts in order to align with upstream best practices/the [official guidance](https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage).

Manifest before:
```json
{
        "schemaVersion": 2,
        "mediaType": "application/vnd.oci.image.manifest.v1+json",
        "artifactType": "application/vnd.docker.compose.project",
        "config": {
                "mediaType": "application/vnd.docker.compose.project",
                "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
                "size": 2,
                "annotations": {
                        "com.docker.compose.version": "2.22.0"
                }
        },
        "layers": [
                {
                        "mediaType": "application/vnd.docker.compose.file+yaml",
                        "digest": "sha256:839ee3e27293c4f021ad49d8e71ec85bfc69706d1f06037b848a4f13564eeba8",
                        "size": 343,
                        "annotations": {
                                "com.docker.compose": "2.22.0"
                        }
                }
        ]
}
```

Manifest after:
```json
{
        "schemaVersion": 2,
        "mediaType": "application/vnd.oci.image.manifest.v1+json",
        "artifactType": "application/vnd.docker.compose.project",
        "config": {
                "mediaType": "application/vnd.oci.empty.v1+json",
                "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
                "size": 2
        },
        "layers": [
                {
                        "mediaType": "application/vnd.docker.compose.file+yaml",
                        "digest": "sha256:839ee3e27293c4f021ad49d8e71ec85bfc69706d1f06037b848a4f13564eeba8",
                        "size": 343,
                        "annotations": {
                                "com.docker.compose.version": "2.22.0"
                        }
                }
        ]
}
```

**Related issue**
N/A
