### PR TITLE
use a dedicated compose file for --quiet-pull e2e test

### DIFF
--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -162,10 +162,10 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("--quiet-pull", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "down", "--rmi", "all")
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/quiet-pull.yaml", "down", "--rmi", "all")
 		res.Assert(t, icmd.Success)
 
-		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--quiet-pull", "back")
+		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/quiet-pull.yaml", "run", "--quiet-pull", "backend")
 		assert.Assert(t, !strings.Contains(res.Combined(), "Pull complete"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "Pulled"), res.Combined())
 	})

--- a/pkg/e2e/fixtures/run-test/quiet-pull.yaml
+++ b/pkg/e2e/fixtures/run-test/quiet-pull.yaml
@@ -1,0 +1,3 @@
+services:
+  backend:
+    image: hello-world


### PR DESCRIPTION
**What I did**
Use a different image for the `run --quiet-pull` e2e test and be sure the image isn't pull concurrently by an another test

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
