### PR TITLE
introduce `stats` command

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -458,6 +458,7 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command { //
 		copyCommand(&opts, dockerCli, backend),
 		waitCommand(&opts, dockerCli, backend),
 		scaleCommand(&opts, dockerCli, backend),
+		statsCommand(&opts, dockerCli),
 		watchCommand(&opts, dockerCli, backend),
 		alphaCommand(&opts, dockerCli, backend),
 	)

--- a/cmd/compose/stats.go
+++ b/cmd/compose/stats.go
@@ -1,0 +1,84 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/compose/v2/pkg/api"
+)
+
+type statsOptions struct {
+	ProjectOptions *ProjectOptions
+	all            bool
+	format         string
+	noStream       bool
+	noTrunc        bool
+}
+
+func statsCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
+	opts := statsOptions{
+		ProjectOptions: p,
+	}
+	cmd := &cobra.Command{
+		Use:   "stats [OPTIONS] [SERVICE]",
+		Short: "Display a live stream of container(s) resource usage statistics",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runStats(ctx, dockerCli, opts, args)
+		}),
+		ValidArgsFunction: completeServiceNames(dockerCli, p),
+	}
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.all, "all", "a", false, "Show all containers (default shows just running)")
+	flags.StringVar(&opts.format, "format", "", `Format output using a custom template:
+'table':            Print output in table format with column headers (default)
+'table TEMPLATE':   Print output in table format using the given Go template
+'json':             Print in JSON format
+'TEMPLATE':         Print output using the given Go template.
+Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates`)
+	flags.BoolVar(&opts.noStream, "no-stream", false, "Disable streaming stats and only pull the first result")
+	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate output")
+	return cmd
+}
+
+func runStats(ctx context.Context, dockerCli command.Cli, opts statsOptions, service []string) error {
+	name, err := opts.ProjectOptions.toProjectName(dockerCli)
+	if err != nil {
+		return err
+	}
+	filter := []filters.KeyValuePair{
+		filters.Arg("label", fmt.Sprintf("%s=%s", api.ProjectLabel, name)),
+	}
+	if len(service) > 0 {
+		filter = append(filter, filters.Arg("label", fmt.Sprintf("%s=%s", api.ServiceLabel, service[0])))
+	}
+	args := filters.NewArgs(filter...)
+	return container.RunStats(ctx, dockerCli, &container.StatsOptions{
+		All:      opts.all,
+		NoStream: opts.noStream,
+		NoTrunc:  opts.noTrunc,
+		Format:   opts.format,
+		Filters:  &args,
+	})
+}

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -28,6 +28,7 @@ Define and run multi-container applications with Docker.
 | [`run`](compose_run.md)         | Run a one-off command on a service.                                                   |
 | [`scale`](compose_scale.md)     | Scale services                                                                        |
 | [`start`](compose_start.md)     | Start services                                                                        |
+| [`stats`](compose_stats.md)     | Display a live stream of container(s) resource usage statistics                       |
 | [`stop`](compose_stop.md)       | Stop services                                                                         |
 | [`top`](compose_top.md)         | Display the running processes                                                         |
 | [`unpause`](compose_unpause.md) | Unpause services                                                                      |

--- a/docs/reference/compose_stats.md
+++ b/docs/reference/compose_stats.md
@@ -1,0 +1,18 @@
+# docker compose stats
+
+<!---MARKER_GEN_START-->
+Display a live stream of container(s) resource usage statistics
+
+### Options
+
+| Name          | Type     | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                          |
+|:--------------|:---------|:--------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-a`, `--all` |          |         | Show all containers (default shows just running)                                                                                                                                                                                                                                                                                                                                                                                     |
+| `--dry-run`   |          |         | Execute command in dry run mode                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `--format`    | `string` |         | Format output using a custom template:<br>'table':            Print output in table format with column headers (default)<br>'table TEMPLATE':   Print output in table format using the given Go template<br>'json':             Print in JSON format<br>'TEMPLATE':         Print output using the given Go template.<br>Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates |
+| `--no-stream` |          |         | Disable streaming stats and only pull the first result                                                                                                                                                                                                                                                                                                                                                                               |
+| `--no-trunc`  |          |         | Do not truncate output                                                                                                                                                                                                                                                                                                                                                                                                               |
+
+
+<!---MARKER_GEN_END-->
+

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -167,6 +167,7 @@ cname:
     - docker compose run
     - docker compose scale
     - docker compose start
+    - docker compose stats
     - docker compose stop
     - docker compose top
     - docker compose unpause
@@ -196,6 +197,7 @@ clink:
     - docker_compose_run.yaml
     - docker_compose_scale.yaml
     - docker_compose_start.yaml
+    - docker_compose_stats.yaml
     - docker_compose_stop.yaml
     - docker_compose_top.yaml
     - docker_compose_unpause.yaml

--- a/docs/reference/docker_compose_stats.yaml
+++ b/docs/reference/docker_compose_stats.yaml
@@ -1,0 +1,71 @@
+command: docker compose stats
+short: Display a live stream of container(s) resource usage statistics
+long: Display a live stream of container(s) resource usage statistics
+usage: docker compose stats [OPTIONS] [SERVICE]
+pname: docker compose
+plink: docker_compose.yaml
+options:
+    - option: all
+      shorthand: a
+      value_type: bool
+      default_value: "false"
+      description: Show all containers (default shows just running)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: format
+      value_type: string
+      description: |-
+        Format output using a custom template:
+        'table':            Print output in table format with column headers (default)
+        'table TEMPLATE':   Print output in table format using the given Go template
+        'json':             Print in JSON format
+        'TEMPLATE':         Print output using the given Go template.
+        Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: no-stream
+      value_type: bool
+      default_value: "false"
+      description: Disable streaming stats and only pull the first result
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: no-trunc
+      value_type: bool
+      default_value: "false"
+      description: Do not truncate output
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+inherited_options:
+    - option: dry-run
+      value_type: bool
+      default_value: "false"
+      description: Execute command in dry run mode
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+deprecated: false
+hidden: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+


### PR DESCRIPTION
**What I did**
introduce `stats` command to monitor service containers

**Related issue**
closes https://github.com/docker/compose/issues/11234

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/cdd0e4a6-a63c-40e8-b3d9-fdee10c189bf)
