### PR TITLE
replace engine manual installation by crazy-max/ghaction-setup-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,15 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       - name: Install Docker ${{ matrix.engine }}
-        run: |
-          sudo apt-get install curl
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sudo sh ./get-docker.sh --version ${{ matrix.engine }}
+        uses: crazy-max/ghaction-setup-docker@v3
+        with:
+          version: v${{ matrix.engine }}
+          set-host: true
+          daemon-config: |
+            {
+              "debug": true
+            }
+
       - name: Check Docker Version
         run: docker --version
       -


### PR DESCRIPTION
**What I did**
CI is currently broken due to issue during Docker engine installation
I use @crazy-max GHA engine installer to fix the CI

edit: this isn't link to the last engine version installation process but a [Microsoft issue in linux package repository](https://github.com/microsoft/linux-package-repositories/issues/130)

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/c75fcad4-28fd-4a85-b829-0824d1e2afb9)
