### PR TITLE
ci(deps): replace buildkit to fix fsutil issues on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,6 +183,8 @@ require (
 	tags.cncf.io/container-device-interface v0.6.2 // indirect
 )
 
-// Fix an issue with fsutil v0.0.0-20230825212630-f09800878302 on Windows
-// See https://github.com/docker/buildx/issues/2207#issuecomment-1908460460
-replace github.com/tonistiigi/fsutil v0.0.0-20230825212630-f09800878302 => github.com/crazy-max/fsutil v0.0.0-20240124164449-376dc28ff40f
+replace (
+	// reverts https://github.com/moby/buildkit/pull/4094 to fix fsutil issues on Windows
+	github.com/moby/buildkit => github.com/crazy-max/buildkit v0.7.1-0.20240130133234-d9aa289bd124 // compose-957cb50df991
+	github.com/tonistiigi/fsutil => github.com/tonistiigi/fsutil v0.0.0-20230629203738-36ef4d8c0dbb
+)

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=
 github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/crazy-max/fsutil v0.0.0-20240124164449-376dc28ff40f h1:f+sk5oEeSYL/2tjWraiDlR/JHJVwtqKYpGtMkfJ7MTc=
-github.com/crazy-max/fsutil v0.0.0-20240124164449-376dc28ff40f/go.mod h1:9kMVqMyQ/Sx2df5LtnGG+nbrmiZzCS7V6gjW3oGHsvI=
+github.com/crazy-max/buildkit v0.7.1-0.20240130133234-d9aa289bd124 h1:rTTqpfm06GSf2gjt8oo9LfUm2iGiYtx1VUDPfTHXqs4=
+github.com/crazy-max/buildkit v0.7.1-0.20240130133234-d9aa289bd124/go.mod h1:eFZFY7VaoWWKmJLwkqmcWR6x0j8q+gXcngg3E4k0558=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
@@ -336,8 +336,6 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/buildkit v0.13.0-beta1.0.20231219135447-957cb50df991 h1:r80LLQ91uOLxU1ElAvrB1o8oBsph51lPzVnr7t2b200=
-github.com/moby/buildkit v0.13.0-beta1.0.20231219135447-957cb50df991/go.mod h1:6MddWPSL5jxy+W8eMMHWDOfZzzRRKWXPZqajw72YHBc=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
@@ -472,6 +470,8 @@ github.com/theupdateframework/notary v0.7.0 h1:QyagRZ7wlSpjT5N2qQAh/pN+DVqgekv4D
 github.com/theupdateframework/notary v0.7.0/go.mod h1:c9DRxcmhHmVLDay4/2fUYdISnHqbFDGRSlXPO0AhYWw=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 h1:QB54BJwA6x8QU9nHY3xJSZR2kX9bgpZekRKGkLTmEXA=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375/go.mod h1:xRroudyp5iVtxKqZCrA6n2TLFRBf8bmnjr1UD4x+z7g=
+github.com/tonistiigi/fsutil v0.0.0-20230629203738-36ef4d8c0dbb h1:uUe8rNyVXM8moActoBol6Xf6xX2GMr7SosR2EywMvGg=
+github.com/tonistiigi/fsutil v0.0.0-20230629203738-36ef4d8c0dbb/go.mod h1:SxX/oNQ/ag6Vaoli547ipFK9J7BZn5JqJG0JE8lf8bA=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/v/cCndK0AMpt1wiVFb/YYmqB3/QG0=
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531 h1:Y/M5lygoNPKwVNLMPXgVfsRT40CSFKXCxuU8LoHySjs=


### PR DESCRIPTION
**What I did**

Commit 7781b7c vendoring buildx master introduced a regression with a bump of the peer dependency `github.com/tonistiigi/fsutil`. full diff: https://github.com/tonistiigi/fsutil/compare/36ef4d8c0dbb...f09800878302

When bisecting, tonistiigi/fsutil#167 is the PR introducing the regression.

We got a similar issue reported before DD 4.27 (docker/buildx#2207) that was fixed with https://github.com/tonistiigi/fsutil/compare/master...crazy-max:fsutil:toslash-keep-gogo but Windows users encountered another issue also related to fsutil.

As the deadline is closed for next DD 4.27 patch release and while a fix is being worked on fsutil repo to address this issue, I have created a branch that reverts this change in fsutil.

This branch for buildkit https://github.com/crazy-max/buildkit/tree/compose-957cb50df991 has been created at the regression point and reverts moby/buildkit#4094.

We are addressing this issue on fsutil with integration tests for Windows https://github.com/tonistiigi/fsutil/pull/173 and are looking for a fix to this specific issue on buildx master.

**Related issue**
* https://github.com/moby/moby/issues/47231
* https://github.com/docker/buildx/issues/2218
* https://github.com/moby/buildkit/issues/4594
* https://github.com/docker/compose/issues/11421

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

cc @glours @milas @thaJeztah 