### PR TITLE
introduce RuntimeVersion for code to check container runtime support

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -295,5 +295,22 @@ func (s *composeService) isSWarmEnabled(ctx context.Context) (bool, error) {
 		}
 	})
 	return swarmEnabled.val, swarmEnabled.err
+}
+
+var runtimeVersion = struct {
+	once sync.Once
+	val  string
+	err  error
+}{}
+
+func (s *composeService) RuntimeVersion(ctx context.Context) (string, error) {
+	runtimeVersion.once.Do(func() {
+		version, err := s.dockerCli.Client().ServerVersion(ctx)
+		if err != nil {
+			runtimeVersion.err = err
+		}
+		runtimeVersion.val = version.APIVersion
+	})
+	return runtimeVersion.val, runtimeVersion.err
 
 }


### PR DESCRIPTION
**What I did**
introduce `RuntimeVersion` so compose components can check container runtime supports required API to apply compose.yaml config - better than expect engine to return an error

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
