### PR TITLE
fix --remove-orphans not to consider disabled services as orphaned

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -83,7 +83,7 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 		return err
 	}
 
-	orphans := containers.filter(isNotService(project.ServiceNames()...))
+	orphans := containers.filter(isOrphaned(project))
 	if options.RemoveOrphans && len(orphans) > 0 {
 		err := s.removeContainers(ctx, w, orphans, options.Timeout, false)
 		if err != nil {


### PR DESCRIPTION
**What I did**
introduce `isOprhaned` predicate to filter container without a known service. Don't consider disabled service as "orphaned"
includes a test case to avoid such a regression in the future

**Related issue**
fixes https://github.com/docker/compose/issues/11203

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
