### PR TITLE
chore(watch): Add changed file paths/count to log

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -547,8 +547,7 @@ func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Pr
 
 // writeWatchSyncMessage prints out a message about the sync for the changed paths.
 func writeWatchSyncMessage(log api.LogConsumer, serviceName string, pathMappings []sync.PathMapping) {
-	const maxPathsToShow = 10
-	if len(pathMappings) <= maxPathsToShow || logrus.IsLevelEnabled(logrus.DebugLevel) {
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		hostPathsToSync := make([]string, len(pathMappings))
 		for i := range pathMappings {
 			hostPathsToSync[i] = pathMappings[i].HostPath

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -553,13 +553,19 @@ func writeWatchSyncMessage(log api.LogConsumer, serviceName string, pathMappings
 		for i := range pathMappings {
 			hostPathsToSync[i] = pathMappings[i].HostPath
 		}
-		log.Log(api.WatchLogger, fmt.Sprintf("Syncing %q after changes were detected", serviceName))
+		log.Log(
+			api.WatchLogger,
+			fmt.Sprintf(
+				"Syncing %q after changes were detected: %s",
+				serviceName,
+				strings.Join(hostPathsToSync, ", "),
+			),
+		)
 	} else {
-		hostPathsToSync := make([]string, len(pathMappings))
-		for i := range pathMappings {
-			hostPathsToSync[i] = pathMappings[i].HostPath
-		}
-		log.Log(api.WatchLogger, fmt.Sprintf("Syncing service %q after %d changes were detected", serviceName, len(pathMappings)))
+		log.Log(
+			api.WatchLogger,
+			fmt.Sprintf("Syncing service %q after %d changes were detected", serviceName, len(pathMappings)),
+		)
 	}
 }
 


### PR DESCRIPTION
**What I did**
Reverted changed file paths/count to the watch logs.  For some reason @ndeloof deleted it from the log, but I think it's pretty useful to see what's going on

![image](https://github.com/user-attachments/assets/2b1da27d-f84d-4f14-aabd-d73d56c4eb4e)

