### PR TITLE
Pull: include error message in warnings/errors

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -200,18 +200,20 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 	// then the status should be warning instead of error
 	if err != nil && service.Build != nil {
 		w.Event(progress.Event{
-			ID:     service.Name,
-			Status: progress.Warning,
-			Text:   "Warning",
+			ID:         service.Name,
+			Status:     progress.Warning,
+			Text:       "Warning",
+			StatusText: err.Error(),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}
 
 	if err != nil {
 		w.Event(progress.Event{
-			ID:     service.Name,
-			Status: progress.Error,
-			Text:   "Error",
+			ID:         service.Name,
+			Status:     progress.Error,
+			Text:       "Error",
+			StatusText: err.Error(),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -169,6 +169,14 @@ func imageAlreadyPresent(serviceImage string, localImages map[string]string) boo
 	return ok && tagged.Tag() != "latest"
 }
 
+func getUnwrappedErrorMessage(err error) string {
+	derr := errors.Unwrap(err)
+	if derr != nil {
+		return getUnwrappedErrorMessage(derr)
+	}
+	return err.Error()
+}
+
 func (s *composeService) pullServiceImage(ctx context.Context, service types.ServiceConfig,
 	configFile driver.Auth, w progress.Writer, quietPull bool, defaultPlatform string) (string, error) {
 	w.Event(progress.Event{
@@ -203,7 +211,7 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 			ID:         service.Name,
 			Status:     progress.Warning,
 			Text:       "Warning",
-			StatusText: err.Error(),
+			StatusText: getUnwrappedErrorMessage(err),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}
@@ -213,7 +221,7 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 			ID:         service.Name,
 			Status:     progress.Error,
 			Text:       "Error",
-			StatusText: err.Error(),
+			StatusText: getUnwrappedErrorMessage(err),
 		})
 		return "", WrapCategorisedComposeError(err, PullFailure)
 	}


### PR DESCRIPTION
**What I did**
When warnings or errors happen during pulling when running `docker compose up`, simply "<service_name> Warning" resp. "<service_name> Error" is printed without any information on what went wrong.

This PR changes this by adding the error message.

Before:
```
[+] Running 3/3
 ! dummy3 Warning                                                                                                                                                                        2.4s 
 ! dummy2 Warning                                                                                                                                                                        2.4s 
 ✘ dummy Error                                                                                                                                                                           2.4s 
```
After:
```
[+] Running 3/3
 ! dummy2 Warning Error response from daemon: pull access denied for dummy2, repository does not exist or may require 'docker login': denied: requested access to the resource is denied2.2s 
 ✘ dummy Error    Error response from daemon: pull access denied for dummy2, repository does not exist or may require 'docker login': denied: requested access to the resource is denied2.2s 
 ! dummy3 Warning Error response from daemon: pull access denied for dummy, repository does not exist or may require 'docker login': denied: requested access to the resource is denied2.2s 
```

**Related issue**
Ref: https://github.com/ansible-collections/community.docker/issues/807

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![A cute cat with rather sharp claws, watch out when petting her](https://spielwiese.fontein.de/photos/2015/05/cats-a-10.jpeg)