### PR TITLE
Fix documentation on default build image name (change to correct separator).

### DIFF
--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -23,7 +23,7 @@ Build or rebuild services
 
 ## Description
 
-Services are built once and then tagged, by default as `project_service`.
+Services are built once and then tagged, by default as `project-service`.
 
 If the Compose file specifies an
 [image](https://github.com/compose-spec/compose-spec/blob/master/spec.md#image) name,

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -1,7 +1,7 @@
 command: docker compose build
 short: Build or rebuild services
 long: |-
-    Services are built once and then tagged, by default as `project_service`.
+    Services are built once and then tagged, by default as `project-service`.
 
     If the Compose file specifies an
     [image](https://github.com/compose-spec/compose-spec/blob/master/spec.md#image) name,


### PR DESCRIPTION
**What I did**
This PR changes old documentation showing the old `_` separator for image names.

**Details:**
150fd4b8cfa39726e68c12fc0fd45ac4e0f20c5f changed the default separator from `_` to `-`, as seen in

https://github.com/docker/compose/blob/86cd52370a6e543ae9503f83b7e9dff971b28d75/pkg/api/api.go#L622-L631

but the compose build docs still mention `_`:

<img width="809" alt="Screenshot 2024-03-19 at 23 11 42" src="https://github.com/docker/compose/assets/43179146/a4bdad07-9211-4f42-818c-4ba06ab9e5b5">

Will this propagate downstream to [docker/docs](https://github.com/docker/docs) or do I need to submit specific PRs there for the updates?

<details>

<summary> <b> A picture of a cute animal, if possible in relation to what you did </b></summary>

<br>

This should be mandatory. Sorry it's not related... This is my cat Panko being dracula.
![panko_dracula](https://github.com/docker/compose/assets/43179146/4d61c429-dd8f-46f3-b0f9-07f512ba6cdc)

</details>

