### PR TITLE
don't set propagation if target engine isn't linux

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -321,6 +321,23 @@ func (s *composeService) RuntimeVersion(ctx context.Context) (string, error) {
 
 }
 
+var windowsContainer = struct {
+	once sync.Once
+	val  bool
+	err  error
+}{}
+
+func (s *composeService) isWindowsContainer(ctx context.Context) (bool, error) {
+	windowsContainer.once.Do(func() {
+		info, err := s.apiClient().Info(ctx)
+		if err != nil {
+			windowsContainer.err = err
+		}
+		windowsContainer.val = info.OSType == "windows"
+	})
+	return windowsContainer.val, windowsContainer.err
+}
+
 func (s *composeService) isDesktopIntegrationActive() bool {
 	return s.desktopCli != nil
 }

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -41,7 +42,8 @@ func TestBuildBindMount(t *testing.T) {
 		Source: "",
 		Target: "/data",
 	}
-	mount, err := buildMount(project, volume)
+	s := composeService{}
+	mount, err := s.buildMount(context.TODO(), project, volume)
 	assert.NilError(t, err)
 	assert.Assert(t, filepath.IsAbs(mount.Source))
 	_, err = os.Stat(mount.Source)
@@ -56,7 +58,8 @@ func TestBuildNamedPipeMount(t *testing.T) {
 		Source: "\\\\.\\pipe\\docker_engine_windows",
 		Target: "\\\\.\\pipe\\docker_engine",
 	}
-	mount, err := buildMount(project, volume)
+	s := composeService{}
+	mount, err := s.buildMount(context.TODO(), project, volume)
 	assert.NilError(t, err)
 	assert.Equal(t, mount.Type, mountTypes.TypeNamedPipe)
 }
@@ -75,7 +78,8 @@ func TestBuildVolumeMount(t *testing.T) {
 		Source: "myVolume",
 		Target: "/data",
 	}
-	mount, err := buildMount(project, volume)
+	s := composeService{}
+	mount, err := s.buildMount(context.TODO(), project, volume)
 	assert.NilError(t, err)
 	assert.Equal(t, mount.Source, "myProject_myVolume")
 	assert.Equal(t, mount.Type, mountTypes.TypeVolume)
@@ -152,8 +156,8 @@ func TestBuildContainerMountOptions(t *testing.T) {
 			},
 		},
 	}
-
-	mounts, err := buildContainerMountOptions(project, project.Services["myService"], moby.ImageInspect{}, inherit)
+	s := composeService{}
+	mounts, err := s.buildContainerMountOptions(context.TODO(), project, project.Services["myService"], moby.ImageInspect{}, inherit)
 	sort.Slice(mounts, func(i, j int) bool {
 		return mounts[i].Target < mounts[j].Target
 	})
@@ -165,7 +169,7 @@ func TestBuildContainerMountOptions(t *testing.T) {
 	assert.Equal(t, mounts[2].VolumeOptions.Subpath, "etc")
 	assert.Equal(t, mounts[3].Target, "\\\\.\\pipe\\docker_engine")
 
-	mounts, err = buildContainerMountOptions(project, project.Services["myService"], moby.ImageInspect{}, inherit)
+	mounts, err = s.buildContainerMountOptions(context.TODO(), project, project.Services["myService"], moby.ImageInspect{}, inherit)
 	sort.Slice(mounts, func(i, j int) bool {
 		return mounts[i].Target < mounts[j].Target
 	})


### PR DESCRIPTION
**What I did**
`propagation` is only relevant on Linux-based docker engine. Don't set value when server has OSType "windows"

**Related issue**
see https://github.com/docker/compose/issues/12137

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/ae7b1ee7-dc64-494d-8497-845f03c4f670)
