### PR TITLE
avoid duplicated "xx exited with code 0" message

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -127,8 +127,10 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 
 	if options.Start.Watch {
 		eg.Go(func() error {
+			buildOpts := *options.Create.Build
+			buildOpts.Quiet = true
 			return s.Watch(ctx, project, options.Start.Services, api.WatchOptions{
-				Build: options.Create.Build,
+				Build: &buildOpts,
 				LogTo: options.Start.Attach,
 			})
 		})

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -445,7 +445,6 @@ func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Pr
 			options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Rebuilding service %q after changes were detected...", serviceName))
 			// restrict the build to ONLY this service, not any of its dependencies
 			options.Build.Services = []string{serviceName}
-			options.Build.Quiet = true
 			_, err := s.build(ctx, project, *options.Build, nil)
 			if err != nil {
 				options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Build failed. Error: %v", err))


### PR DESCRIPTION
**What I did**
As `up --watch` recreates a container, I noticed we get duplicated message "xx-1 exited with code 0". This is caused by both `stop` and `die` event being received as we update service container
Also restore build output for the standalone `compose watch` command


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
