### PR TITLE
capture exit code for container being stopped, and return according to `--exit-code-from`

### DIFF
--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -138,9 +138,11 @@ func (p *printer) Run(cascade api.Cascade, exitCodeFrom string, stopFn func() er
 					if cascade == api.CascadeStop && exitCodeFrom == "" {
 						exitCodeFrom = event.Service
 					}
-					if exitCodeFrom == event.Service {
-						exitCode = event.ExitCode
-					}
+				}
+
+				if exitCodeFrom == event.Service && (event.Type == api.ContainerEventExit || event.Type == api.ContainerEventStopped) {
+					// Container was interrupted or exited, let's capture exit code
+					exitCode = event.ExitCode
 				}
 				if len(containers) == 0 {
 					// Last container terminated, done

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -268,6 +268,7 @@ func (s *composeService) watchContainers(ctx context.Context, //nolint:gocyclo
 						Container: name,
 						ID:        container.ID,
 						Service:   service,
+						ExitCode:  inspected.State.ExitCode,
 					})
 				}
 


### PR DESCRIPTION
**What I did**
capture container's exitCode on stop event, as container has been interrupted

**Related issue**
fixes https://github.com/docker/compose/issues/11712

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/2e4fc29b-790b-493d-a76d-4d823b0cc8fd)
