### PR TITLE
Fix progress timer and spinner

### DIFF
--- a/internal/desktop/file_shares.go
+++ b/internal/desktop/file_shares.go
@@ -139,9 +139,6 @@ func NewFileShareManager(cli *Client, projectName string, hostPaths []string) *F
 // flow can continue.
 func (m *FileShareManager) EnsureExists(ctx context.Context) (err error) {
 	w := progress.ContextWriter(ctx)
-	// TODO(milas): this should be a per-node option, not global
-	w.HasMore(false)
-
 	w.Event(progress.NewEvent(fileShareProgressID, progress.Working, ""))
 	defer func() {
 		if err != nil {

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -757,7 +757,7 @@ func (s *composeService) isServiceCompleted(ctx context.Context, containers Cont
 	return false, 0, nil
 }
 
-func (s *composeService) startService(ctx context.Context, project *types.Project, service types.ServiceConfig, containers Containers, wait bool) error {
+func (s *composeService) startService(ctx context.Context, project *types.Project, service types.ServiceConfig, containers Containers) error {
 	if service.Deploy != nil && service.Deploy.Replicas != nil && *service.Deploy.Replicas == 0 {
 		return nil
 	}
@@ -785,26 +785,9 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 		if err != nil {
 			return err
 		}
-		status := progress.Done
-		if wait || dependencyWaiting(project, service.Name) {
-			status = progress.Working
-		}
-		w.Event(progress.NewEvent(eventName, status, "Started"))
+		w.Event(progress.StartedEvent(eventName))
 	}
 	return nil
-}
-
-func dependencyWaiting(project *types.Project, name string) bool {
-	for _, service := range project.Services {
-		depends, ok := service.DependsOn[name]
-		if !ok {
-			continue
-		}
-		if depends.Condition == types.ServiceConditionHealthy {
-			return true
-		}
-	}
-	return false
 }
 
 func mergeLabels(ls ...types.Labels) types.Labels {

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -68,11 +68,11 @@ type createConfigs struct {
 
 func (s *composeService) Create(ctx context.Context, project *types.Project, createOpts api.CreateOptions) error {
 	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
-		return s.create(ctx, project, createOpts, false)
+		return s.create(ctx, project, createOpts)
 	}, s.stdinfo(), "Creating")
 }
 
-func (s *composeService) create(ctx context.Context, project *types.Project, options api.CreateOptions, willAttach bool) error {
+func (s *composeService) create(ctx context.Context, project *types.Project, options api.CreateOptions) error {
 	if len(options.Services) == 0 {
 		options.Services = project.ServiceNames()
 	}
@@ -112,10 +112,6 @@ func (s *composeService) create(ctx context.Context, project *types.Project, opt
 				"file, you can run this command with the "+
 				"--remove-orphans flag to clean it up.", orphans.names())
 		}
-	}
-
-	if willAttach {
-		progress.ContextWriter(ctx).HasMore(willAttach)
 	}
 	return newConvergence(options.Services, observedState, s).apply(ctx, project, options)
 }

--- a/pkg/compose/scale.go
+++ b/pkg/compose/scale.go
@@ -26,7 +26,7 @@ import (
 
 func (s *composeService) Scale(ctx context.Context, project *types.Project, options api.ScaleOptions) error {
 	return progress.Run(ctx, tracing.SpanWrapFunc("project/scale", tracing.ProjectOptions(ctx, project), func(ctx context.Context) error {
-		err := s.create(ctx, project, api.CreateOptions{Services: options.Services}, true)
+		err := s.create(ctx, project, api.CreateOptions{Services: options.Services})
 		if err != nil {
 			return err
 		}

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -129,7 +129,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 			return err
 		}
 
-		return s.startService(ctx, project, service, containers, options.Wait)
+		return s.startService(ctx, project, service, containers)
 	})
 	if err != nil {
 		return err

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -37,8 +37,7 @@ import (
 
 func (s *composeService) Up(ctx context.Context, project *types.Project, options api.UpOptions) error { //nolint:gocyclo
 	err := progress.Run(ctx, tracing.SpanWrapFunc("project/up", tracing.ProjectOptions(ctx, project), func(ctx context.Context) error {
-		w := progress.ContextWriter(ctx)
-		err := s.create(ctx, project, options.Create, options.Start.Attach != nil)
+		err := s.create(ctx, project, options.Create)
 		if err != nil {
 			return err
 		}

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -43,7 +43,6 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 			return err
 		}
 		if options.Start.Attach == nil {
-			w.HasMore(false)
 			return s.start(ctx, project.Name, options.Start, nil)
 		}
 		return nil

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -470,7 +470,7 @@ func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Pr
 				Services: []string{serviceName},
 				Inherit:  true,
 				Recreate: api.RecreateForce,
-			}, true)
+			})
 			if err != nil {
 				options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Failed to recreate service after update. Error: %v", err))
 				return err

--- a/pkg/progress/event.go
+++ b/pkg/progress/event.go
@@ -191,6 +191,6 @@ func (e *Event) Spinner() any {
 	case Error:
 		return ErrorColor(spinnerError)
 	default:
-		return CountColor(e.spinner.String())
+		return e.spinner.String()
 	}
 }

--- a/pkg/progress/event.go
+++ b/pkg/progress/event.go
@@ -176,6 +176,10 @@ func (e *Event) stop() {
 	e.spinner.Stop()
 }
 
+func (e *Event) hasMore() {
+	e.spinner.Restart()
+}
+
 var (
 	spinnerDone    = "✔"
 	spinnerWarning = "!"
@@ -191,6 +195,6 @@ func (e *Event) Spinner() any {
 	case Error:
 		return ErrorColor(spinnerError)
 	default:
-		return e.spinner.String()
+		return CountColor(e.spinner.String())
 	}
 }

--- a/pkg/progress/noop.go
+++ b/pkg/progress/noop.go
@@ -38,6 +38,3 @@ func (p *noopWriter) TailMsgf(_ string, _ ...interface{}) {
 
 func (p *noopWriter) Stop() {
 }
-
-func (p *noopWriter) HasMore(bool) {
-}

--- a/pkg/progress/plain.go
+++ b/pkg/progress/plain.go
@@ -64,6 +64,3 @@ func (p *plainWriter) TailMsgf(msg string, args ...interface{}) {
 func (p *plainWriter) Stop() {
 	p.done <- true
 }
-
-func (p *plainWriter) HasMore(bool) {
-}

--- a/pkg/progress/quiet.go
+++ b/pkg/progress/quiet.go
@@ -35,6 +35,3 @@ func (q quiet) Events(_ []Event) {
 
 func (q quiet) TailMsgf(_ string, _ ...interface{}) {
 }
-
-func (q quiet) HasMore(bool) {
-}

--- a/pkg/progress/spinner.go
+++ b/pkg/progress/spinner.go
@@ -64,3 +64,7 @@ func (s *spinner) String() string {
 func (s *spinner) Stop() {
 	s.stop = true
 }
+
+func (s *spinner) Restart() {
+	s.stop = false
+}

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -84,14 +84,11 @@ func (w *ttyWriter) event(e Event) {
 		last := w.events[e.ID]
 		switch e.Status {
 		case Done, Error, Warning:
-			if last.endTime.IsZero() {
+			if last.Status != e.Status {
 				last.stop()
 			}
 		case Working:
-			if !last.endTime.IsZero() {
-				// already done, don't overwrite
-				return
-			}
+			last.hasMore()
 		}
 		last.Status = e.Status
 		last.Text = e.Text

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -33,18 +33,17 @@ import (
 )
 
 type ttyWriter struct {
-	out               io.Writer
-	events            map[string]Event
-	eventIDs          []string
-	repeated          bool
-	numLines          int
-	done              chan bool
-	mtx               *sync.Mutex
-	tailEvents        []string
-	dryRun            bool
-	skipChildEvents   bool
-	progressTitle     string
-	hasFollowupAction bool
+	out             io.Writer
+	events          map[string]Event
+	eventIDs        []string
+	repeated        bool
+	numLines        int
+	done            chan bool
+	mtx             *sync.Mutex
+	tailEvents      []string
+	dryRun          bool
+	skipChildEvents bool
+	progressTitle   string
 }
 
 func (w *ttyWriter) Start(ctx context.Context) error {
@@ -71,10 +70,6 @@ func (w *ttyWriter) Stop() {
 	w.done <- true
 }
 
-func (w *ttyWriter) HasMore(b bool) {
-	w.hasFollowupAction = b
-}
-
 func (w *ttyWriter) Event(e Event) {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
@@ -87,9 +82,6 @@ func (w *ttyWriter) event(e Event) {
 	}
 	if _, ok := w.events[e.ID]; ok {
 		last := w.events[e.ID]
-		if e.Status == Done && w.hasFollowupAction {
-			e.Status = Working
-		}
 		switch e.Status {
 		case Done, Error, Warning:
 			if last.endTime.IsZero() {

--- a/pkg/progress/tty_test.go
+++ b/pkg/progress/tty_test.go
@@ -42,7 +42,7 @@ func TestLineText(t *testing.T) {
 	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
 
 	out := tty().lineText(ev, "", 50, lineWidth, false)
-	assert.Equal(t, out, " . id Text Status                            \x1b[34m0.0s \x1b[0m\n")
+	assert.Equal(t, out, " \x1b[33m.\x1b[0m id Text Status                            \x1b[34m0.0s \x1b[0m\n")
 
 	ev.Status = Done
 	out = tty().lineText(ev, "", 50, lineWidth, false)

--- a/pkg/progress/tty_test.go
+++ b/pkg/progress/tty_test.go
@@ -42,7 +42,7 @@ func TestLineText(t *testing.T) {
 	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
 
 	out := tty().lineText(ev, "", 50, lineWidth, false)
-	assert.Equal(t, out, " \x1b[33m.\x1b[0m id Text Status                            \x1b[34m0.0s \x1b[0m\n")
+	assert.Equal(t, out, " . id Text Status                            \x1b[34m0.0s \x1b[0m\n")
 
 	ev.Status = Done
 	out = tty().lineText(ev, "", 50, lineWidth, false)

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -36,7 +36,6 @@ type Writer interface {
 	Event(Event)
 	Events([]Event)
 	TailMsgf(string, ...interface{})
-	HasMore(more bool)
 }
 
 type writerKey struct{}


### PR DESCRIPTION
**What I did**
https://github.com/docker/compose/pull/11357 was way too optimistic: we can't guess the last event expected for a resource. Better allow progress to manage "more work coming in" and restart the timer/spinner.

progress will report "done" state for some milliseconds before a new task starts and switch it back to "working", so there might be some flicker in UI but at least the end result is correct.

**Related issue**
fixes https://github.com/docker/compose/issues/11717

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/931fc49d-a768-4403-a377-c6d2afe88243)
