### PR TITLE
config --environment

### DIFF
--- a/docs/reference/compose_config.md
+++ b/docs/reference/compose_config.md
@@ -12,6 +12,7 @@ Parse, resolve and render compose file in canonical format
 | Name                      | Type     | Default | Description                                                                 |
 |:--------------------------|:---------|:--------|:----------------------------------------------------------------------------|
 | `--dry-run`               |          |         | Execute command in dry run mode                                             |
+| `--environment`           |          |         | Print environment used for interpolation.                                   |
 | `--format`                | `string` | `yaml`  | Format the output. Values: [yaml \| json]                                   |
 | `--hash`                  | `string` |         | Print the service config hash, one per line.                                |
 | `--images`                |          |         | Print the image names, one per line.                                        |

--- a/docs/reference/docker_compose_config.yaml
+++ b/docs/reference/docker_compose_config.yaml
@@ -9,6 +9,16 @@ usage: docker compose config [OPTIONS] [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
 options:
+    - option: environment
+      value_type: bool
+      default_value: "false"
+      description: Print environment used for interpolation.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: format
       value_type: string
       default_value: yaml


### PR DESCRIPTION
**What I did**
introduce `docker compose config --environment` to output the resolved environment variables used for interpolation


**Related issue**
closes https://github.com/docker/compose/issues/11873

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/132757/53202bb6-fb93-4d02-85ed-10a8aedd3e10)
