### PR TITLE
feat(desktop): add Docker Desktop detection and client skeleton

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/theupdateframework/notary v0.7.0
 	github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0
@@ -147,7 +148,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.45.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.45.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.42.0 // indirect

--- a/internal/desktop/client.go
+++ b/internal/desktop/client.go
@@ -1,0 +1,93 @@
+/*
+   Copyright 2024 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package desktop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/docker/compose/v2/internal/memnet"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// Client for integration with Docker Desktop features.
+type Client struct {
+	client *http.Client
+}
+
+// NewClient creates a Desktop integration client for the provided in-memory
+// socket address (AF_UNIX or named pipe).
+func NewClient(apiEndpoint string) *Client {
+	var transport http.RoundTripper = &http.Transport{
+		DisableCompression: true,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return memnet.DialEndpoint(ctx, apiEndpoint)
+		},
+	}
+	transport = otelhttp.NewTransport(transport)
+
+	c := &Client{
+		client: &http.Client{Transport: transport},
+	}
+	return c
+}
+
+// Close releases any open connections.
+func (c *Client) Close() error {
+	c.client.CloseIdleConnections()
+	return nil
+}
+
+type PingResponse struct {
+	ServerTime int64 `json:"serverTime"`
+}
+
+// Ping is a minimal API used to ensure that the server is available.
+func (c *Client) Ping(ctx context.Context) (*PingResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, backendURL("/ping"), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var ret PingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+// backendURL generates a URL for the given API path.
+//
+// NOTE: Custom transport handles communication. The host is to create a valid
+// URL for the Go http.Client that is also descriptive in error/logs.
+func backendURL(path string) string {
+	return "http://docker-desktop/" + strings.TrimPrefix(path, "/")
+}

--- a/internal/desktop/integration.go
+++ b/internal/desktop/integration.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 Docker Compose CLI authors
+   Copyright 2024 Docker Compose CLI authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,22 +14,12 @@
    limitations under the License.
 */
 
-package tracing
+package desktop
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"strings"
-
-	"github.com/Microsoft/go-winio"
 )
 
-func DialInMemory(ctx context.Context, addr string) (net.Conn, error) {
-	if !strings.HasPrefix(addr, "npipe://") {
-		return nil, fmt.Errorf("not a named pipe address: %s", addr)
-	}
-	addr = strings.TrimPrefix(addr, "npipe://")
-
-	return winio.DialPipeContext(ctx, addr)
+type IntegrationService interface {
+	MaybeEnableDesktopIntegration(ctx context.Context) error
 }

--- a/internal/memnet/conn.go
+++ b/internal/memnet/conn.go
@@ -1,0 +1,50 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package memnet
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+)
+
+func DialEndpoint(ctx context.Context, endpoint string) (net.Conn, error) {
+	if addr, ok := strings.CutPrefix(endpoint, "unix://"); ok {
+		return Dial(ctx, "unix", addr)
+	}
+	if addr, ok := strings.CutPrefix(endpoint, "npipe://"); ok {
+		return Dial(ctx, "npipe", addr)
+	}
+	return nil, fmt.Errorf("unsupported protocol for address: %s", endpoint)
+}
+
+func Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	var d net.Dialer
+	switch network {
+	case "unix":
+		if err := validateSocketPath(addr); err != nil {
+			return nil, err
+		}
+		return d.DialContext(ctx, "unix", addr)
+	case "npipe":
+		// N.B. this will return an error on non-Windows
+		return dialNamedPipe(ctx, addr)
+	default:
+		return nil, fmt.Errorf("unsupported network: %s", network)
+	}
+}

--- a/internal/memnet/conn_unix.go
+++ b/internal/memnet/conn_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+/*
+   Copyright 2023 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package memnet
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+)
+
+const maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
+
+func dialNamedPipe(_ context.Context, _ string) (net.Conn, error) {
+	return nil, fmt.Errorf("named pipes are only available on Windows")
+}
+
+func validateSocketPath(addr string) error {
+	if len(addr) > maxUnixSocketPathSize {
+		return fmt.Errorf("socket address is too long: %s", addr)
+	}
+	return nil
+}

--- a/internal/memnet/conn_windows.go
+++ b/internal/memnet/conn_windows.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 /*
    Copyright 2023 Docker Compose CLI authors
 
@@ -16,29 +14,20 @@
    limitations under the License.
 */
 
-package tracing
+package memnet
 
 import (
 	"context"
-	"fmt"
 	"net"
-	"strings"
-	"syscall"
+
+	"github.com/Microsoft/go-winio"
 )
 
-const maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
+func dialNamedPipe(ctx context.Context, addr string) (net.Conn, error) {
+	return winio.DialPipeContext(ctx, addr)
+}
 
-func DialInMemory(ctx context.Context, addr string) (net.Conn, error) {
-	if !strings.HasPrefix(addr, "unix://") {
-		return nil, fmt.Errorf("not a Unix socket address: %s", addr)
-	}
-	addr = strings.TrimPrefix(addr, "unix://")
-
-	if len(addr) > maxUnixSocketPathSize {
-		//goland:noinspection GoErrorStringFormat
-		return nil, fmt.Errorf("Unix socket address is too long: %s", addr)
-	}
-
-	var d net.Dialer
-	return d.DialContext(ctx, "unix", addr)
+func validateSocketPath(addr string) error {
+	// AF_UNIX sockets do not have strict path limits on Windows
+	return nil
 }

--- a/internal/tracing/docker_context.go
+++ b/internal/tracing/docker_context.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/context/store"
+	"github.com/docker/compose/v2/internal/memnet"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"google.golang.org/grpc"
@@ -67,7 +68,9 @@ func traceClientFromDockerContext(dockerCli command.Cli, otelEnv envMap) (otlptr
 	conn, err := grpc.DialContext(
 		dialCtx,
 		cfg.Endpoint,
-		grpc.WithContextDialer(DialInMemory),
+		grpc.WithContextDialer(memnet.DialEndpoint),
+		// this dial is restricted to using a local Unix socket / named pipe,
+		// so there is no need for TLS
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/pkg/compose/desktop.go
+++ b/pkg/compose/desktop.go
@@ -1,0 +1,77 @@
+/*
+   Copyright 2024 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/docker/compose/v2/internal/desktop"
+	"github.com/sirupsen/logrus"
+)
+
+// engineLabelDesktopAddress is used to detect that Compose is running with a
+// Docker Desktop context. When this label is present, the value is an endpoint
+// address for an in-memory socket (AF_UNIX or named pipe).
+const engineLabelDesktopAddress = "com.docker.desktop.address"
+
+var _ desktop.IntegrationService = &composeService{}
+
+// MaybeEnableDesktopIntegration initializes the desktop.Client instance if
+// the server info from the Docker Engine is a Docker Desktop instance.
+//
+// EXPERIMENTAL: Requires `COMPOSE_EXPERIMENTAL_DESKTOP=1` env var set.
+func (s *composeService) MaybeEnableDesktopIntegration(ctx context.Context) error {
+	if desktopEnabled, _ := strconv.ParseBool(os.Getenv("COMPOSE_EXPERIMENTAL_DESKTOP")); !desktopEnabled {
+		return nil
+	}
+
+	if s.dryRun {
+		return nil
+	}
+
+	// safeguard to make sure this doesn't get stuck indefinitely
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	info, err := s.dockerCli.Client().Info(ctx)
+	if err != nil {
+		return fmt.Errorf("querying server info: %w", err)
+	}
+	for _, l := range info.Labels {
+		k, v, ok := strings.Cut(l, "=")
+		if !ok || k != engineLabelDesktopAddress {
+			continue
+		}
+
+		desktopCli := desktop.NewClient(v)
+		_, err := desktopCli.Ping(ctx)
+		if err != nil {
+			return fmt.Errorf("pinging Desktop API: %w", err)
+		}
+		logrus.Debugf("Enabling Docker Desktop integration (experimental): %s", v)
+		s.desktopCli = desktopCli
+		return nil
+	}
+
+	logrus.Trace("Docker Desktop not detected, no integration enabled")
+	return nil
+}


### PR DESCRIPTION
**What I did**
Use the system info Engine API to auto-discover the Desktop integration API endpoint (a local `AF_UNIX` socket or named pipe).

If present and responding to a `/ping`, the client is populated on the Compose service for use. Otherwise, it's left `nil`, and Compose will not try to use any functionality that relies on Docker Desktop (e.g. opening `docker-desktop://` deep links to the GUI).

This refactors some of the in-memory socket dialer code, so we can share it easier (time to bring back `docker/go-connections`? 🤔) and make it slightly more robust.

**Related issue**
JIRA: [COMP-457](https://docker.atlassian.net/browse/COMP-457)

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![badger](https://github.com/docker/compose/assets/841263/fbf727bc-5cb1-42e2-95da-9af264a45854)

[COMP-457]: https://docker.atlassian.net/browse/COMP-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ