### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: 'Close stale issues'
+on:
+  # schedule:
+  #   - cron: '0 0 * * *' # at midnight UTC every day
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'To run in debug mode'
+        required: false
+        default: "true"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: ${{ github.event.inputs.debug_enabled }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          days-before-issue-stale: 180
+          days-before-issue-close: 180
+          stale-issue-label: "stale"
+          exempt-issue-labels: "kind/feature,kind/enhancement"
+          

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,14 +1,7 @@
 name: 'Close stale issues'
 on:
-  # schedule:
-  #   - cron: '0 0 * * *' # at midnight UTC every day
-  pull_request:
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        description: 'To run in debug mode'
-        required: false
-        default: "true"
+  schedule:
+    - cron: '0 0 * * 0,3' # at midnight UTC every Sunday and Tuesday
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -19,7 +12,6 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: ${{ github.event.inputs.debug_enabled }}
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you


### PR DESCRIPTION
**What I did**
Add gitHub action for compose stale bot with same configurations as previous [stale bot](https://github.com/docker/compose/blob/main/.github/stale.yml). 

To see the results from this action run go to:
Actions > (on the left) Close stale issues 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
https://docker.atlassian.net/browse/COMP-647?atlOrigin=eyJpIjoiODlmZWVlMDQ3ODY2NGY2NWFhOGMyZTA4MTY3ZmRjMzgiLCJwIjoiaiJ9

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/docker/compose/assets/22371565/bfbd15e1-7fdb-412d-9147-a448a86318cf)
