### PR TITLE
watch: remove requirements for tar binary and for sync target to be rw

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -419,6 +419,12 @@ func (t tarDockerClient) Exec(ctx context.Context, containerID string, cmd []str
 	return nil
 }
 
+func (t tarDockerClient) Untar(ctx context.Context, id string, archive io.ReadCloser) error {
+	return t.s.apiClient().CopyToContainer(ctx, id, "/", archive, moby.CopyToContainerOptions{
+		CopyUIDGID: true,
+	})
+}
+
 func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Project, serviceName string, build api.BuildOptions, batch []fileEvent, syncer sync.Syncer) error {
 	pathMappings := make([]sync.PathMapping, len(batch))
 	restartService := false


### PR DESCRIPTION
**What I did*
Replaced execution of `tar` within an exec to untar files by a PutContainerArchive API call (untar is managed by engine)
This removes requirement for container to have (gnu) `tar` command available + target path doesn't have to be RW by (unprivileged) container user

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
