### PR TITLE
allow to add empty line in the logs when nav menu activated

### DIFF
--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -348,6 +348,7 @@ func (lk *LogKeyboard) HandleKeyEvents(event keyboard.KeyEvent, ctx context.Cont
 		// will notify main thread to kill and will handle gracefully
 		lk.signalChannel <- syscall.SIGINT
 	case keyboard.KeyEnter:
+		NewLine()
 		lk.printNavigationMenu()
 	}
 }


### PR DESCRIPTION
**What I did**
Add new line to the logs when users explicitly hit `enter` when Compose navigation menu is activated

**Related issue**
https://github.com/docker/for-mac/issues/7366

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/1bb5f179-e158-4f7d-a703-9c6e1790be8e)
