### PR TITLE
fix(tracing): batch span exports to prevent blocking

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -115,11 +115,9 @@ func InitProvider(dockerCli command.Cli) (ShutdownFunc, error) {
 	}
 
 	muxExporter := MuxExporter{exporters: exporters}
-	sp := sdktrace.NewSimpleSpanProcessor(muxExporter)
 	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithResource(res),
-		sdktrace.WithSpanProcessor(sp),
+		sdktrace.WithBatcher(muxExporter),
 	)
 	otel.SetTracerProvider(tracerProvider)
 


### PR DESCRIPTION
**What I did**
This was a bad configuration (my fault) that meant each span was exported synchronously, as it ended. That can cause weird behavior such as stuttering/blocking.

There's really no reason to NOT use the batch processor, it's the recommended way to configure it. In the future, it might make sense to tune the intervals based on the fact that Compose is a CLI vs a long-running server app, but we handle flushing out on exit already, so it's not a huge deal.

**Related issue**
https://docker.atlassian.net/browse/COMP-387

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![hippo](https://github.com/docker/compose/assets/841263/8d244475-ca04-498c-b6f9-f220156b1250)