### PR TITLE
fix TestBuildPlatformsWithCorrectBuildxConfig

### DIFF
--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -306,7 +306,7 @@ func TestBuildPlatformsWithCorrectBuildxConfig(t *testing.T) {
 			"-f", "fixtures/build-test/platforms/compose-unsupported-platform.yml", "build")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 17,
-			Err:      "failed to solve: alpine: no match for platform in",
+			Err:      "no match for platform in",
 		})
 	})
 


### PR DESCRIPTION
fix TestBuildPlatformsWithCorrectBuildxConfig failing on CI