### PR TITLE
introduce --resolve-image-digests for publish to seal service images

### DIFF
--- a/cmd/compose/publish.go
+++ b/cmd/compose/publish.go
@@ -25,11 +25,16 @@ import (
 	"github.com/docker/compose/v2/pkg/api"
 )
 
+type publishOptions struct {
+	*ProjectOptions
+	resolveImageDigests bool
+}
+
 func publishCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
-	opts := pushOptions{
+	opts := publishOptions{
 		ProjectOptions: p,
 	}
-	publishCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "publish [OPTIONS] [REPOSITORY]",
 		Short: "Publish compose application",
 		RunE: Adapt(func(ctx context.Context, args []string) error {
@@ -37,14 +42,18 @@ func publishCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Servic
 		}),
 		Args: cobra.ExactArgs(1),
 	}
-	return publishCmd
+	flags := cmd.Flags()
+	flags.BoolVar(&opts.resolveImageDigests, "resolve-image-digests", false, "Pin image tags to digests.")
+	return cmd
 }
 
-func runPublish(ctx context.Context, dockerCli command.Cli, backend api.Service, opts pushOptions, repository string) error {
+func runPublish(ctx context.Context, dockerCli command.Cli, backend api.Service, opts publishOptions, repository string) error {
 	project, err := opts.ToProject(dockerCli, nil)
 	if err != nil {
 		return err
 	}
 
-	return backend.Publish(ctx, project, repository, api.PublishOptions{})
+	return backend.Publish(ctx, project, repository, api.PublishOptions{
+		ResolveImageDigests: opts.resolveImageDigests,
+	})
 }

--- a/docs/reference/compose_alpha_publish.md
+++ b/docs/reference/compose_alpha_publish.md
@@ -5,9 +5,10 @@ Publish compose application
 
 ### Options
 
-| Name        | Type | Default | Description                     |
-|:------------|:-----|:--------|:--------------------------------|
-| `--dry-run` |      |         | Execute command in dry run mode |
+| Name                      | Type | Default | Description                     |
+|:--------------------------|:-----|:--------|:--------------------------------|
+| `--dry-run`               |      |         | Execute command in dry run mode |
+| `--resolve-image-digests` |      |         | Pin image tags to digests.      |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_alpha_publish.yaml
+++ b/docs/reference/docker_compose_alpha_publish.yaml
@@ -4,6 +4,17 @@ long: Publish compose application
 usage: docker compose alpha publish [OPTIONS] [REPOSITORY]
 pname: docker compose alpha
 plink: docker_compose_alpha.yaml
+options:
+    - option: resolve-image-digests
+      value_type: bool
+      default_value: "false"
+      description: Pin image tags to digests.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -363,6 +363,7 @@ type PortOptions struct {
 
 // PublishOptions group options of the Publish API
 type PublishOptions struct {
+	ResolveImageDigests bool
 }
 
 func (e Event) String() string {


### PR DESCRIPTION
**What I did**
introduce `--resolve-image-digests` so user can seal service images by digest when publishing a compose application, comparable to docker/app

**Related issue**
see https://github.com/docker/compose/issues/11119

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
