### PR TITLE
Fix canonical container name in --dry-run

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -132,7 +132,8 @@ func getCanonicalContainerName(c moby.Container) string {
 			return name[1:]
 		}
 	}
-	return c.Names[0][1:]
+
+	return strings.TrimPrefix(c.Names[0], "/")
 }
 
 func getContainerNameWithoutProject(c moby.Container) string {


### PR DESCRIPTION
**What I did**
Fix getCanonicalContainerName to strip the prefix "/". Before, we were removing always the first char (`/`) but in `--dry-run` this is non-existent. So the fix makes sure we only remove what we intend to.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes #11402 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![IMG_0049](https://github.com/docker/compose/assets/22371565/3d742a75-c0fa-4081-a146-803c6edd6379)
