### PR TITLE
log we don't expose service ports when --verbose

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	xprogress "github.com/moby/buildkit/util/progress/progressui"
+	"github.com/sirupsen/logrus"
 
 	cgo "github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/loader"
@@ -83,6 +84,9 @@ func (options runOptions) apply(project *types.Project) error {
 
 	// --service-ports and --publish are incompatible
 	if !options.servicePorts {
+		if len(target.Ports) > 0 {
+			logrus.Debug("Running service without ports exposed as --service-ports=false")
+		}
 		target.Ports = []types.ServicePortConfig{}
 		for _, p := range options.publish {
 			config, err := types.ParsePortConfig(p)
@@ -181,7 +185,7 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *
 	flags.StringArrayVarP(&options.volumes, "volume", "v", []string{}, "Bind mount a volume.")
 	flags.StringArrayVarP(&options.publish, "publish", "p", []string{}, "Publish a container's port(s) to the host.")
 	flags.BoolVar(&options.useAliases, "use-aliases", false, "Use the service's network useAliases in the network(s) the container connects to.")
-	flags.BoolVar(&options.servicePorts, "service-ports", false, "Run command with the service's ports enabled and mapped to the host.")
+	flags.BoolVarP(&options.servicePorts, "service-ports", "P", false, "Run command with all service's ports enabled and mapped to the host.")
 	flags.BoolVar(&options.quietPull, "quiet-pull", false, "Pull without printing progress information.")
 	flags.BoolVar(&createOpts.Build, "build", false, "Build image before starting container.")
 	flags.BoolVar(&createOpts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -5,29 +5,29 @@ Run a one-off command on a service.
 
 ### Options
 
-| Name                  | Type          | Default | Description                                                                       |
-|:----------------------|:--------------|:--------|:----------------------------------------------------------------------------------|
-| `--build`             |               |         | Build image before starting container.                                            |
-| `--cap-add`           | `list`        |         | Add Linux capabilities                                                            |
-| `--cap-drop`          | `list`        |         | Drop Linux capabilities                                                           |
-| `-d`, `--detach`      |               |         | Run container in background and print container ID                                |
-| `--dry-run`           |               |         | Execute command in dry run mode                                                   |
-| `--entrypoint`        | `string`      |         | Override the entrypoint of the image                                              |
-| `-e`, `--env`         | `stringArray` |         | Set environment variables                                                         |
-| `-i`, `--interactive` |               |         | Keep STDIN open even if not attached.                                             |
-| `-l`, `--label`       | `stringArray` |         | Add or override a label                                                           |
-| `--name`              | `string`      |         | Assign a name to the container                                                    |
-| `-T`, `--no-TTY`      |               |         | Disable pseudo-TTY allocation (default: auto-detected).                           |
-| `--no-deps`           |               |         | Don't start linked services.                                                      |
-| `-p`, `--publish`     | `stringArray` |         | Publish a container's port(s) to the host.                                        |
-| `--quiet-pull`        |               |         | Pull without printing progress information.                                       |
-| `--remove-orphans`    |               |         | Remove containers for services not defined in the Compose file.                   |
-| `--rm`                |               |         | Automatically remove the container when it exits                                  |
-| `--service-ports`     |               |         | Run command with the service's ports enabled and mapped to the host.              |
-| `--use-aliases`       |               |         | Use the service's network useAliases in the network(s) the container connects to. |
-| `-u`, `--user`        | `string`      |         | Run as specified username or uid                                                  |
-| `-v`, `--volume`      | `stringArray` |         | Bind mount a volume.                                                              |
-| `-w`, `--workdir`     | `string`      |         | Working directory inside the container                                            |
+| Name                    | Type          | Default | Description                                                                       |
+|:------------------------|:--------------|:--------|:----------------------------------------------------------------------------------|
+| `--build`               |               |         | Build image before starting container.                                            |
+| `--cap-add`             | `list`        |         | Add Linux capabilities                                                            |
+| `--cap-drop`            | `list`        |         | Drop Linux capabilities                                                           |
+| `-d`, `--detach`        |               |         | Run container in background and print container ID                                |
+| `--dry-run`             |               |         | Execute command in dry run mode                                                   |
+| `--entrypoint`          | `string`      |         | Override the entrypoint of the image                                              |
+| `-e`, `--env`           | `stringArray` |         | Set environment variables                                                         |
+| `-i`, `--interactive`   |               |         | Keep STDIN open even if not attached.                                             |
+| `-l`, `--label`         | `stringArray` |         | Add or override a label                                                           |
+| `--name`                | `string`      |         | Assign a name to the container                                                    |
+| `-T`, `--no-TTY`        |               |         | Disable pseudo-TTY allocation (default: auto-detected).                           |
+| `--no-deps`             |               |         | Don't start linked services.                                                      |
+| `-p`, `--publish`       | `stringArray` |         | Publish a container's port(s) to the host.                                        |
+| `--quiet-pull`          |               |         | Pull without printing progress information.                                       |
+| `--remove-orphans`      |               |         | Remove containers for services not defined in the Compose file.                   |
+| `--rm`                  |               |         | Automatically remove the container when it exits                                  |
+| `-P`, `--service-ports` |               |         | Run command with all service's ports enabled and mapped to the host.              |
+| `--use-aliases`         |               |         | Use the service's network useAliases in the network(s) the container connects to. |
+| `-u`, `--user`          | `string`      |         | Run as specified username or uid                                                  |
+| `-v`, `--volume`        | `stringArray` |         | Bind mount a volume.                                                              |
+| `-w`, `--workdir`       | `string`      |         | Working directory inside the container                                            |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -211,10 +211,11 @@ options:
       kubernetes: false
       swarm: false
     - option: service-ports
+      shorthand: P
       value_type: bool
       default_value: "false"
       description: |
-        Run command with the service's ports enabled and mapped to the host.
+        Run command with all service's ports enabled and mapped to the host.
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
**What I did**
when ran in `--verbose` mode, log we don't expose service ports until requested by options
also make `-P` an alias to align with docker/cli

**Related issue**
closes https://github.com/docker/compose/issues/10138

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
