### PR TITLE
Make port arg optional in `docker compose port`

### DIFF
--- a/cmd/formatter/container.go
+++ b/cmd/formatter/container.go
@@ -216,8 +216,8 @@ func (c *ContainerContext) Ports() string {
 	for _, publisher := range c.c.Publishers {
 		ports = append(ports, types.Port{
 			IP:          publisher.URL,
-			PrivatePort: uint16(publisher.TargetPort),
-			PublicPort:  uint16(publisher.PublishedPort),
+			PrivatePort: publisher.TargetPort,
+			PublicPort:  publisher.PublishedPort,
 			Type:        publisher.Protocol,
 		})
 	}

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -20,7 +20,7 @@ Define and run multi-container applications with Docker
 | [`logs`](compose_logs.md)       | View output from containers                                                             |
 | [`ls`](compose_ls.md)           | List running compose projects                                                           |
 | [`pause`](compose_pause.md)     | Pause services                                                                          |
-| [`port`](compose_port.md)       | Print the public port for a port binding                                                |
+| [`port`](compose_port.md)       | List port mappings or print the public port of a specific mapping for the service       |
 | [`ps`](compose_ps.md)           | List containers                                                                         |
 | [`pull`](compose_pull.md)       | Pull service images                                                                     |
 | [`push`](compose_push.md)       | Push service images                                                                     |

--- a/docs/reference/compose_port.md
+++ b/docs/reference/compose_port.md
@@ -1,7 +1,7 @@
 # docker compose port
 
 <!---MARKER_GEN_START-->
-Print the public port for a port binding
+List port mappings or print the public port of a specific mapping for the service
 
 ### Options
 

--- a/docs/reference/docker_compose_port.yaml
+++ b/docs/reference/docker_compose_port.yaml
@@ -1,7 +1,8 @@
 command: docker compose port
-short: Print the public port for a port binding
+short: |
+    List port mappings or print the public port of a specific mapping for the service
 long: Prints the public port for a port binding
-usage: docker compose port [OPTIONS] SERVICE PRIVATE_PORT
+usage: docker compose port [OPTIONS] SERVICE [PRIVATE_PORT]
 pname: docker compose
 plink: docker_compose.yaml
 options:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,6 +19,8 @@ package api
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -73,7 +75,7 @@ type Service interface {
 	// Events executes the equivalent to a `compose events`
 	Events(ctx context.Context, projectName string, options EventsOptions) error
 	// Port executes the equivalent to a `compose port`
-	Port(ctx context.Context, projectName string, service string, port uint16, options PortOptions) (string, int, error)
+	Port(ctx context.Context, projectName string, service string, port uint16, options PortOptions) (PortPublishers, error)
 	// Publish executes the equivalent to a `compose publish`
 	Publish(ctx context.Context, project *types.Project, repository string, options PublishOptions) error
 	// Images executes the equivalent of a `compose images`
@@ -448,8 +450,8 @@ type CopyOptions struct {
 // PortPublisher hold status about published port
 type PortPublisher struct {
 	URL           string
-	TargetPort    int
-	PublishedPort int
+	TargetPort    uint16
+	PublishedPort uint16
 	Protocol      string
 }
 
@@ -474,6 +476,10 @@ type ContainerSummary struct {
 	Mounts       []string
 	Networks     []string
 	LocalVolumes int
+}
+
+func (p *PortPublisher) String() string {
+	return fmt.Sprintf("%d/%s -> %s", p.TargetPort, p.Protocol, net.JoinHostPort(p.URL, strconv.Itoa(int(p.PublishedPort))))
 }
 
 // PortPublishers is a slice of PortPublisher

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -36,3 +36,36 @@ func TestRunOptionsEnvironmentMap(t *testing.T) {
 	assert.Equal(t, *env["ZOT"], "")
 	assert.Check(t, env["QIX"] == nil)
 }
+
+func TestPortPublisherString(t *testing.T) {
+	tests := map[string]struct {
+		pub    PortPublisher
+		expect string
+	}{
+		"ipv6_udp": {
+			pub: PortPublisher{
+				Protocol:      "udp",
+				PublishedPort: 32769,
+				TargetPort:    5060,
+				URL:           "::",
+			},
+			expect: "5060/udp -> [::]:32769",
+		},
+		"ipv4_tcp": {
+			pub: PortPublisher{
+				Protocol:      "tcp",
+				PublishedPort: 5060,
+				TargetPort:    5060,
+				URL:           "0.0.0.0",
+			},
+			expect: "5060/tcp -> 0.0.0.0:5060",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.pub.String()
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}

--- a/pkg/compose/ps.go
+++ b/pkg/compose/ps.go
@@ -52,8 +52,8 @@ func (s *composeService) Ps(ctx context.Context, projectName string, options api
 			for i, p := range container.Ports {
 				publishers[i] = api.PortPublisher{
 					URL:           p.IP,
-					TargetPort:    int(p.PrivatePort),
-					PublishedPort: int(p.PublicPort),
+					TargetPort:    p.PrivatePort,
+					PublishedPort: p.PublicPort,
 					Protocol:      p.Type,
 				}
 			}

--- a/pkg/mocks/mock_docker_compose_api.go
+++ b/pkg/mocks/mock_docker_compose_api.go
@@ -240,13 +240,12 @@ func (mr *MockServiceMockRecorder) Pause(ctx, projectName, options any) *gomock.
 }
 
 // Port mocks base method.
-func (m *MockService) Port(ctx context.Context, projectName, service string, port uint16, options api.PortOptions) (string, int, error) {
+func (m *MockService) Port(ctx context.Context, projectName, service string, port uint16, options api.PortOptions) (api.PortPublishers, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Port", ctx, projectName, service, port, options)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(api.PortPublishers)
+	ret1, _ := ret[2].(error)
+	return ret0, ret1
 }
 
 // Port indicates an expected call of Port.


### PR DESCRIPTION
**What I did**

This comand no longer needs a mandatory port. If no port is provided it will instead list all published ports. This behavior falls in line with the behavior provided by `docker port`.

**Related issue**
Closes #11859.