### PR TITLE
run: add support --no-build, --pull flags

### DIFF
--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -57,29 +57,31 @@ specified in the service configuration.
 
 ### Options
 
-| Name                    | Type          | Default | Description                                                                      |
-|:------------------------|:--------------|:--------|:---------------------------------------------------------------------------------|
-| `--build`               | `bool`        |         | Build image before starting container                                            |
-| `--cap-add`             | `list`        |         | Add Linux capabilities                                                           |
-| `--cap-drop`            | `list`        |         | Drop Linux capabilities                                                          |
-| `-d`, `--detach`        | `bool`        |         | Run container in background and print container ID                               |
-| `--dry-run`             | `bool`        |         | Execute command in dry run mode                                                  |
-| `--entrypoint`          | `string`      |         | Override the entrypoint of the image                                             |
-| `-e`, `--env`           | `stringArray` |         | Set environment variables                                                        |
-| `-i`, `--interactive`   | `bool`        | `true`  | Keep STDIN open even if not attached                                             |
-| `-l`, `--label`         | `stringArray` |         | Add or override a label                                                          |
-| `--name`                | `string`      |         | Assign a name to the container                                                   |
-| `-T`, `--no-TTY`        | `bool`        | `true`  | Disable pseudo-TTY allocation (default: auto-detected)                           |
-| `--no-deps`             | `bool`        |         | Don't start linked services                                                      |
-| `-p`, `--publish`       | `stringArray` |         | Publish a container's port(s) to the host                                        |
-| `--quiet-pull`          | `bool`        |         | Pull without printing progress information                                       |
-| `--remove-orphans`      | `bool`        |         | Remove containers for services not defined in the Compose file                   |
-| `--rm`                  | `bool`        |         | Automatically remove the container when it exits                                 |
-| `-P`, `--service-ports` | `bool`        |         | Run command with all service's ports enabled and mapped to the host              |
-| `--use-aliases`         | `bool`        |         | Use the service's network useAliases in the network(s) the container connects to |
-| `-u`, `--user`          | `string`      |         | Run as specified username or uid                                                 |
-| `-v`, `--volume`        | `stringArray` |         | Bind mount a volume                                                              |
-| `-w`, `--workdir`       | `string`      |         | Working directory inside the container                                           |
+| Name                    | Type          | Default  | Description                                                                      |
+|:------------------------|:--------------|:---------|:---------------------------------------------------------------------------------|
+| `--build`               | `bool`        |          | Build image before starting container                                            |
+| `--cap-add`             | `list`        |          | Add Linux capabilities                                                           |
+| `--cap-drop`            | `list`        |          | Drop Linux capabilities                                                          |
+| `-d`, `--detach`        | `bool`        |          | Run container in background and print container ID                               |
+| `--dry-run`             | `bool`        |          | Execute command in dry run mode                                                  |
+| `--entrypoint`          | `string`      |          | Override the entrypoint of the image                                             |
+| `-e`, `--env`           | `stringArray` |          | Set environment variables                                                        |
+| `-i`, `--interactive`   | `bool`        | `true`   | Keep STDIN open even if not attached                                             |
+| `-l`, `--label`         | `stringArray` |          | Add or override a label                                                          |
+| `--name`                | `string`      |          | Assign a name to the container                                                   |
+| `-T`, `--no-TTY`        | `bool`        | `true`   | Disable pseudo-TTY allocation (default: auto-detected)                           |
+| `--no-build`            | `bool`        |          | Don't build an image, even if it's policy                                        |
+| `--no-deps`             | `bool`        |          | Don't start linked services                                                      |
+| `-p`, `--publish`       | `stringArray` |          | Publish a container's port(s) to the host                                        |
+| `--pull`                | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                         |
+| `--quiet-pull`          | `bool`        |          | Pull without printing progress information                                       |
+| `--remove-orphans`      | `bool`        |          | Remove containers for services not defined in the Compose file                   |
+| `--rm`                  | `bool`        |          | Automatically remove the container when it exits                                 |
+| `-P`, `--service-ports` | `bool`        |          | Run command with all service's ports enabled and mapped to the host              |
+| `--use-aliases`         | `bool`        |          | Use the service's network useAliases in the network(s) the container connects to |
+| `-u`, `--user`          | `string`      |          | Run as specified username or uid                                                 |
+| `-v`, `--volume`        | `stringArray` |          | Bind mount a volume                                                              |
+| `-w`, `--workdir`       | `string`      |          | Working directory inside the container                                           |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -159,6 +159,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: no-build
+      value_type: bool
+      default_value: "false"
+      description: Don't build an image, even if it's policy
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: no-deps
       value_type: bool
       default_value: "false"
@@ -174,6 +184,16 @@ options:
       value_type: stringArray
       default_value: '[]'
       description: Publish a container's port(s) to the host
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: pull
+      value_type: string
+      default_value: policy
+      description: Pull image before running ("always"|"missing"|"never")
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
Allows setting build- and pull policies for `docker-compose run` like for `docker run` and `docker-compose up`.
