### PR TITLE
in watch mode force pull policy to build for services with both build and develop attributes

### DIFF
--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/compose-spec/compose-go/types"
+
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v2/internal/locker"
 	"github.com/docker/compose/v2/pkg/api"
@@ -85,6 +87,12 @@ func runWatch(ctx context.Context, dockerCli command.Cli, backend api.Service, w
 	}
 
 	if !watchOpts.noUp {
+		for index, service := range project.Services {
+			if service.Build != nil && service.Develop != nil {
+				service.PullPolicy = types.PullPolicyBuild
+			}
+			project.Services[index] = service
+		}
 		upOpts := api.UpOptions{
 			Create: api.CreateOptions{
 				Build:                &build,


### PR DESCRIPTION
This default behaviour will force a rebuild of the service images at watch process startup and be sure containers will be in sync with the local source code

**What I did**
For each service target by `watch` process (with a `develop` configuration) force the pull policy to build to be sure they will be rebuild at watch startup

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/ec2831b5-49a0-4129-b922-dc12c43ee619)
