### PR TITLE
`--with-dependencies` let `docker compose build` build dependencies transitively

### DIFF
--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -5,17 +5,18 @@ Build or rebuild services
 
 ### Options
 
-| Name             | Type          | Default | Description                                                                                                 |
-|:-----------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
-| `--build-arg`    | `stringArray` |         | Set build-time variables for services.                                                                      |
-| `--builder`      | `string`      |         | Set builder to use.                                                                                         |
-| `--dry-run`      |               |         | Execute command in dry run mode                                                                             |
-| `-m`, `--memory` | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
-| `--no-cache`     |               |         | Do not use cache when building the image                                                                    |
-| `--pull`         |               |         | Always attempt to pull a newer version of the image.                                                        |
-| `--push`         |               |         | Push service images.                                                                                        |
-| `-q`, `--quiet`  |               |         | Don't print anything to STDOUT                                                                              |
-| `--ssh`          | `string`      |         | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
+| Name                  | Type          | Default | Description                                                                                                 |
+|:----------------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
+| `--build-arg`         | `stringArray` |         | Set build-time variables for services.                                                                      |
+| `--builder`           | `string`      |         | Set builder to use.                                                                                         |
+| `--dry-run`           |               |         | Execute command in dry run mode                                                                             |
+| `-m`, `--memory`      | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
+| `--no-cache`          |               |         | Do not use cache when building the image                                                                    |
+| `--pull`              |               |         | Always attempt to pull a newer version of the image.                                                        |
+| `--push`              |               |         | Push service images.                                                                                        |
+| `-q`, `--quiet`       |               |         | Don't print anything to STDOUT                                                                              |
+| `--ssh`               | `string`      |         | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
+| `--with-dependencies` |               |         | Also build dependencies (transitively).                                                                     |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -147,6 +147,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: with-dependencies
+      value_type: bool
+      default_value: "false"
+      description: Also build dependencies (transitively).
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -135,6 +135,8 @@ type BuildOptions struct {
 	Quiet bool
 	// Services passed in the command line to be built
 	Services []string
+	// Deps also build selected services dependencies
+	Deps bool
 	// Ssh authentications passed in the command line
 	SSHs []types.SSHKey
 	// Memory limit for the build container


### PR DESCRIPTION
**What I did**
introduce `--with-dependencies` flag so `docker compose build` will also build dependencies transitively

**Related issue**
closes https://github.com/docker/compose/issues/11275

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
