### PR TITLE
warn user remote resource is disabled

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -252,29 +252,17 @@ func (o *ProjectOptions) ToProject(dockerCli command.Cli, services []string, po 
 }
 
 func (o *ProjectOptions) configureRemoteLoaders(dockerCli command.Cli, po []cli.ProjectOptionsFn) ([]cli.ProjectOptionsFn, error) {
-	enabled, err := remote.GitRemoteLoaderEnabled()
+	git, err := remote.NewGitRemoteLoader(o.Offline)
 	if err != nil {
 		return nil, err
-	}
-	if enabled {
-		git, err := remote.NewGitRemoteLoader(o.Offline)
-		if err != nil {
-			return nil, err
-		}
-		po = append(po, cli.WithResourceLoader(git))
 	}
 
-	enabled, err = remote.OCIRemoteLoaderEnabled()
+	oci, err := remote.NewOCIRemoteLoader(dockerCli, o.Offline)
 	if err != nil {
 		return nil, err
 	}
-	if enabled {
-		git, err := remote.NewOCIRemoteLoader(dockerCli, o.Offline)
-		if err != nil {
-			return nil, err
-		}
-		po = append(po, cli.WithResourceLoader(git))
-	}
+
+	po = append(po, cli.WithResourceLoader(git), cli.WithResourceLoader(oci))
 	return po, nil
 }
 

--- a/pkg/remote/git.go
+++ b/pkg/remote/git.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 
 	"github.com/adrg/xdg"
-
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
@@ -34,8 +33,10 @@ import (
 	"github.com/moby/buildkit/util/gitutil"
 )
 
-func GitRemoteLoaderEnabled() (bool, error) {
-	if v := os.Getenv("COMPOSE_EXPERIMENTAL_GIT_REMOTE"); v != "" {
+const GIT_REMOTE_ENABLED = "COMPOSE_EXPERIMENTAL_GIT_REMOTE"
+
+func gitRemoteLoaderEnabled() (bool, error) {
+	if v := os.Getenv(GIT_REMOTE_ENABLED); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
 			return false, fmt.Errorf("COMPOSE_EXPERIMENTAL_GIT_REMOTE environment variable expects boolean value: %w", err)
@@ -74,6 +75,14 @@ func (g gitRemoteLoader) Accept(path string) bool {
 var commitSHA = regexp.MustCompile(`^[a-f0-9]{40}$`)
 
 func (g gitRemoteLoader) Load(ctx context.Context, path string) (string, error) {
+	enabled, err := gitRemoteLoaderEnabled()
+	if err != nil {
+		return "", err
+	}
+	if !enabled {
+		return "", fmt.Errorf("experimental git remote resource is disabled. %q must be set", GIT_REMOTE_ENABLED)
+	}
+
 	ref, err := gitutil.ParseGitRef(path)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What I did**
as user forgot (?) to enable git/oci remote resource support (still experimental) compose tries to resolve a local path from URL. This is obvious something is wrong, but the way to get this fixed isn't.

this PR let the remote resource loader detect it _should_ load a remote resource, but report an explicit error and way to fix it.

