### PR TITLE
don't check external network existence when swarm is enabled

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1246,19 +1246,16 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 		n.Name = networks[0].ID
 		return nil
 	case 0:
-		if n.Driver == "overlay" {
+		enabled, err := s.isSWarmEnabled(ctx)
+		if err != nil {
+			return err
+		}
+		if enabled {
 			// Swarm nodes do not register overlay networks that were
 			// created on a different node unless they're in use.
-			// Here we assume `driver` is relevant for a network we don't manage
-			// which is a non-sense, but this is our legacy ¯\(ツ)/¯
+			// So we can't preemptively check network exists, but
 			// networkAttach will later fail anyway if network actually doesn't exists
-			enabled, err := s.isSWarmEnabled(ctx)
-			if err != nil {
-				return err
-			}
-			if enabled {
-				return nil
-			}
+			return nil
 		}
 		return fmt.Errorf("network %s declared as external, but could not be found", n.Name)
 	default:


### PR DESCRIPTION
**What I did**
we can't check a swarm overlay network exists until we connect a container. Asking user to declare `driver: overlay` is conter-intuitive and incorrect (an external resource should have no config element declared). Better ignore and wait for connect API call to (maybe) fail and report an error to user.

**Related issue**
fixes https://github.com/docker/compose/issues/11387

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
