### PR TITLE
Change menu information text to dim

### DIFF
--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -102,8 +102,6 @@ func (l *logConsumer) Err(container, message string) {
 	l.write(l.stderr, container, message)
 }
 
-var navColor = makeColorFunc("90")
-
 func (l *logConsumer) write(w io.Writer, container, message string) {
 	if l.ctx.Err() != nil {
 		return

--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -187,7 +187,6 @@ func (lk *LogKeyboard) printNavigationMenu() {
 }
 
 func (lk *LogKeyboard) navigationMenu() string {
-	var options string
 	var openDDInfo string
 	if lk.IsDockerDesktopActive {
 		openDDInfo = shortcutKeyColor("v") + navColor(" View in Docker Desktop")
@@ -201,7 +200,7 @@ func (lk *LogKeyboard) navigationMenu() string {
 		isEnabled = " Disable"
 	}
 	watchInfo = watchInfo + shortcutKeyColor("w") + navColor(isEnabled+" Watch")
-	return options + openDDInfo + watchInfo
+	return openDDInfo + watchInfo
 }
 
 func (lk *LogKeyboard) clearNavigationMenu() {
@@ -324,4 +323,8 @@ func shortcutKeyColor(key string) string {
 	background := "48;2"
 	white := "255;255;255"
 	return ansiColor(foreground+";"+black+";"+background+";"+white, key, BOLD)
+}
+
+func navColor(key string) string {
+	return ansiColor(FAINT, key)
 }


### PR DESCRIPTION
**What I did**
Change hard coded gray color to use dim code `\033[2m` instead and let the terminal handle the dimming of the default color text.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes https://docker.atlassian.net/jira/software/c/projects/COMP/boards/576?selectedIssue=COMP-502

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/22371565/003e3652-ea2d-4bdd-8aa9-01bbc228a8dc)
