### PR TITLE
exclude unecessary resources after services have been selected

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -342,11 +342,14 @@ func (o *ProjectOptions) ToProject(ctx context.Context, dockerCli command.Cli, s
 		project.Services[name] = s
 	}
 
+	project, err = project.WithSelectedServices(services)
+	if err != nil {
+		return nil, tracing.Metrics{}, err
+	}
+
 	if !o.All {
 		project = project.WithoutUnnecessaryResources()
 	}
-
-	project, err = project.WithSelectedServices(services)
 	return project, metrics, err
 }
 

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1307,11 +1307,10 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 	if len(networks) == 0 {
 		// in this instance, n.Name is really an ID
 		sn, err := s.apiClient().NetworkInspect(ctx, n.Name, network.InspectOptions{})
-		if err != nil {
+		if err != nil && !errdefs.IsNotFound(err) {
 			return err
 		}
 		networks = append(networks, sn)
-
 	}
 
 	// NetworkList API doesn't return the exact name match, so we can retrieve more than one network with a request

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -388,3 +388,20 @@ func TestNestedDotEnv(t *testing.T) {
 	})
 
 }
+
+func TestUnnecesaryResources(t *testing.T) {
+	const projectName = "compose-e2e-unnecessary-resources"
+	c := NewParallelCLI(t)
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "-p", projectName, "down", "-t=0")
+	})
+
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/external/compose.yaml", "-p", projectName, "up", "-d")
+	res.Assert(t, icmd.Expected{
+		ExitCode: 1,
+		Err:      "network foo_bar declared as external, but could not be found",
+	})
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/external/compose.yaml", "-p", projectName, "up", "-d", "test")
+	// Should not fail as missing external network is not used
+}

--- a/pkg/e2e/fixtures/external/compose.yaml
+++ b/pkg/e2e/fixtures/external/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  test:
+    image: nginx:alpine
+
+  other:
+    image: nginx:alpine
+    networks:
+      test_network:
+        ipv4_address: 8.8.8.8
+
+networks:
+  test_network:
+    external: true
+    name: foo_bar


### PR DESCRIPTION
**What I did**
remove definition for unused resources _after_  services have been selected
includes e2e test to avoid a future regression with this feature

**Related issue**
fixes https://github.com/docker/compose/issues/11976

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
