### PR TITLE
docs: update link to use canonical URL for command

### DIFF
--- a/docs/reference/compose_events.md
+++ b/docs/reference/compose_events.md
@@ -33,4 +33,4 @@ With the `--json` flag, a json object is printed one per line with the format:
 }
 ```
 
-The events that can be received using this can be seen [here](https://docs.docker.com/engine/reference/commandline/events/#object-types).
+The events that can be received using this can be seen [here](https://docs.docker.com/engine/reference/commandline/system_events/#object-types).

--- a/docs/reference/docker_compose_events.yaml
+++ b/docs/reference/docker_compose_events.yaml
@@ -19,7 +19,7 @@ long: |-
     }
     ```
 
-    The events that can be received using this can be seen [here](/engine/reference/commandline/events/#object-types).
+    The events that can be received using this can be seen [here](/engine/reference/commandline/system_events/#object-types).
 usage: docker compose events [OPTIONS] [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml


### PR DESCRIPTION
**What I did**

docker/docs#19045 moves the CLI reference commands to their canonical locations instead of shorthand aliases. Updated the link to the `docker events` command to use URL of the canonical `docker system events`.

**Related issue**

- Relates to https://github.com/docker/docs/pull/19045

We should wait for moby 25 before merging

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
