### PR TITLE
Issue-11374: Modified compose up command to respect COMPOSE_REMOVE_ORPHANS environment variable

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -104,7 +105,8 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *c
 	flags.BoolVar(&create.Build, "build", false, "Build images before starting containers")
 	flags.BoolVar(&create.noBuild, "no-build", false, "Don't build an image, even if it's policy")
 	flags.StringVar(&create.Pull, "pull", "policy", `Pull image before running ("always"|"missing"|"never")`)
-	flags.BoolVar(&create.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
+	removeOrphans := utils.StringToBool(os.Getenv(ComposeRemoveOrphans))
+	flags.BoolVar(&create.removeOrphans, "remove-orphans", removeOrphans, "Remove containers for services not defined in the Compose file")
 	flags.StringArrayVar(&create.scale, "scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
 	flags.BoolVar(&up.noColor, "no-color", false, "Produce monochrome output")
 	flags.BoolVar(&up.noPrefix, "no-log-prefix", false, "Don't print prefix in logs")


### PR DESCRIPTION

**What I did:**
Modified the up command to respect the `COMPOSE_REMOVE_ORPHANS` environment variable, It now picks up the default value for the remove orphans flag from the environment variable if the `remove-orphans` flag isn't provided via the CLI

**Related issue:**
Fixes https://github.com/docker/compose/issues/11374

**How did I test my fix:**

I created a test container using the docker compose command, then I modified the name of the service and reran the docker compose up command after including my changes

Here's the command I ran:

`COMPOSE_REMOVE_ORPHANS=1 ./docker-compose up`

It now respects the environment variable and deletes the orphaned containers

<img width="941" alt="Screenshot 2024-02-06 at 12 40 50 AM" src="https://github.com/docker/compose/assets/46633282/43431028-c839-4df4-bef9-1dfa8963f0e9">

**A picture of a cute animal, if possible in relation to what you did**

![image](https://github.com/docker/compose/assets/46633282/4ea18ed0-8e44-4c0b-9814-d4ff90c9619c)
