### PR TITLE
bump ddev to 1.22.4

### DIFF
--- a/pkg/e2e/ddev_test.go
+++ b/pkg/e2e/ddev_test.go
@@ -29,7 +29,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-const ddevVersion = "v1.19.1"
+const ddevVersion = "v1.21.1"
 
 func TestComposeRunDdev(t *testing.T) {
 	if !composeStandaloneMode {
@@ -73,7 +73,7 @@ func TestComposeRunDdev(t *testing.T) {
 	}
 
 	compressedFilename := fmt.Sprintf("ddev_%s-%s.%s.tar.gz", osName, runtime.GOARCH, ddevVersion)
-	c.RunCmdInDir(t, ddevDir, "curl", "-LO", fmt.Sprintf("https://github.com/drud/ddev/releases/download/%s/%s",
+	c.RunCmdInDir(t, ddevDir, "curl", "-LO", fmt.Sprintf("https://github.com/ddev/ddev/releases/download/%s/%s",
 		ddevVersion,
 		compressedFilename))
 


### PR DESCRIPTION
**What I did**
update ddev release used for integration testing
note: since https://github.com/ddev/ddev/pull/4142 a pre-released version will be rejected, so we can't use it for CI :
```
Your docker-compose version does not exist or is set to an invalid version. 
Please use the built-in docker-compose.
Fix with 'ddev config global --required-docker-compose-version="" --use-docker-compose-from-path=false': 2.23.3-6-g1c2048854.m is a prerelease version and the constraint is only looking for release versions
```