### PR TITLE
check that the pull policy provided is a valid one

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -138,6 +139,9 @@ func (opts createOptions) GetTimeout() *time.Duration {
 
 func (opts createOptions) Apply(project *types.Project) error {
 	if opts.pullChanged {
+		if !opts.isPullPolicyValid() {
+			return fmt.Errorf("invalid --pull option %q", opts.Pull)
+		}
 		for i, service := range project.Services {
 			service.PullPolicy = opts.Pull
 			project.Services[i] = service
@@ -186,4 +190,10 @@ func (opts createOptions) Apply(project *types.Project) error {
 		}
 	}
 	return nil
+}
+
+func (opts createOptions) isPullPolicyValid() bool {
+	pullPolicies := []string{types.PullPolicyAlways, types.PullPolicyNever, types.PullPolicyBuild,
+		types.PullPolicyMissing, types.PullPolicyIfNotPresent}
+	return slices.Contains(pullPolicies, opts.Pull)
 }


### PR DESCRIPTION
or is not missing when --pull is used

**What I did**
Check the value passed or captured by Cobra for `--pull` flag is valid or not missing

**Related issue**
fixes #11104

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/e1af6979-2485-4bc4-ba20-e8a291b17dd0)
