### PR TITLE
Does not start menu manager if there is no tty on up

### DIFF
--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -275,10 +275,6 @@ func (lk *LogKeyboard) StartWatch(ctx context.Context, project *types.Project, o
 	}
 }
 
-func (lk *LogKeyboard) KeyboardClose() {
-	_ = keyboard.Close()
-}
-
 func (lk *LogKeyboard) HandleKeyEvents(event keyboard.KeyEvent, ctx context.Context, project *types.Project, options api.UpOptions) {
 	switch kRune := event.Rune; kRune {
 	case 'v':
@@ -288,8 +284,7 @@ func (lk *LogKeyboard) HandleKeyEvents(event keyboard.KeyEvent, ctx context.Cont
 	}
 	switch key := event.Key; key {
 	case keyboard.KeyCtrlC:
-		lk.KeyboardClose()
-
+		_ = keyboard.Close()
 		lk.clearNavigationMenu()
 		ShowCursor()
 


### PR DESCRIPTION
**What I did**
Handle when there is no tty available and navigation menu is enabled. Also gracefully handle key events when an error occurs instead of panic.
Also did small refactor in `cmd/up.go` related with `NavigationMenu` validation.

This can be tested locally by running:
```
(/opt/homebrew/opt/util-linux/bin/setsid ~/workspace/compose/bin/build/docker-compose up --menu=true) </dev/null |& cat
```

make sure you have `util-linux` install
```
brew install util-linux
```

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes https://docker.atlassian.net/browse/DDB-25

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/22371565/ef5b11d2-dd35-41b3-ae3d-9002b3d09e03)
