### PR TITLE
enforce keyboard.Close is always executed to restore terminal

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -95,6 +95,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 			if err != nil {
 				logrus.Warn("could not start menu, an error occurred while starting.")
 			} else {
+				defer keyboard.Close() //nolint:errcheck
 				isWatchConfigured := s.shouldWatch(project)
 				isDockerDesktopActive := s.isDesktopIntegrationActive()
 				isDockerDesktopComposeUI := s.isDesktopUIEnabled()


### PR DESCRIPTION
**What I did**
ensure `keyboard.Close()` is called as `up` command complete. `Close()` is re-entrant so this is not an issue it get called even after an interruption (Ctrl+C) and clean shutdown, where codebase manages this already

**Related issue**
fixes https://github.com/docker/compose/issues/11869
