### PR TITLE
configure image exported when push is requested

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -410,10 +410,9 @@ func (s *composeService) toBuildOptions(project *types.Project, service types.Se
 		Type: "docker",
 		Attrs: map[string]string{
 			"load": "true",
-			"push": fmt.Sprint(push),
 		},
 	}}
-	if len(service.Build.Platforms) > 1 {
+	if push {
 		exports = []bclient.ExportEntry{{
 			Type: "image",
 			Attrs: map[string]string{


### PR DESCRIPTION
**What I did**
when `--push` is requested, configure buildx `image` exporter to push image.

single platform
```
$ docker buildx use --builder default 
$ docker compose build --push
 => [test] pushing ndeloof/test:platform with docker                                                                                                 3.9s
 => => pushing layer 3033c8a8ba59                                                                                                                    3.4s

$ docker buildx use --builder container 
$ docker compose build --push
[+] Building 3.4s (5/5) FINISHED                                                                                               docker-container:container
...
 => => exporting manifest list sha256:129a5c06460b209e6d4bdaf24e23ae0efdbef506c4a11c764f9b6d6817c44829                                               0.0s
 => => pushing layers                                                                                                                                1.4s
 => => pushing manifest for docker.io/ndeloof/test:platform@sha256:129a5c06460b209e6d4bdaf24e23ae0efdbef506c4a11c764f9b6d6817c44829                  1.3s
```

mutli-platform:
```
$ docker compose build --push
[+] Building 8.0s (10/10) FINISHED                                                                                             docker-container:container
...
 => => exporting layers                                                                                                                              0.0s
 => => exporting manifest sha256:ff8937353882193be8c9ba90967807aeb9bd4a34e8650e932cc7ca9ae1da5fe3                                                    0.0s
 => => exporting config sha256:95d6f1765811354856f0ab3eef332de5ad8d3997c95af10a60ac18b2332a639f                                                      0.0s
 => => exporting attestation manifest sha256:1c671b045553d2310015b4b5853799fd018fb08b20ca6d481de98a3c23255b6b                                        0.0s
 => => exporting manifest sha256:fe0eddffe0ffbf1b890863d4ab705b64ffd88b7f54dbf7129a5c17125a8597c0                                                    0.0s
 => => exporting config sha256:a14ad0697b3af58ef74d54a2b288e46de9351d404dcff25489df15b27f261578                                                      0.0s
 => => exporting attestation manifest sha256:133dd80338e4eda4e61452dc7005cad34a882ce8070510eb2cd64cbd49a2dc28                                        0.0s
 => => exporting manifest list sha256:43d36c8b1cd5403084f3ecdf276a12817389296c6a4126437ad5470af8285581                                               0.0s
 => => pushing layers                                                                                                                                3.5s
 => => pushing manifest for docker.io/ndeloof/test:platform@sha256:43d36c8b1cd5403084f3ecdf276a12817389296c6a4126437ad5470af8285581                  2.8s
 => [test auth] ndeloof/test:pull,push token for registry-1.docker.io                                                                                0.0s
 => [test auth] library/nginx:pull ndeloof/test:pull,push token for registry-1.docker.io                                                             0.0s

$ docker buildx use --builder default 
$ docker compose build --push
[+] Building 0.0s (0/0)                                                                                                                    docker:default
Multi-platform build is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/build-multi-platform/
```

**Related issue**
closes https://github.com/docker/compose/issues/11072

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
