### PR TITLE
Apply --quiet-pull option when creating dependencies from run command

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -75,6 +75,7 @@ func createCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service
 	flags.BoolVar(&opts.Build, "build", false, "Build images before starting containers")
 	flags.BoolVar(&opts.noBuild, "no-build", false, "Don't build an image, even if it's policy")
 	flags.StringVar(&opts.Pull, "pull", "policy", `Pull image before running ("always"|"missing"|"never"|"build")`)
+	flags.BoolVar(&opts.quietPull, "quiet-pull", false, "Pull without printing progress information")
 	flags.BoolVar(&opts.forceRecreate, "force-recreate", false, "Recreate containers even if their configuration and image haven't changed")
 	flags.BoolVar(&opts.noRecreate, "no-recreate", false, "If containers already exist, don't recreate them. Incompatible with --force-recreate.")
 	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
@@ -105,7 +106,7 @@ func runCreate(ctx context.Context, _ command.Cli, backend api.Service, createOp
 		RecreateDependencies: createOpts.dependenciesRecreateStrategy(),
 		Inherit:              !createOpts.noInherit,
 		Timeout:              createOpts.GetTimeout(),
-		QuietPull:            false,
+		QuietPull:            createOpts.quietPull,
 	})
 }
 

--- a/docs/reference/compose_create.md
+++ b/docs/reference/compose_create.md
@@ -13,6 +13,7 @@ Creates containers for a service
 | `--no-build`       |               |          | Don't build an image, even if it's policy                                                     |
 | `--no-recreate`    |               |          | If containers already exist, don't recreate them. Incompatible with --force-recreate.         |
 | `--pull`           | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never"\|"build")                             |
+| `--quiet-pull`     |               |          | Pull without printing progress information                                                    |
 | `--remove-orphans` |               |          | Remove containers for services not defined in the Compose file                                |
 | `--scale`          | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present. |
 

--- a/docs/reference/docker_compose_create.yaml
+++ b/docs/reference/docker_compose_create.yaml
@@ -57,6 +57,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: quiet-pull
+      value_type: bool
+      default_value: "false"
+      description: Pull without printing progress information
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: remove-orphans
       value_type: bool
       default_value: "false"

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -160,4 +160,13 @@ func TestLocalComposeRun(t *testing.T) {
 
 		c.RunDockerComposeCmd(t, "-f", "./fixtures/dependencies/deps-not-required.yaml", "down", "--remove-orphans")
 	})
+
+	t.Run("--quiet-pull", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "down", "--rmi", "all")
+		res.Assert(t, icmd.Success)
+
+		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--quiet-pull", "back")
+		assert.Assert(t, !strings.Contains(res.Combined(), "Pull complete"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "Pulled"), res.Combined())
+	})
 }


### PR DESCRIPTION
**What I did**
`--quiet-pull` flag wasn't pass to dependencies creation process.
As a result pull logs of the dependency are displayed even if you explicitly activated `--quiet-pull`.

I also added the support of the `--quiet-pull` option to the `create` command

**Related issue**
https://github.com/docker/compose/issues/10714

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/a4553abc-6050-45e7-a8f9-8aaca664fd30)
