### PR TITLE
fix terminal console check

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -129,11 +128,11 @@ func (s *composeService) stdin() *streams.In {
 	return s.dockerCli.In()
 }
 
-func (s *composeService) stderr() io.Writer {
+func (s *composeService) stderr() *streams.Out {
 	return s.dockerCli.Err()
 }
 
-func (s *composeService) stdinfo() io.Writer {
+func (s *composeService) stdinfo() *streams.Out {
 	if stdioToStdout {
 		return s.dockerCli.Out()
 	}

--- a/pkg/progress/console.go
+++ b/pkg/progress/console.go
@@ -1,0 +1,31 @@
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package progress
+
+import (
+	"os"
+
+	"github.com/containerd/console"
+)
+
+func checkConsole(fd uintptr) (console.File, bool) {
+	file := os.NewFile(fd, "")
+	return file, file != nil
+}

--- a/pkg/progress/console.go
+++ b/pkg/progress/console.go
@@ -26,6 +26,6 @@ import (
 )
 
 func checkConsole(fd uintptr) (console.File, bool) {
-	file := os.NewFile(fd, "")
+	file := os.NewFile(fd, "/dev/stderr")
 	return file, file != nil
 }

--- a/pkg/progress/console_windows.go
+++ b/pkg/progress/console_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+// +build windows
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package progress
+
+import (
+	"os"
+
+	"github.com/containerd/console"
+	"golang.org/x/sys/windows"
+)
+
+func checkConsole(fd uintptr) (console.File, bool) {
+	var mode uint32
+	if err := windows.GetConsoleMode(windows.Handle(fd), &mode); err != nil {
+		return nil, false
+	}
+	file := os.NewFile(fd, "")
+	return file, file != nil
+}


### PR DESCRIPTION
this was broken by cli v27 release and usage of stream writer for the stderr the new type encapsulates the io.Writer and don't pass the console.File type assertion

**What I did**
Introduce the check of the console in Compose code (for windows terminal)

**Related issue**
fixes #11928 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/705411/5aaa53da-7826-43f2-a7af-decaf9cd2d88)
