### PR TITLE
add an option to use a custom progress printer for the build progress output

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -147,6 +148,8 @@ type BuildOptions struct {
 	Memory int64
 	// Builder name passed in the command line
 	Builder string
+	// OutPrinter used for printing the progress output
+	OutPrinter io.Writer
 }
 
 // Apply mutates project according to build options


### PR DESCRIPTION
**What I did**

Adds a new optional field `OutPrinter` to the `BuildOptions` struct to allow customizing where the build progress goes. If this field is not specified, output will go to `os.Stdout`, which is the current behavior.

The motivation for this change is when building tooling around this project, you might want to capture these logs and use them accordingly, example:

```go
type cacheMessagesPrinter struct {
	msgs []string
}

func (c *cacheMessagesPrinter) Write(p []byte) (n int, err error) {
	c.msgs = append(c.msgs, string(p))
	return len(p), nil
}

func TestMyStuff(t *testing.T) {
	myPrinter: = &cacheMessagesPrinter{}
	
	buildOpts := &api.BuildOptions{
		Pull:     true,
		Progress: "auto",
		Args:     nil,
		NoCache:  false,
		Quiet:    false,
		Memory:   0,
		OutPrinter: myPrinter,
	}
	err := startMyDockerComposeProject(buildOpts)
	if err != nil {
        // this is particularly useful if using t.Parallel(), so you can associate logs to the proper test instead of everything
        // being mixed in stdout.
		t.Log("docker compose project build failed - see build logs below")
		buildLogs := strings.Join(myPrinter.msgs, "\n")
		t.Log(buildLogs)
   }
}

```

Hope you find this feature useful, please let me know what you think!

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
