### PR TITLE
Per endpoint driver opts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.1.1-0.20240516145816-197e6352c64a
+	github.com/compose-spec/compose-go/v2 v2.1.1-0.20240514125539-94bd7356c641
 	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd v1.7.16
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.1.1-0.20240514125539-94bd7356c641
+	github.com/compose-spec/compose-go/v2 v2.1.1
 	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd v1.7.16
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.1.1-0.20240516145816-197e6352c64a h1:R0ufvPulvRvFa8JaFEWzSJmkhjfeArXD9vKk0jpmpM4=
-github.com/compose-spec/compose-go/v2 v2.1.1-0.20240516145816-197e6352c64a/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
+github.com/compose-spec/compose-go/v2 v2.1.0 h1:qdW2qISQlCQG8v1O2TChcdxgAWTUGgUX/CPSO+ES9+E=
+github.com/compose-spec/compose-go/v2 v2.1.0/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.1.0 h1:qdW2qISQlCQG8v1O2TChcdxgAWTUGgUX/CPSO+ES9+E=
-github.com/compose-spec/compose-go/v2 v2.1.0/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
+github.com/compose-spec/compose-go/v2 v2.1.1 h1:tKuYJwAVgxIryRrsvWJSf1kNviVOQVVqwyHsV6YoIUc=
+github.com/compose-spec/compose-go/v2 v2.1.1/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -439,6 +439,7 @@ func createEndpointSettings(p *types.Project, service types.ServiceConfig, servi
 		ipv4Address string
 		ipv6Address string
 		macAddress  string
+		driverOpts  types.Options
 	)
 	if config != nil {
 		ipv4Address = config.Ipv4Address
@@ -449,6 +450,7 @@ func createEndpointSettings(p *types.Project, service types.ServiceConfig, servi
 			LinkLocalIPs: config.LinkLocalIPs,
 		}
 		macAddress = config.MacAddress
+		driverOpts = config.DriverOpts
 	}
 	return &network.EndpointSettings{
 		Aliases:     getAliases(p, service, serviceIndex, networkKey, useNetworkAliases),
@@ -457,6 +459,7 @@ func createEndpointSettings(p *types.Project, service types.ServiceConfig, servi
 		IPv6Gateway: ipv6Address,
 		IPAMConfig:  ipam,
 		MacAddress:  macAddress,
+		DriverOpts:  driverOpts,
 	}
 }
 


### PR DESCRIPTION
**What I did**

It's possible to set driver options when creating a network using compose ... [compose spec](https://github.com/robmry/compose-go/blob/b08e2159a8b1fd78444c2ef434bd4913d74697d1/schema/compose-spec.json#L637-L641) / [engine API](https://github.com/moby/moby/blob/9d07820b221db010bf1bdc26ca904468804ca712/api/swagger.yaml#L10134-L10138).

But not when connecting an endpoint to a network ... [compose spec](https://github.com/robmry/compose-go/blob/b08e2159a8b1fd78444c2ef434bd4913d74697d1/schema/compose-spec.json#L293-L300) / [engine API](https://github.com/moby/moby/blob/9d07820b221db010bf1bdc26ca904468804ca712/api/swagger.yaml#L2541-L2544).

The API field isn't new, but upcoming change https://github.com/moby/moby/pull/47686 means it'll be useful for setting per-interface sysctls.

https://github.com/compose-spec/compose-go/pull/627 adds the types.
https://github.com/compose-spec/compose-spec/pull/498 updates the spec to match.
This PR pulls in the `go-compose` changes, and copies the driver options to `EndpointSettings` for the API.

_I noticed a couple of fields in `EndpointSettings` that perhaps shouldn't be set ... the struct is an unfortunate mix of config and operational-data (used to report running state). Those fields will be cleared by the daemon, so the only potential problem is a bit of confusion - in particular, the container's IPv6 address is provided in the IPv6 gateway. But, probably best to deal with that separately, so I just left a FIXME comment in the new test._ 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
