### PR TITLE
dependency graph visitor to receive ServiceConfig

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -81,12 +81,10 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 	imageIDs := map[string]string{}
 	serviceToBeBuild := map[string]serviceToBuild{}
 	mapServiceMutx := sync.Mutex{}
-	err = InDependencyOrder(ctx, project, func(ctx context.Context, name string) error {
+	err = InDependencyOrder(ctx, project, func(ctx context.Context, name string, service types.ServiceConfig) error {
 		if len(options.Services) > 0 && !utils.Contains(options.Services, name) {
 			return nil
 		}
-		service := project.Services[name]
-
 		if service.Build == nil {
 			return nil
 		}
@@ -157,15 +155,14 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		}
 		return -1
 	}
-	err = InDependencyOrder(ctx, project, func(ctx context.Context, name string) error {
+	err = InDependencyOrder(ctx, project, func(ctx context.Context, name string, service types.ServiceConfig) error {
 		if len(options.Services) > 0 && !utils.Contains(options.Services, name) {
 			return nil
 		}
-		serviceToBuild, ok := serviceToBeBuild[name]
+		_, ok := serviceToBeBuild[name]
 		if !ok {
 			return nil
 		}
-		service := serviceToBuild.service
 
 		if !buildkitEnabled {
 			id, err := s.doBuildClassic(ctx, project, service, options)

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -91,12 +91,7 @@ func newConvergence(services []string, state Containers, s *composeService) *con
 }
 
 func (c *convergence) apply(ctx context.Context, project *types.Project, options api.CreateOptions) error {
-	return InDependencyOrder(ctx, project, func(ctx context.Context, name string) error {
-		service, err := project.GetService(name)
-		if err != nil {
-			return err
-		}
-
+	return InDependencyOrder(ctx, project, func(ctx context.Context, name string, service types.ServiceConfig) error {
 		return tracing.SpanWrapFunc("service/apply", tracing.ServiceOptions(service), func(ctx context.Context) error {
 			strategy := options.RecreateDependencies
 			if utils.StringContains(options.Services, name) {

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -74,7 +74,7 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 		resourceToRemove = true
 	}
 
-	err = InReverseDependencyOrder(ctx, project, func(c context.Context, service string) error {
+	err = InReverseDependencyOrder(ctx, project, func(c context.Context, service string, _ types.ServiceConfig) error {
 		serviceContainers := containers.filter(isService(service))
 		err := s.removeContainers(ctx, w, serviceContainers, options.Timeout, options.Volumes)
 		return err

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -73,7 +73,7 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 	}
 
 	w := progress.ContextWriter(ctx)
-	return InDependencyOrder(ctx, project, func(c context.Context, service string) error {
+	return InDependencyOrder(ctx, project, func(c context.Context, service string, _ types.ServiceConfig) error {
 		eg, ctx := errgroup.WithContext(ctx)
 		for _, container := range containers.filter(isService(service)) {
 			container := container

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -123,12 +123,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 		return err
 	}
 
-	err = InDependencyOrder(ctx, project, func(c context.Context, name string) error {
-		service, err := project.GetService(name)
-		if err != nil {
-			return err
-		}
-
+	err = InDependencyOrder(ctx, project, func(c context.Context, name string, service types.ServiceConfig) error {
 		return s.startService(ctx, project, service, containers)
 	})
 	if err != nil {

--- a/pkg/compose/stop.go
+++ b/pkg/compose/stop.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
 	"github.com/docker/compose/v2/pkg/utils"
@@ -50,7 +51,7 @@ func (s *composeService) stop(ctx context.Context, projectName string, options a
 	}
 
 	w := progress.ContextWriter(ctx)
-	return InReverseDependencyOrder(ctx, project, func(c context.Context, service string) error {
+	return InReverseDependencyOrder(ctx, project, func(c context.Context, service string, _ types.ServiceConfig) error {
 		if !utils.StringContains(options.Services, service) {
 			return nil
 		}


### PR DESCRIPTION
**What I did**
refactored dependency graph so that `InDependencyOrder` visitor get immediate access to the visited `ServiceConfig` (as in most cases, first action is to get this from project)

