### PR TITLE
bump golang to version 1.21.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.21.1
+ARG GO_VERSION=1.21.4
 ARG XX_VERSION=1.2.1
 ARG GOLANGCI_LINT_VERSION=v1.54.2
 ARG ADDLICENSE_VERSION=v1.0.0


### PR DESCRIPTION
**What I did**
Bump Golang to `v1.21.4`
>go1.21.4 (released 2023-11-07) includes security fixes to the path/filepath package, as well as bug fixes to the linker, the runtime, the compiler, and the go/types, net/http, and runtime/cgo packages. See the [Go 1.21.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.4+label%3ACherryPickApproved) on our issue tracker for details.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
