### PR TITLE
introduce `--all-resources` to _not_ exclude resources not used by services

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -125,6 +125,10 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service, ex
 
 			up.validateNavigationMenu(dockerCli, experiments)
 
+			if !p.All && len(project.Services) == 0 {
+				return fmt.Errorf("no service selected")
+			}
+
 			return runUp(ctx, dockerCli, backend, create, up, build, project, services)
 		}),
 		ValidArgsFunction: completeServiceNames(dockerCli, p),
@@ -205,10 +209,6 @@ func runUp(
 	project *types.Project,
 	services []string,
 ) error {
-	if len(project.Services) == 0 {
-		return fmt.Errorf("no service selected")
-	}
-
 	err := createOptions.Apply(project)
 	if err != nil {
 		return err

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -43,6 +43,7 @@ Define and run multi-container applications with Docker
 
 | Name                   | Type          | Default | Description                                                                                         |
 |:-----------------------|:--------------|:--------|:----------------------------------------------------------------------------------------------------|
+| `--all-resources`      |               |         | Include all resources, even those not used by services                                              |
 | `--ansi`               | `string`      | `auto`  | Control when to print ANSI control characters ("never"\|"always"\|"auto")                           |
 | `--compatibility`      |               |         | Run compose in backward compatibility mode                                                          |
 | `--dry-run`            |               |         | Execute command in dry run mode                                                                     |

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -208,6 +208,16 @@ clink:
     - docker_compose_wait.yaml
     - docker_compose_watch.yaml
 options:
+    - option: all-resources
+      value_type: bool
+      default_value: "false"
+      description: Include all resources, even those not used by services
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: ansi
       value_type: string
       default_value: auto

--- a/pkg/e2e/fixtures/resources/compose.yaml
+++ b/pkg/e2e/fixtures/resources/compose.yaml
@@ -1,0 +1,5 @@
+volumes:
+  my_vol: {}
+
+networks:
+  my_net: {}

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -164,4 +165,16 @@ func TestUpWithDependencyNotRequired(t *testing.T) {
 		"--profile", "not-required", "up", "-d")
 	assert.Assert(t, strings.Contains(res.Combined(), "foo"), res.Combined())
 	assert.Assert(t, strings.Contains(res.Combined(), " optional dependency \"bar\" failed to start"), res.Combined())
+}
+
+func TestUpWithAllResources(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "compose-e2e-all-resources"
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "-v")
+	})
+
+	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/resources/compose.yaml", "--all-resources", "--project-name", projectName, "up")
+	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf(`Volume "%s_my_vol"  Created`, projectName)), res.Combined())
+	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf(`Network %s_my_net  Created`, projectName)), res.Combined())
 }


### PR DESCRIPTION
**What I did**
introduce `--all-resources` so that compose model don't get resources not used by services excluded
This allows to use `docker compose create` to manage non-services resources, when such a resource is shared by multiple compose application.

**Related issue**
closes https://github.com/docker/compose/issues/10930

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/24d65a64-352d-4c8b-bae6-129ba7dcc74d)
