### PR TITLE
wait for dependent service up to delay set by --wait-timeout

### DIFF
--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -239,7 +239,7 @@ func TestWaitDependencies(t *testing.T) {
 			"db":    {Condition: ServiceConditionRunningOrHealthy},
 			"redis": {Condition: ServiceConditionRunningOrHealthy},
 		}
-		assert.NilError(t, tested.waitDependencies(context.Background(), &project, "", dependencies, nil))
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, "", dependencies, nil, 0))
 	})
 	t.Run("should skip dependencies with condition service_started", func(t *testing.T) {
 		dbService := types.ServiceConfig{Name: "db", Scale: intPtr(1)}
@@ -252,7 +252,7 @@ func TestWaitDependencies(t *testing.T) {
 			"db":    {Condition: types.ServiceConditionStarted, Required: true},
 			"redis": {Condition: types.ServiceConditionStarted, Required: true},
 		}
-		assert.NilError(t, tested.waitDependencies(context.Background(), &project, "", dependencies, nil))
+		assert.NilError(t, tested.waitDependencies(context.Background(), &project, "", dependencies, nil, 0))
 	})
 }
 

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -93,7 +93,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	}
 
 	if !opts.NoDeps {
-		if err := s.waitDependencies(ctx, project, service.Name, service.DependsOn, observedState); err != nil {
+		if err := s.waitDependencies(ctx, project, service.Name, service.DependsOn, observedState, 0); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -129,7 +129,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 			return err
 		}
 
-		return s.startService(ctx, project, service, containers)
+		return s.startService(ctx, project, service, containers, options.WaitTimeout)
 	})
 	if err != nil {
 		return err
@@ -149,7 +149,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 			defer cancel()
 		}
 
-		err = s.waitDependencies(ctx, project, project.Name, depends, containers)
+		err = s.waitDependencies(ctx, project, project.Name, depends, containers, 0)
 		if err != nil {
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return fmt.Errorf("application not healthy after %s", options.WaitTimeout)


### PR DESCRIPTION
**What I did**
Apply --wait-timeout delay while waiting for dependencies, so that process don't get stuck waiting.

**Related issue**
fixes https://github.com/docker/compose/issues/12134

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/0f6755dd-ae9d-4a62-8d81-d8a03c809c65)
