### PR TITLE
Handle --no-build and --watch args

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -137,6 +137,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service, ex
 	return upCmd
 }
 
+//nolint:gocyclo
 func validateFlags(up *upOptions, create *createOptions) error {
 	if up.exitCodeFrom != "" {
 		up.cascadeStop = true
@@ -158,6 +159,9 @@ func validateFlags(up *upOptions, create *createOptions) error {
 	}
 	if create.recreateDeps && create.noRecreate {
 		return fmt.Errorf("--always-recreate-deps and --no-recreate are incompatible")
+	}
+	if create.noBuild && up.watch {
+		return fmt.Errorf("--no-build and --watch are incompatible")
 	}
 	return nil
 }

--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -259,6 +259,12 @@ func (lk *LogKeyboard) StartWatch(ctx context.Context, project *types.Project, o
 	} else {
 		eg.Go(tracing.EventWrapFuncForErrGroup(ctx, "menu/watch", tracing.SpanOptions{},
 			func(ctx context.Context) error {
+				if options.Create.Build == nil {
+					err := fmt.Errorf("Cannot run watch mode with flag --no-build")
+					lk.keyboardError("Watch", err)
+					return err
+				}
+
 				lk.Watch.newContext(ctx)
 				buildOpts := *options.Create.Build
 				buildOpts.Quiet = true


### PR DESCRIPTION
**What I did**
Fix case when running
```
docker compose up --watch --no-build
```
and 
```
docker compose up --no-build --menu (and then hit w - triggering watch)
```
It was throwing a panic since we were trying to access `options.Create.Build` which was nil.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes https://docker.atlassian.net/browse/COMP-501

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
