### PR TITLE
include disabled services for shell completion

### DIFF
--- a/cmd/compose/completion.go
+++ b/cmd/compose/completion.go
@@ -41,8 +41,8 @@ func completeServiceNames(dockerCli command.Cli, p *ProjectOptions) validArgsFn 
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		var serviceNames []string
-		for _, s := range project.ServiceNames() {
+		serviceNames := append(project.ServiceNames(), project.DisabledServiceNames()...)
+		for _, s := range serviceNames {
 			if toComplete == "" || strings.HasPrefix(s, toComplete) {
 				serviceNames = append(serviceNames, s)
 			}


### PR DESCRIPTION
**What I did**
As invoking a service name explicitly does enable it without the need to pass a profile, those should be offered as candidates by shell completion

**Related issue**
close https://github.com/docker/compose/issues/11245

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
