### PR TITLE
Remove `console.Terminal` check and use `IsTerminal` from `streams.Out`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
 	github.com/compose-spec/compose-go/v2 v2.1.3
-	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd v1.7.18
 	github.com/davecgh/go-spew v1.1.1
 	github.com/distribution/reference v0.6.0
@@ -81,6 +80,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/containerd/console v1.0.4 // indirect
 	github.com/containerd/continuity v0.4.3 // indirect
 	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -129,11 +128,11 @@ func (s *composeService) stdin() *streams.In {
 	return s.dockerCli.In()
 }
 
-func (s *composeService) stderr() io.Writer {
+func (s *composeService) stderr() *streams.Out {
 	return s.dockerCli.Err()
 }
 
-func (s *composeService) stdinfo() io.Writer {
+func (s *composeService) stdinfo() *streams.Out {
 	if stdioToStdout {
 		return s.dockerCli.Out()
 	}


### PR DESCRIPTION
- follow up to: https://github.com/docker/compose/pull/11926

**What I did**
Remove `console.Terminal` check and use `IsTerminal` from `streams.Out`

docker/cli v27 changed the return value of `Err()` to `streams.Out`
which made the typecheck for `console.File` fail.

The check is no longer needed due to the `IsTerminal` method present in
`streams.Out` which also has a special handling for Windows console.


**Related issue**
fixes https://github.com/docker/compose/issues/11928

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
