### PR TITLE
introduce config --variables to list compose model variables

### DIFF
--- a/docs/reference/compose_config.md
+++ b/docs/reference/compose_config.md
@@ -13,18 +13,19 @@ Parse, resolve and render compose file in canonical format
 |:--------------------------|:---------|:--------|:----------------------------------------------------------------------------|
 | `--dry-run`               |          |         | Execute command in dry run mode                                             |
 | `--format`                | `string` | `yaml`  | Format the output. Values: [yaml \| json]                                   |
-| `--hash`                  | `string` |         | Print the service config hash, one per line                                 |
-| `--images`                |          |         | Print the image names, one per line                                         |
+| `--hash`                  | `string` |         | Print the service config hash, one per line.                                |
+| `--images`                |          |         | Print the image names, one per line.                                        |
 | `--no-consistency`        |          |         | Don't check model consistency - warning: may produce invalid Compose output |
 | `--no-interpolate`        |          |         | Don't interpolate environment variables                                     |
 | `--no-normalize`          |          |         | Don't normalize compose model                                               |
 | `--no-path-resolution`    |          |         | Don't resolve file paths                                                    |
 | `-o`, `--output`          | `string` |         | Save to file (default to stdout)                                            |
-| `--profiles`              |          |         | Print the profile names, one per line                                       |
+| `--profiles`              |          |         | Print the profile names, one per line.                                      |
 | `-q`, `--quiet`           |          |         | Only validate the configuration, don't print anything                       |
 | `--resolve-image-digests` |          |         | Pin image tags to digests                                                   |
-| `--services`              |          |         | Print the service names, one per line                                       |
-| `--volumes`               |          |         | Print the volume names, one per line                                        |
+| `--services`              |          |         | Print the service names, one per line.                                      |
+| `--variables`             |          |         | Print model variables and default values.                                   |
+| `--volumes`               |          |         | Print the volume names, one per line.                                       |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_config.yaml
+++ b/docs/reference/docker_compose_config.yaml
@@ -21,7 +21,7 @@ options:
       swarm: false
     - option: hash
       value_type: string
-      description: Print the service config hash, one per line
+      description: Print the service config hash, one per line.
       deprecated: false
       hidden: false
       experimental: false
@@ -31,7 +31,7 @@ options:
     - option: images
       value_type: bool
       default_value: "false"
-      description: Print the image names, one per line
+      description: Print the image names, one per line.
       deprecated: false
       hidden: false
       experimental: false
@@ -92,7 +92,7 @@ options:
     - option: profiles
       value_type: bool
       default_value: "false"
-      description: Print the profile names, one per line
+      description: Print the profile names, one per line.
       deprecated: false
       hidden: false
       experimental: false
@@ -123,7 +123,17 @@ options:
     - option: services
       value_type: bool
       default_value: "false"
-      description: Print the service names, one per line
+      description: Print the service names, one per line.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: variables
+      value_type: bool
+      default_value: "false"
+      description: Print model variables and default values.
       deprecated: false
       hidden: false
       experimental: false
@@ -133,7 +143,7 @@ options:
     - option: volumes
       value_type: bool
       default_value: "false"
-      description: Print the volume names, one per line
+      description: Print the volume names, one per line.
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
**What I did**
introduce `config --variables` pseudo-command to list compose model variables

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
