### PR TITLE
ci: bump engine version to `25.0.3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           - standalone
         engine:
           - 24.0.9
-          - 25.0.2
+          - 25.0.3
     steps:
       -
         name: Checkout


### PR DESCRIPTION
**What I did**

Bump the engine version used in CI (`25.0.2` -> `25.0.3`).

Changes: https://github.com/moby/moby/releases/tag/v25.0.3

Hopefully, this fixes some networking flakyness seen in https://github.com/docker/compose/blob/de3da829ea01daeecc73303364f3affdbe48efa6/pkg/e2e/networks_test.go#L30 (see runs like https://github.com/docker/compose/actions/runs/7898881759/job/21557172714?pr=11499)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![image](https://github.com/docker/compose/assets/70572044/9da9cc5e-99e1-433b-8c0e-cf4ece10a29e)
