### PR TITLE
Remove docker cli step in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,6 @@ jobs:
           check-latest: true
           cache: true
       -
-        name: Setup docker CLI
-        run: |
-          curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz | tar xz
-          sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-      -
         name: Build
         uses: docker/bake-action@v2
         with:


### PR DESCRIPTION
**What I did**
Removed `Setup docker CLI` step because it was overriding docker version to `25.0.1` thus ignoring the matrix.engine versions previously installed. 

After looking at this [PR](https://github.com/docker/compose/pull/11535), I noticed something was odd, since this network issue has been fixed not long ago. 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/22371565/10b41687-5c7d-404d-9091-62c22d42ef7c)
