### PR TITLE
Update config/secret handling: Copy files into containers instead of bind mounting

### DIFF
--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -52,7 +52,7 @@ func TestLocalComposeVolume(t *testing.T) {
 		res := c.RunDockerCmd(t, "inspect", "compose-e2e-volume-nginx2-1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
 		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/src/app/node_modules","Driver":"local","Mode":"z","RW":true,"Propagation":""`), output)
-		assert.Assert(t, strings.Contains(output, `"Destination":"/myconfig","Mode":"","RW":false,"Propagation":"rprivate"`), output)
+		assert.Assert(t, !strings.Contains(output, `"Destination":"/myconfig","Mode":"","RW":false,"Propagation":"rprivate"`), output)
 	})
 
 	t.Run("check config content", func(t *testing.T) {


### PR DESCRIPTION
Currently, Docker Compose copies a config or secret into the container if the source is an environment variable or inlined content. However, if the source is a file, the file is bind mounted into the container. This approach fails when Docker Compose is invoked on a different filesystem than the Docker daemon host filesystem (e.g., when called from within a container or remotely using the -H option).

This PR changes the behavior for file-based config/secret sources to match the handling of environment variables and inlined content. Specifically, it reads the file from the filesystem where Docker Compose is executed (like Docker Stack) and copies it into the container.

This update enhances the functionality of Docker Compose when run "remotely," providing the ability to push configuration files, a feature previously available only with Docker Stack/Swarm.

What I did:

* Updated the behavior for handling configs and secrets sourced from files.
* Ensured consistency with the documentation and the behavior of Docker Stack.
* Enabled Docker Compose to push configuration files when run remotely, aligning with Docker Stack/Swarm capabilities.