### PR TITLE
remove watch subcommand from the alpha command

### DIFF
--- a/cmd/compose/alpha.go
+++ b/cmd/compose/alpha.go
@@ -31,7 +31,6 @@ func alphaCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 		},
 	}
 	cmd.AddCommand(
-		watchCommand(p, dockerCli, backend),
 		vizCommand(p, dockerCli, backend),
 		publishCommand(p, dockerCli, backend),
 	)

--- a/docs/reference/docker_compose_alpha.yaml
+++ b/docs/reference/docker_compose_alpha.yaml
@@ -6,11 +6,9 @@ plink: docker_compose.yaml
 cname:
     - docker compose alpha publish
     - docker compose alpha viz
-    - docker compose alpha watch
 clink:
     - docker_compose_alpha_publish.yaml
     - docker_compose_alpha_viz.yaml
-    - docker_compose_alpha_watch.yaml
 inherited_options:
     - option: dry-run
       value_type: bool


### PR DESCRIPTION
**What I did**
Remove `watch` as a subcommand of `alpha` command


**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/624e807b-4446-468f-b436-e823da444134)
