### PR TITLE
prefer mount API over bind

### DIFF
--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -28,7 +28,6 @@ import (
 	containerType "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/go-connections/nat"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 
@@ -301,17 +300,10 @@ func TestCreateMobyContainer(t *testing.T) {
 			},
 		}
 
-		var falseBool bool
-		apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any(), gomock.Eq(
-			&containerType.HostConfig{
-				PortBindings: nat.PortMap{},
-				ExtraHosts:   []string{},
-				Tmpfs:        map[string]string{},
-				Resources: containerType.Resources{
-					OomKillDisable: &falseBool,
-				},
-				NetworkMode: "b-moby-name",
-			}), gomock.Eq(
+		apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any(), gomock.Cond(func(x any) bool {
+			v := x.(*containerType.HostConfig)
+			return v.NetworkMode == "b-moby-name"
+		}), gomock.Eq(
 			&network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
 					"b-moby-name": {
@@ -390,17 +382,10 @@ func TestCreateMobyContainer(t *testing.T) {
 			},
 		}
 
-		var falseBool bool
-		apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any(), gomock.Eq(
-			&containerType.HostConfig{
-				PortBindings: nat.PortMap{},
-				ExtraHosts:   []string{},
-				Tmpfs:        map[string]string{},
-				Resources: containerType.Resources{
-					OomKillDisable: &falseBool,
-				},
-				NetworkMode: "b-moby-name",
-			}), gomock.Eq(
+		apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any(), gomock.Cond(func(x any) bool {
+			v := x.(*containerType.HostConfig)
+			return v.NetworkMode == "b-moby-name"
+		}), gomock.Eq(
 			&network.NetworkingConfig{
 				EndpointsConfig: map[string]*network.EndpointSettings{
 					"a-moby-name": {


### PR DESCRIPTION
**What I did**

This basically reverts https://github.com/docker/compose/pull/9514 and does not force use of Bind API over Mount as it comes with limitations and lack support for SubPath.
The way https://github.com/docker/compose/pull/9514 was supposed to fix https://github.com/docker/for-mac/issues/6317 is unclear to me. Sounds like an issue with mounts set in Docker Desktop that could be reproduced with a plain `docker run --mount ...` command and should not have been closed. I also assume we can consider VirtioFS to be the recommended way to run Docker Desktop so this is not a blocker

**Related issue**
closes https://github.com/docker/compose/issues/12075

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
