### PR TITLE
update compose-go to version using immutable Project functions

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -226,7 +226,7 @@ func (o *ProjectOptions) ToProject(dockerCli command.Cli, services []string, po 
 		return nil, errors.New("project name can't be empty. Use `--project-name` to set a valid name")
 	}
 
-	err = project.EnableServices(services...)
+	project, err = project.WithServicesEnabled(services...)
 	if err != nil {
 		return nil, err
 	}
@@ -246,9 +246,9 @@ func (o *ProjectOptions) ToProject(dockerCli command.Cli, services []string, po 
 		project.Services[name] = s
 	}
 
-	project.WithoutUnnecessaryResources()
+	project = project.WithoutUnnecessaryResources()
 
-	err = project.ForServices(services)
+	project, err = project.WithSelectedServices(services)
 	return project, err
 }
 

--- a/cmd/compose/compose_test.go
+++ b/cmd/compose/compose_test.go
@@ -44,7 +44,7 @@ func TestFilterServices(t *testing.T) {
 			},
 		},
 	}
-	err := p.ForServices([]string{"bar"})
+	p, err := p.WithSelectedServices([]string{"bar"})
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(p.Services), 2)

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -159,10 +159,11 @@ func runServices(ctx context.Context, dockerCli command.Cli, opts configOptions)
 	if err != nil {
 		return err
 	}
-	return project.WithServices(project.ServiceNames(), func(s types.ServiceConfig) error {
-		fmt.Fprintln(dockerCli.Out(), s.Name)
+	err = project.ForEachService(project.ServiceNames(), func(serviceName string, _ *types.ServiceConfig) error {
+		fmt.Fprintln(dockerCli.Out(), serviceName)
 		return nil
 	})
+	return err
 }
 
 func runVolumes(ctx context.Context, dockerCli command.Cli, opts configOptions) error {

--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -72,11 +72,12 @@ func pullCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) 
 	return cmd
 }
 
-func (opts pullOptions) apply(project *types.Project, services []string) error {
+func (opts pullOptions) apply(project *types.Project, services []string) (*types.Project, error) {
 	if !opts.includeDeps {
-		err := project.ForServices(services, types.IgnoreDependencies)
+		var err error
+		project, err = project.WithSelectedServices(services, types.IgnoreDependencies)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -89,7 +90,7 @@ func (opts pullOptions) apply(project *types.Project, services []string) error {
 			project.Services[i] = service
 		}
 	}
-	return nil
+	return project, nil
 }
 
 func runPull(ctx context.Context, dockerCli command.Cli, backend api.Service, opts pullOptions, services []string) error {
@@ -98,7 +99,7 @@ func runPull(ctx context.Context, dockerCli command.Cli, backend api.Service, op
 		return err
 	}
 
-	err = opts.apply(project, services)
+	project, err = opts.apply(project, services)
 	if err != nil {
 		return err
 	}

--- a/cmd/compose/pullOptions_test.go
+++ b/cmd/compose/pullOptions_test.go
@@ -46,7 +46,7 @@ func TestApplyPullOptions(t *testing.T) {
 			},
 		},
 	}
-	err := pullOptions{
+	project, err := pullOptions{
 		policy: types.PullPolicyMissing,
 	}.apply(project, nil)
 	assert.NilError(t, err)

--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -60,7 +60,7 @@ func runPush(ctx context.Context, dockerCli command.Cli, backend api.Service, op
 	}
 
 	if !opts.IncludeDeps {
-		err := project.ForServices(services, types.IgnoreDependencies)
+		project, err = project.WithSelectedServices(services, types.IgnoreDependencies)
 		if err != nil {
 			return err
 		}

--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -62,7 +62,7 @@ func runRestart(ctx context.Context, dockerCli command.Cli, backend api.Service,
 	}
 
 	if project != nil && len(services) > 0 {
-		err := project.EnableServices(services...)
+		project, err = project.WithServicesEnabled(services...)
 		if err != nil {
 			return err
 		}

--- a/cmd/compose/scale.go
+++ b/cmd/compose/scale.go
@@ -67,7 +67,7 @@ func runScale(ctx context.Context, dockerCli command.Cli, backend api.Service, o
 	}
 
 	if opts.noDeps {
-		if err := project.ForServices(services, types.IgnoreDependencies); err != nil {
+		if project, err = project.WithSelectedServices(services, types.IgnoreDependencies); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.0.0-beta.2
+	github.com/compose-spec/compose-go/v2 v2.0.0-beta.3
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.11
 	github.com/davecgh/go-spew v1.1.1
@@ -114,6 +114,8 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.0.0-beta.2 h1:UrKM2RA9qel+EGsHvdK/0y6XA047iDuK75dJYHWXZnc=
-github.com/compose-spec/compose-go/v2 v2.0.0-beta.2/go.mod h1:PWCgeD8cxiI/DmdpBM407CuLDrZ2W4xuS6/Z9jAi0YQ=
+github.com/compose-spec/compose-go/v2 v2.0.0-beta.3 h1:9MsMdwLaHE0uplnF2baXtM3yExD8Yaw3HUGlwm8Z+fQ=
+github.com/compose-spec/compose-go/v2 v2.0.0-beta.3/go.mod h1:IVsvFyGVhw4FASzUtlWNVaAOhYmakXAFY9IlZ7LAuD8=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
@@ -327,9 +327,13 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/buildkit v0.13.0-beta1.0.20231219135447-957cb50df991 h1:r80LLQ91uOLxU1ElAvrB1o8oBsph51lPzVnr7t2b200=
 github.com/moby/buildkit v0.13.0-beta1.0.20231219135447-957cb50df991/go.mod h1:6MddWPSL5jxy+W8eMMHWDOfZzzRRKWXPZqajw72YHBc=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -84,17 +84,16 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 	if options.Deps {
 		policy = types.IncludeDependencies
 	}
-	err = project.WithServices(options.Services, func(service types.ServiceConfig) error {
+	err = project.ForEachService(options.Services, func(serviceName string, service *types.ServiceConfig) error {
 		if service.Build == nil {
 			return nil
 		}
-		image := api.GetImageNameOrDefault(service, project.Name)
+		image := api.GetImageNameOrDefault(*service, project.Name)
 		_, localImagePresent := localImages[image]
 		if localImagePresent && service.PullPolicy != types.PullPolicyBuild {
 			return nil
 		}
-		name := service.Name
-		serviceToBeBuild[name] = serviceToBuild{name: name, service: service}
+		serviceToBeBuild[serviceName] = serviceToBuild{name: serviceName, service: *service}
 		return nil
 	}, policy)
 	if err != nil || len(serviceToBeBuild) == 0 {

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -148,7 +148,8 @@ func getContainerNameWithoutProject(c moby.Container) string {
 
 func (s *composeService) Config(ctx context.Context, project *types.Project, options api.ConfigOptions) ([]byte, error) {
 	if options.ResolveImageDigests {
-		err := project.ResolveImages(func(named reference.Named) (digest.Digest, error) {
+		var err error
+		project, err = project.WithImagesResolved(func(named reference.Named) (digest.Digest, error) {
 			auth, err := encodedAuth(named, s.configFile())
 			if err != nil {
 				return "", err
@@ -233,7 +234,7 @@ SERVICES:
 		}
 		return project, fmt.Errorf("no such service: %q: %w", qs, api.ErrNotFound)
 	}
-	err := project.ForServices(services)
+	project, err := project.WithSelectedServices(services)
 	if err != nil {
 		return project, err
 	}

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -107,8 +107,11 @@ func (s *composeService) publish(ctx context.Context, project *types.Project, re
 }
 
 func (s *composeService) generateImageDigestsOverride(ctx context.Context, project *types.Project) ([]byte, error) {
-	project.ApplyProfiles([]string{"*"})
-	err := project.ResolveImages(func(named reference.Named) (digest.Digest, error) {
+	project, err := project.WithProfiles([]string{"*"})
+	if err != nil {
+		return nil, err
+	}
+	project, err = project.WithImagesResolved(func(named reference.Named) (digest.Digest, error) {
 		auth, err := encodedAuth(named, s.configFile())
 		if err != nil {
 			return "", err

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -49,7 +49,7 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 	}
 
 	if options.NoDeps {
-		err := project.ForServices(options.Services, types.IgnoreDependencies)
+		project, err = project.WithSelectedServices(options.Services, types.IgnoreDependencies)
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 	}
 
 	if len(options.Services) != 0 {
-		err = project.ForServices(options.Services, types.IncludeDependents)
+		project, err = project.WithSelectedServices(options.Services, types.IncludeDependents)
 		if err != nil {
 			return err
 		}

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -64,7 +64,8 @@ func (s *composeService) getSyncImplementation(project *types.Project) sync.Sync
 }
 
 func (s *composeService) Watch(ctx context.Context, project *types.Project, services []string, options api.WatchOptions) error { //nolint: gocyclo
-	if err := project.ForServices(services); err != nil {
+	var err error
+	if project, err = project.WithSelectedServices(services); err != nil {
 		return err
 	}
 	syncer := s.getSyncImplementation(project)


### PR DESCRIPTION
Before merging: need PR https://github.com/compose-spec/compose-go/pull/518 to be merged and a new version of `compose-go` to be released 

**What I did**
Test the version of `compose-go` which introduces `Project` immutable functions
- replace `compose-go` with the version of [the following PR](https://github.com/compose-spec/compose-go/pull/518)
- adapt current code to support the new `compose-go` version without using the advantage of the immutability for now, basically just replace the current `Project` instance with the new one.

**Related issue**
https://docker.atlassian.net/browse/COMP-380

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/7a9bedcb-4e54-4c54-b9d0-a5196e49ad1f)
