### PR TITLE
read COMPOSE_REMOVE_ORPHANS from .env

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -112,6 +112,9 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service, ex
 			create.pullChanged = cmd.Flags().Changed("pull")
 			create.timeChanged = cmd.Flags().Changed("timeout")
 			up.navigationMenuChanged = cmd.Flags().Changed("menu")
+			if !cmd.Flags().Changed("remove-orphans") {
+				create.removeOrphans = utils.StringToBool(os.Getenv(ComposeRemoveOrphans))
+			}
 			return validateFlags(&up, &create)
 		}),
 		RunE: p.WithServices(dockerCli, func(ctx context.Context, project *types.Project, services []string) error {
@@ -138,8 +141,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service, ex
 	flags.BoolVar(&create.Build, "build", false, "Build images before starting containers")
 	flags.BoolVar(&create.noBuild, "no-build", false, "Don't build an image, even if it's policy")
 	flags.StringVar(&create.Pull, "pull", "policy", `Pull image before running ("always"|"missing"|"never")`)
-	removeOrphans := utils.StringToBool(os.Getenv(ComposeRemoveOrphans))
-	flags.BoolVar(&create.removeOrphans, "remove-orphans", removeOrphans, "Remove containers for services not defined in the Compose file")
+	flags.BoolVar(&create.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
 	flags.StringArrayVar(&create.scale, "scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
 	flags.BoolVar(&up.noColor, "no-color", false, "Produce monochrome output")
 	flags.BoolVar(&up.noPrefix, "no-log-prefix", false, "Don't print prefix in logs")


### PR DESCRIPTION
**What I did**

read `COMPOSE_REMOVE_ORPHANS` from project environment (after os.env and .env file has been loaded)
and assign --remove-orphans accordingly until user has explictely set the flag

**Related issue**
closes https://github.com/docker/compose/issues/11707

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/88aa8764-4d05-4291-bc71-84e6d9a0fa99)
