### PR TITLE
introduce stopAndRemoveContainer to share logic scaling down

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -134,14 +134,7 @@ func (c *convergence) ensureService(ctx context.Context, project *types.Project,
 			container := container
 			traceOpts := append(tracing.ServiceOptions(service), tracing.ContainerOptions(container)...)
 			eg.Go(tracing.SpanWrapFuncForErrGroup(ctx, "service/scale/down", traceOpts, func(ctx context.Context) error {
-				timeoutInSecond := utils.DurationSecondToInt(timeout)
-				err := c.service.apiClient().ContainerStop(ctx, container.ID, containerType.StopOptions{
-					Timeout: timeoutInSecond,
-				})
-				if err != nil {
-					return err
-				}
-				return c.service.apiClient().ContainerRemove(ctx, container.ID, containerType.RemoveOptions{})
+				return c.service.stopAndRemoveContainer(ctx, container, timeout, false)
 			}))
 			continue
 		}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -99,8 +99,7 @@ func (s *composeService) create(ctx context.Context, project *types.Project, opt
 	orphans := observedState.filter(isNotService(allServiceNames...))
 	if len(orphans) > 0 && !options.IgnoreOrphans {
 		if options.RemoveOrphans {
-			w := progress.ContextWriter(ctx)
-			err := s.removeContainers(ctx, w, orphans, nil, false)
+			err := s.removeContainers(ctx, orphans, nil, false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**What I did**
introduced `stopAndRemoveContainer` to share logic scaling down and removing container. To be used both by `down` and `convergence`.


**Related issue**
fixes https://github.com/docker/compose/issues/11391

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
