### PR TITLE
Restore `Project` is ps json output

### DIFF
--- a/cmd/formatter/container.go
+++ b/cmd/formatter/container.go
@@ -33,6 +33,7 @@ const (
 	defaultContainerTableFormat = "table {{.Name}}\t{{.Image}}\t{{.Command}}\t{{.Service}}\t{{.RunningFor}}\t{{.Status}}\t{{.Ports}}"
 
 	nameHeader       = "NAME"
+	projectHeader    = "PROJECT"
 	serviceHeader    = "SERVICE"
 	commandHeader    = "COMMAND"
 	runningForHeader = "CREATED"
@@ -112,6 +113,7 @@ func NewContainerContext() *ContainerContext {
 	containerCtx.Header = formatter.SubHeaderContext{
 		"ID":         formatter.ContainerIDHeader,
 		"Name":       nameHeader,
+		"Project":    projectHeader,
 		"Service":    serviceHeader,
 		"Image":      formatter.ImageHeader,
 		"Command":    commandHeader,
@@ -162,6 +164,10 @@ func (c *ContainerContext) Names() string {
 
 func (c *ContainerContext) Service() string {
 	return c.c.Service
+}
+
+func (c *ContainerContext) Project() string {
+	return c.c.Project
 }
 
 func (c *ContainerContext) Image() string {

--- a/pkg/e2e/ps_test.go
+++ b/pkg/e2e/ps_test.go
@@ -64,6 +64,7 @@ func TestPs(t *testing.T) {
 			"--format", "json")
 		type element struct {
 			Name       string
+			Project    string
 			Publishers api.PortPublishers
 		}
 		var output []element
@@ -78,6 +79,7 @@ func TestPs(t *testing.T) {
 		count := 0
 		assert.Equal(t, 2, len(output))
 		for _, service := range output {
+			assert.Equal(t, projectName, service.Project)
 			publishers := service.Publishers
 			if service.Name == "e2e-ps-busybox-1" {
 				assert.Equal(t, 1, len(publishers))


### PR DESCRIPTION
**What I did**
Restore `Project` entry in `compose ps --format json` which disappeared after we aligned with docker/cli rendering

**Related issue**
closes https://github.com/docker/compose/issues/11222

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
