### PR TITLE
After container restart register printer consumer

### DIFF
--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -98,7 +98,7 @@ func (p *printer) Run(cascade api.Cascade, exitCodeFrom string, stopFn func() er
 			case api.UserCancel:
 				aborting = true
 			case api.ContainerEventAttach:
-				if _, ok := containers[id]; ok {
+				if attached, ok := containers[id]; ok && attached {
 					continue
 				}
 				containers[id] = true


### PR DESCRIPTION
**What I did**
When a container restarts, the value for its id is set to `false` from `containers` - meaning it is no longer attached (line 113). However, when the container starts and it is going to be attached, this container id exists in `containers` with `false` value but we never set it back to `true` leading to the events being ignored in line 107.

https://github.com/docker/compose/blob/34b18194f7e9efa1ac8c0e67c554c46b61bf5690/pkg/compose/printer.go#L100-L116
**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
- fixes #12111

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/9fd05789-8213-4042-ba28-1e9356d92c51)