### PR TITLE
Add environment variables for client OS/arch and client user UID/GID

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -595,6 +597,14 @@ func RootCommand(dockerCli command.Cli, backend Backend) *cobra.Command { //noli
 }
 
 func setEnvWithDotEnv(prjOpts *ProjectOptions) error {
+	os.Setenv("COMPOSE_CLIENT_OS", runtime.GOOS)
+	os.Setenv("COMPOSE_CLIENT_ARCH", runtime.GOARCH)
+
+	if user, err := user.Current(); err == nil {
+		os.Setenv("COMPOSE_CLIENT_UID", user.Uid)
+		os.Setenv("COMPOSE_CLIENT_GID", user.Gid)
+	}
+
 	if len(prjOpts.EnvFiles) == 0 {
 		if envFiles := os.Getenv(ComposeEnvFiles); envFiles != "" {
 			prjOpts.EnvFiles = strings.Split(envFiles, ",")


### PR DESCRIPTION
When using Docker Compose for development setup, you often need to tweak the configuration to vary on Linux, macOS, and Windows. And some services you would like to run with the same UID/GID as your current client user.

To help with that, we introduce four new environment variables while parsing the configuration files:

- `COMPOSE_CLIENT_OS`: set to Go's `runtime.GOOS`
- `COMPOSE_CLIENT_ARCH`: set to Go's `runtime.GOARCH`
- `COMPOSE_CLIENT_UID`: set to the current users UID
- `COMPOSE_CLIENT_GUID`: set to the current users GID

This way, we can now have a Docker Compose setup like this:

compose.yaml:
```yaml
services:
  php:
    image: php
    volumes:
      - .:/code
    user: ${COMPOSE_CLIENT_UID}:${COMPOSE_CLIENT_GID}
  web:
    image: apache
    extends:
      file: compose.${COMPOSE_CLIENT_OS}.yaml
      service: web
```

compose.linux.yaml:
```yaml
services:
  web:
    environment:
      VIRTUAL_HOST: mysite.local
```

compose.darwin.yaml:
```yaml
services:
  web:
    environment:
      VIRTUAL_HOST: mysite.docker
```

Closes #11820.
