### PR TITLE
add new navigation menu to open Compose app configuration in Docker Desktop

### DIFF
--- a/internal/experimental/experimental.go
+++ b/internal/experimental/experimental.go
@@ -71,6 +71,10 @@ func (s *State) NavBar() bool {
 	return s.determineFeatureState("ComposeNav")
 }
 
+func (s *State) ComposeUI() bool {
+	return s.determineFeatureState("ComposeUIView")
+}
+
 func (s *State) determineFeatureState(name string) bool {
 	if s == nil || !s.active || s.desktopValues == nil {
 		return false

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -324,3 +324,10 @@ func (s *composeService) RuntimeVersion(ctx context.Context) (string, error) {
 func (s *composeService) isDesktopIntegrationActive() bool {
 	return s.desktopCli != nil
 }
+
+func (s *composeService) isDesktopUIEnabled() bool {
+	if !s.isDesktopIntegrationActive() {
+		return false
+	}
+	return s.experiments.ComposeUI()
+}

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -97,9 +97,10 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 			} else {
 				isWatchConfigured := s.shouldWatch(project)
 				isDockerDesktopActive := s.isDesktopIntegrationActive()
+				isDDComposeUI := s.isDesktopUIEnabled()
 				tracing.KeyboardMetrics(ctx, options.Start.NavigationMenu, isDockerDesktopActive, isWatchConfigured)
 
-				formatter.NewKeyboardManager(ctx, isDockerDesktopActive, isWatchConfigured, signalChan, s.Watch)
+				formatter.NewKeyboardManager(ctx, isDockerDesktopActive, isWatchConfigured, isDDComposeUI, signalChan, s.Watch)
 				if options.Start.Watch {
 					formatter.KeyboardManager.StartWatch(ctx, project, options)
 				}


### PR DESCRIPTION
**What I did**
Add new entry in the navigation menu to open the Compose application configuration into the new Compose UI in Docker Desktop

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
https://docker.atlassian.net/browse/COMP-579

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/5aae5a45-e5f1-48ca-8583-9b3fc9c474d2)
