### PR TITLE
Use logrus instead of direct output to stderr

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -44,6 +44,8 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 
 	"github.com/docker/compose/v2/pkg/api"
+
+	"github.com/sirupsen/logrus"
 )
 
 //nolint:gocyclo
@@ -180,7 +182,7 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 	aux := func(msg jsonmessage.JSONMessage) {
 		var result dockertypes.BuildResult
 		if err := json.Unmarshal(*msg.Aux, &result); err != nil {
-			fmt.Fprintf(s.stderr(), "Failed to parse aux message: %s", err)
+			logrus.Errorf("Failed to parse aux message: %s", err)
 		} else {
 			imageID = result.ID
 		}

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -33,6 +33,7 @@ import (
 	imageapi "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -107,7 +108,7 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 	}
 
 	if !resourceToRemove && len(ops) == 0 {
-		fmt.Fprintf(s.stderr(), "Warning: No resource found to remove for project %q.\n", projectName)
+		logrus.Warnf("Warning: No resource found to remove for project %q.", projectName)
 	}
 
 	eg, _ := errgroup.WithContext(ctx)


### PR DESCRIPTION
**What I did**
There are two warnings on stderr that `--progress json` (#11478) still emits as plain text. This is because they are printed there directly, without using logrus or the events framework.

This PR changes these places to use `logrus.Warnf(...)` instead of `fmt.Fprintf(s.stderr(), ...)`.

**Related issue**
Ref: #11478 (not an issue, but a PR)
