### PR TITLE
enable profile when down is ran with explicit service names

### DIFF
--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -78,7 +78,7 @@ func downCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) 
 }
 
 func runDown(ctx context.Context, dockerCli command.Cli, backend api.Service, opts downOptions, services []string) error {
-	project, name, err := opts.projectOrName(dockerCli)
+	project, name, err := opts.projectOrName(dockerCli, services...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What I did**
enable services explicitly selected by user running `down` command

**Related issue**
closes https://github.com/docker/compose/issues/11091

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
