### PR TITLE
fail start if depependency is missing

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -306,7 +306,7 @@ func containerReasonEvents(containers Containers, eventFunc func(string, string)
 const ServiceConditionRunningOrHealthy = "running_or_healthy"
 
 //nolint:gocyclo
-func (s *composeService) waitDependencies(ctx context.Context, project *types.Project, dependencies types.DependsOnConfig, containers Containers) error {
+func (s *composeService) waitDependencies(ctx context.Context, project *types.Project, dependant string, dependencies types.DependsOnConfig, containers Containers) error {
 	eg, _ := errgroup.WithContext(ctx)
 	w := progress.ContextWriter(ctx)
 	for dep, config := range dependencies {
@@ -318,6 +318,13 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 
 		waitingFor := containers.filter(isService(dep))
 		w.Events(containerEvents(waitingFor, progress.Waiting))
+		if len(waitingFor) == 0 {
+			if config.Required {
+				return fmt.Errorf("%s is missing dependency %s", dependant, dep)
+			}
+			logrus.Warnf("%s is missing dependency %s", dependant, dep)
+			continue
+		}
 
 		dep, config := dep, config
 		eg.Go(func() error {
@@ -717,7 +724,7 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 		return nil
 	}
 
-	err := s.waitDependencies(ctx, project, service.DependsOn, containers)
+	err := s.waitDependencies(ctx, project, service.Name, service.DependsOn, containers)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -229,7 +229,7 @@ func TestWaitDependencies(t *testing.T) {
 			"db":    {Condition: ServiceConditionRunningOrHealthy},
 			"redis": {Condition: ServiceConditionRunningOrHealthy},
 		}
-		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies, nil))
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, "", dependencies, nil))
 	})
 	t.Run("should skip dependencies with condition service_started", func(t *testing.T) {
 		dbService := types.ServiceConfig{Name: "db", Scale: 1}
@@ -239,6 +239,6 @@ func TestWaitDependencies(t *testing.T) {
 			"db":    {Condition: types.ServiceConditionStarted, Required: true},
 			"redis": {Condition: types.ServiceConditionStarted, Required: true},
 		}
-		assert.NilError(t, tested.waitDependencies(context.Background(), &project, dependencies, nil))
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, "", dependencies, nil))
 	})
 }

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -96,7 +96,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	updateServices(&service, observedState)
 
 	if !opts.NoDeps {
-		if err := s.waitDependencies(ctx, project, service.DependsOn, observedState); err != nil {
+		if err := s.waitDependencies(ctx, project, service.Name, service.DependsOn, observedState); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -117,7 +117,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 			defer cancel()
 		}
 
-		err = s.waitDependencies(ctx, project, depends, containers)
+		err = s.waitDependencies(ctx, project, project.Name, depends, containers)
 		if err != nil {
 			if ctx.Err() == context.DeadlineExceeded {
 				return fmt.Errorf("application not healthy after %s", options.WaitTimeout)


### PR DESCRIPTION
**What I did**
as we wait for dependencies, if no container is found fail or warn user. This should never happen using `up` as convergence created the dependencies in order.

**Related issue**
closes https://github.com/docker/compose/issues/11107

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
