### PR TITLE
bump compose-go to v1.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go v1.20.0
+	github.com/compose-spec/compose-go v1.20.1
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.7
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go v1.20.0 h1:h4ZKOst1EF/DwZp7dWkb+wbTVE4nEyT9Lc89to84Ol4=
-github.com/compose-spec/compose-go v1.20.0/go.mod h1:+MdqXV4RA7wdFsahh/Kb8U0pAJqkg7mr4PM9tFKU8RM=
+github.com/compose-spec/compose-go v1.20.1 h1:I6gCMGLl96kEf8XZwaozeTwnNfxA2eVsO46W+5ciTEg=
+github.com/compose-spec/compose-go v1.20.1/go.mod h1:+MdqXV4RA7wdFsahh/Kb8U0pAJqkg7mr4PM9tFKU8RM=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -623,6 +623,11 @@ func (s *composeService) createMobyContainer(ctx context.Context,
 	}
 
 	err = s.injectSecrets(ctx, project, service, created.ID)
+	if err != nil {
+		return created, err
+	}
+
+	err = s.injectConfigs(ctx, project, service, created.ID)
 	return created, err
 }
 

--- a/pkg/e2e/configs_test.go
+++ b/pkg/e2e/configs_test.go
@@ -1,0 +1,48 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/v3/icmd"
+)
+
+func TestConfigFromEnv(t *testing.T) {
+	c := NewParallelCLI(t)
+
+	t.Run("config from file", func(t *testing.T) {
+		res := icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/configs/compose.yaml", "run", "from_file"))
+		res.Assert(t, icmd.Expected{Out: "This is my config file"})
+	})
+
+	t.Run("config from env", func(t *testing.T) {
+		res := icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/configs/compose.yaml", "run", "from_env"),
+			func(cmd *icmd.Cmd) {
+				cmd.Env = append(cmd.Env, "CONFIG=config")
+			})
+		res.Assert(t, icmd.Expected{Out: "config"})
+	})
+
+	t.Run("config inlined", func(t *testing.T) {
+		res := icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/configs/compose.yaml", "run", "inlined"),
+			func(cmd *icmd.Cmd) {
+				cmd.Env = append(cmd.Env, "CONFIG=config")
+			})
+		res.Assert(t, icmd.Expected{Out: "This is my config"})
+	})
+}

--- a/pkg/e2e/fixtures/configs/compose.yaml
+++ b/pkg/e2e/fixtures/configs/compose.yaml
@@ -1,0 +1,29 @@
+services:
+  from_env:
+    image: alpine
+    configs:
+      - source: from_env
+        target: /from_env
+    command: cat /from_env
+
+  from_file:
+    image: alpine
+    configs:
+      - source: from_file
+        target: /from_file
+    command: cat /from_file
+
+  inlined:
+    image: alpine
+    configs:
+      - source: inlined
+        target: /inlined
+    command: cat /inlined
+
+configs:
+  from_env:
+    environment: CONFIG
+  from_file:
+    file: config.txt
+  inlined:
+    content: This is my $CONFIG

--- a/pkg/e2e/fixtures/configs/config.txt
+++ b/pkg/e2e/fixtures/configs/config.txt
@@ -1,0 +1,1 @@
+This is my config file


### PR DESCRIPTION
**What I did**
bump compose-go to v1.20.1
implemented support for build.ulimits
implemented support for config.content (inlined config)
