### PR TITLE
Remove dead url reference.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,7 @@ before anybody starts working on it.
 
 We are always thrilled to receive pull requests. We do our best to process them
 quickly. If your pull request is not accepted on the first try,
-don't get discouraged! Our contributor's guide explains
-[the review process we use for simple changes](https://docs.docker.com/opensource/workflow/make-a-contribution/).
+don't get discouraged!
 
 ### Talking to other Docker users and contributors
 


### PR DESCRIPTION
**- What I did**
I removed a sentence with a dead url, i would have preferred to fix the reference, but there doesn't seem to be a review process anymore in the official docs.

**- How to verify it**
Just by trying to access https://docs.docker.com/opensource/workflow/make-a-contribution/
I even searched for the old reference in the wayback machine but nothing similar is present in the current docs.

**Related issue**
None

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![c466907bfa75c5598d6a193a589531a4](https://github.com/docker/compose/assets/62723360/d6ffa5df-01dc-4474-b99a-81797756c2e4)
