### PR TITLE
list all containers as we filter by status

### DIFF
--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -56,6 +56,7 @@ func (p *psOptions) parseFilter() error {
 	switch parts[0] {
 	case "status":
 		p.Status = append(p.Status, parts[1])
+		p.All = true
 	case "source":
 		return api.ErrNotImplemented
 	default:

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -98,10 +99,13 @@ func (l *logConsumer) Err(container, message string) {
 	l.write(l.stderr, container, message)
 }
 
+var navColor = makeColorFunc("90")
+
 func (l *logConsumer) write(w io.Writer, container, message string) {
 	if l.ctx.Err() != nil {
 		return
 	}
+	fmt.Fprint(os.Stderr, "\r                                                              \r")
 	p := l.getPresenter(container)
 	timestamp := time.Now().Format(jsonmessage.RFC3339NanoFixed)
 	for _, line := range strings.Split(message, "\n") {
@@ -111,6 +115,7 @@ func (l *logConsumer) write(w io.Writer, container, message string) {
 			fmt.Fprintf(w, "%s%s\n", p.prefix, line)
 		}
 	}
+	fmt.Fprint(os.Stderr, navColor("Press [T] to toggle timestamp, [$] to get more features"))
 }
 
 func (l *logConsumer) Status(container, msg string) {


### PR DESCRIPTION
**What I did**
As `compose ps` is set to filter by status, list all containers otherwise we will miss those with non-running status

**Related issue**
fixes https://github.com/docker/compose/issues/11464

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
