### PR TITLE
update to go1.21.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.21.11
+ARG GO_VERSION=1.21.12
 ARG XX_VERSION=1.2.1
 ARG GOLANGCI_LINT_VERSION=v1.55.2
 ARG ADDLICENSE_VERSION=v1.0.0


### PR DESCRIPTION
go1.21.12 (released 2024-07-02) includes security fixes to the net/http package, as well as bug fixes to the compiler, the go command, the runtime, and the crypto/x509, net/http, net/netip, and os packages. See the Go 1.21.12 milestone on our issue tracker for details:

- https://github.com/golang/go/issues?q=milestone%3AGo1.21.12+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.21.11...go1.21.12

From the security mailing:

> Hello gophers,
>
> We have just released Go versions 1.22.5 and 1.21.12, minor point releases.
>
> These minor releases include 1 security fixes following the security policy:
>
> * net/http: denial of service due to improper 100-continue handling
>
>   The net/http HTTP/1.1 client mishandled the case where a server responds
>   to a request with an “Expect: 100-continue” header with a non-informational
>   (200 or higher) status. This mishandling could leave a client connection
>   in an invalid state, where the next request sent on the connection will fail.
>
> An attacker sending a request to a net/http/httputil.ReverseProxy proxy can
> exploit this mishandling to cause a denial of service by sending
> “Expect: 100-continue” requests which elicit a non-informational response
> from the backend. Each such request leaves the proxy with an invalid connection,
> and causes one subsequent request using that connection to fail.
>
> Thanks to Geoff Franks for reporting this issue.
>
> This is CVE-2024-24791 and Go issue https://go.dev/issue/67555.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
