### PR TITLE
fix support for `--flag=value` syntax in compatibility mode

### DIFF
--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -39,6 +39,11 @@ func Test_convert(t *testing.T) {
 			want: []string{"--context", "foo", "compose", "-f", "compose.yaml", "up"},
 		},
 		{
+			name: "with context arg",
+			args: []string{"--context=foo", "-f", "compose.yaml", "up"},
+			want: []string{"--context", "foo", "compose", "-f", "compose.yaml", "up"},
+		},
+		{
 			name: "with host",
 			args: []string{"--host", "tcp://1.2.3.4", "up"},
 			want: []string{"--host", "tcp://1.2.3.4", "compose", "up"},


### PR DESCRIPTION
**What I did**
fix support for `--flag=value` syntax in compatibility mode

**Related issue**
fixes https://github.com/docker/compose/issues/11749

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/02b54ae5-c53a-4ce0-958c-f523c2d33da1)
