### PR TITLE
bump golang to version v1.21.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.21.5
+ARG GO_VERSION=1.21.6
 ARG XX_VERSION=1.2.1
 ARG GOLANGCI_LINT_VERSION=v1.54.2
 ARG ADDLICENSE_VERSION=v1.0.0


### PR DESCRIPTION
**What I did**
Bump Golang to version `v1.21.6`

> go1.21.6 (released 2024-01-09) includes fixes to the compiler, the runtime, and the crypto/tls, maps, and runtime/pprof packages. See the [Go 1.21.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.6+label%3ACherryPickApproved) on our issue tracker for details.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
