### PR TITLE
Fix COMPOSE_PROFILES can be set by .env file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.1.1
+	github.com/compose-spec/compose-go/v2 v2.1.2-0.20240530052535-7dfa54c9658b
 	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd v1.7.17
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+g
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.1.1 h1:tKuYJwAVgxIryRrsvWJSf1kNviVOQVVqwyHsV6YoIUc=
-github.com/compose-spec/compose-go/v2 v2.1.1/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
+github.com/compose-spec/compose-go/v2 v2.1.2-0.20240530052535-7dfa54c9658b h1:tjysHJZrxQVzGbklQsdYOjgZC9rVFa8Ersn82QP8H1M=
+github.com/compose-spec/compose-go/v2 v2.1.2-0.20240530052535-7dfa54c9658b/go.mod h1:bEPizBkIojlQ20pi2vNluBa58tevvj0Y18oUSHPyfdc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=

--- a/pkg/e2e/fixtures/profiles/test-profile.env
+++ b/pkg/e2e/fixtures/profiles/test-profile.env
@@ -1,0 +1,1 @@
+COMPOSE_PROFILES=test-profile

--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -185,3 +185,23 @@ func TestActiveProfileViaTargetedService(t *testing.T) {
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }
+
+func TestDotEnvProfileUsage(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "compose-e2e-dotenv-profiles"
+	const profileName = "test-profile"
+
+	t.Cleanup(func() {
+		_ = c.RunDockerComposeCmd(t, "--project-name", projectName, "down")
+	})
+
+	t.Run("compose up with profile", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/compose.yaml",
+			"--env-file", "./fixtures/profiles/test-profile.env",
+			"-p", projectName, "--profile", profileName, "up", "-d")
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		res = c.RunDockerComposeCmd(t, "-p", projectName, "ps")
+		res.Assert(t, icmd.Expected{Out: regularService})
+		res.Assert(t, icmd.Expected{Out: profiledService})
+	})
+}


### PR DESCRIPTION
Fix COMPOSE_PROFILES can be set by .env file

relies on https://github.com/compose-spec/compose-go/pull/632
test case to cover this scenario so this regression won't silently come back

fix https://github.com/docker/compose/issues/11856
