### PR TITLE
gha: update DOCKER_CLI_VERSION to v24.0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
         default: "false"
 
 env:
-  DOCKER_CLI_VERSION: "20.10.17"
+  DOCKER_CLI_VERSION: "24.0.7"
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
I noticed that the CLI was still on 20.10, but the daemon on 24.0.7;

    Docker info
    /usr/bin/docker version
    Client:
    Version:           20.10.17
    API version:       1.41
    Go version:        go1.17.11
    Git commit:        100c701
    Built:             Mon Jun  6 22:56:42 2022
    OS/Arch:           linux/amd64
    Context:           default
    Experimental:      true
    Server: Docker Engine - Community
    Engine:
    Version:          24.0.7
    API version:      1.43 (minimum version 1.12)
    Go version:       go1.20.10
    Git commit:       311b9ff
    Built:            Thu Oct 26 09:07:41 2023
    OS/Arch:          linux/amd64
    Experimental:     false
    containerd:
    Version:          1.6.26
    GitCommit:        3dd1e886e55dd695541fdcd67420c2888645a495
    runc:
    Version:          1.1.10
    GitCommit:        v1.1.10-0-g18a0cb0
    docker-init:
    Version:          0.19.0
    GitCommit:        de40ad0

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
