### PR TITLE
allow a local .env file to override compose.yaml sibling .env

### DIFF
--- a/pkg/e2e/compose_environment_test.go
+++ b/pkg/e2e/compose_environment_test.go
@@ -117,7 +117,8 @@ func TestEnvPriority(t *testing.T) {
 			"run", "--rm", "-e", "WHEREAMI", "env-compose-priority")
 		cmd.Env = append(cmd.Env, "COMPOSE_ENV_FILES=./fixtures/environment/env-priority/.env.override.with.default")
 		res := icmd.RunCmd(cmd)
-		assert.Equal(t, strings.TrimSpace(res.Stdout()), "EnvFileDefaultValue")
+		stdout := res.Stdout()
+		assert.Equal(t, strings.TrimSpace(stdout), "EnvFileDefaultValue")
 	})
 
 	// No Compose file and env variable pass to the run command

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -329,3 +329,24 @@ func TestResolveDotEnv(t *testing.T) {
 		Out:      "image: backend:latest",
 	})
 }
+
+func TestNestedDotEnv(t *testing.T) {
+	c := NewCLI(t)
+
+	cmd := c.NewDockerComposeCmd(t, "run", "echo")
+	cmd.Dir = filepath.Join(".", "fixtures", "nested")
+	res := icmd.RunCmd(cmd)
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Out:      "root win=root",
+	})
+
+	cmd = c.NewDockerComposeCmd(t, "run", "echo")
+	cmd.Dir = filepath.Join(".", "fixtures", "nested", "sub")
+	res = icmd.RunCmd(cmd)
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Out:      "root sub win=sub",
+	})
+
+}

--- a/pkg/e2e/fixtures/environment/env-priority/compose.yaml
+++ b/pkg/e2e/fixtures/environment/env-priority/compose.yaml
@@ -1,3 +1,5 @@
 services:
   env-compose-priority:
     image: env-compose-priority
+    build:
+      context: .

--- a/pkg/e2e/fixtures/nested/.env
+++ b/pkg/e2e/fixtures/nested/.env
@@ -1,0 +1,2 @@
+ROOT=root
+WIN=root

--- a/pkg/e2e/fixtures/nested/compose.yaml
+++ b/pkg/e2e/fixtures/nested/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  echo:
+    image: alpine
+    command: echo $ROOT $SUB win=$WIN

--- a/pkg/e2e/fixtures/nested/sub/.env
+++ b/pkg/e2e/fixtures/nested/sub/.env
@@ -1,0 +1,2 @@
+SUB=sub
+WIN=sub


### PR DESCRIPTION
**What I did**
Allow local .env file both to set COMPOSE_* variables and override .env file aside the target compose.yaml file

This restores behavior seen in compose v2 before v2.24.x, while undocumented. Was initially introduced by https://github.com/docker/compose/pull/9512 while not designed for this usage, but users started then to rely on this "feature"

A doc PR will follow so this is well documented

**Related issue**
fixes https://github.com/docker/compose/issues/11823
fixes https://github.com/docker/compose/issues/11575

https://docker.atlassian.net/browse/COMP-570

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
