### PR TITLE
Fix --hash regression

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -190,6 +190,10 @@ func runHash(ctx context.Context, dockerCli command.Cli, opts configOptions) err
 		return err
 	}
 
+	if len(services) == 0 {
+		services = project.ServiceNames()
+	}
+
 	sorted := services
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i] < sorted[j]


### PR DESCRIPTION
**What I did**
When I previously changed the hashing behavior in #11010, I neglected to consider the case where someone provides `--hash=*` to `docker configure`. My code assumed that a service name would always be passed in explicitly. This change uses all project service names in the absence of any provided name .

**Related issue**
Fixes #11145, thanks for pointing this out!

