### PR TITLE
Fix configs are mounted under /<id>

### DIFF
--- a/pkg/e2e/configs_test.go
+++ b/pkg/e2e/configs_test.go
@@ -45,4 +45,12 @@ func TestConfigFromEnv(t *testing.T) {
 			})
 		res.Assert(t, icmd.Expected{Out: "This is my config"})
 	})
+
+	t.Run("custom target", func(t *testing.T) {
+		res := icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/configs/compose.yaml", "run", "target"),
+			func(cmd *icmd.Cmd) {
+				cmd.Env = append(cmd.Env, "CONFIG=config")
+			})
+		res.Assert(t, icmd.Expected{Out: "This is my config"})
+	})
 }

--- a/pkg/e2e/fixtures/configs/compose.yaml
+++ b/pkg/e2e/fixtures/configs/compose.yaml
@@ -3,22 +3,26 @@ services:
     image: alpine
     configs:
       - source: from_env
-        target: /from_env
     command: cat /from_env
 
   from_file:
     image: alpine
     configs:
       - source: from_file
-        target: /from_file
     command: cat /from_file
 
   inlined:
     image: alpine
     configs:
       - source: inlined
-        target: /inlined
     command: cat /inlined
+
+  target:
+    image: alpine
+    configs:
+      - source: inlined
+        target: /target
+    command: cat /target
 
 configs:
   from_env:


### PR DESCRIPTION
**What I did**
Fix inlined and environment-defined configs to be mounted under `/<id>` until an explicit target is set
includes a test case to avoid such a regression to appear again

**Related issue**
see https://github.com/compose-spec/compose-spec/issues/346#issuecomment-1831861104

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
