### PR TITLE
Fix #10661: docker compose up always kills the containers on second Ctrl-C

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -312,6 +312,8 @@ type KillOptions struct {
 	Services []string
 	// Signal to send to containers
 	Signal string
+	// All can be set to true to try to kill all found containers, independently of their state
+	All bool
 }
 
 // RemoveOptions group options of the Remove API

--- a/pkg/compose/containers.go
+++ b/pkg/compose/containers.go
@@ -41,12 +41,12 @@ const (
 	oneOffOnly
 )
 
-func (s *composeService) getContainers(ctx context.Context, project string, oneOff oneOff, stopped bool, selectedServices ...string) (Containers, error) {
+func (s *composeService) getContainers(ctx context.Context, project string, oneOff oneOff, all bool, selectedServices ...string) (Containers, error) {
 	var containers Containers
 	f := getDefaultFilters(project, oneOff, selectedServices...)
 	containers, err := s.apiClient().ContainerList(ctx, containerType.ListOptions{
 		Filters: filters.NewArgs(f...),
-		All:     stopped,
+		All:     all,
 	})
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func getDefaultFilters(projectName string, oneOff oneOff, selectedServices ...st
 	return f
 }
 
-func (s *composeService) getSpecifiedContainer(ctx context.Context, projectName string, oneOff oneOff, stopped bool, serviceName string, containerIndex int) (moby.Container, error) {
+func (s *composeService) getSpecifiedContainer(ctx context.Context, projectName string, oneOff oneOff, all bool, serviceName string, containerIndex int) (moby.Container, error) {
 	defaultFilters := getDefaultFilters(projectName, oneOff, serviceName)
 	if containerIndex > 0 {
 		defaultFilters = append(defaultFilters, containerNumberFilter(containerIndex))
@@ -82,7 +82,7 @@ func (s *composeService) getSpecifiedContainer(ctx context.Context, projectName 
 		Filters: filters.NewArgs(
 			defaultFilters...,
 		),
-		All: stopped,
+		All: all,
 	})
 	if err != nil {
 		return moby.Container{}, err

--- a/pkg/compose/kill.go
+++ b/pkg/compose/kill.go
@@ -40,7 +40,7 @@ func (s *composeService) kill(ctx context.Context, projectName string, options a
 	services := options.Services
 
 	var containers Containers
-	containers, err := s.getContainers(ctx, projectName, oneOffInclude, false, services...)
+	containers, err := s.getContainers(ctx, projectName, oneOffInclude, options.All, services...)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -119,11 +119,14 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 					gracefulTeardown()
 				} else {
 					eg.Go(func() error {
-						return s.Kill(context.Background(), project.Name, api.KillOptions{
+						// Intentionally ignore errors, for cases where some
+						// of the containers are already stopped.
+						s.kill(context.Background(), project.Name, api.KillOptions{
 							Services: options.Create.Services,
 							Project:  project,
 							All:      true,
 						})
+						return nil
 					})
 					return nil
 				}

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -122,6 +122,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 						return s.Kill(context.Background(), project.Name, api.KillOptions{
 							Services: options.Create.Services,
 							Project:  project,
+							All:      true,
 						})
 					})
 					return nil


### PR DESCRIPTION
**What I did**

Hitting Ctrl-C twice in docker compose up is supposed to immediately kill the containers. 
Kill executed on the second Ctrl-C was filtering containers depending on its state. In some
cases the containers can reach an state for what these filters don't get any container, and
the command hangs while printing `no container to kill`.

Remove this filtering, so it tries to kill any container it finds, independently of their state.

**Related issue**

Fixes https://github.com/docker/compose/issues/10661