### PR TITLE
sort containers to optimize scale down

### DIFF
--- a/pkg/e2e/fixtures/scale/compose.yaml
+++ b/pkg/e2e/fixtures/scale/compose.yaml
@@ -5,6 +5,8 @@ services:
       - db
   db:
     image: nginx:alpine
+    environment:
+      - MAYBE
   front:
     image: nginx:alpine
     deploy:


### PR DESCRIPTION
**What I did**
sort containers to prepare scale down:
1. select first containers which have obsolete configuration, so that they get removed (would be recreated otherwise)
2. sort containers by container number label so we remove those with highest value first. This prevent number to grow iterating with scale up and down
3. eventually sort by creation date, as an alternative to container number label (should be always present, but who knows...)

**Related issue**
fixes https://github.com/docker/compose/issues/11460

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/b4e5738a-965e-4d1f-869b-e7849512ba44)
