### PR TITLE
don't use ansi espace sequence when disabled

### DIFF
--- a/cmd/formatter/ansi.go
+++ b/cmd/formatter/ansi.go
@@ -22,36 +22,65 @@ import (
 	"github.com/acarl005/stripansi"
 )
 
+var disableAnsi bool
+
 func ansi(code string) string {
 	return fmt.Sprintf("\033%s", code)
 }
 func SaveCursor() {
+	if disableAnsi {
+		return
+	}
 	fmt.Print(ansi("7"))
 }
 func RestoreCursor() {
+	if disableAnsi {
+		return
+	}
 	fmt.Print(ansi("8"))
 }
 func HideCursor() {
+	if disableAnsi {
+		return
+	}
 	fmt.Print(ansi("[?25l"))
 }
 func ShowCursor() {
+	if disableAnsi {
+		return
+	}
 	fmt.Print(ansi("[?25h"))
 }
 func MoveCursor(y, x int) {
+	if disableAnsi {
+		return
+	}
 	fmt.Print(ansi(fmt.Sprintf("[%d;%dH", y, x)))
 }
 func MoveCursorX(pos int) {
+	if disableAnsi {
+		return
+	}
 	fmt.Print(ansi(fmt.Sprintf("[%dG", pos)))
 }
 func ClearLine() {
+	if disableAnsi {
+		return
+	}
 	// Does not move cursor from its current position
 	fmt.Print(ansi("[2K"))
 }
 func MoveCursorUp(lines int) {
+	if disableAnsi {
+		return
+	}
 	// Does not add new lines
 	fmt.Print(ansi(fmt.Sprintf("[%dA", lines)))
 }
 func MoveCursorDown(lines int) {
+	if disableAnsi {
+		return
+	}
 	// Does not add new lines
 	fmt.Print(ansi(fmt.Sprintf("[%dB", lines)))
 }

--- a/cmd/formatter/colors.go
+++ b/cmd/formatter/colors.go
@@ -64,6 +64,7 @@ func SetANSIMode(streams api.Streams, ansi string) {
 		nextColor = func() colorFunc {
 			return monochrome
 		}
+		disableAnsi = true
 	}
 }
 


### PR DESCRIPTION
**What I did**
when ansi is disabled or output is not a terminal, fully disable any ANSI magic

**Related issue**
closes https://github.com/docker/compose/issues/11681

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
