### PR TITLE
Strip empty DNS entries to avoid Moby parse errors when creating sandbox DNS

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -99,6 +99,8 @@ func (s *composeService) create(ctx context.Context, project *types.Project, opt
 		return err
 	}
 
+	prepareServiceDNS(project)
+
 	if err := s.ensureProjectVolumes(ctx, project); err != nil {
 		return err
 	}
@@ -139,6 +141,17 @@ func (s *composeService) ensureNetworks(ctx context.Context, networks types.Netw
 		networks[i] = network
 	}
 	return nil
+}
+
+func prepareServiceDNS(project *types.Project) {
+	for k, service := range project.Services {
+		trimmedDNS := utils.Remove(service.DNS, "")
+		if len(trimmedDNS) != len(service.DNS) {
+			logrus.Warnf("The %q service has one or more empty DNS entries. Skipping them.", k)
+		}
+		service.DNS = trimmedDNS
+		project.Services[k] = service
+	}
 }
 
 func (s *composeService) ensureProjectVolumes(ctx context.Context, project *types.Project) error {

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -327,3 +327,31 @@ func TestCreateEndpointSettings(t *testing.T) {
 		IPv6Gateway: "fdb4:7a7f:373a:3f0c::42",
 	}))
 }
+
+func TestPrepareServiceDNS(t *testing.T) {
+	t.Run("returns DNS list without empty strings", func(t *testing.T) {
+		const (
+			serviceName = "myService"
+			dns1        = "dns-1"
+			dns2        = "dns-2"
+		)
+		project := composetypes.Project{
+			Services: composetypes.Services{
+				serviceName: composetypes.ServiceConfig{
+					DNS: []string{
+						dns1,
+						"",
+						dns2,
+						"",
+					},
+				},
+			},
+		}
+
+		prepareServiceDNS(&project)
+		dnsConfig := project.Services[serviceName].DNS
+		assert.Equal(t, len(dnsConfig), 2)
+		assert.Equal(t, dnsConfig[0], dns1)
+		assert.Equal(t, dnsConfig[1], dns2)
+	})
+}


### PR DESCRIPTION
**What I did**

Ensured that each service's DNS settings are stripped from empty entries that could result from using ENV variables that defaulted to blank strings.

For example:
```
  service:
    # ANOTHER_SERVICE_IP is not set and defaults to blank string
    dns: ${ANOTHER_SERVICE_IP}
    ...
```

**Related issue**
https://github.com/docker/compose/issues/11690
