### PR TITLE
Fix load .env from project directory when project file is set by COMPOSE_FILE

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -261,10 +261,10 @@ func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 		append(po,
 			cli.WithWorkingDirectory(o.ProjectDir),
 			cli.WithOsEnv,
-			cli.WithEnvFiles(o.EnvFiles...),
-			cli.WithDotEnv,
 			cli.WithConfigFileEnv,
 			cli.WithDefaultConfigPath,
+			cli.WithEnvFiles(o.EnvFiles...),
+			cli.WithDotEnv,
 			cli.WithDefaultProfiles(o.Profiles...),
 			cli.WithName(o.ProjectName))...)
 }

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -313,3 +313,15 @@ func TestRemoveOrphaned(t *testing.T) {
 	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/sentences/compose.yaml", "-p", projectName, "ps", "--format", "{{.Name}}")
 	res.Assert(t, icmd.Expected{Out: fmt.Sprintf("%s-words-1", projectName)})
 }
+
+func TestResolveDotEnv(t *testing.T) {
+	c := NewCLI(t)
+
+	cmd := c.NewDockerComposeCmd(t, "config")
+	cmd.Dir = filepath.Join(".", "fixtures", "dotenv")
+	res := icmd.RunCmd(cmd)
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Out:      "image: backend:latest",
+	})
+}

--- a/pkg/e2e/fixtures/dotenv/.env
+++ b/pkg/e2e/fixtures/dotenv/.env
@@ -1,0 +1,1 @@
+COMPOSE_FILE="${COMPOSE_FILE:-development/compose.yaml}"

--- a/pkg/e2e/fixtures/dotenv/development/.env
+++ b/pkg/e2e/fixtures/dotenv/development/.env
@@ -1,0 +1,2 @@
+IMAGE_NAME="${IMAGE_NAME:-backend}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"

--- a/pkg/e2e/fixtures/dotenv/development/compose.yaml
+++ b/pkg/e2e/fixtures/dotenv/development/compose.yaml
@@ -1,0 +1,3 @@
+services:
+  backend:
+    image: $IMAGE_NAME:$IMAGE_TAG


### PR DESCRIPTION
**What I did**
get location of the compose file (maybe set by env) before loading default .env file. Doing so, if COMPOSE_FILE is set to a distinct directory, we will load sibling `.env` file as user would expect

**Related issue**
fixes https://github.com/docker/compose/issues/11392

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
