### PR TITLE
check secret source exists, as bind mount would create target

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1003,11 +1003,18 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 			continue
 		}
 
+		if _, err := os.Stat(definedSecret.File); os.IsNotExist(err) {
+			logrus.Warnf("secret file %s does not exist", definedSecret.Name)
+		}
+
 		mnt, err := buildMount(p, types.ServiceVolumeConfig{
 			Type:     types.VolumeTypeBind,
 			Source:   definedSecret.File,
 			Target:   target,
 			ReadOnly: true,
+			Bind: &types.ServiceVolumeBind{
+				CreateHostPath: false,
+			},
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What I did**
Check secret.file exists otherwise target will be silently created as a folder by bind mount

**Related issue**
fixes https://github.com/docker/compose/issues/8305

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
