### PR TITLE
restore support for `config --no-interpolate`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.0.0-rc.8
+	github.com/compose-spec/compose-go/v2 v2.0.0-rc.8.0.20240228111658-a0507e98fe60
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.12
 	github.com/davecgh/go-spew v1.1.1
@@ -49,6 +49,7 @@ require (
 	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.16.0
 	google.golang.org/grpc v1.59.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
 )
 
@@ -170,7 +171,6 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.7 // indirect
 	k8s.io/apimachinery v0.26.7 // indirect
 	k8s.io/apiserver v0.26.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.0.0-rc.8 h1:b7l+GqFF+2W4M4kLQUDRTGhqmTiRwT3bYd9X7xrxp5Q=
-github.com/compose-spec/compose-go/v2 v2.0.0-rc.8/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
+github.com/compose-spec/compose-go/v2 v2.0.0-rc.8.0.20240228111658-a0507e98fe60 h1:NlkpaLBPFr05mNJWVMH7PP4L30gFG6k4z1QpypLUSh8=
+github.com/compose-spec/compose-go/v2 v2.0.0-rc.8.0.20240228111658-a0507e98fe60/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,8 +52,6 @@ type Service interface {
 	Ps(ctx context.Context, projectName string, options PsOptions) ([]ContainerSummary, error)
 	// List executes the equivalent to a `docker stack ls`
 	List(ctx context.Context, options ListOptions) ([]Stack, error)
-	// Config executes the equivalent to a `compose config`
-	Config(ctx context.Context, project *types.Project, options ConfigOptions) ([]byte, error)
 	// Kill executes the equivalent to a `compose kill`
 	Kill(ctx context.Context, projectName string, options KillOptions) error
 	// RunOneOffContainer creates a service oneoff container and starts its dependencies

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -26,7 +26,6 @@ import (
 	"github.com/docker/compose/v2/internal/ocipush"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
-	"github.com/opencontainers/go-digest"
 )
 
 func (s *composeService) Publish(ctx context.Context, project *types.Project, repository string, options api.PublishOptions) error {
@@ -111,17 +110,7 @@ func (s *composeService) generateImageDigestsOverride(ctx context.Context, proje
 	if err != nil {
 		return nil, err
 	}
-	project, err = project.WithImagesResolved(func(named reference.Named) (digest.Digest, error) {
-		auth, err := encodedAuth(named, s.configFile())
-		if err != nil {
-			return "", err
-		}
-		inspect, err := s.apiClient().DistributionInspect(ctx, named.String(), auth)
-		if err != nil {
-			return "", err
-		}
-		return inspect.Descriptor.Digest, nil
-	})
+	project, err = project.WithImagesResolved(ImageDigestResolver(ctx, s.configFile(), s.apiClient()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -235,7 +235,7 @@ func TestCompatibility(t *testing.T) {
 	})
 }
 
-func TestConvert(t *testing.T) {
+func TestConfig(t *testing.T) {
 	const projectName = "compose-e2e-convert"
 	c := NewParallelCLI(t)
 
@@ -244,20 +244,22 @@ func TestConvert(t *testing.T) {
 
 	t.Run("up", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose.yaml", "-p", projectName, "convert")
-		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`services:
+		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`name: %s
+networks:
+  default:
+    name: compose-e2e-convert_default
+services:
   nginx:
     build:
       context: %s
       dockerfile: Dockerfile
     networks:
       default: null
-networks:
-  default:
-    name: compose-e2e-convert_default`, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
+`, projectName, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
 	})
 }
 
-func TestConvertInterpolate(t *testing.T) {
+func TestConfigInterpolate(t *testing.T) {
 	const projectName = "compose-e2e-convert-interpolate"
 	c := NewParallelCLI(t)
 
@@ -266,16 +268,18 @@ func TestConvertInterpolate(t *testing.T) {
 
 	t.Run("convert", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose-interpolate.yaml", "-p", projectName, "convert", "--no-interpolate")
-		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`services:
+		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`name: %s
+networks:
+  default:
+    name: compose-e2e-convert-interpolate_default
+services:
   nginx:
     build:
       context: %s
       dockerfile: ${MYVAR}
     networks:
       default: null
-networks:
-  default:
-    name: compose-e2e-convert-interpolate_default`, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
+`, projectName, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
 	})
 }
 


### PR DESCRIPTION
**What I did**
implement `config` using compose-go `LoadModel` so we can actually skip interpolation

this PR uses a direct ref to compose-go HEAD waiting for a new release

**Related issue**
fixes https://github.com/docker/compose/issues/7964
