### PR TITLE
using as flag of the up command, watch was blocking process shutdown

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -183,15 +183,13 @@ func (s *composeService) watch(ctx context.Context, syncChannel chan bool, proje
 	}
 	options.LogTo.Log(api.WatchLogger, "Watch enabled")
 
-	err = eg.Wait()
 	for {
 		select {
 		case <-ctx.Done():
-			return err
+			return eg.Wait()
 		case <-syncChannel:
 			options.LogTo.Log(api.WatchLogger, "Watch disabled")
-			ctx.Done()
-			return err
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
This happened when sunsetting the application from docker compose down command


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
