### PR TITLE
Service name shell completion bugfix

### DIFF
--- a/cmd/compose/completion.go
+++ b/cmd/compose/completion.go
@@ -41,13 +41,14 @@ func completeServiceNames(dockerCli command.Cli, p *ProjectOptions) validArgsFn 
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
+		var values []string
 		serviceNames := append(project.ServiceNames(), project.DisabledServiceNames()...)
 		for _, s := range serviceNames {
 			if toComplete == "" || strings.HasPrefix(s, toComplete) {
-				serviceNames = append(serviceNames, s)
+				values = append(values, s)
 			}
 		}
-		return serviceNames, cobra.ShellCompDirectiveNoFileComp
+		return values, cobra.ShellCompDirectiveNoFileComp
 	}
 }
 


### PR DESCRIPTION
**What I did**
Fix broken shell completion logic for service names.
The bug was introduced in #11251  effectively returning all services regardless of  `toComplete` value.
Use a separate variable to only return the matching service names.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes #11526
