### PR TITLE
Fix: change append to use slice index in ps

### DIFF
--- a/pkg/compose/ps.go
+++ b/pkg/compose/ps.go
@@ -45,17 +45,17 @@ func (s *composeService) Ps(ctx context.Context, projectName string, options api
 	for i, container := range containers {
 		i, container := i, container
 		eg.Go(func() error {
-			var publishers []api.PortPublisher
+			publishers := make([]api.PortPublisher, len(container.Ports))
 			sort.Slice(container.Ports, func(i, j int) bool {
 				return container.Ports[i].PrivatePort < container.Ports[j].PrivatePort
 			})
-			for _, p := range container.Ports {
-				publishers = append(publishers, api.PortPublisher{
+			for i, p := range container.Ports {
+				publishers[i] = api.PortPublisher{
 					URL:           p.IP,
 					TargetPort:    int(p.PrivatePort),
 					PublishedPort: int(p.PublicPort),
 					Protocol:      p.Type,
-				})
+				}
 			}
 
 			inspect, err := s.apiClient().ContainerInspect(ctx, container.ID)

--- a/pkg/compose/ps_test.go
+++ b/pkg/compose/ps_test.go
@@ -56,7 +56,7 @@ func TestPs(t *testing.T) {
 
 	expected := []compose.ContainerSummary{
 		{ID: "123", Name: "123", Names: []string{"/123"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service1",
-			State: "running", Health: "healthy", Publishers: nil,
+			State: "running", Health: "healthy", Publishers: []compose.PortPublisher{},
 			Labels: map[string]string{
 				compose.ProjectLabel:     strings.ToLower(testProject),
 				compose.ConfigFilesLabel: "/src/pkg/compose/testdata/compose.yaml",
@@ -75,7 +75,7 @@ func TestPs(t *testing.T) {
 			},
 		},
 		{ID: "789", Name: "789", Names: []string{"/789"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service2",
-			State: "exited", Health: "", ExitCode: 130, Publishers: nil,
+			State: "exited", Health: "", ExitCode: 130, Publishers: []compose.PortPublisher{},
 			Labels: map[string]string{
 				compose.ProjectLabel:     strings.ToLower(testProject),
 				compose.ConfigFilesLabel: "/src/pkg/compose/testdata/compose.yaml",


### PR DESCRIPTION
**What I did**
Changed slice appending to use index to remove overhead from using build in append function.
Also made the slice using the length of slice we are copying values from to remove overhead of making new backing arrays.

**Related issue**
Fixes #11858 
https://github.com/docker/compose/issues/11858
