### PR TITLE
fix engine version require to use healthcheck.start_interval

### DIFF
--- a/pkg/compose/convert.go
+++ b/pkg/compose/convert.go
@@ -74,7 +74,7 @@ func (s *composeService) ToMobyHealthCheck(ctx context.Context, check *compose.H
 			return nil, err
 		}
 		if versions.LessThan(version, "1.44") {
-			return nil, errors.New("can't set healthcheck.start_interval as feature require Docker Engine 1.25 or later")
+			return nil, errors.New("can't set healthcheck.start_interval as feature require Docker Engine v25 or later")
 		} else {
 			startInterval = time.Duration(*check.StartInterval)
 		}


### PR DESCRIPTION
**What I did**
moby API 1.44 is implemented by Docker engine v25

**Related issue**
fixes https://github.com/docker/compose/pull/10939#pullrequestreview-1825139499

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
