### PR TITLE
build: replace uses of archive.CanonicalTarNameForPath

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -124,7 +124,7 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 		}
 
 		// And canonicalize dockerfile name to a platform-independent one
-		relDockerfile = archive.CanonicalTarNameForPath(relDockerfile)
+		relDockerfile = filepath.ToSlash(relDockerfile)
 
 		excludes = build.TrimBuildFilesFromExcludes(excludes, relDockerfile, false)
 		buildCtx, err = archive.TarWithOptions(contextDir, &archive.TarOptions{


### PR DESCRIPTION

This function is an alias for filepath.IsAbs and we are considering deprecating and/or removing this function in the archive package, so removing its uses helps transitioning if we decide to deprecate and/or remove it.

[docker/cli@fb0788f] also added a normalize step in TrimBuildFilesFromExcludes, so that callers are not _required_ to first normalize the path, so the normalizeation may be redunant, but keeping the normalization as this variable is used further down the code.

[docker/cli@fb0788f]: https://github.com/docker/cli/commit/fb0788f18fcd90dbe95a7c7324d2c22e05050d71

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

- relates to https://github.com/docker/cli/pull/3762
- relates to https://github.com/moby/moby/issues/21700


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
