### PR TITLE
get log to manage `attach`

### DIFF
--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -75,6 +75,16 @@ func runLogs(ctx context.Context, dockerCli command.Cli, backend api.Service, op
 	if err != nil {
 		return err
 	}
+
+	// exclude services configured to ignore output (attach: false), until explicitly selected
+	if project != nil && len(services) == 0 {
+		for n, service := range project.Services {
+			if service.Attach == nil || *service.Attach {
+				services = append(services, n)
+			}
+		}
+	}
+
 	consumer := formatter.NewLogConsumer(ctx, dockerCli.Out(), dockerCli.Err(), !opts.noColor, !opts.noPrefix, false)
 	return backend.Logs(ctx, name, consumer, api.LogOptions{
 		Project:    project,


### PR DESCRIPTION
if compose file is configured not to attach to a service, `logs` command should not include this service


closes https://github.com/docker/compose/issues/11529