### PR TITLE
some commands don't need Dependencies being checked

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -118,6 +118,7 @@ type ProjectOptions struct {
 	Compatibility bool
 	Progress      string
 	Offline       bool
+	Dependencies  types.DependencyOption
 }
 
 // ProjectFunc does stuff within a types.Project
@@ -247,7 +248,7 @@ func (o *ProjectOptions) ToProject(dockerCli command.Cli, services []string, po 
 
 	project.WithoutUnnecessaryResources()
 
-	err = project.ForServices(services)
+	err = project.ForServices(services, o.Dependencies)
 	return project, err
 }
 
@@ -311,7 +312,9 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command { //
 		"commandConn.CloseRead:",
 	))
 
-	opts := ProjectOptions{}
+	opts := ProjectOptions{
+		Dependencies: types.IncludeDependencies,
+	}
 	var (
 		ansi     string
 		noAnsi   bool

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -63,6 +63,7 @@ func (o *configOptions) ToProject(ctx context.Context, dockerCli command.Cli, se
 }
 
 func configCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := configOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/cp.go
+++ b/cmd/compose/cp.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
@@ -39,6 +40,7 @@ type copyOptions struct {
 }
 
 func copyCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := copyOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/events.go
+++ b/cmd/compose/events.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v2/pkg/api"
 
@@ -28,15 +29,14 @@ import (
 )
 
 type eventsOpts struct {
-	*composeOptions
+	*ProjectOptions
 	json bool
 }
 
 func eventsCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := eventsOpts{
-		composeOptions: &composeOptions{
-			ProjectOptions: p,
-		},
+		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
 		Use:   "events [OPTIONS] [SERVICE...]",

--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -28,7 +28,7 @@ import (
 )
 
 type execOpts struct {
-	*composeOptions
+	*ProjectOptions
 
 	service     string
 	command     []string
@@ -44,10 +44,9 @@ type execOpts struct {
 }
 
 func execCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := execOpts{
-		composeOptions: &composeOptions{
-			ProjectOptions: p,
-		},
+		ProjectOptions: p,
 	}
 	runCmd := &cobra.Command{
 		Use:   "exec [OPTIONS] SERVICE COMMAND [ARGS...]",
@@ -86,7 +85,7 @@ func runExec(ctx context.Context, dockerCli command.Cli, backend api.Service, op
 	if err != nil {
 		return err
 	}
-	projectOptions, err := opts.composeOptions.toProjectOptions()
+	projectOptions, err := opts.toProjectOptions()
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/images.go
+++ b/cmd/compose/images.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-units"
@@ -40,6 +41,7 @@ type imageOptions struct {
 }
 
 func imagesCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := imageOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/kill.go
+++ b/cmd/compose/kill.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
@@ -34,6 +35,7 @@ type killOptions struct {
 }
 
 func killCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := killOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
@@ -28,7 +29,6 @@ import (
 
 type logsOptions struct {
 	*ProjectOptions
-	composeOptions
 	follow     bool
 	tail       string
 	since      string
@@ -39,6 +39,7 @@ type logsOptions struct {
 }
 
 func logsCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := logsOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/pause.go
+++ b/cmd/compose/pause.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
@@ -30,6 +31,7 @@ type pauseOptions struct {
 }
 
 func pauseCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := pauseOptions{
 		ProjectOptions: p,
 	}
@@ -61,6 +63,7 @@ type unpauseOptions struct {
 }
 
 func unpauseCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := unpauseOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/port.go
+++ b/cmd/compose/port.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
@@ -36,6 +37,7 @@ type portOptions struct {
 }
 
 func portCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := portOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/compose/v2/cmd/formatter"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/utils"
@@ -64,6 +65,7 @@ func (p *psOptions) parseFilter() error {
 }
 
 func psCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := psOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -31,7 +31,6 @@ import (
 
 type pullOptions struct {
 	*ProjectOptions
-	composeOptions
 	quiet              bool
 	parallel           bool
 	noParallel         bool
@@ -42,6 +41,7 @@ type pullOptions struct {
 }
 
 func pullCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := pullOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -28,13 +28,13 @@ import (
 
 type pushOptions struct {
 	*ProjectOptions
-	composeOptions
 	IncludeDeps    bool
 	Ignorefailures bool
 	Quiet          bool
 }
 
 func pushCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := pushOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ type removeOptions struct {
 }
 
 func removeCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := removeOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -39,7 +39,7 @@ import (
 )
 
 type runOptions struct {
-	*composeOptions
+	*ProjectOptions
 	Service       string
 	Command       []string
 	environment   []string
@@ -114,11 +114,9 @@ func (options runOptions) apply(project *types.Project) error {
 
 func runCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
 	options := runOptions{
-		composeOptions: &composeOptions{
-			ProjectOptions: p,
-		},
-		capAdd:  opts.NewListOpts(nil),
-		capDrop: opts.NewListOpts(nil),
+		ProjectOptions: p,
+		capAdd:         opts.NewListOpts(nil),
+		capDrop:        opts.NewListOpts(nil),
 	}
 	createOpts := createOptions{}
 	buildOpts := buildOptions{

--- a/cmd/compose/scale.go
+++ b/cmd/compose/scale.go
@@ -37,6 +37,7 @@ type scaleOptions struct {
 }
 
 func scaleCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := scaleOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/top.go
+++ b/cmd/compose/top.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
@@ -35,6 +36,7 @@ type topOptions struct {
 }
 
 func topCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := topOptions{
 		ProjectOptions: p,
 	}

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -34,13 +34,7 @@ import (
 	"github.com/docker/compose/v2/pkg/utils"
 )
 
-// composeOptions hold options common to `up` and `run` to run compose project
-type composeOptions struct {
-	*ProjectOptions
-}
-
 type upOptions struct {
-	*composeOptions
 	Detach             bool
 	noStart            bool
 	noDeps             bool

--- a/cmd/compose/wait.go
+++ b/cmd/compose/wait.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v2/pkg/api"
@@ -35,6 +36,7 @@ type waitOptions struct {
 }
 
 func waitCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
+	p.Dependencies = types.IgnoreDependencies
 	opts := waitOptions{
 		ProjectOptions: p,
 	}


### PR DESCRIPTION
**What I did**
some commands like `docker compose logs SERVICE` don't have to validate dependencies are well defined in project model

**Related issue**
fixes https://github.com/docker/compose/issues/10993

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
