### PR TITLE
Restore compose v1 behavior to recreate containers when ran with -V

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -117,6 +117,9 @@ func (opts createOptions) recreateStrategy() string {
 	if opts.forceRecreate {
 		return api.RecreateForce
 	}
+	if opts.noInherit {
+		return api.RecreateForce
+	}
 	return api.RecreateDiverged
 }
 

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -189,6 +189,9 @@ func validateFlags(up *upOptions, create *createOptions) error {
 	if up.Detach && (up.attachDependencies || up.cascadeStop || up.cascadeFail || len(up.attach) > 0 || up.watch) {
 		return fmt.Errorf("--detach cannot be combined with --abort-on-container-exit, --abort-on-container-failure, --attach, --attach-dependencies or --watch")
 	}
+	if create.noInherit && create.noRecreate {
+		return fmt.Errorf("--no-recreate and --renew-anon-volumes are incompatible")
+	}
 	if create.forceRecreate && create.noRecreate {
 		return fmt.Errorf("--force-recreate and --no-recreate are incompatible")
 	}


### PR DESCRIPTION
**What I did**
Compose v1 made it implicit for `--renew-anon-volumes` to imply `--force-recreate`. Indeed if we don't do,existing container that doesn't need to be re-created for other reasons won't get a fresh new volume attached?

**Related issue**
closes https://github.com/docker/compose/issues/10774

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
