### PR TITLE
fix(wait): Wait only until first container exit

### DIFF
--- a/cmd/compose/wait.go
+++ b/cmd/compose/wait.go
@@ -43,7 +43,7 @@ func waitCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) 
 	var err error
 	cmd := &cobra.Command{
 		Use:   "wait SERVICE [SERVICE...] [OPTIONS]",
-		Short: "Block until the first service container stops",
+		Short: "Block until containers of all (or specified) services stop.",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: Adapt(func(ctx context.Context, services []string) error {
 			opts.services = services

--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -178,7 +178,7 @@ Dry Run mode works with almost all commands. You cannot use Dry Run mode with a 
 | [`unpause`](compose_unpause.md) | Unpause services                                                                        |
 | [`up`](compose_up.md)           | Create and start containers                                                             |
 | [`version`](compose_version.md) | Show the Docker Compose version information                                             |
-| [`wait`](compose_wait.md)       | Block until the first service container stops                                           |
+| [`wait`](compose_wait.md)       | Block until containers of all (or specified) services stop.                             |
 | [`watch`](compose_watch.md)     | Watch build context for service and rebuild/refresh containers when files are updated   |
 
 

--- a/docs/reference/compose_wait.md
+++ b/docs/reference/compose_wait.md
@@ -1,7 +1,7 @@
 # docker compose wait
 
 <!---MARKER_GEN_START-->
-Block until the first service container stops
+Block until containers of all (or specified) services stop.
 
 ### Options
 

--- a/docs/reference/docker_compose_wait.yaml
+++ b/docs/reference/docker_compose_wait.yaml
@@ -1,6 +1,6 @@
 command: docker compose wait
-short: Block until the first service container stops
-long: Block until the first service container stops
+short: Block until containers of all (or specified) services stop.
+long: Block until containers of all (or specified) services stop.
 usage: docker compose wait SERVICE [SERVICE...] [OPTIONS]
 pname: docker compose
 plink: docker_compose.yaml


### PR DESCRIPTION
**What I did**
The doc says https://docs.docker.com/reference/cli/docker/compose/wait/ `Block until the first service container stops` but in reality it waits for all containers, changed logic to wait only for first container exit

**Related issue**
https://github.com/docker/compose/issues/12063

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/1e8bf19f-266d-4282-8a66-1a66c98a3fc4)
