### PR TITLE
Update README.md to use standard `compose.yaml` file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Quick Start
 Using Docker Compose is a three-step process:
 1. Define your app's environment with a `Dockerfile` so it can be
    reproduced anywhere.
-2. Define the services that make up your app in `docker-compose.yml` so
+2. Define the services that make up your app in `compose.yaml` so
    they can be run together in an isolated environment.
 3. Lastly, run `docker compose up` and Compose will start and run your entire
    app.


### PR DESCRIPTION
**What I did**

Update the README to recommend using the standard Compose file name, `compose.yaml`

- https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file
- https://docs.docker.com/compose/gettingstarted/#step-3-define-services-in-a-compose-file

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://github.com/docker/compose/assets/10340167/907efe3d-4243-4146-854a-f0f87b699fda)
