### PR TITLE
Emit events for building images

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -158,11 +158,16 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		}
 		service := serviceToBuild.service
 
+		cw := progress.ContextWriter(ctx)
+		serviceName := fmt.Sprintf("Service %s", name)
+
 		if !buildkitEnabled {
+			cw.Event(progress.BuildingEvent(serviceName))
 			id, err := s.doBuildClassic(ctx, project, service, options)
 			if err != nil {
 				return err
 			}
+			cw.Event(progress.BuiltEvent(serviceName))
 			builtDigests[getServiceIndex(name)] = id
 
 			if options.Push {
@@ -180,10 +185,12 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 			return err
 		}
 
+		cw.Event(progress.BuildingEvent(serviceName))
 		digest, err := s.doBuildBuildkit(ctx, name, buildOptions, w, nodes)
 		if err != nil {
 			return err
 		}
+		cw.Event(progress.BuiltEvent(serviceName))
 		builtDigests[getServiceIndex(name)] = digest
 
 		return nil

--- a/pkg/compose/build_buildkit.go
+++ b/pkg/compose/build_buildkit.go
@@ -71,11 +71,6 @@ func (s composeService) dryRunBuildResponse(ctx context.Context, name string, op
 	buildResponse := map[string]*client.SolveResponse{}
 	dryRunUUID := fmt.Sprintf("dryRun-%x", sha1.Sum([]byte(name)))
 	w.Event(progress.Event{
-		ID:     " ",
-		Status: progress.Done,
-		Text:   fmt.Sprintf("build service %s", name),
-	})
-	w.Event(progress.Event{
 		ID:     "==>",
 		Status: progress.Done,
 		Text:   fmt.Sprintf("==> writing image %s", dryRunUUID),

--- a/pkg/progress/event.go
+++ b/pkg/progress/event.go
@@ -153,6 +153,16 @@ func RemovedEvent(id string) Event {
 	return NewEvent(id, Done, "Removed")
 }
 
+// BuildingEvent creates a new Building in progress Event
+func BuildingEvent(id string) Event {
+	return NewEvent(id, Working, "Building")
+}
+
+// BuiltEvent creates a new built (done) Event
+func BuiltEvent(id string) Event {
+	return NewEvent(id, Done, "Built")
+}
+
 // SkippedEvent creates a new Skipped Event
 func SkippedEvent(id string, reason string) Event {
 	return Event{


### PR DESCRIPTION
**What I did**
Right now `docker compose build` or `docker compose up --build` does not emit events. The only way to notice that something was built is by looking at stdout. The only case events are written (to stderr) is when using BuildKit in dry-mode (there's special code to emit some fake events in that case).

This PR makes building emit proper events (one before and one after building). This improves using `docker compose` from other programs. (Especially together with #11478.)

**Related issue**
Fixes #11403.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![A cute cat with rather sharp claws, watch out when petting her](https://spielwiese.fontein.de/photos/2015/05/cats-a-10.jpeg)
