### PR TITLE
Up: teardown when command context is cancelled

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -278,12 +278,7 @@ const PluginName = "compose"
 
 // RunningAsStandalone detects when running as a standalone program
 func RunningAsStandalone() bool {
-	println("check running as standalone")
-	standalone := len(os.Args) < 2 || os.Args[1] != manager.MetadataSubcommandName && os.Args[1] != PluginName
-	fmt.Fprintf(os.Stderr, "%v+\n", os.Args)
-	println("len os.args", len(os.Args))
-	println("STANDALONE:", standalone)
-	return standalone
+	return len(os.Args) < 2 || os.Args[1] != manager.MetadataSubcommandName && os.Args[1] != PluginName
 }
 
 // RootCommand returns the compose command with its child commands


### PR DESCRIPTION
**What I did**

Previously, if a long-lived plugin process (such as an execution of `compose up`) was running and then detached from a terminal, signalling the parent CLI process to exit would leave the plugin process behind.

To address this, changes were introduced on the CLI side (see: https://github.com/docker/cli/pull/4599) to enable the CLI to notify a running plugin process that it should exit. This makes it so that, when the parent CLI process is going to exit, the command context of the plugin command being executed is cancelled.

This PR takes advantage of that change by using that channel on an `up` to know when to teardown.

Also fixed the "cancellable context" detection in `cmd/compose/compose.go`, as the string suffix matching was missing contexts such as:
```go
context.Background.WithCancel.WithValue(type trace.traceContextKeyType, val <not Stringer>).WithValue(type api.DryRunKey, val <not Stringer>)
```

*Before*:

https://github.com/docker/compose/assets/70572044/e1ffa1f5-469b-410a-a281-61aa970867bd

*After*:

https://github.com/docker/compose/assets/70572044/9e27f4da-4f02-4aef-addb-9c72e605a98a


**Related issue**
https://github.com/docker/cli/pull/4599

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="376" alt="Screenshot 2023-12-21 at 12 15 46" src="https://github.com/docker/compose/assets/70572044/d6a322f8-381f-4c39-9e30-23fd5b45ba12">
