### PR TITLE
chore(desktop): revised feature detection for file shares

### DIFF
--- a/internal/desktop/client.go
+++ b/internal/desktop/client.go
@@ -123,6 +123,37 @@ func (c *Client) FeatureFlags(ctx context.Context) (FeatureFlagResponse, error) 
 	return ret, nil
 }
 
+type GetFileSharesConfigResponse struct {
+	Active  bool `json:"active"`
+	Compose struct {
+		ManageBindMounts bool `json:"manageBindMounts"`
+	}
+}
+
+func (c *Client) GetFileSharesConfig(ctx context.Context) (*GetFileSharesConfigResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, backendURL("/mutagen/file-shares/config"), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newHTTPStatusCodeError(resp)
+	}
+
+	var ret GetFileSharesConfigResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
 type CreateFileShareRequest struct {
 	HostPath string            `json:"hostPath"`
 	Labels   map[string]string `json:"labels,omitempty"`

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -152,7 +152,7 @@ func (s *composeService) ensureProjectVolumes(ctx context.Context, project *type
 	}
 
 	err := func() error {
-		if s.experiments.AutoFileShares() && s.isDesktopIntegrationActive() {
+		if s.manageDesktopFileSharesEnabled(ctx) {
 			// collect all the bind mount paths and try to set up file shares in
 			// Docker Desktop for them
 			var paths []string

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -145,7 +145,7 @@ func (s *composeService) ensureVolumesDown(ctx context.Context, project *types.P
 		})
 	}
 
-	if s.experiments.AutoFileShares() && s.isDesktopIntegrationActive() {
+	if s.manageDesktopFileSharesEnabled(ctx) {
 		ops = append(ops, func() error {
 			desktop.RemoveFileSharesForProject(ctx, s.desktopCli, project.Name)
 			return nil


### PR DESCRIPTION
**What I did**
Unfortunately, the feature flag mechanism for experimental features isn't adequate. To avoid some edge cases where Compose might try to use Synchronized file shares with Desktop when the feature isn't available, we need to query a new endpoint.

Before we move any of this out of experimental, we need to improve the integration here with Desktop & Compose so that we get all the necessary feature/experiment state up-front to reduce the quantity of IPC calls needed up-front.

For now, there's some intentional redundancy to avoid making this extra call if we can avoid it. The actual endpoint is very cheap/ fast, but every IPC call is a potential point of of failure, so it's worth it.

**Related issue**
JIRA: [COMP-456]

[COMP-456]: https://docker.atlassian.net/browse/COMP-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ