### PR TITLE
Fix for "Application failed to start after update" when an external network is on a watched service

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1130,9 +1130,9 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 	}
 
 	if len(networks) == 0 {
-		networks, err = s.apiClient().NetworkList(ctx, moby.NetworkListOptions{
-			Filters: filters.NewArgs(filters.Arg("id", n.Name)),
-		})
+		// in this instance, n.Name is really an ID
+		network, err := s.apiClient().NetworkInspect(ctx, n.Name, moby.NetworkInspectOptions{})
+		networks = append(networks, network)
 		if err != nil {
 			return err
 		}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1131,11 +1131,12 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 
 	if len(networks) == 0 {
 		// in this instance, n.Name is really an ID
-		network, err := s.apiClient().NetworkInspect(ctx, n.Name, moby.NetworkInspectOptions{})
-		networks = append(networks, network)
+		sn, err := s.apiClient().NetworkInspect(ctx, n.Name, moby.NetworkInspectOptions{})
 		if err != nil {
 			return err
 		}
+		networks = append(networks, sn)
+
 	}
 
 	// NetworkList API doesn't return the exact name match, so we can retrieve more than one network with a request

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -438,7 +438,7 @@ func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Pr
 				},
 			})
 			if err != nil {
-				fmt.Fprintf(s.stderr(), "Application failed to start after update\n")
+				fmt.Fprintf(s.stderr(), "Application failed to start after update. Error: %v\n", err)
 			}
 			return nil
 		}

--- a/pkg/e2e/fixtures/watch/with-external-network.yaml
+++ b/pkg/e2e/fixtures/watch/with-external-network.yaml
@@ -1,0 +1,19 @@
+
+services:
+  ext-alpine:
+    build:
+      dockerfile_inline: |-
+        FROM alpine
+    init: true
+    command: sleep infinity
+    develop: 
+      watch:
+        - action: rebuild
+          path: .env
+    networks:
+      - external_network_test
+
+networks:
+  external_network_test:
+    name: e2e-watch-external_network_test
+    external: true

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -80,8 +80,9 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 	assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 
 	t.Log("create a dotenv file that will be used to trigger the rebuild")
-	os.WriteFile(dotEnvFilepath, []byte("HELLO=WORLD"), 0666)
-	_, err := os.ReadFile(dotEnvFilepath)
+	err := os.WriteFile(dotEnvFilepath, []byte("HELLO=WORLD"), 0o666)
+	assert.NilError(t, err)
+	_, err = os.ReadFile(dotEnvFilepath)
 	assert.NilError(t, err)
 
 	// TODO: refactor this duplicated code into frameworks? Maybe?
@@ -114,7 +115,8 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 	assert.Equal(t, pn.Stdout(), n.Stdout())
 
 	t.Log("create a dotenv file that will be used to trigger the rebuild")
-	os.WriteFile(dotEnvFilepath, []byte("HELLO=WORLD\nTEST=REBUILD"), 0666)
+	err = os.WriteFile(dotEnvFilepath, []byte("HELLO=WORLD\nTEST=REBUILD"), 0o666)
+	assert.NilError(t, err)
 	_, err = os.ReadFile(dotEnvFilepath)
 	assert.NilError(t, err)
 


### PR DESCRIPTION
**What I did**

I'll keep editing this part with progress. WIP

At present:
- e2e test that shows bug reported in issue
- fix for bug :partying_face: 
- rebased commits so I could amend a signoff on work done

Remaining:
- duplicate code in e2e test should be refactored.
- anything that gets flagged by automated tests below

**Related issue**
Fixes: https://github.com/docker/compose/issues/11081

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
https://giphy.com/gifs/justviralnet-funny-dog-corgi-ZFFVNwIbjsKtP3lHYK 
