### PR TITLE
prevent concurrent map write relying on project immutability

### DIFF
--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -56,13 +56,16 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 	}
 
 	// ignore depends_on relations which are not impacted by restarting service or not required
-	for i, service := range project.Services {
-		for name, r := range service.DependsOn {
+	project, err = project.WithServicesTransform(func(name string, s types.ServiceConfig) (types.ServiceConfig, error) {
+		for name, r := range s.DependsOn {
 			if !r.Restart {
-				delete(service.DependsOn, name)
+				delete(s.DependsOn, name)
 			}
 		}
-		project.Services[i] = service
+		return s, nil
+	})
+	if err != nil {
+		return err
 	}
 
 	if len(options.Services) != 0 {


### PR DESCRIPTION
**What I did**
Use `WithServicesTransform` to transform project, in respect with immutability to prevent concurrent map write

**Related issue**
fixes https://github.com/docker/compose/issues/11857
https://docker.atlassian.net/browse/COMP-590

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/1e3088f8-f5a4-4119-8fcc-412c9afbbf28)
