### PR TITLE
fix combination of --pull always --no-build

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -159,16 +159,6 @@ func (opts createOptions) Apply(project *types.Project) error {
 			project.Services[i] = service
 		}
 	}
-	// opts.noBuild, however, means do not perform ANY builds
-	if opts.noBuild {
-		for i, service := range project.Services {
-			service.Build = nil
-			if service.Image == "" {
-				service.Image = api.GetImageNameOrDefault(service, project.Name)
-			}
-			project.Services[i] = service
-		}
-	}
 
 	if err := applyPlatforms(project, true); err != nil {
 		return err

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -177,8 +177,6 @@ func runUp(
 	}
 
 	var build *api.BuildOptions
-	// this check is technically redundant as createOptions::apply()
-	// already removed all the build sections
 	if !createOptions.noBuild {
 		if createOptions.quietPull {
 			buildOptions.Progress = string(xprogress.QuietMode)


### PR DESCRIPTION
**What I did**
initial implementation of `--no-build` was based on mutating the project to drop `build` section. As either image or build section are required we inferred local image name. This then impacts `--pull always` as such an image is just a local name.

hopefully the code already had explicit support for `createOptions.noBuild` so the impact here are minimal

**Related issue**
fixes https://github.com/docker/compose/issues/11236

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
