### PR TITLE
ci: switch to ghaction-setup-docker action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ on:
         required: false
         default: "false"
 
-env:
-  DOCKER_CLI_VERSION: "25.0.1"
-
 permissions:
   contents: read # to fetch code (actions/checkout)
 
@@ -139,19 +136,18 @@ jobs:
           - plugin
           - standalone
         engine:
-          - 24.0.9
-          - 25.0.3
+          - v24.0.9
+          - v25.0.3
     steps:
       -
         name: Checkout
         uses: actions/checkout@v3
-      - name: Install Docker ${{ matrix.engine }}
-        run: |
-          sudo apt-get install curl
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sudo sh ./get-docker.sh --version ${{ matrix.engine }}
-      - name: Check Docker Version
-        run: docker --version
+      -
+        name: Set up Docker
+        uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          version: ${{ matrix.engine }}
+          set-host: true
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
**What I did**

Use https://github.com/crazy-max/ghaction-setup-docker to setup docker.

output example: https://github.com/docker/compose/actions/runs/8063420687/job/22025179631?pr=11550#step:3:5

![image](https://github.com/docker/compose/assets/1951866/ddb7b945-ef1d-41ba-aad7-73eeb824c3b8)

cc @jhrotko

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
