### PR TITLE
refactor(cmd/compose/run): remove redundant `len` check

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -80,10 +80,9 @@ func (options runOptions) apply(project *types.Project) error {
 
 	target.Tty = !options.noTty
 	target.StdinOpen = options.interactive
+
+	// --service-ports and --publish are incompatible
 	if !options.servicePorts {
-		target.Ports = []types.ServicePortConfig{}
-	}
-	if len(options.publish) > 0 {
 		target.Ports = []types.ServicePortConfig{}
 		for _, p := range options.publish {
 			config, err := types.ParsePortConfig(p)
@@ -93,14 +92,13 @@ func (options runOptions) apply(project *types.Project) error {
 			target.Ports = append(target.Ports, config...)
 		}
 	}
-	if len(options.volumes) > 0 {
-		for _, v := range options.volumes {
-			volume, err := loader.ParseVolume(v)
-			if err != nil {
-				return err
-			}
-			target.Volumes = append(target.Volumes, volume)
+
+	for _, v := range options.volumes {
+		volume, err := loader.ParseVolume(v)
+		if err != nil {
+			return err
 		}
+		target.Volumes = append(target.Volumes, volume)
 	}
 
 	for i, s := range project.Services {

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -96,10 +96,18 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("compose run --publish", func(t *testing.T) {
-		c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--publish", "8081:80", "-d", "back",
+		c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/ports.yaml", "run", "--publish", "8081:80", "-d", "back",
 			"/bin/sh", "-c", "sleep 1")
 		res := c.RunDockerCmd(t, "ps")
 		assert.Assert(t, strings.Contains(res.Stdout(), "8081->80/tcp"), res.Stdout())
+		assert.Assert(t, !strings.Contains(res.Stdout(), "8082->80/tcp"), res.Stdout())
+	})
+
+	t.Run("compose run --service-ports", func(t *testing.T) {
+		c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/ports.yaml", "run", "--service-ports", "-d", "back",
+			"/bin/sh", "-c", "sleep 1")
+		res := c.RunDockerCmd(t, "ps")
+		assert.Assert(t, strings.Contains(res.Stdout(), "8082->80/tcp"), res.Stdout())
 	})
 
 	t.Run("compose run orphan", func(t *testing.T) {

--- a/pkg/e2e/fixtures/run-test/ports.yaml
+++ b/pkg/e2e/fixtures/run-test/ports.yaml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  back:
+    image: alpine
+    ports:
+      - 8082:80


### PR DESCRIPTION
**What I did**

1. Remove redundant `len(v) > 0` checks in `docker compose run` command.

   From the Go specification (https://go.dev/ref/spec#For_range):

   > "1. For a nil slice, the number of iterations is 0."

   `len` returns 0 if the slice is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` before a loop is unnecessary.

   Also it is unnecessary to initialise `target.Ports = []types.ServicePortConfig{}`. `append` works on nil slices (https://go.dev/tour/moretypes/15).

2. Update existing test case for `docker compose run --publish` and add a new test case for `docker compose run --service-ports` to verify the documented behaviour.

   https://github.com/docker/compose/blob/a345515f91c7bc6a7822fc8668cda65734584890/docs/reference/compose_run.md?plain=1#L52-L64


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://user-images.githubusercontent.com/20135478/218251101-20b5df0f-74cf-4cbe-8d76-c72896cb9d6a.png)