### PR TITLE
chore(log): fix debug/verbose logging flags

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -32,8 +32,7 @@ func getCompletionCommands() []string {
 
 func getBoolFlags() []string {
 	return []string{
-		"--debug", "-D",
-		"--verbose",
+		"-D",
 		"--tls",
 		"--tlsverify",
 	}
@@ -50,7 +49,8 @@ func getStringFlags() []string {
 	}
 }
 
-// Convert transforms standalone docker-compose args into CLI plugin compliant ones
+// Convert transforms v1 args into v2 ones and is used when the binary is
+// invoked standalone, i.e. as `docker-compose`.
 func Convert(args []string) []string {
 	var rootFlags []string
 	command := []string{compose.PluginName}
@@ -67,8 +67,6 @@ func Convert(args []string) []string {
 		}
 
 		switch arg {
-		case "--verbose":
-			arg = "--debug"
 		case "-h":
 			// docker cli has deprecated -h to avoid ambiguity with -H, while docker-compose still support it
 			arg = "--help"

--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -46,7 +46,7 @@ func Test_convert(t *testing.T) {
 		{
 			name: "compose --verbose",
 			args: []string{"--verbose"},
-			want: []string{"--debug", "compose"},
+			want: []string{"compose", "--verbose"},
 		},
 		{
 			name: "compose --version",

--- a/docs/yaml/main/generate.go
+++ b/docs/yaml/main/generate.go
@@ -36,7 +36,8 @@ func generateDocs(opts *options) error {
 		Use:               "docker",
 		DisableAutoGenTag: true,
 	}
-	cmd.AddCommand(compose.RootCommand(dockerCLI, nil))
+	var debugLogging bool
+	cmd.AddCommand(compose.RootCommand(dockerCLI, nil, &debugLogging))
 	disableFlagsInUseLine(cmd)
 
 	tool, err := clidocstool.New(clidocstool.Options{


### PR DESCRIPTION
**What I did**
Re-claim the `--debug` flag for debug logging.

Keep the `--verbose` flag hidden (for compat), but now as a no-op.

In the future, we should use `--verbose` for more detailed user-facing output.

**Related issue**
n/a

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![a lil inch worm](https://github.com/docker/compose/assets/841263/95b5e5f7-7021-4119-b3f5-ca3c24139754)
