### PR TITLE
reject compose file using `secrets|configs.driver or template_driver`

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -804,6 +805,13 @@ func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount
 			return nil, fmt.Errorf("unsupported external config %s", definedConfig.Name)
 		}
 
+		if definedConfig.Driver != "" {
+			return nil, errors.New("Docker Compose does not support configs.*.driver")
+		}
+		if definedConfig.TemplateDriver != "" {
+			return nil, errors.New("Docker Compose does not support configs.*.template_driver")
+		}
+
 		bindMount, err := buildMount(p, types.ServiceVolumeConfig{
 			Type:     types.VolumeTypeBind,
 			Source:   definedConfig.File,
@@ -841,6 +849,13 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 		definedSecret := p.Secrets[secret.Source]
 		if definedSecret.External.External {
 			return nil, fmt.Errorf("unsupported external secret %s", definedSecret.Name)
+		}
+
+		if definedSecret.Driver != "" {
+			return nil, errors.New("Docker Compose does not support secrets.*.driver")
+		}
+		if definedSecret.TemplateDriver != "" {
+			return nil, errors.New("Docker Compose does not support secrets.*.template_driver")
 		}
 
 		if definedSecret.Environment != "" {


### PR DESCRIPTION
**What I did**
reject compose file using `secrets|configs.driver or template_driver`
those are implemented by docker swarm configs/secrets engine-drivers, which have no equivalent component in Docker Compose, and we have no "extensibility" mechanism that would allow to run such a "driver" client-side (assuming we want to)

**Related issue**
see https://github.com/docker/compose/issues/11179