### PR TITLE
Fix stoping compose process for single container for file change on sync-restart action

### DIFF
--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 func TestWatch(t *testing.T) {
-	t.Skip("Skipping watch tests until we can figure out why they are flaky/failing")
 
 	services := []string{"alpine", "busybox", "debian"}
 	for _, svcName := range services {


### PR DESCRIPTION
**What I did**
For a single container project, when changing a file inside a `sync+restart` target, the container lifecycle is: `stop -> die -> start -> restart`. However, for an watched attached single container, when there are no more available containers we stop compose execution. Another issue is that we read `inpect.State.Restarting` the value is `false` ¯\\_(ツ)_/¯. The proposed fix, evaluates that the restarted container is currently running.

Tried locally the e2e tests for watch and they look like they are stable now, so I enabled them (let's see in the CI)
**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes: https://github.com/docker/compose/issues/11773

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/69232256-cd55-4b2b-a424-df8fc8ecda3e)
