### PR TITLE
only use ToModel when --no-interpolate is set

### DIFF
--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -245,9 +245,6 @@ func TestConfig(t *testing.T) {
 	t.Run("up", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose.yaml", "-p", projectName, "convert")
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`name: %s
-networks:
-  default:
-    name: compose-e2e-convert_default
 services:
   nginx:
     build:
@@ -255,6 +252,9 @@ services:
       dockerfile: Dockerfile
     networks:
       default: null
+networks:
+  default:
+    name: compose-e2e-convert_default
 `, projectName, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
 	})
 }


### PR DESCRIPTION
**What I did**
https://github.com/docker/compose/pull/11556 has impact on `compose config` which disturbs our users. This PR allows to preserve the previous behavior as long as `--no-interpolate` isn't set, and only switch to raw model parsing when set

We can then work in parallel to get `ToModel` closer to `ToProject` until we can eventually remove duplicated code path

**Related issue**
https://github.com/docker/compose/issues/11598

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
