### PR TITLE
fix(desktop): remove overly-aggressive feature flag check

### DIFF
--- a/internal/experimental/experimental.go
+++ b/internal/experimental/experimental.go
@@ -71,10 +71,6 @@ func (s *State) NavBar() bool {
 	return s.determineFeatureState("ComposeNav")
 }
 
-func (s *State) AutoFileShares() bool {
-	return s.determineFeatureState("ComposeAutoFileShares")
-}
-
 func (s *State) determineFeatureState(name string) bool {
 	if s == nil || !s.active || s.desktopValues == nil {
 		return false

--- a/pkg/compose/desktop.go
+++ b/pkg/compose/desktop.go
@@ -33,12 +33,12 @@ func (s *composeService) SetExperiments(experiments *experimental.State) {
 }
 
 func (s *composeService) manageDesktopFileSharesEnabled(ctx context.Context) bool {
-	// there's some slightly redundancy here to avoid fetching the config if
-	// we can already tell the feature state - in practice, we
-	if !s.isDesktopIntegrationActive() || !s.experiments.AutoFileShares() {
+	if !s.isDesktopIntegrationActive() {
 		return false
 	}
 
+	// synchronized file share support in Docker Desktop is dependent upon
+	// a variety of factors (settings, OS, etc), which this endpoint abstracts
 	fileSharesConfig, err := s.desktopCli.GetFileSharesConfig(ctx)
 	if err != nil {
 		logrus.Debugf("Failed to retrieve file shares config: %v", err)


### PR DESCRIPTION
**What I did**
Synchronized file share integration between Desktop & Compose is still experimental, so there's a feature flag. However, it's slightly more complex than that - not all OS/hypervisor combos support Synchronized file shares and it's an entitled feature, so the config API from Desktop covers all this logic.

I accidentally left the old feature flag check in, but it's possible to opt-in via settings independent of the feature flag, which wasn't being respected. (That is, it's possible to enable the feature w/o the feature flag being on because of weirdness about how feature flags & settings work in Desktop currently.)

**Related issue**
https://docker.atlassian.net/browse/COMP-533

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="492" alt="tortoise shell cat camouflaged against a similar patterned wall" src="https://github.com/docker/compose/assets/841263/b64243a3-a3e2-474f-8cb5-2c35dc48099c">
