### PR TITLE
Add documentation for --menu up option and COMPOSE_MENU environment var

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -164,8 +164,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service, ex
 	flags.BoolVar(&up.wait, "wait", false, "Wait for services to be running|healthy. Implies detached mode.")
 	flags.IntVar(&up.waitTimeout, "wait-timeout", 0, "Maximum duration to wait for the project to be running|healthy")
 	flags.BoolVarP(&up.watch, "watch", "w", false, "Watch source code and rebuild/refresh containers when files are updated.")
-	flags.BoolVar(&up.navigationMenu, "menu", false, "Enable interactive shortcuts when running attached (Experimental). Incompatible with --detach.")
-	flags.MarkHidden("menu") //nolint:errcheck
+	flags.BoolVar(&up.navigationMenu, "menu", false, "Enable interactive shortcuts when running attached. Incompatible with --detach. Can also be enable/disable by setting COMPOSE_MENU environment var.")
 
 	return upCmd
 }

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -177,6 +177,9 @@ If flags are explicitly set on the command line, the associated environment vari
 Setting the `COMPOSE_IGNORE_ORPHANS` environment variable to `true` stops docker compose from detecting orphaned
 containers for the project.
 
+Setting the `COMPOSE_MENU` environment variable to `false` disables the helper menu when running `docker compose up`
+in attached mode. Alternatively, you can also run `docker compose up --menu=false` to disable the helper menu.
+
 ### Use Dry Run mode to test your command
 
 Use `--dry-run` flag to test a command without changing your application stack state.

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -5,35 +5,36 @@ Create and start containers
 
 ### Options
 
-| Name                           | Type          | Default  | Description                                                                                             |
-|:-------------------------------|:--------------|:---------|:--------------------------------------------------------------------------------------------------------|
-| `--abort-on-container-exit`    |               |          | Stops all containers if any container was stopped. Incompatible with -d                                 |
-| `--abort-on-container-failure` |               |          | Stops all containers if any container exited with failure. Incompatible with -d                         |
-| `--always-recreate-deps`       |               |          | Recreate dependent containers. Incompatible with --no-recreate.                                         |
-| `--attach`                     | `stringArray` |          | Restrict attaching to the specified services. Incompatible with --attach-dependencies.                  |
-| `--attach-dependencies`        |               |          | Automatically attach to log output of dependent services                                                |
-| `--build`                      |               |          | Build images before starting containers                                                                 |
-| `-d`, `--detach`               |               |          | Detached mode: Run containers in the background                                                         |
-| `--dry-run`                    |               |          | Execute command in dry run mode                                                                         |
-| `--exit-code-from`             | `string`      |          | Return the exit code of the selected service container. Implies --abort-on-container-exit               |
-| `--force-recreate`             |               |          | Recreate containers even if their configuration and image haven't changed                               |
-| `--no-attach`                  | `stringArray` |          | Do not attach (stream logs) to the specified services                                                   |
-| `--no-build`                   |               |          | Don't build an image, even if it's policy                                                               |
-| `--no-color`                   |               |          | Produce monochrome output                                                                               |
-| `--no-deps`                    |               |          | Don't start linked services                                                                             |
-| `--no-log-prefix`              |               |          | Don't print prefix in logs                                                                              |
-| `--no-recreate`                |               |          | If containers already exist, don't recreate them. Incompatible with --force-recreate.                   |
-| `--no-start`                   |               |          | Don't start the services after creating them                                                            |
-| `--pull`                       | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                                                |
-| `--quiet-pull`                 |               |          | Pull without printing progress information                                                              |
-| `--remove-orphans`             |               |          | Remove containers for services not defined in the Compose file                                          |
-| `-V`, `--renew-anon-volumes`   |               |          | Recreate anonymous volumes instead of retrieving data from the previous containers                      |
-| `--scale`                      | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.           |
-| `-t`, `--timeout`              | `int`         | `0`      | Use this timeout in seconds for container shutdown when attached or when containers are already running |
-| `--timestamps`                 |               |          | Show timestamps                                                                                         |
-| `--wait`                       |               |          | Wait for services to be running\|healthy. Implies detached mode.                                        |
-| `--wait-timeout`               | `int`         | `0`      | Maximum duration to wait for the project to be running\|healthy                                         |
-| `-w`, `--watch`                |               |          | Watch source code and rebuild/refresh containers when files are updated.                                |
+| Name                           | Type          | Default  | Description                                                                                                                                         |
+|:-------------------------------|:--------------|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--abort-on-container-exit`    |               |          | Stops all containers if any container was stopped. Incompatible with -d                                                                             |
+| `--abort-on-container-failure` |               |          | Stops all containers if any container exited with failure. Incompatible with -d                                                                     |
+| `--always-recreate-deps`       |               |          | Recreate dependent containers. Incompatible with --no-recreate.                                                                                     |
+| `--attach`                     | `stringArray` |          | Restrict attaching to the specified services. Incompatible with --attach-dependencies.                                                              |
+| `--attach-dependencies`        |               |          | Automatically attach to log output of dependent services                                                                                            |
+| `--build`                      |               |          | Build images before starting containers                                                                                                             |
+| `-d`, `--detach`               |               |          | Detached mode: Run containers in the background                                                                                                     |
+| `--dry-run`                    |               |          | Execute command in dry run mode                                                                                                                     |
+| `--exit-code-from`             | `string`      |          | Return the exit code of the selected service container. Implies --abort-on-container-exit                                                           |
+| `--force-recreate`             |               |          | Recreate containers even if their configuration and image haven't changed                                                                           |
+| `--menu`                       |               |          | Enable interactive shortcuts when running attached. Incompatible with --detach. Can also be enable/disable by setting COMPOSE_MENU environment var. |
+| `--no-attach`                  | `stringArray` |          | Do not attach (stream logs) to the specified services                                                                                               |
+| `--no-build`                   |               |          | Don't build an image, even if it's policy                                                                                                           |
+| `--no-color`                   |               |          | Produce monochrome output                                                                                                                           |
+| `--no-deps`                    |               |          | Don't start linked services                                                                                                                         |
+| `--no-log-prefix`              |               |          | Don't print prefix in logs                                                                                                                          |
+| `--no-recreate`                |               |          | If containers already exist, don't recreate them. Incompatible with --force-recreate.                                                               |
+| `--no-start`                   |               |          | Don't start the services after creating them                                                                                                        |
+| `--pull`                       | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                                                                                            |
+| `--quiet-pull`                 |               |          | Pull without printing progress information                                                                                                          |
+| `--remove-orphans`             |               |          | Remove containers for services not defined in the Compose file                                                                                      |
+| `-V`, `--renew-anon-volumes`   |               |          | Recreate anonymous volumes instead of retrieving data from the previous containers                                                                  |
+| `--scale`                      | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.                                                       |
+| `-t`, `--timeout`              | `int`         | `0`      | Use this timeout in seconds for container shutdown when attached or when containers are already running                                             |
+| `--timestamps`                 |               |          | Show timestamps                                                                                                                                     |
+| `--wait`                       |               |          | Wait for services to be running\|healthy. Implies detached mode.                                                                                    |
+| `--wait-timeout`               | `int`         | `0`      | Maximum duration to wait for the project to be running\|healthy                                                                                     |
+| `-w`, `--watch`                |               |          | Watch source code and rebuild/refresh containers when files are updated.                                                                            |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -118,6 +118,9 @@ long: |-
     Setting the `COMPOSE_IGNORE_ORPHANS` environment variable to `true` stops docker compose from detecting orphaned
     containers for the project.
 
+    Setting the `COMPOSE_MENU` environment variable to `false` disables the helper menu when running `docker compose up`
+    in attached mode. Alternatively, you can also run `docker compose up --menu=false` to disable the helper menu.
+
     ### Use Dry Run mode to test your command
 
     Use `--dry-run` flag to test a command without changing your application stack state.

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -123,9 +123,9 @@ options:
       value_type: bool
       default_value: "false"
       description: |
-        Enable interactive shortcuts when running attached (Experimental). Incompatible with --detach.
+        Enable interactive shortcuts when running attached. Incompatible with --detach. Can also be enable/disable by setting COMPOSE_MENU environment var.
       deprecated: false
-      hidden: true
+      hidden: false
       experimental: false
       experimentalcli: false
       kubernetes: false


### PR DESCRIPTION
**What I did**
Added documentation related to recent added option in `up` command to enable/disable the helper menu in detach mode.
Seems like this information was lacking in our documentation and some users were confused on how to enable/disable the menu.

**Related issue**
relates to https://github.com/docker/for-win/issues/14021
https://docker.atlassian.net/browse/COMP-540

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/22371565/6815089d-66b9-4a5c-81b7-fdca2517a342)
