### PR TITLE
Introduce --abort-on-container-failure

### DIFF
--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -104,10 +104,9 @@ func runWatch(ctx context.Context, dockerCli command.Cli, backend api.Service, w
 				QuietPull:            buildOpts.quiet,
 			},
 			Start: api.StartOptions{
-				Project:     project,
-				Attach:      nil,
-				CascadeStop: false,
-				Services:    services,
+				Project:  project,
+				Attach:   nil,
+				Services: services,
 			},
 		}
 		if err := backend.Up(ctx, project, upOpts); err != nil {

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -5,34 +5,35 @@ Create and start containers
 
 ### Options
 
-| Name                         | Type          | Default  | Description                                                                                             |
-|:-----------------------------|:--------------|:---------|:--------------------------------------------------------------------------------------------------------|
-| `--abort-on-container-exit`  |               |          | Stops all containers if any container was stopped. Incompatible with -d                                 |
-| `--always-recreate-deps`     |               |          | Recreate dependent containers. Incompatible with --no-recreate.                                         |
-| `--attach`                   | `stringArray` |          | Restrict attaching to the specified services. Incompatible with --attach-dependencies.                  |
-| `--attach-dependencies`      |               |          | Automatically attach to log output of dependent services                                                |
-| `--build`                    |               |          | Build images before starting containers                                                                 |
-| `-d`, `--detach`             |               |          | Detached mode: Run containers in the background                                                         |
-| `--dry-run`                  |               |          | Execute command in dry run mode                                                                         |
-| `--exit-code-from`           | `string`      |          | Return the exit code of the selected service container. Implies --abort-on-container-exit               |
-| `--force-recreate`           |               |          | Recreate containers even if their configuration and image haven't changed                               |
-| `--no-attach`                | `stringArray` |          | Do not attach (stream logs) to the specified services                                                   |
-| `--no-build`                 |               |          | Don't build an image, even if it's policy                                                               |
-| `--no-color`                 |               |          | Produce monochrome output                                                                               |
-| `--no-deps`                  |               |          | Don't start linked services                                                                             |
-| `--no-log-prefix`            |               |          | Don't print prefix in logs                                                                              |
-| `--no-recreate`              |               |          | If containers already exist, don't recreate them. Incompatible with --force-recreate.                   |
-| `--no-start`                 |               |          | Don't start the services after creating them                                                            |
-| `--pull`                     | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                                                |
-| `--quiet-pull`               |               |          | Pull without printing progress information                                                              |
-| `--remove-orphans`           |               |          | Remove containers for services not defined in the Compose file                                          |
-| `-V`, `--renew-anon-volumes` |               |          | Recreate anonymous volumes instead of retrieving data from the previous containers                      |
-| `--scale`                    | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.           |
-| `-t`, `--timeout`            | `int`         | `0`      | Use this timeout in seconds for container shutdown when attached or when containers are already running |
-| `--timestamps`               |               |          | Show timestamps                                                                                         |
-| `--wait`                     |               |          | Wait for services to be running\|healthy. Implies detached mode.                                        |
-| `--wait-timeout`             | `int`         | `0`      | Maximum duration to wait for the project to be running\|healthy                                         |
-| `-w`, `--watch`              |               |          | Watch source code and rebuild/refresh containers when files are updated.                                |
+| Name                           | Type          | Default  | Description                                                                                             |
+|:-------------------------------|:--------------|:---------|:--------------------------------------------------------------------------------------------------------|
+| `--abort-on-container-exit`    |               |          | Stops all containers if any container was stopped. Incompatible with -d                                 |
+| `--abort-on-container-failure` |               |          | Stops all containers if any container exited with failure. Incompatible with -d                         |
+| `--always-recreate-deps`       |               |          | Recreate dependent containers. Incompatible with --no-recreate.                                         |
+| `--attach`                     | `stringArray` |          | Restrict attaching to the specified services. Incompatible with --attach-dependencies.                  |
+| `--attach-dependencies`        |               |          | Automatically attach to log output of dependent services                                                |
+| `--build`                      |               |          | Build images before starting containers                                                                 |
+| `-d`, `--detach`               |               |          | Detached mode: Run containers in the background                                                         |
+| `--dry-run`                    |               |          | Execute command in dry run mode                                                                         |
+| `--exit-code-from`             | `string`      |          | Return the exit code of the selected service container. Implies --abort-on-container-exit               |
+| `--force-recreate`             |               |          | Recreate containers even if their configuration and image haven't changed                               |
+| `--no-attach`                  | `stringArray` |          | Do not attach (stream logs) to the specified services                                                   |
+| `--no-build`                   |               |          | Don't build an image, even if it's policy                                                               |
+| `--no-color`                   |               |          | Produce monochrome output                                                                               |
+| `--no-deps`                    |               |          | Don't start linked services                                                                             |
+| `--no-log-prefix`              |               |          | Don't print prefix in logs                                                                              |
+| `--no-recreate`                |               |          | If containers already exist, don't recreate them. Incompatible with --force-recreate.                   |
+| `--no-start`                   |               |          | Don't start the services after creating them                                                            |
+| `--pull`                       | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                                                |
+| `--quiet-pull`                 |               |          | Pull without printing progress information                                                              |
+| `--remove-orphans`             |               |          | Remove containers for services not defined in the Compose file                                          |
+| `-V`, `--renew-anon-volumes`   |               |          | Recreate anonymous volumes instead of retrieving data from the previous containers                      |
+| `--scale`                      | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.           |
+| `-t`, `--timeout`              | `int`         | `0`      | Use this timeout in seconds for container shutdown when attached or when containers are already running |
+| `--timestamps`                 |               |          | Show timestamps                                                                                         |
+| `--wait`                       |               |          | Wait for services to be running\|healthy. Implies detached mode.                                        |
+| `--wait-timeout`               | `int`         | `0`      | Maximum duration to wait for the project to be running\|healthy                                         |
+| `-w`, `--watch`                |               |          | Watch source code and rebuild/refresh containers when files are updated.                                |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -35,6 +35,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: abort-on-container-failure
+      value_type: bool
+      default_value: "false"
+      description: |
+        Stops all containers if any container exited with failure. Incompatible with -d
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: always-recreate-deps
       value_type: bool
       default_value: "false"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -209,8 +209,8 @@ type StartOptions struct {
 	Attach LogConsumer
 	// AttachTo set the services to attach to
 	AttachTo []string
-	// CascadeStop stops the application when a container stops
-	CascadeStop bool
+	// OnExit defines behavior when a container stops
+	OnExit Cascade
 	// ExitCodeFrom return exit code from specified service
 	ExitCodeFrom string
 	// Wait won't return until containers reached the running|healthy state
@@ -221,6 +221,14 @@ type StartOptions struct {
 	Watch          bool
 	NavigationMenu bool
 }
+
+type Cascade int
+
+const (
+	CascadeIgnore Cascade = iota
+	CascadeStop   Cascade = iota
+	CascadeFail   Cascade = iota
+)
 
 // RestartOptions group options of the Restart API
 type RestartOptions struct {

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -80,7 +80,7 @@ func (s *composeService) Logs(
 		containers = containers.filter(isRunning())
 		printer := newLogPrinter(consumer)
 		eg.Go(func() error {
-			_, err := printer.Run(false, "", nil)
+			_, err := printer.Run(api.CascadeIgnore, "", nil)
 			return err
 		})
 

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -134,7 +134,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 
 	var exitCode int
 	eg.Go(func() error {
-		code, err := printer.Run(options.Start.CascadeStop, options.Start.ExitCodeFrom, func() error {
+		code, err := printer.Run(options.Start.OnExit, options.Start.ExitCodeFrom, func() error {
 			fmt.Fprintln(s.stdinfo(), "Aborting on container exit...")
 			return progress.Run(ctx, func(ctx context.Context) error {
 				return s.Stop(ctx, project.Name, api.StopOptions{

--- a/pkg/e2e/cascade_test.go
+++ b/pkg/e2e/cascade_test.go
@@ -1,0 +1,53 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright 2022 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCascadeStop(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "compose-e2e-cascade-stop"
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	})
+
+	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/cascade/compose.yaml", "--project-name", projectName,
+		"up", "--abort-on-container-exit")
+	assert.Assert(t, strings.Contains(res.Combined(), "exit-1 exited with code 0"), res.Combined())
+}
+
+func TestCascadeFail(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "compose-e2e-cascade-fail"
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	})
+
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/cascade/compose.yaml", "--project-name", projectName,
+		"up", "--abort-on-container-failure")
+	assert.Assert(t, strings.Contains(res.Combined(), "exit-1 exited with code 0"), res.Combined())
+	assert.Assert(t, strings.Contains(res.Combined(), "fail-1 exited with code 1"), res.Combined())
+	assert.Equal(t, res.ExitCode, 1)
+}

--- a/pkg/e2e/fixtures/cascade/compose.yaml
+++ b/pkg/e2e/fixtures/cascade/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  exit:
+    image: alpine
+    command: /bin/true
+
+  fail:
+    image: alpine
+    command: sh -c "sleep 0.1 && /bin/false"


### PR DESCRIPTION
**What I did**

Introduce `--abort-on-container-failure` as a custom flavor for cascade stop, which only stops on container failure (exit != 0). This allows to run "tasks" defined by services (sorry for the conceptual mismatch) and complete successfully if all succeeded, but fail if any failed, and kill the others (aka "fail fast")


**Related issue**
closes https://github.com/docker/compose/issues/10225

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/659bbc7e-2190-4d31-a1ee-9d68a34a39bb)
