### PR TITLE
append unix-style relative path when computing container target path

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -294,7 +294,7 @@ func maybeFileEvent(trigger types.Trigger, hostPath string, ignore watch.PathMat
 			return nil
 		}
 		// always use Unix-style paths for inside the container
-		containerPath = path.Join(trigger.Target, rel)
+		containerPath = path.Join(trigger.Target, filepath.ToSlash(rel))
 	}
 
 	return &fileEvent{


### PR DESCRIPTION
**What I did**
as watch computes path in container to be deleted/updated, use unix-style separator. Otherwise, we run a `docker rm -rf /target/foo\bar` (with a back slash) command, which will match no file and keep the original file on rename

**Related issue**
fixes https://github.com/docker/compose/issues/12113

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/96ae930d-0f1c-4048-9cf5-55b5a0db7b7b)
