### PR TITLE
chore(e2e): fix flaky test & standalone behavior

### DIFF
--- a/pkg/e2e/e2e_config_plugin.go
+++ b/pkg/e2e/e2e_config_plugin.go
@@ -18,4 +18,4 @@
 
 package e2e
 
-const composeStandaloneMode = true
+const composeStandaloneMode = false


### PR DESCRIPTION
**What I did**
This test was flaking in CI even though it was succeeding; I think there's a race with us killing and getting the output. Regardless, refactored so that it watches the process, which should make the test more reliable and faster.

Additionally, I noticed that the standalone config was incorrect, so I (reset) the bool to the correct value to ensure we test things in plugin mode for E2E.

**Related issue**
n/a

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="398" alt="fox in the snow" src="https://github.com/docker/compose/assets/841263/daf8b1b4-648d-43bb-a424-fccf9f2da15d">
