### PR TITLE
pass All option to backend api.Service when length statuses is not equal to zero

### DIFF
--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -113,7 +113,7 @@ func runPs(ctx context.Context, dockerCli command.Cli, backend api.Service, serv
 
 	containers, err := backend.Ps(ctx, name, api.PsOptions{
 		Project:  project,
-		All:      opts.All,
+		All:      opts.All || len(opts.Status) != 0,
 		Services: services,
 	})
 	if err != nil {


### PR DESCRIPTION
**What I did**
For ps command: Aligned --status=exited behaviour with the documentation.
https://docs.docker.com/engine/reference/commandline/compose_ps/#status

The compose service internally calls docker cli client which lists only running containers by default unless the `all` flag is passed. 

With the change the all flag is passed when the statuses includes `exited`.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Fixes #11464

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/42278019/fc5cd0e6-2b64-4e59-b494-af3cbb1f4792)

