### PR TITLE
re-implement cache folder detection

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -256,15 +256,8 @@ func (o *ProjectOptions) ToProject(dockerCli command.Cli, services []string, po 
 }
 
 func (o *ProjectOptions) configureRemoteLoaders(dockerCli command.Cli, po []cli.ProjectOptionsFn) ([]cli.ProjectOptionsFn, error) {
-	git, err := remote.NewGitRemoteLoader(o.Offline)
-	if err != nil {
-		return nil, err
-	}
-
-	oci, err := remote.NewOCIRemoteLoader(dockerCli, o.Offline)
-	if err != nil {
-		return nil, err
-	}
+	git := remote.NewGitRemoteLoader(o.Offline)
+	oci := remote.NewOCIRemoteLoader(dockerCli, o.Offline)
 
 	po = append(po, cli.WithResourceLoader(git), cli.WithResourceLoader(oci))
 	return po, nil

--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -204,11 +204,7 @@ func (o *ProjectOptions) toProjectName(dockerCli command.Cli) (string, error) {
 
 func (o *ProjectOptions) ToProject(dockerCli command.Cli, services []string, po ...cli.ProjectOptionsFn) (*types.Project, error) {
 	if !o.Offline {
-		var err error
-		po, err = o.configureRemoteLoaders(dockerCli, po)
-		if err != nil {
-			return nil, err
-		}
+		po = o.configureRemoteLoaders(dockerCli, po)
 	}
 
 	options, err := o.toProjectOptions(po...)
@@ -255,12 +251,12 @@ func (o *ProjectOptions) ToProject(dockerCli command.Cli, services []string, po 
 	return project, err
 }
 
-func (o *ProjectOptions) configureRemoteLoaders(dockerCli command.Cli, po []cli.ProjectOptionsFn) ([]cli.ProjectOptionsFn, error) {
+func (o *ProjectOptions) configureRemoteLoaders(dockerCli command.Cli, po []cli.ProjectOptionsFn) []cli.ProjectOptionsFn {
 	git := remote.NewGitRemoteLoader(o.Offline)
 	oci := remote.NewOCIRemoteLoader(dockerCli, o.Offline)
 
 	po = append(po, cli.WithResourceLoader(git), cli.WithResourceLoader(oci))
-	return po, nil
+	return po
 }
 
 func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/sync v0.4.0
+	golang.org/x/sys v0.11.0
 	google.golang.org/grpc v1.59.0
 	gotest.tools/v3 v3.5.1
 )
@@ -154,7 +155,6 @@ require (
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/term v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Microsoft/go-winio v0.6.1
-	github.com/adrg/xdg v0.4.0
 	github.com/buger/goterm v1.0.4
 	github.com/compose-spec/compose-go v1.20.0
 	github.com/containerd/console v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/Shopify/logrus-bugsnag v0.0.0-20170309145241-6dbc35f2c30d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
-github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
-github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=

--- a/internal/locker/runtime.go
+++ b/internal/locker/runtime.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 Docker Compose CLI authors
+   Copyright 2020 Docker Compose CLI authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,26 +17,19 @@
 package locker
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
-
-	"github.com/docker/docker/pkg/pidfile"
 )
 
-type Pidfile struct {
-	path string
-}
-
-func NewPidfile(projectName string) (*Pidfile, error) {
-	run, err := runDir()
-	if err != nil {
-		return nil, err
+func runDir() (string, error) {
+	run, ok := os.LookupEnv("XDG_RUNTIME_DIR")
+	if ok {
+		return run, nil
 	}
-	path := filepath.Join(run, fmt.Sprintf("%s.pid", projectName))
-	return &Pidfile{path: path}, nil
-}
 
-func (f *Pidfile) Lock() error {
-	return pidfile.Write(f.path, os.Getpid())
+	path, err := osDependentRunDir()
+	if err != nil {
+		return "", err
+	}
+	err = os.MkdirAll(path, 0o700)
+	return path, err
 }

--- a/internal/locker/runtime_darwin.go
+++ b/internal/locker/runtime_darwin.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 Docker Compose CLI authors
+   Copyright 2020 Docker Compose CLI authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,26 +17,14 @@
 package locker
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/docker/docker/pkg/pidfile"
 )
 
-type Pidfile struct {
-	path string
-}
-
-func NewPidfile(projectName string) (*Pidfile, error) {
-	run, err := runDir()
+func osDependentRunDir() (string, error) {
+	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	path := filepath.Join(run, fmt.Sprintf("%s.pid", projectName))
-	return &Pidfile{path: path}, nil
-}
-
-func (f *Pidfile) Lock() error {
-	return pidfile.Write(f.path, os.Getpid())
+	return filepath.Join(home, "Library", "Application Support", "com.docker.compose"), nil
 }

--- a/internal/locker/runtime_darwin.go
+++ b/internal/locker/runtime_darwin.go
@@ -21,6 +21,10 @@ import (
 	"path/filepath"
 )
 
+// Based on https://github.com/adrg/xdg
+// Licensed under MIT License (MIT)
+// Copyright (c) 2014 Adrian-George Bostan <adrg@epistack.com>
+
 func osDependentRunDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/locker/runtime_unix.go
+++ b/internal/locker/runtime_unix.go
@@ -24,10 +24,14 @@ import (
 	"strconv"
 )
 
+// Based on https://github.com/adrg/xdg
+// Licensed under MIT License (MIT)
+// Copyright (c) 2014 Adrian-George Bostan <adrg@epistack.com>
+
 func osDependentRunDir() (string, error) {
 	run := filepath.Join("run", "user", strconv.Itoa(os.Getuid()))
 	if _, err := os.Stat(run); err == nil {
-		return run
+		return run, nil
 	}
 
 	// /run/user/$uid is set by pam_systemd, but might not be present, especially in containerized environments

--- a/internal/locker/runtime_windows.go
+++ b/internal/locker/runtime_windows.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 Docker Compose CLI authors
+   Copyright 2020 Docker Compose CLI authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,26 +17,29 @@
 package locker
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/pkg/pidfile"
+	"golang.org/x/sys/windows"
 )
 
-type Pidfile struct {
-	path string
-}
-
-func NewPidfile(projectName string) (*Pidfile, error) {
-	run, err := runDir()
-	if err != nil {
-		return nil, err
+func osDependentRunDir() (string, error) {
+	flags := []uint32{windows.KF_FLAG_DEFAULT, windows.KF_FLAG_DEFAULT_PATH}
+	for _, flag := range flags {
+		p, _ := windows.KnownFolderPath(windows.FOLDERID_LocalAppData, flag|windows.KF_FLAG_DONT_VERIFY)
+		if p != "" {
+			return filepath.Join(p, "docker-compose"), nil
+		}
 	}
-	path := filepath.Join(run, fmt.Sprintf("%s.pid", projectName))
-	return &Pidfile{path: path}, nil
-}
 
-func (f *Pidfile) Lock() error {
-	return pidfile.Write(f.path, os.Getpid())
+	appData, ok := os.LookupEnv("LOCALAPPDATA")
+	if ok {
+		return filepath.Join(appData, "docker-compose"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "AppData", "Local", "docker-compose"), nil
 }

--- a/internal/locker/runtime_windows.go
+++ b/internal/locker/runtime_windows.go
@@ -23,6 +23,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Based on https://github.com/adrg/xdg
+// Licensed under MIT License (MIT)
+// Copyright (c) 2014 Adrian-George Bostan <adrg@epistack.com>
+
 func osDependentRunDir() (string, error) {
 	flags := []uint32{windows.KF_FLAG_DEFAULT, windows.KF_FLAG_DEFAULT_PATH}
 	for _, flag := range flags {

--- a/pkg/remote/cache.go
+++ b/pkg/remote/cache.go
@@ -1,0 +1,36 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package remote
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func cacheDir() (string, error) {
+	cache, ok := os.LookupEnv("XDG_CACHE_HOME")
+	if ok {
+		return filepath.Join(cache, "docker-compose"), nil
+	}
+
+	path, err := osDependentCacheDir()
+	if err != nil {
+		return "", err
+	}
+	err = os.MkdirAll(path, 0o700)
+	return path, err
+}

--- a/pkg/remote/cache_darwin.go
+++ b/pkg/remote/cache_darwin.go
@@ -1,0 +1,30 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package remote
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func osDependentCacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "Caches", "docker-compose"), nil
+}

--- a/pkg/remote/cache_darwin.go
+++ b/pkg/remote/cache_darwin.go
@@ -21,6 +21,10 @@ import (
 	"path/filepath"
 )
 
+// Based on https://github.com/adrg/xdg
+// Licensed under MIT License (MIT)
+// Copyright (c) 2014 Adrian-George Bostan <adrg@epistack.com>
+
 func osDependentCacheDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/pkg/remote/cache_unix.go
+++ b/pkg/remote/cache_unix.go
@@ -23,6 +23,10 @@ import (
 	"path/filepath"
 )
 
+// Based on https://github.com/adrg/xdg
+// Licensed under MIT License (MIT)
+// Copyright (c) 2014 Adrian-George Bostan <adrg@epistack.com>
+
 func osDependentCacheDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/pkg/remote/cache_unix.go
+++ b/pkg/remote/cache_unix.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package remote
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func osDependentCacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache", "docker-compose"), nil
+}

--- a/pkg/remote/cache_windows.go
+++ b/pkg/remote/cache_windows.go
@@ -23,6 +23,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Based on https://github.com/adrg/xdg
+// Licensed under MIT License (MIT)
+// Copyright (c) 2014 Adrian-George Bostan <adrg@epistack.com>
+
 func osDependentCacheDir() (string, error) {
 	flags := []uint32{windows.KF_FLAG_DEFAULT, windows.KF_FLAG_DEFAULT_PATH}
 	for _, flag := range flags {

--- a/pkg/remote/cache_windows.go
+++ b/pkg/remote/cache_windows.go
@@ -1,0 +1,45 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package remote
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func osDependentCacheDir() (string, error) {
+	flags := []uint32{windows.KF_FLAG_DEFAULT, windows.KF_FLAG_DEFAULT_PATH}
+	for _, flag := range flags {
+		p, _ := windows.KnownFolderPath(windows.FOLDERID_LocalAppData, flag|windows.KF_FLAG_DONT_VERIFY)
+		if p != "" {
+			return filepath.Join(p, "cache", "docker-compose"), nil
+		}
+	}
+
+	appData, ok := os.LookupEnv("LOCALAPPDATA")
+	if ok {
+		return filepath.Join(appData, "cache", "docker-compose"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "AppData", "Local", "cache", "docker-compose"), nil
+}

--- a/pkg/remote/git.go
+++ b/pkg/remote/git.go
@@ -25,7 +25,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/adrg/xdg"
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
@@ -47,15 +46,10 @@ func gitRemoteLoaderEnabled() (bool, error) {
 }
 
 func NewGitRemoteLoader(offline bool) (loader.ResourceLoader, error) {
-	// xdg.CacheFile creates the parent directories for the target file path
-	// and returns the fully qualified path, so use "git" as a filename and
-	// then chop it off after, i.e. no ~/.cache/docker-compose/git file will
-	// ever be created
-	cache, err := xdg.CacheFile(filepath.Join("docker-compose", "git"))
+	cache, err := cacheDir()
 	if err != nil {
-		return nil, fmt.Errorf("initializing git cache: %w", err)
+		return nil, fmt.Errorf("initializing remote resource cache: %w", err)
 	}
-	cache = filepath.Dir(cache)
 	return gitRemoteLoader{
 		cache:   cache,
 		offline: offline,

--- a/pkg/remote/git.go
+++ b/pkg/remote/git.go
@@ -45,19 +45,13 @@ func gitRemoteLoaderEnabled() (bool, error) {
 	return false, nil
 }
 
-func NewGitRemoteLoader(offline bool) (loader.ResourceLoader, error) {
-	cache, err := cacheDir()
-	if err != nil {
-		return nil, fmt.Errorf("initializing remote resource cache: %w", err)
-	}
+func NewGitRemoteLoader(offline bool) loader.ResourceLoader {
 	return gitRemoteLoader{
-		cache:   cache,
 		offline: offline,
-	}, err
+	}
 }
 
 type gitRemoteLoader struct {
-	cache   string
 	offline bool
 }
 
@@ -106,7 +100,12 @@ func (g gitRemoteLoader) Load(ctx context.Context, path string) (string, error) 
 		ref.Commit = sha
 	}
 
-	local := filepath.Join(g.cache, ref.Commit)
+	cache, err := cacheDir()
+	if err != nil {
+		return "", fmt.Errorf("initializing remote resource cache: %w", err)
+	}
+
+	local := filepath.Join(cache, ref.Commit)
 	if _, err := os.Stat(local); os.IsNotExist(err) {
 		if g.offline {
 			return "", nil

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/adrg/xdg"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/distribution/reference"
 	"github.com/docker/buildx/store/storeutil"
@@ -48,15 +47,11 @@ func ociRemoteLoaderEnabled() (bool, error) {
 }
 
 func NewOCIRemoteLoader(dockerCli command.Cli, offline bool) (loader.ResourceLoader, error) {
-	// xdg.CacheFile creates the parent directories for the target file path
-	// and returns the fully qualified path, so use "git" as a filename and
-	// then chop it off after, i.e. no ~/.cache/docker-compose/git file will
-	// ever be created
-	cache, err := xdg.CacheFile(filepath.Join("docker-compose", "oci"))
+	cache, err := cacheDir()
 	if err != nil {
-		return nil, fmt.Errorf("initializing git cache: %w", err)
+		return nil, fmt.Errorf("initializing remote resource cache: %w", err)
 	}
-	cache = filepath.Dir(cache)
+
 	return ociRemoteLoader{
 		cache:     cache,
 		dockerCli: dockerCli,

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -46,21 +46,14 @@ func ociRemoteLoaderEnabled() (bool, error) {
 	return false, nil
 }
 
-func NewOCIRemoteLoader(dockerCli command.Cli, offline bool) (loader.ResourceLoader, error) {
-	cache, err := cacheDir()
-	if err != nil {
-		return nil, fmt.Errorf("initializing remote resource cache: %w", err)
-	}
-
+func NewOCIRemoteLoader(dockerCli command.Cli, offline bool) loader.ResourceLoader {
 	return ociRemoteLoader{
-		cache:     cache,
 		dockerCli: dockerCli,
 		offline:   offline,
-	}, err
+	}
 }
 
 type ociRemoteLoader struct {
-	cache     string
 	dockerCli command.Cli
 	offline   bool
 }
@@ -100,7 +93,12 @@ func (g ociRemoteLoader) Load(ctx context.Context, path string) (string, error) 
 		return "", err
 	}
 
-	local := filepath.Join(g.cache, descriptor.Digest.Hex())
+	cache, err := cacheDir()
+	if err != nil {
+		return "", fmt.Errorf("initializing remote resource cache: %w", err)
+	}
+
+	local := filepath.Join(cache, descriptor.Digest.Hex())
 	composeFile := filepath.Join(local, "compose.yaml")
 	if _, err = os.Stat(local); os.IsNotExist(err) {
 		var manifest v1.Manifest


### PR DESCRIPTION
**What I did**
replace `xdg.CacheFile` with our own implementation (basically, a copy/paste) so that we detect `HOME` is not set and don't assume we can use `/` as a replacement. Unclear to me if this is legitimate from a Posix point of view, but we should offer users a better error message for diagnostic than "can't write /.cache/docker-compose"

**Related issue**
closes https://github.com/docker/compose/issues/11126
closes https://github.com/docker/compose/issues/11137

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
