### PR TITLE
feat(watch): Add --prune option to docker-compose watch command

### DIFF
--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -32,7 +32,8 @@ import (
 
 type watchOptions struct {
 	*ProjectOptions
-	noUp bool
+	prune bool
+	noUp  bool
 }
 
 func watchCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
@@ -58,6 +59,7 @@ func watchCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 	}
 
 	cmd.Flags().BoolVar(&buildOpts.quiet, "quiet", false, "hide build output")
+	cmd.Flags().BoolVar(&watchOpts.prune, "prune", false, "Prune dangling images on rebuild")
 	cmd.Flags().BoolVar(&watchOpts.noUp, "no-up", false, "Do not build & start services before watching")
 	return cmd
 }
@@ -118,5 +120,6 @@ func runWatch(ctx context.Context, dockerCli command.Cli, backend api.Service, w
 	return backend.Watch(ctx, project, services, api.WatchOptions{
 		Build: &build,
 		LogTo: consumer,
+		Prune: watchOpts.prune,
 	})
 }

--- a/docs/reference/compose_watch.md
+++ b/docs/reference/compose_watch.md
@@ -9,6 +9,7 @@ Watch build context for service and rebuild/refresh containers when files are up
 |:------------|:-----|:--------|:----------------------------------------------|
 | `--dry-run` |      |         | Execute command in dry run mode               |
 | `--no-up`   |      |         | Do not build & start services before watching |
+| `--prune`   |      |         | Prune dangling images on rebuild              |
 | `--quiet`   |      |         | hide build output                             |
 
 

--- a/docs/reference/docker_compose_watch.yaml
+++ b/docs/reference/docker_compose_watch.yaml
@@ -17,6 +17,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: prune
+      value_type: bool
+      default_value: "false"
+      description: Prune dangling images on rebuild
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet
       value_type: bool
       default_value: "false"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -121,6 +121,7 @@ const WatchLogger = "#watch"
 type WatchOptions struct {
 	Build *BuildOptions
 	LogTo LogConsumer
+	Prune bool
 }
 
 // BuildOptions group options of the Build API

--- a/pkg/compose/watch_test.go
+++ b/pkg/compose/watch_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/docker/compose/v2/pkg/mocks"
 	"github.com/docker/compose/v2/pkg/watch"
 	moby "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -120,12 +122,26 @@ func TestWatch_Sync(t *testing.T) {
 	apiClient.EXPECT().ContainerList(gomock.Any(), gomock.Any()).Return([]moby.Container{
 		testContainer("test", "123", false),
 	}, nil).AnyTimes()
+	// we expect the image to be pruned
+	apiClient.EXPECT().ImageList(gomock.Any(), image.ListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("dangling", "true"),
+			filters.Arg("label", api.ProjectLabel+"=myProjectName"),
+		),
+	}).Return([]image.Summary{
+		{ID: "123"},
+		{ID: "456"},
+	}, nil).Times(1)
+	apiClient.EXPECT().ImageRemove(gomock.Any(), "123", image.RemoveOptions{}).Times(1)
+	apiClient.EXPECT().ImageRemove(gomock.Any(), "456", image.RemoveOptions{}).Times(1)
+	//
 	cli.EXPECT().Client().Return(apiClient).AnyTimes()
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
 	proj := types.Project{
+		Name: "myProjectName",
 		Services: types.Services{
 			"test": {
 				Name: "test",
@@ -148,6 +164,7 @@ func TestWatch_Sync(t *testing.T) {
 		err := service.watchEvents(ctx, &proj, "test", api.WatchOptions{
 			Build: &api.BuildOptions{},
 			LogTo: stdLogger{},
+			Prune: true,
 		}, watcher, syncer, []types.Trigger{
 			{
 				Path:   "/sync",


### PR DESCRIPTION
**What I did**
Added the `--prune` option to the `docker-compose watch` command. This option ensures that dangling images are pruned automatically when rebuilding, helping to keep the Docker environment clean and efficient.


**Related issue**
https://github.com/docker/compose/issues/11073

![image](https://github.com/docker/compose/assets/3595194/083511d7-dafa-4c9e-a665-721eb24bbb9d)
