### PR TITLE
attach: close streams when done

### DIFF
--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -102,9 +102,7 @@ func (s *composeService) attachContainer(ctx context.Context, container moby.Con
 
 func (s *composeService) attachContainerStreams(ctx context.Context, container string, tty bool, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (func(), chan bool, error) {
 	detached := make(chan bool)
-	var (
-		restore = func() { /* noop */ }
-	)
+	restore := func() { /* noop */ }
 	if stdin != nil {
 		in := streams.NewIn(stdin)
 		if in.IsTerminal() {
@@ -128,7 +126,6 @@ func (s *composeService) attachContainerStreams(ctx context.Context, container s
 		if stdin != nil {
 			stdin.Close() //nolint:errcheck
 		}
-		streamOut.Close() //nolint:errcheck
 	}()
 
 	if streamIn != nil && stdin != nil {
@@ -143,8 +140,9 @@ func (s *composeService) attachContainerStreams(ctx context.Context, container s
 
 	if stdout != nil {
 		go func() {
-			defer stdout.Close() //nolint:errcheck
-			defer stderr.Close() //nolint:errcheck
+			defer stdout.Close()    //nolint:errcheck
+			defer stderr.Close()    //nolint:errcheck
+			defer streamOut.Close() //nolint:errcheck
 			if tty {
 				io.Copy(stdout, streamOut) //nolint:errcheck
 			} else {


### PR DESCRIPTION
**What I did**

When Compose is watching a project/reattaching streams on container start, it will make new API `ContainerAttach()` calls every time a container it's watching is started. However, it only closes the stream when the context used to start the attach is canceled.

This means that if a user has a project with multiple containers where containers keep restarting, Compose will attach to the new containers but never close the previous streams, causing fds to pile up and goroutines on the engine to get stuck.

You can verify this by using a Dockerfile such as:
```Dockerfile
FROM alpine:latest AS occupied

CMD ["sleep", "3600"]

FROM alpine:latest AS surplus

CMD ["sleep", "10"]
```

And the following Compose file:
```yaml
services:
  occupied:
    image: container-used:latest
  
  surplus:
    restart: unless-stopped
    image: container-surplus:latest
```

Run
```console
docker compose up --scale occupied=8 --scale surplus=2`.
```

In another terminal, run 
```console
watch -n1 "lsof -p `pgrep docker-compose` | grep unix"
```

And gradually watch the connections pile up.

(There might also be some bug engine-side here, I haven't looked into it yet.)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes https://github.com/docker/compose/issues/12023

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
