### PR TITLE
improve watch configuration logging

### DIFF
--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -106,7 +106,7 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 		out := r.String()
 		errors := r.String()
 		return strings.Contains(out,
-				"watching"), fmt.Sprintf("'watching' not found in : \n%s\nStderr: \n%s\n", out,
+				"Watch configuration"), fmt.Sprintf("'Watch configuration' not found in : \n%s\nStderr: \n%s\n", out,
 				errors)
 	}, 30*time.Second, 1*time.Second)
 


### PR DESCRIPTION
Add action associated to each managed path

**What I did**
Improve the configuration output of watch mode to display for each service which action is associated to each managed path

Previous output:
```
> docker compose watch
[+] Building 0.0s (0/0)                                                                                                                                                                                                  docker:desktop-linux
[+] Running 3/0
 ✔ Container avatars-api-1    Running                                                                                                                                                                                                    0.0s
 ✔ Container avatars-web-1    Running                                                                                                                                                                                                    0.0s
 ✔ Container avatars-proxy-1  Running                                                                                                                                                                                                    0.0s
watching [/Users/glours/sources/avatars/proxy/nginx.conf]
watching [/Users/glours/sources/avatars/api/requirements.txt /Users/glours/sources/avatars/api]
watching [/Users/glours/sources/avatars/web/package.json /Users/glours/sources/avatars/web/yarn.lock /Users/glours/sources/avatars/web]
```

New one:
```
docker compose watch
[+] Building 0.0s (0/0)                                                                                                                                                                                                  docker:desktop-linux
[+] Running 3/3
 ✔ Container avatars-web-1    Running                                                                                                                                                                                                    0.0s
 ✔ Container avatars-api-1    Running                                                                                                                                                                                                    0.0s
 ✔ Container avatars-proxy-1  Running                                                                                                                                                                                                    0.0s
Watch configuration for service "api":
  - Action rebuild for path "/Users/glours/sources/avatars/api/requirements.txt"
  - Action rebuild for path "/Users/glours/sources/avatars/api"
Watch configuration for service "web":
  - Action rebuild for path "/Users/glours/sources/avatars/web/package.json"
  - Action rebuild for path "/Users/glours/sources/avatars/web/yarn.lock"
  - Action sync for path "/Users/glours/sources/avatars/web"
Watch configuration for service "proxy":
  - Action sync+restart for path "/Users/glours/sources/avatars/proxy/nginx.conf"
```


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/4cb558bf-04fa-4b16-a621-2c64de42cbe9)
