### PR TITLE
gha: test against docker v27.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
           - 24.0.9
           - 25.0.5
           - 26.1.4
+          - 27.0.3
     steps:
       - name: Prepare
         run: |
@@ -158,7 +159,7 @@ jobs:
           sudo systemctl stop docker.service
           sudo apt-get purge docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras docker-buildx-plugin
           sudo apt-get install curl
-          curl -fsSL https://get.docker.com -o get-docker.sh
+          curl -fsSL https://test.docker.com -o get-docker.sh
           sudo sh ./get-docker.sh --version ${{ matrix.engine }}
       - name: Check Docker Version
         run: docker --version


### PR DESCRIPTION
- supersedes/closes https://github.com/docker/compose/pull/11946

Switch to the test-channel, using the test.docker.com script, which has both stable and pre-releases.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
