### PR TITLE
Stop the resource timer after last expected event

### DIFF
--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -129,7 +129,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 			return err
 		}
 
-		return s.startService(ctx, project, service, containers)
+		return s.startService(ctx, project, service, containers, options.Wait)
 	})
 	if err != nil {
 		return err

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -33,11 +33,14 @@ import (
 
 func (s *composeService) Up(ctx context.Context, project *types.Project, options api.UpOptions) error { //nolint:gocyclo
 	err := progress.Run(ctx, tracing.SpanWrapFunc("project/up", tracing.ProjectOptions(project), func(ctx context.Context) error {
+		w := progress.ContextWriter(ctx)
+		w.HasMore(options.Start.Attach == nil)
 		err := s.create(ctx, project, options.Create)
 		if err != nil {
 			return err
 		}
 		if options.Start.Attach == nil {
+			w.HasMore(false)
 			return s.start(ctx, project.Name, options.Start, nil)
 		}
 		return nil

--- a/pkg/progress/event.go
+++ b/pkg/progress/event.go
@@ -191,6 +191,6 @@ func (e *Event) Spinner() any {
 	case Error:
 		return ErrorColor(spinnerError)
 	default:
-		return e.spinner.String()
+		return CountColor(e.spinner.String())
 	}
 }

--- a/pkg/progress/noop.go
+++ b/pkg/progress/noop.go
@@ -38,3 +38,6 @@ func (p *noopWriter) TailMsgf(_ string, _ ...interface{}) {
 
 func (p *noopWriter) Stop() {
 }
+
+func (p *noopWriter) HasMore(bool) {
+}

--- a/pkg/progress/plain.go
+++ b/pkg/progress/plain.go
@@ -64,3 +64,6 @@ func (p *plainWriter) TailMsgf(msg string, args ...interface{}) {
 func (p *plainWriter) Stop() {
 	p.done <- true
 }
+
+func (p *plainWriter) HasMore(bool) {
+}

--- a/pkg/progress/quiet.go
+++ b/pkg/progress/quiet.go
@@ -35,3 +35,6 @@ func (q quiet) Events(_ []Event) {
 
 func (q quiet) TailMsgf(_ string, _ ...interface{}) {
 }
+
+func (q quiet) HasMore(bool) {
+}

--- a/pkg/progress/tty_test.go
+++ b/pkg/progress/tty_test.go
@@ -42,7 +42,7 @@ func TestLineText(t *testing.T) {
 	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
 
 	out := tty().lineText(ev, "", 50, lineWidth, false)
-	assert.Equal(t, out, " . id Text Status                            \x1b[34m0.0s \x1b[0m\n")
+	assert.Equal(t, out, " \x1b[33m.\x1b[0m id Text Status                            \x1b[34m0.0s \x1b[0m\n")
 
 	ev.Status = Done
 	out = tty().lineText(ev, "", 50, lineWidth, false)

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -36,6 +36,7 @@ type Writer interface {
 	Event(Event)
 	Events([]Event)
 	TailMsgf(string, ...interface{})
+	HasMore(more bool)
 }
 
 type writerKey struct{}


### PR DESCRIPTION
**What I did**
`Done` event status doesn't mean the resource reached the expected status, it typically is first `Created` then `Started` and eventually `Healthy`. We need the TUI to be aware more events are expected and not stop the timer.

**Related issue**
fixes https://github.com/docker/compose/issues/11326

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![631631](https://github.com/docker/compose/assets/132757/878436db-b6fb-4f85-9b34-8d94f72c95da)
