### PR TITLE
feat: add support globs pattern for compose files include

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -204,7 +204,7 @@ func makeJSONError(err error) error {
 func (o *ProjectOptions) addProjectFlags(f *pflag.FlagSet) {
 	f.StringArrayVar(&o.Profiles, "profile", []string{}, "Specify a profile to enable")
 	f.StringVarP(&o.ProjectName, "project-name", "p", "", "Project name")
-	f.StringArrayVarP(&o.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	f.StringArrayVarP(&o.ConfigPaths, "file", "f", []string{}, "Compose configuration files(supports glob pattern)")
 	f.StringArrayVar(&o.EnvFiles, "env-file", defaultStringArrayVar(ComposeEnvFiles), "Specify an alternate environment file")
 	f.StringVar(&o.ProjectDir, "project-directory", "", "Specify an alternate working directory\n(default: the path of the, first specified, Compose file)")
 	f.StringVar(&o.WorkDir, "workdir", "", "DEPRECATED! USE --project-directory INSTEAD.\nSpecify an alternate working directory\n(default: the path of the, first specified, Compose file)")


### PR DESCRIPTION
**What I did**
Added glob pattern support for compose-files include, for example, `docker compose up -f compose.*.yaml` will use all files:
```
compose.1.yaml
compose.2.yaml
compose.local.yaml
compose.{anything}.yaml
```

**Related issue**
https://github.com/docker/compose/issues/11971

![image](https://github.com/docker/compose/assets/3595194/310df28f-5359-4a4a-a42e-cb08d94fa8f9)

