### PR TITLE
Fix #11569 : Prevent service from depending on itself

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -447,7 +447,11 @@ func (s *composeService) prepareLabels(labels types.Labels, service types.Servic
 
 	var dependencies []string
 	for s, d := range service.DependsOn {
-		dependencies = append(dependencies, fmt.Sprintf("%s:%s:%t", s, d.Condition, d.Restart))
+		if s != service.Name {
+			dependencies = append(dependencies, fmt.Sprintf("%s:%s:%t", s, d.Condition, d.Restart))
+		} else {
+			fmt.Printf("Warning: Service '%s' has a self-dependency. This is not recommended.\n", s)
+		}
 	}
 	labels[api.DependenciesLabel] = strings.Join(dependencies, ",")
 	return labels, nil


### PR DESCRIPTION
**What I did**
This commit fixes a bug where a service in Docker Compose can be set to depend on itself, which results in an error. The fix prevents this by adding a check in the code that prevents a service from depending on itself.

**Related issue**
fixes #11569
