### PR TITLE
fix(hash): recreate container on project config content change

### DIFF
--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -31,6 +31,10 @@ const (
 	ServiceLabel = "com.docker.compose.service"
 	// ConfigHashLabel stores configuration hash for a compose service
 	ConfigHashLabel = "com.docker.compose.config-hash"
+	// ServiceConfigsHash stores configuration hash for a compose service configs
+	ServiceConfigsHash = "com.docker.compose.service.%s.configs.hash"
+	// ServiceSecretsHash stores configuration hash for a compose service secrets
+	ServiceSecretsHash = "com.docker.compose.service.%s.secrets.hash"
 	// ContainerNumberLabel stores the container index of a replicated service
 	ContainerNumberLabel = "com.docker.compose.container-number"
 	// VolumeLabel allow to track resource related to a compose volume

--- a/pkg/compose/hash_test.go
+++ b/pkg/compose/hash_test.go
@@ -23,21 +23,193 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestServiceHash(t *testing.T) {
-	hash1, err := ServiceHash(serviceConfig(1))
+func TestServiceHashWithAllValuesTheSame(t *testing.T) {
+	hash1, err := ServiceHash(serviceConfig("myContext1", "always", 1))
 	assert.NilError(t, err)
-	hash2, err := ServiceHash(serviceConfig(2))
+	hash2, err := ServiceHash(serviceConfig("myContext1", "always", 1))
 	assert.NilError(t, err)
 	assert.Equal(t, hash1, hash2)
 }
 
-func serviceConfig(replicas int) types.ServiceConfig {
+func TestServiceHashWithIgnorableValues(t *testing.T) {
+	hash1, err := ServiceHash(serviceConfig("myContext1", "always", 1))
+	assert.NilError(t, err)
+	hash2, err := ServiceHash(serviceConfig("myContext2", "never", 2))
+	assert.NilError(t, err)
+	assert.Equal(t, hash1, hash2)
+}
+
+func TestServiceConfigsHashWithoutChangesContent(t *testing.T) {
+	serviceNameToConfigHash1, err := ServiceConfigsHash(projectWithConfigs("a", "", ""), serviceConfig("myContext1", "always", 1))
+	assert.NilError(t, err)
+	serviceNameToConfigHas2, err := ServiceConfigsHash(projectWithConfigs("a", "", ""), serviceConfig("myContext2", "never", 2))
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToConfigHash1), len(serviceNameToConfigHas2))
+
+	for serviceName, hash := range serviceNameToConfigHash1 {
+		assert.Equal(t, hash, serviceNameToConfigHas2[serviceName])
+	}
+}
+
+func TestServiceConfigsHashWithChangedConfigContent(t *testing.T) {
+	serviceNameToConfigHash1, err := ServiceConfigsHash(projectWithConfigs("a", "", ""), serviceConfig("myContext1", "always", 1))
+	assert.NilError(t, err)
+	serviceNameToConfigHash2, err := ServiceConfigsHash(projectWithConfigs("b", "", ""), serviceConfig("myContext2", "never", 2))
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToConfigHash1), len(serviceNameToConfigHash2))
+
+	for serviceName, hash := range serviceNameToConfigHash1 {
+		assert.Assert(t, hash != serviceNameToConfigHash2[serviceName])
+	}
+}
+
+func TestServiceConfigsHashWithChangedConfigEnvironment(t *testing.T) {
+	serviceNameToConfigHash1, err := ServiceConfigsHash(projectWithConfigs("", "a", ""), serviceConfig("myContext1", "always", 1))
+	assert.NilError(t, err)
+	serviceNameToConfigHash2, err := ServiceConfigsHash(projectWithConfigs("", "b", ""), serviceConfig("myContext2", "never", 2))
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToConfigHash1), len(serviceNameToConfigHash2))
+
+	for serviceName, hash := range serviceNameToConfigHash1 {
+		assert.Assert(t, hash != serviceNameToConfigHash2[serviceName])
+	}
+}
+
+func TestServiceConfigsHashWithChangedConfigFile(t *testing.T) {
+	serviceNameToConfigHash1, err := ServiceConfigsHash(
+		projectWithConfigs("", "", "./testdata/config1.txt"),
+		serviceConfig("myContext1", "always", 1),
+	)
+	assert.NilError(t, err)
+	serviceNameToConfigHash2, err := ServiceConfigsHash(
+		projectWithConfigs("", "", "./testdata/config2.txt"),
+		serviceConfig("myContext2", "never", 2),
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToConfigHash1), len(serviceNameToConfigHash2))
+
+	for serviceName, hash := range serviceNameToConfigHash1 {
+		assert.Assert(t, hash != serviceNameToConfigHash2[serviceName])
+	}
+}
+
+func TestServiceSecretsHashWithoutChangesContent(t *testing.T) {
+	serviceNameToSecretHash1, err := ServiceSecretsHash(projectWithSecrets("a", "", ""), serviceConfig("myContext1", "always", 1))
+	assert.NilError(t, err)
+	serviceNameToSecretHash2, err := ServiceSecretsHash(projectWithSecrets("a", "", ""), serviceConfig("myContext2", "never", 2))
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToSecretHash1), len(serviceNameToSecretHash2))
+
+	for serviceName, hash := range serviceNameToSecretHash1 {
+		assert.Equal(t, hash, serviceNameToSecretHash2[serviceName])
+	}
+}
+
+func TestServiceSecretsHashWithChangedSecretContent(t *testing.T) {
+	serviceNameToSecretHash1, err := ServiceSecretsHash(projectWithSecrets("a", "", ""), serviceConfig("myContext1", "always", 1))
+	assert.NilError(t, err)
+	serviceNameToSecretHash2, err := ServiceSecretsHash(projectWithSecrets("b", "", ""), serviceConfig("myContext2", "never", 2))
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToSecretHash1), len(serviceNameToSecretHash2))
+
+	for serviceName, hash := range serviceNameToSecretHash1 {
+		assert.Assert(t, hash != serviceNameToSecretHash2[serviceName])
+	}
+}
+
+func TestServiceSecretsHashWithChangedSecretEnvironment(t *testing.T) {
+	serviceNameToSecretHash1, err := ServiceSecretsHash(projectWithSecrets("", "a", ""), serviceConfig("myContext1", "always", 1))
+	assert.NilError(t, err)
+	serviceNameToSecretHash2, err := ServiceSecretsHash(projectWithSecrets("", "b", ""), serviceConfig("myContext2", "never", 2))
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToSecretHash1), len(serviceNameToSecretHash2))
+
+	for serviceName, hash := range serviceNameToSecretHash1 {
+		assert.Assert(t, hash != serviceNameToSecretHash2[serviceName])
+	}
+}
+
+func TestServiceSecretsHashWithChangedSecretFile(t *testing.T) {
+	serviceNameToSecretHash1, err := ServiceSecretsHash(
+		projectWithSecrets("", "", "./testdata/config1.txt"),
+		serviceConfig("myContext1", "always", 1),
+	)
+	assert.NilError(t, err)
+	serviceNameToSecretHash2, err := ServiceSecretsHash(
+		projectWithSecrets("", "", "./testdata/config2.txt"),
+		serviceConfig("myContext2", "never", 2),
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, len(serviceNameToSecretHash1), len(serviceNameToSecretHash2))
+
+	for serviceName, hash := range serviceNameToSecretHash1 {
+		assert.Assert(t, hash != serviceNameToSecretHash2[serviceName])
+	}
+}
+
+func projectWithConfigs(configContent, configEnvironmentValue, configFile string) *types.Project {
+	envName := "myEnv"
+
+	if configEnvironmentValue == "" {
+		envName = ""
+	}
+
+	return &types.Project{
+		Environment: types.Mapping{
+			envName: configEnvironmentValue,
+		},
+		Configs: types.Configs{
+			"myConfigSource": types.ConfigObjConfig{
+				Content:     configContent,
+				Environment: envName,
+				File:        configFile,
+			},
+		},
+	}
+}
+
+func projectWithSecrets(secretContent, secretEnvironmentValue, secretFile string) *types.Project {
+	envName := "myEnv"
+
+	if secretEnvironmentValue == "" {
+		envName = ""
+	}
+
+	return &types.Project{
+		Environment: types.Mapping{
+			envName: secretEnvironmentValue,
+		},
+		Secrets: types.Secrets{
+			"mySecretSource": types.SecretConfig{
+				Content:     secretContent,
+				Environment: envName,
+				File:        secretFile,
+			},
+		},
+	}
+}
+
+func serviceConfig(buildContext, pullPolicy string, replicas int) types.ServiceConfig {
 	return types.ServiceConfig{
-		Scale: &replicas,
+		Build: &types.BuildConfig{
+			Context: buildContext,
+		},
+		PullPolicy: pullPolicy,
+		Scale:      &replicas,
 		Deploy: &types.DeployConfig{
 			Replicas: &replicas,
 		},
 		Name:  "foo",
 		Image: "bar",
+		Configs: []types.ServiceConfigObjConfig{
+			{
+				Source: "myConfigSource",
+			},
+		},
+		Secrets: []types.ServiceSecretConfig{
+			{
+				Source: "mySecretSource",
+			},
+		},
 	}
 }

--- a/pkg/compose/testdata/config1.txt
+++ b/pkg/compose/testdata/config1.txt
@@ -1,0 +1,1 @@
+This is 1 config file

--- a/pkg/compose/testdata/config2.txt
+++ b/pkg/compose/testdata/config2.txt
@@ -1,0 +1,1 @@
+This is 2 config file

--- a/pkg/utils/tar.go
+++ b/pkg/utils/tar.go
@@ -1,0 +1,132 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/compose-spec/compose-go/v2/types"
+)
+
+func CreateTar(content string, config types.FileReferenceConfig, modTime time.Time) (bytes.Buffer, error) {
+	value := []byte(content)
+	b := bytes.Buffer{}
+	tarWriter := tar.NewWriter(&b)
+	mode := types.FileMode(0o444)
+	if config.Mode != nil {
+		mode = *config.Mode
+	}
+
+	var uid, gid int
+	if config.UID != "" {
+		v, err := strconv.Atoi(config.UID)
+		if err != nil {
+			return b, err
+		}
+		uid = v
+	}
+	if config.GID != "" {
+		v, err := strconv.Atoi(config.GID)
+		if err != nil {
+			return b, err
+		}
+		gid = v
+	}
+
+	header := &tar.Header{
+		Name:    config.Target,
+		Size:    int64(len(value)),
+		Mode:    int64(mode),
+		ModTime: modTime,
+		Uid:     uid,
+		Gid:     gid,
+	}
+	err := tarWriter.WriteHeader(header)
+	if err != nil {
+		return bytes.Buffer{}, err
+	}
+	_, err = tarWriter.Write(value)
+	if err != nil {
+		return bytes.Buffer{}, err
+	}
+	err = tarWriter.Close()
+	return b, err
+}
+
+func CreateTarByPath(path string, modTime time.Time) (*bytes.Buffer, error) {
+	b := new(bytes.Buffer)
+	tw := tar.NewWriter(b)
+	defer func() {
+		_ = tw.Close()
+	}()
+
+	// Walk the directory or file tree at the given path
+	err := filepath.Walk(path, func(file string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Create tar header
+		header, err := tar.FileInfoHeader(fi, fi.Name())
+		if err != nil {
+			return err
+		}
+
+		// Preserve folder structure by using relative paths
+		header.Name, err = filepath.Rel(filepath.Dir(path), file)
+		if err != nil {
+			return err
+		}
+
+		// Set custom modification time
+		header.ModTime = modTime.UTC()
+
+		// Write header to the tarball
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		// If it's a directory, we don't need to write file content
+		if fi.Mode().IsRegular() {
+			// Open the file and write its contents
+			f, err := os.Open(file)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = f.Close()
+			}()
+
+			if _, err := io.Copy(tw, f); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/pkg/utils/tar.go
+++ b/pkg/utils/tar.go
@@ -124,9 +124,6 @@ func CreateTarByPath(path string, modTime time.Time) (*bytes.Buffer, error) {
 
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return b, nil
+	return b, err
 }


### PR DESCRIPTION
**What I did**
Fixed `hash.ServiceHash()` to support config content change

**Related issue**
https://github.com/docker/compose/issues/11900

![image](https://github.com/docker/compose/assets/3595194/4044449c-e6f8-4463-81e3-81e98980947f)

