### PR TITLE
build(deps): bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -28,14 +28,14 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Upload reference YAML docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-yaml
           path: docs/reference
           retention-days: 1
 
   validate:
-    uses: docker/docs/.github/workflows/validate-upstream.yml@main
+    uses: docker/docs/.github/workflows/validate-upstream.yml@919a9b9104a34a40b30d116529bcce589a544d1c  # pin for artifact v4 support: https://github.com/docker/docs/pull/19220
     needs:
       - docs-yaml
     with:


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

**What I did**

- Upgrade actions/artifact-upload (`@v4`) as needed by docs upstream workflow
- Pin upstream workflow

**Related issue**

docker/docs#19220

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
