### PR TITLE
Strip project prefix from docker-compose up output

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -136,13 +136,14 @@ func getCanonicalContainerName(c moby.Container) string {
 }
 
 func getContainerNameWithoutProject(c moby.Container) string {
-	name := getCanonicalContainerName(c)
 	project := c.Labels[api.ProjectLabel]
-	prefix := fmt.Sprintf("%s_%s_", project, c.Labels[api.ServiceLabel])
-	if strings.HasPrefix(name, prefix) {
-		return name[len(project)+1:]
+	defaultName := getDefaultContainerName(project, c.Labels[api.ServiceLabel], c.Labels[api.ContainerNumberLabel])
+	name := getCanonicalContainerName(c)
+	if name != defaultName {
+		// service declares a custom container_name
+		return name
 	}
-	return name
+	return name[len(project)+1:]
 }
 
 func (s *composeService) Config(ctx context.Context, project *types.Project, options api.ConfigOptions) ([]byte, error) {

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -287,11 +287,15 @@ func mustRecreate(expected types.ServiceConfig, actual moby.Container, policy st
 }
 
 func getContainerName(projectName string, service types.ServiceConfig, number int) string {
-	name := strings.Join([]string{projectName, service.Name, strconv.Itoa(number)}, api.Separator)
+	name := getDefaultContainerName(projectName, service.Name, strconv.Itoa(number))
 	if service.ContainerName != "" {
 		name = service.ContainerName
 	}
 	return name
+}
+
+func getDefaultContainerName(projectName, serviceName, index string) string {
+	return strings.Join([]string{projectName, serviceName, index}, api.Separator)
 }
 
 func getContainerProgressName(container moby.Container) string {

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -333,7 +333,7 @@ func TestBuildPlatformsWithCorrectBuildxConfig(t *testing.T) {
 	t.Run("multi-arch up --build", func(t *testing.T) {
 		res := c.RunDockerComposeCmdNoCheck(t, "--project-directory", "fixtures/build-test/platforms", "up", "--build")
 		assert.NilError(t, res.Error, res.Stderr())
-		res.Assert(t, icmd.Expected{Out: "platforms-platforms-1 exited with code 0"})
+		res.Assert(t, icmd.Expected{Out: "platforms-1 exited with code 0"})
 	})
 
 	t.Run("use DOCKER_DEFAULT_PLATFORM value when up --build", func(t *testing.T) {

--- a/pkg/e2e/logs_test.go
+++ b/pkg/e2e/logs_test.go
@@ -17,7 +17,6 @@
 package e2e
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -75,18 +74,15 @@ func TestLocalComposeLogsFollow(t *testing.T) {
 		_ = res.Cmd.Process.Kill()
 	})
 
-	expected := fmt.Sprintf("%s-ping-1 ", projectName)
-	poll.WaitOn(t, expectOutput(res, expected), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(1*time.Second))
+	poll.WaitOn(t, expectOutput(res, "ping-1 "), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(1*time.Second))
 
 	c.RunDockerComposeCmd(t, "-f", "./fixtures/logs-test/compose.yaml", "--project-name", projectName, "up", "-d")
 
-	expected = fmt.Sprintf("%s-hello-1 ", projectName)
-	poll.WaitOn(t, expectOutput(res, expected), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(1*time.Second))
+	poll.WaitOn(t, expectOutput(res, "hello-1 "), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(1*time.Second))
 
 	c.RunDockerComposeCmd(t, "-f", "./fixtures/logs-test/compose.yaml", "--project-name", projectName, "up", "-d", "--scale", "ping=2", "ping")
 
-	expected = fmt.Sprintf("%s-ping-2 ", projectName)
-	poll.WaitOn(t, expectOutput(res, expected), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(20*time.Second))
+	poll.WaitOn(t, expectOutput(res, "ping-2 "), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(20*time.Second))
 }
 
 func expectOutput(res *icmd.Result, expected string) func(t poll.LogT) poll.Result {


### PR DESCRIPTION
**What I did**
fix `getContainerNameWithoutProject` to correctly remove project name prefix from container name 

**Related issue**
fixes https://github.com/docker/compose/issues/11188

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
