### PR TITLE
bump golang to version 1.21.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.21.4
+ARG GO_VERSION=1.21.5
 ARG XX_VERSION=1.2.1
 ARG GOLANGCI_LINT_VERSION=v1.54.2
 ARG ADDLICENSE_VERSION=v1.0.0


### PR DESCRIPTION
**What I did**
Upgrade Golang to version `1.21.5` which include security fixes
see https://go.dev/doc/devel/release#go1.21.5

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
