### PR TITLE
don't clear line when navigation is disabled

### DIFF
--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -110,7 +110,9 @@ func (l *logConsumer) write(w io.Writer, container, message string) {
 		p := l.getPresenter(container)
 		timestamp := time.Now().Format(jsonmessage.RFC3339NanoFixed)
 		for _, line := range strings.Split(message, "\n") {
-			ClearLine()
+			if KeyboardManager != nil {
+				ClearLine()
+			}
 			if l.timestamp {
 				fmt.Fprintf(w, "%s%s%s\n", p.prefix, timestamp, line)
 			} else {


### PR DESCRIPTION
**What I did**
Quick and dirty fix for #11727 : only emit `ERASE` when `KeyboardManager` is set, which reflects navigation menu being enabled.
We should invest some time to redesign the log printing logic, so that `logConsumer` is not a weird combination of `if` statements.

**Related issue**
fixes https://github.com/docker/compose/issues/11727

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/bca7daa5-70e7-4353-9e20-6ed7ca24f3d8)
