### PR TITLE
stop watch process when associated up process is stopped

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -101,9 +101,9 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 				isDockerDesktopComposeUI := s.isDesktopUIEnabled()
 				tracing.KeyboardMetrics(ctx, options.Start.NavigationMenu, isDockerDesktopActive, isWatchConfigured, isDockerDesktopComposeUI)
 
-				formatter.NewKeyboardManager(ctx, isDockerDesktopActive, isWatchConfigured, isDockerDesktopComposeUI, signalChan, s.Watch)
+				formatter.NewKeyboardManager(ctx, isDockerDesktopActive, isWatchConfigured, isDockerDesktopComposeUI, signalChan, s.watch)
 				if options.Start.Watch {
-					formatter.KeyboardManager.StartWatch(ctx, project, options)
+					formatter.KeyboardManager.StartWatch(ctx, doneCh, project, options)
 				}
 			}
 		}
@@ -136,7 +136,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 				})
 				return nil
 			case event := <-kEvents:
-				formatter.KeyboardManager.HandleKeyEvents(event, ctx, project, options)
+				formatter.KeyboardManager.HandleKeyEvents(event, ctx, doneCh, project, options)
 			}
 		}
 	})
@@ -160,7 +160,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		eg.Go(func() error {
 			buildOpts := *options.Create.Build
 			buildOpts.Quiet = true
-			return s.Watch(ctx, project, options.Start.Services, api.WatchOptions{
+			return s.watch(ctx, doneCh, project, options.Start.Services, api.WatchOptions{
 				Build: &buildOpts,
 				LogTo: options.Start.Attach,
 			})

--- a/pkg/compose/watch_test.go
+++ b/pkg/compose/watch_test.go
@@ -144,7 +144,7 @@ func TestWatch_Sync(t *testing.T) {
 			dockerCli: cli,
 			clock:     clock,
 		}
-		err := service.watch(ctx, &proj, "test", api.WatchOptions{
+		err := service.watchEvents(ctx, &proj, "test", api.WatchOptions{
 			Build: &api.BuildOptions{},
 			LogTo: stdLogger{},
 		}, watcher, syncer, []types.Trigger{


### PR DESCRIPTION
**What I did**
Share the `doneCh` channel of the `up` command to `watch` process so it could be stop when the `up` command is stopped by an external `down` command.

I moved the existing content of the `func (s *composeService) Watch` function to an internal `watch` function. This avoids changing the `Watch` API and eliminates the need to add the channel as a new parameter to the API.

**Related issue**
https://docker.atlassian.net/browse/COMP-621

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/daab6a4a-f997-46ba-bb8d-aeb25e00b223)
