### PR TITLE
Fix menu print when logs/menu number of lines change

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v2/pkg/api"
+	ui "github.com/docker/compose/v2/pkg/progress"
 	"github.com/docker/compose/v2/pkg/utils"
 )
 
@@ -301,7 +302,7 @@ func runUp(
 			WaitTimeout:    timeout,
 			Watch:          upOptions.watch,
 			Services:       services,
-			NavigationMenu: upOptions.navigationMenu,
+			NavigationMenu: upOptions.navigationMenu && ui.Mode != "plain",
 		},
 	})
 }

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buger/goterm"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/docker/pkg/jsonmessage"
 )
@@ -106,30 +107,28 @@ func (l *logConsumer) write(w io.Writer, container, message string) {
 	if l.ctx.Err() != nil {
 		return
 	}
-	printFn := func() {
-		p := l.getPresenter(container)
-		timestamp := time.Now().Format(jsonmessage.RFC3339NanoFixed)
-		for _, line := range strings.Split(message, "\n") {
-			if KeyboardManager != nil {
-				ClearLine()
-			}
-			if l.timestamp {
-				fmt.Fprintf(w, "%s%s%s\n", p.prefix, timestamp, line)
-			} else {
-				fmt.Fprintf(w, "%s%s\n", p.prefix, line)
-			}
+	if KeyboardManager != nil {
+		KeyboardManager.ClearKeyboardInfo()
+	}
+
+	p := l.getPresenter(container)
+	timestamp := time.Now().Format(jsonmessage.RFC3339NanoFixed)
+	for _, line := range strings.Split(message, "\n") {
+		if l.timestamp {
+			fmt.Fprintf(w, "%s%s%s\n", p.prefix, timestamp, line)
+		} else {
+			fmt.Fprintf(w, "%s%s\n", p.prefix, line)
 		}
 	}
+
 	if KeyboardManager != nil {
-		KeyboardManager.PrintKeyboardInfo(printFn)
-	} else {
-		printFn()
+		KeyboardManager.PrintKeyboardInfo()
 	}
 }
 
 func (l *logConsumer) Status(container, msg string) {
 	p := l.getPresenter(container)
-	s := p.colors(fmt.Sprintf("%s %s\n", container, msg))
+	s := p.colors(fmt.Sprintf("%s%s %s\n", goterm.RESET_LINE, container, msg))
 	l.stdout.Write([]byte(s)) //nolint:errcheck
 }
 

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -77,7 +77,6 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		first := true
 		gracefulTeardown := func() {
 			printer.Cancel()
-			formatter.ClearLine()
 			fmt.Fprintln(s.stdinfo(), "Gracefully stopping... (press Ctrl+C again to force)")
 			eg.Go(func() error {
 				err := s.Stop(context.WithoutCancel(ctx), project.Name, api.StopOptions{


### PR DESCRIPTION
**What I did**
The is related with the clean up of the navigation menu which can be tricky when the number of lines change.
Removed all ClearLines and kept the cleaning of the menu inside shortcut.go. Please check the video.

https://github.com/docker/compose/assets/22371565/8744d6d1-c9a8-44a4-ac9b-517e8feae22a

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes [#14021](https://github.com/docker/for-win/issues/14021)
https://docker.atlassian.net/jira/software/c/projects/COMP/boards/576?selectedIssue=COMP-536

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/22371565/b752a6eb-93ab-4752-ac6e-3169fafb6de7)

