### PR TITLE
Updated COMPOSE_ENV_FILES in env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 coverage.out
 covdatafiles/
 .DS_Store
+/.idea

--- a/pkg/e2e/fixtures/environment/env-recursion/.env
+++ b/pkg/e2e/fixtures/environment/env-recursion/.env
@@ -1,0 +1,2 @@
+COMPOSE_ENV_FILES=./.env.2
+WHEREAMI="Env File"

--- a/pkg/e2e/fixtures/environment/env-recursion/.env.2
+++ b/pkg/e2e/fixtures/environment/env-recursion/.env.2
@@ -1,0 +1,2 @@
+COMPOSE_ENV_FILES=.env.3,.env.2
+WHEREAMI="Env File 2"

--- a/pkg/e2e/fixtures/environment/env-recursion/.env.3
+++ b/pkg/e2e/fixtures/environment/env-recursion/.env.3
@@ -1,0 +1,2 @@
+COMPOSE_ENV_FILES=.env
+WHEREAMI="Env File 3"

--- a/pkg/e2e/fixtures/environment/env-recursion/.env.test-missing
+++ b/pkg/e2e/fixtures/environment/env-recursion/.env.test-missing
@@ -1,0 +1,2 @@
+COMPOSE_ENV_FILES=.env.test-missing.2
+WHEREAMI="Env File Test Missing"

--- a/pkg/e2e/fixtures/environment/env-recursion/.env.test-missing.2
+++ b/pkg/e2e/fixtures/environment/env-recursion/.env.test-missing.2
@@ -1,0 +1,2 @@
+COMPOSE_ENV_FILES=.env.test-missing.idontexist,.env.test-missing.3
+WHEREAMI="Env File Test Missing 2"

--- a/pkg/e2e/fixtures/environment/env-recursion/.env.test-missing.3
+++ b/pkg/e2e/fixtures/environment/env-recursion/.env.test-missing.3
@@ -1,0 +1,1 @@
+WHEREAMI="Env File Test Missing 3"

--- a/pkg/e2e/fixtures/environment/env-recursion/Dockerfile
+++ b/pkg/e2e/fixtures/environment/env-recursion/Dockerfile
@@ -1,0 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM alpine
+ENV  WHEREAMI=Dockerfile
+CMD ["printenv", "WHEREAMI"]

--- a/pkg/e2e/fixtures/environment/env-recursion/compose.yaml
+++ b/pkg/e2e/fixtures/environment/env-recursion/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  env-compose-recursion:
+    image: env-compose-recursion
+    build:
+      context: .


### PR DESCRIPTION
Updated the docker compose command to recursively search through any specified .env files for the COMPOSE_ENV_FILES parameter.

When found, the paths are followed recursively to extend the list of .env files used in the command.
A cache is kept that prevents circular dependencies.
Recursion is depth first.

**Related issue**

Example fix for #11122

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![Recursive guinea pigs](http://blog.tdg5.com/assets/images/featured/2015-01-12-tail-call-optimization-in-ruby-background.jpg)

