### PR TITLE
fix support for 2nd Ctrl+C to kill containers

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -122,8 +122,6 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		return err
 	}
 
-	// signal for the goroutines to stop & wait for them to finish any remaining work
-	signalCancel()
 	printer.Stop()
 	err = eg.Wait().ErrorOrNil()
 	if exitCode != 0 {


### PR DESCRIPTION
**What I did**
Don't close signal channel before we return from `up` func otherwise we don't manage second Ctrl+C and don't kill container which didn't reacted to graceful stop signal.

**Related issue**
closes https://github.com/docker/compose/issues/11123

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
