### PR TITLE
service hash must exclude depends_on

### DIFF
--- a/pkg/compose/hash.go
+++ b/pkg/compose/hash.go
@@ -32,6 +32,7 @@ func ServiceHash(o types.ServiceConfig) (string, error) {
 	if o.Deploy != nil {
 		o.Deploy.Replicas = nil
 	}
+	o.DependsOn = nil
 
 	bytes, err := json.Marshal(o)
 	if err != nil {


### PR DESCRIPTION
**What I did**

remove depends_on from service hash, as this information is used to orchestrate container creation ordering, but has no impact on individual container: if dependencies change for any reason, container is still valid regarding the desired state

**Related issue**
https://github.com/docker/compose/issues/12069

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
