### PR TITLE
add support of COMPOSE_ENV_FILES env variable to pass a list of env files

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -60,6 +60,8 @@ const (
 	ComposeRemoveOrphans = "COMPOSE_REMOVE_ORPHANS"
 	// ComposeIgnoreOrphans ignore "orphaned" containers
 	ComposeIgnoreOrphans = "COMPOSE_IGNORE_ORPHANS"
+	// ComposeEnvFiles defines the env files to use if --env-file isn't used
+	ComposeEnvFiles = "COMPOSE_ENV_FILES"
 )
 
 // Command defines a compose CLI command as a func with args
@@ -517,6 +519,11 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command { //
 }
 
 func setEnvWithDotEnv(prjOpts *ProjectOptions) error {
+	if len(prjOpts.EnvFiles) == 0 {
+		if envFiles := os.Getenv(ComposeEnvFiles); envFiles != "" {
+			prjOpts.EnvFiles = strings.Split(envFiles, ",")
+		}
+	}
 	options, err := prjOpts.toProjectOptions()
 	if err != nil {
 		return compose.WrapComposeError(err)

--- a/pkg/e2e/compose_environment_test.go
+++ b/pkg/e2e/compose_environment_test.go
@@ -106,6 +106,20 @@ func TestEnvPriority(t *testing.T) {
 		assert.Equal(t, strings.TrimSpace(res.Stdout()), "EnvFileDefaultValue")
 	})
 
+	// No Compose file, all other options with env variable from OS environment
+	// 1. Command Line (docker compose run --env <KEY[=VAL]>)  <-- Result expected (From environment default value from file in COMPOSE_ENV_FILES)
+	// 2. Compose File (service::environment section)
+	// 3. Compose File (service::env_file section file)
+	// 4. Container Image ENV directive
+	// 5. Variable is not defined
+	t.Run("shell priority from COMPOSE_ENV_FILES variable", func(t *testing.T) {
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/environment/env-priority/compose.yaml",
+			"run", "--rm", "-e", "WHEREAMI", "env-compose-priority")
+		cmd.Env = append(cmd.Env, "COMPOSE_ENV_FILES=./fixtures/environment/env-priority/.env.override.with.default")
+		res := icmd.RunCmd(cmd)
+		assert.Equal(t, strings.TrimSpace(res.Stdout()), "EnvFileDefaultValue")
+	})
+
 	// No Compose file and env variable pass to the run command
 	// 1. Command Line (docker compose run --env <KEY[=VAL]>)  <-- Result expected
 	// 2. Compose File (service::environment section)


### PR DESCRIPTION
**What I did**
Add a new `COMPOSE_ENV_FILES` to allow users to define once the env files they want to associate to their Compose configuration
This PR will need a follow up PR in the doc repo to add the new env var cc @aevesdocker  

**Related issue**
Internal discussion with Docker Captains

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/e8fa32e0-8597-4367-a163-27841cc0f145)
