### PR TITLE
chore(deps): revert "Bump compose-go to v2.0.1"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.0.1
+	github.com/compose-spec/compose-go/v2 v2.0.0
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.12
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.0.1 h1:XIvwK9RltlwAikI1d8aOaGGTr0/i2Jev3LoRn2nLEmA=
-github.com/compose-spec/compose-go/v2 v2.0.1/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
+github.com/compose-spec/compose-go/v2 v2.0.0 h1:RLI8GmNxRLg759CzZITh/kGYZTYhEak121FaVYdXTC8=
+github.com/compose-spec/compose-go/v2 v2.0.0/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -710,8 +710,10 @@ func setLimits(limits *types.Resource, resources *container.Resources) {
 	if limits.MemoryBytes != 0 {
 		resources.Memory = int64(limits.MemoryBytes)
 	}
-	if limits.NanoCPUs != 0 {
-		resources.NanoCPUs = int64(limits.NanoCPUs * 1e9)
+	if limits.NanoCPUs != "" {
+		if f, err := strconv.ParseFloat(limits.NanoCPUs, 64); err == nil {
+			resources.NanoCPUs = int64(f * 1e9)
+		}
 	}
 	if limits.Pids > 0 {
 		resources.PidsLimit = &limits.Pids


### PR DESCRIPTION
**What I did**
compose-go v2.0.1 is causing E2E test failures around dependency semantics.

This reverts commit ad414613090d031583181d34cf93f15024d0524c until we can figure that out.