### PR TITLE
Assume /src/pkg/compose/testdata absolute workingdir to make tests reproducible

### DIFF
--- a/pkg/compose/kill_test.go
+++ b/pkg/compose/kill_test.go
@@ -114,7 +114,7 @@ func testContainer(service string, id string, oneOff bool) moby.Container {
 }
 
 func containerLabels(service string, oneOff bool) map[string]string {
-	workingdir, _ := filepath.Abs("testdata")
+	workingdir := "/src/pkg/compose/testdata"
 	composefile := filepath.Join(workingdir, "compose.yaml")
 	labels := map[string]string{
 		compose.ServiceLabel:     service,


### PR DESCRIPTION
tests ran inside a container by CI actually have `/src` as root, but when ran on developer's workstation filepath.Abs resolves to a non-portable path, and this makes the assertion fail (https://github.com/docker/compose/blob/main/pkg/compose/ps_test.go#L61).

**What I did**
assume working dir is `/src` for tests to get a reproducible absolute path

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
