### PR TITLE
Fix minor typos

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,5 +69,5 @@ linters-settings:
     line-length: 200
 issues:
   # golangci hides some golint warnings (the warning about exported things
-  # withtout documentation for example), this will make it show them anyway.
+  # without documentation for example), this will make it show them anyway.
   exclude-use-default: false

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -49,7 +49,7 @@ To execute both CLI and standalone e2e tests, run :
 make e2e
 ```
 
-Or if you need to build the CLI, run: 
+Or if you need to build the CLI, run:
 ```console
 make build-and-e2e
 ```
@@ -85,7 +85,7 @@ make build-and-e2e-compose-standalone
 
 To create a new release:
 * Check that the CI is green on the main branch for the commit you want to release
-* Run the release Github Actions workflow with a tag of form vx.y.z following existing tags.
+* Run the release GitHub Actions workflow with a tag of form vx.y.z following existing tags.
 
 This will automatically create a new tag, release and make binaries for
 Windows, macOS, and Linux available for download on the

--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -60,7 +60,7 @@ const (
 	ComposeProjectName = "COMPOSE_PROJECT_NAME"
 	// ComposeCompatibility try to mimic compose v1 as much as possible
 	ComposeCompatibility = "COMPOSE_COMPATIBILITY"
-	// ComposeRemoveOrphans remove “orphaned" containers, i.e. containers tagged for current project but not declared as service
+	// ComposeRemoveOrphans remove "orphaned" containers, i.e. containers tagged for current project but not declared as service
 	ComposeRemoveOrphans = "COMPOSE_REMOVE_ORPHANS"
 	// ComposeIgnoreOrphans ignore "orphaned" containers
 	ComposeIgnoreOrphans = "COMPOSE_IGNORE_ORPHANS"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -196,7 +196,7 @@ type CreateOptions struct {
 	RecreateDependencies string
 	// Inherit reuse anonymous volumes from previous container
 	Inherit bool
-	// Timeout set delay to wait for container to gracelfuly stop before sending SIGKILL
+	// Timeout set delay to wait for container to gracefully stop before sending SIGKILL
 	Timeout *time.Duration
 	// QuietPull makes the pulling process quiet
 	QuietPull bool

--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -43,7 +43,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, lis
 		return containers, nil
 	}
 
-	containers.sorted() // This enforce predictable colors assignment
+	containers.sorted() // This enforces predictable colors assignment
 
 	var names []string
 	for _, c := range containers {

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -173,7 +173,7 @@ func (s *composeService) ensureProjectVolumes(ctx context.Context, project *type
 							continue
 						}
 					} else if err != nil {
-						// if we can't read the path, we won't be able ot make
+						// if we can't read the path, we won't be able to make
 						// a file share for it
 						logrus.Debugf("Skipping creating file share for %q: %v", p, err)
 						continue
@@ -1183,7 +1183,7 @@ func (s *composeService) resolveOrCreateNetwork(ctx context.Context, n *types.Ne
 	inspect, err := s.apiClient().NetworkInspect(ctx, n.Name, network.InspectOptions{})
 	if err == nil {
 		// NetworkInspect will match on ID prefix, so double check we get the expected one
-		// as looking for network named `db` we could erroneously matched network ID `db9086999caf`
+		// as looking for network named `db` we could erroneously match network ID `db9086999caf`
 		if inspect.Name == n.Name || inspect.ID == n.Name {
 			p, ok := inspect.Labels[api.ProjectLabel]
 			if !ok {
@@ -1329,7 +1329,7 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 			// Swarm nodes do not register overlay networks that were
 			// created on a different node unless they're in use.
 			// So we can't preemptively check network exists, but
-			// networkAttach will later fail anyway if network actually doesn't exists
+			// networkAttach will later fail anyway if network actually doesn't exist
 			return nil
 		}
 		return fmt.Errorf("network %s declared as external, but could not be found", n.Name)

--- a/pkg/compose/dependencies.go
+++ b/pkg/compose/dependencies.go
@@ -224,7 +224,7 @@ func getParents(v *Vertex) []*Vertex {
 	return v.GetParents()
 }
 
-// GetParents returns a slice with the parent vertices of the a Vertex
+// GetParents returns a slice with the parent vertices of the Vertex
 func (v *Vertex) GetParents() []*Vertex {
 	var res []*Vertex
 	for _, p := range v.Parents {
@@ -247,7 +247,7 @@ func getAncestors(v *Vertex) []*Vertex {
 	return descendents
 }
 
-// GetChildren returns a slice with the child vertices of the a Vertex
+// GetChildren returns a slice with the child vertices of the Vertex
 func (v *Vertex) GetChildren() []*Vertex {
 	var res []*Vertex
 	for _, p := range v.Children {

--- a/pkg/compose/metrics.go
+++ b/pkg/compose/metrics.go
@@ -35,9 +35,9 @@ const (
 	FileNotFoundFailureStatus = "failure-file-not-found"
 	// CommandSyntaxFailureStatus failure reading command
 	CommandSyntaxFailureStatus = "failure-cmd-syntax"
-	// BuildFailureStatus failure building imge
+	// BuildFailureStatus failure building image
 	BuildFailureStatus = "failure-build"
-	// PullFailureStatus failure pulling imge
+	// PullFailureStatus failure pulling image
 	PullFailureStatus = "failure-pull"
 	// CanceledStatus command canceled
 	CanceledStatus = "canceled"

--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/compose/v2/pkg/api"
 )
 
-// logPrinter watch application containers an collect their logs
+// logPrinter watch application containers and collect their logs
 type logPrinter interface {
 	HandleEvent(event api.ContainerEvent)
 	Run(cascade api.Cascade, exitCodeFrom string, stopFn func() error) (int, error)

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -265,7 +265,7 @@ func ImageDigestResolver(ctx context.Context, file *configfile.ConfigFile, apiCl
 		inspect, err := apiClient.DistributionInspect(ctx, named.String(), auth)
 		if err != nil {
 			return "",
-				fmt.Errorf("failed ot resolve digest for %s: %w", named.String(), err)
+				fmt.Errorf("failed to resolve digest for %s: %w", named.String(), err)
 		}
 		return inspect.Descriptor.Digest, nil
 	}

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -389,7 +389,7 @@ func TestNestedDotEnv(t *testing.T) {
 
 }
 
-func TestUnnecesaryResources(t *testing.T) {
+func TestUnnecessaryResources(t *testing.T) {
 	const projectName = "compose-e2e-unnecessary-resources"
 	c := NewParallelCLI(t)
 	t.Cleanup(func() {

--- a/pkg/utils/writer.go
+++ b/pkg/utils/writer.go
@@ -21,7 +21,7 @@ import (
 	"io"
 )
 
-// GetWriter creates a io.Writer that will actually split by line and format by LogConsumer
+// GetWriter creates an io.Writer that will actually split by line and format by LogConsumer
 func GetWriter(consumer func(string)) io.WriteCloser {
 	return &splitWriter{
 		buffer:   bytes.Buffer{},

--- a/pkg/watch/ephemeral.go
+++ b/pkg/watch/ephemeral.go
@@ -36,7 +36,7 @@ func EphemeralPathMatcher() PathMatcher {
 	// seems safe and should catch most cases
 	vimPatterns := []string{"**/4913", "**/*~", "**/.*.swp", "**/.*.swx", "**/.*.swo", "**/.*.swn"}
 	// kate (the default text editor for KDE) uses a file similar to Vim's .swp
-	// files, but it doesn't have the "incrememnting" character problem mentioned
+	// files, but it doesn't have the "incrementing" character problem mentioned
 	// above
 	katePatterns := []string{"**/.*.kate-swp"}
 	// go stdlib creates tmpfiles to determine umask for setting permissions


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on. Nothing controversial (hopefully), just 18 simple fixes.

Use the following command to get a quick and dirty summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the typos are:
* imge -> image
* ot -> to
* gracelfuly -> gracefully
* incrememnting -> incrementing
* withtout -> without
* unnecesary -> unnecessary
* enforce -> enforces
* exists -> exist
* Github -> GitHub