### PR TITLE
Add source policies for build

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -410,6 +410,11 @@ func (s *composeService) toBuildOptions(project *types.Project, service types.Se
 		}}
 	}
 
+	sp, err := build.ReadSourcePolicy()
+	if err != nil {
+		return build.Options{}, err
+	}
+
 	return build.Options{
 		Inputs: build.Inputs{
 			ContextPath:      service.Build.Context,
@@ -417,21 +422,22 @@ func (s *composeService) toBuildOptions(project *types.Project, service types.Se
 			DockerfilePath:   dockerFilePath(service.Build.Context, service.Build.Dockerfile),
 			NamedContexts:    toBuildContexts(service.Build.AdditionalContexts),
 		},
-		CacheFrom:   pb.CreateCaches(cacheFrom),
-		CacheTo:     pb.CreateCaches(cacheTo),
-		NoCache:     service.Build.NoCache,
-		Pull:        service.Build.Pull,
-		BuildArgs:   flatten(resolveAndMergeBuildArgs(s.dockerCli, project, service, options)),
-		Tags:        tags,
-		Target:      service.Build.Target,
-		Exports:     exports,
-		Platforms:   plats,
-		Labels:      imageLabels,
-		NetworkMode: service.Build.Network,
-		ExtraHosts:  service.Build.ExtraHosts.AsList(":"),
-		Ulimits:     toUlimitOpt(service.Build.Ulimits),
-		Session:     sessionConfig,
-		Allow:       allow,
+		CacheFrom:    pb.CreateCaches(cacheFrom),
+		CacheTo:      pb.CreateCaches(cacheTo),
+		NoCache:      service.Build.NoCache,
+		Pull:         service.Build.Pull,
+		BuildArgs:    flatten(resolveAndMergeBuildArgs(s.dockerCli, project, service, options)),
+		Tags:         tags,
+		Target:       service.Build.Target,
+		Exports:      exports,
+		Platforms:    plats,
+		Labels:       imageLabels,
+		NetworkMode:  service.Build.Network,
+		ExtraHosts:   service.Build.ExtraHosts.AsList(":"),
+		Ulimits:      toUlimitOpt(service.Build.Ulimits),
+		Session:      sessionConfig,
+		Allow:        allow,
+		SourcePolicy: sp,
 	}, nil
 }
 


### PR DESCRIPTION
Build{x,kit} support passing in source policies via an (experimental) env var.
This change adds those policies to the build request.

Equivalent code in `buildx build`
https://github.com/docker/buildx/blob/7c590ecb9a8005d7b9e8f4ef7217130d79310200/commands/build.go#L144-L147

`ReadSourcePolicy` code:
https://github.com/docker/buildx/blob/7c590ecb9a8005d7b9e8f4ef7217130d79310200/build/build.go#L1502-L1525