### PR TITLE
set propagation default

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1114,8 +1114,15 @@ func buildBindOption(bind *types.ServiceVolumeBind) *mount.BindOptions {
 	if bind == nil {
 		return nil
 	}
+
+	// I miss ternary operator
+	propagation := types.PropagationRPrivate
+	if bind.Propagation != "" {
+		propagation = bind.Propagation
+	}
+
 	return &mount.BindOptions{
-		Propagation:      mount.Propagation(bind.Propagation),
+		Propagation:      mount.Propagation(propagation),
 		CreateMountpoint: bind.CreateHostPath,
 		// NonRecursive: false, FIXME missing from model ?
 	}


### PR DESCRIPTION
**What I did**

enforce `bind.propagation` is set to default `rprivate` if user didn't explicitly set a value
see https://docs.docker.com/engine/storage/bind-mounts/#configure-bind-propagation

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
