### PR TITLE
Correct typo in comment

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -166,7 +166,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		})
 	}
 
-	// We use the parent context without cancelation as we manage sigterm to stop the stack
+	// We use the parent context without cancellation as we manage sigterm to stop the stack
 	err = s.start(context.WithoutCancel(ctx), project.Name, options.Start, printer.HandleEvent)
 	if err != nil && !isTerminated.Load() { // Ignore error if the process is terminated
 		return err


### PR DESCRIPTION
**What I did**
Corrected a typo I stumbled upon in a comment reading through this codebase.

**Related issue**
`N/A`