### PR TITLE
build(deps): bump docker, docker/cli to v27.3.0-rc.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/distribution/reference v0.6.0
 	github.com/docker/buildx v0.17.1
-	github.com/docker/cli v27.3.0-rc.1+incompatible
+	github.com/docker/cli v27.3.0-rc.2+incompatible
 	github.com/docker/cli-docs-tool v0.8.0
 	github.com/docker/docker v27.3.0-rc.1+incompatible
 	github.com/docker/go-connections v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/buildx v0.17.1
 	github.com/docker/cli v27.3.0-rc.2+incompatible
 	github.com/docker/cli-docs-tool v0.8.0
-	github.com/docker/docker v27.3.0-rc.1+incompatible
+	github.com/docker/docker v27.3.0-rc.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/buildx v0.17.1 h1:9ob2jGp4+W9PxWw68GsoNFp+eYFc7eUoRL9VljLCSM4=
 github.com/docker/buildx v0.17.1/go.mod h1:kJOhOhS47LRvrLFRulFiO5SE6VJf54yYMn7DzjgO5W0=
-github.com/docker/cli v27.3.0-rc.1+incompatible h1:yc++0aWWMlq4QBYrvuuzYhVHc+Y/MRrWa4T/g/0mVPQ=
-github.com/docker/cli v27.3.0-rc.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v27.3.0-rc.2+incompatible h1:z/lQXreGSzWl0RySxyFOm6WygLQtre2EkB4SCwsEut0=
+github.com/docker/cli v27.3.0-rc.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.8.0 h1:YcDWl7rQJC3lJ7WVZRwSs3bc9nka97QLWfyJQli8yJU=
 github.com/docker/cli-docs-tool v0.8.0/go.mod h1:8TQQ3E7mOXoYUs811LiPdUnAhXrcVsBIrW21a5pUbdk=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/docker/cli-docs-tool v0.8.0/go.mod h1:8TQQ3E7mOXoYUs811LiPdUnAhXrcVsB
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v27.3.0-rc.1+incompatible h1:rqvkkh1Ukw3IYyI0DYbMuLd0r5EvIRC4bAaFg4uC8sU=
-github.com/docker/docker v27.3.0-rc.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.3.0-rc.2+incompatible h1:+WSuhLOwbip2IuVKZ4ecSQfG/grbPw96d3b7jBC8MSQ=
+github.com/docker/docker v27.3.0-rc.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=


### PR DESCRIPTION
not yet tagged, but these are the commits used to build v27.3.0-rc.2


### build(deps): bump github.com/docker/cli v27.3.0-rc.2

full diff: https://github.com/docker/cli/compare/v27.3.0-rc.1...v27.3.0-rc.2

### build(deps): bump github.com/docker/docker v27.3.0-rc.2

full diff: https://github.com/docker/docker/compare/v27.3.0-rc.1...v27.3.0-rc.2