### PR TITLE
Allow overlapping bind mounts and watches

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -156,8 +156,7 @@ func (s *composeService) watch(ctx context.Context, syncChannel chan bool, proje
 		var paths, pathLogs []string
 		for _, trigger := range config.Watch {
 			if checkIfPathAlreadyBindMounted(trigger.Path, service.Volumes) {
-				logrus.Warnf("path '%s' also declared by a bind mount volume, this path won't be monitored!\n", trigger.Path)
-				continue
+				logrus.Infof("path '%s' also declared by a bind mount volume\n", trigger.Path)
 			} else {
 				var initialSync bool
 				success, err := trigger.Extensions.Get("x-initialSync", &initialSync)


### PR DESCRIPTION
By relaxing this check, we can support the following use case: bind mount a directory, but also declare a watch for a file that triggers a rebuild. We still log the occurrence as Info, so we can find out this overlap if it was not intended.

**What I did**

**Related issue**
closes #12082

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/1f4e8e81-5571-4504-a98c-cf6346777247)
