### PR TITLE
show logs on watch

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -119,6 +119,8 @@ type VizOptions struct {
 // WatchOptions group options of the Watch API
 type WatchOptions struct {
 	Build BuildOptions
+	// Attach to container and forward logs if not nil
+	Attach LogConsumer
 }
 
 // BuildOptions group options of the Build API


### PR DESCRIPTION
**What I did**
Show logs for containers on `compose watch` with the `logs` flag, and include related flags for logs such as color, prefix, and timestamp.

**Related issue**
#11089 

**Why I did**
I believe that the 'compose watch' command is not complete without logs.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![Cute-Baby-Owl-Bird-Watercolor-Clip-art-Graphics-82135327-1-1-580x435](https://github.com/docker/compose/assets/92581846/5937a227-19d3-495f-880b-b7fc6baedd6e)
