### PR TITLE
when ran with ANSI disabled, force progress=plain

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -395,6 +395,9 @@ func RootCommand(dockerCli command.Cli, backend api.Service) *cobra.Command { //
 			switch opts.Progress {
 			case ui.ModeAuto:
 				ui.Mode = ui.ModeAuto
+				if ansi == "never" {
+					ui.Mode = ui.ModePlain
+				}
 			case ui.ModeTTY:
 				if ansi == "never" {
 					return fmt.Errorf("can't use --progress tty while ANSI support is disabled")


### PR DESCRIPTION
**What I did**
`--ansi=never` is used to disable fancy terminal magic. This should also apply to the progress mode, so this one switch to raw "plain text" mode.

