### PR TITLE
Allow combination of bind mounts and 'rebuild' watches

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -155,7 +155,7 @@ func (s *composeService) watch(ctx context.Context, syncChannel chan bool, proje
 
 		var paths, pathLogs []string
 		for _, trigger := range config.Watch {
-			if checkIfPathAlreadyBindMounted(trigger.Path, service.Volumes) {
+			if trigger.Action != types.WatchActionRebuild && checkIfPathAlreadyBindMounted(trigger.Path, service.Volumes) {
 				logrus.Warnf("path '%s' also declared by a bind mount volume, this path won't be monitored!\n", trigger.Path)
 				continue
 			} else {


### PR DESCRIPTION
**What I did**
Instead of skipping all watches that overlap with a bind mount, only skip watches that have an action other than "rebuild". This allows us to trigger rebuilds for some files in a large mounted directory, while still avoiding the infinite loops that can happen when "sync" watches are combined with mounts.

**Related issue**
closes #12082

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/83cf66b9-7e78-4ec6-a4eb-7fb6920fa63b)
