### PR TITLE
fix(down): Fix down command if specified services are not running

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -67,10 +67,17 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 	}
 
 	// Check requested services exists in model
-	options.Services, err = checkSelectedServices(options, project)
+	services, err := checkSelectedServices(options, project)
 	if err != nil {
 		return err
 	}
+
+	if len(options.Services) > 0 && len(services) == 0 {
+		logrus.Infof("Any of the services %v not running in project %q", options.Services, projectName)
+		return nil
+	}
+
+	options.Services = services
 
 	if len(containers) > 0 {
 		resourceToRemove = true


### PR DESCRIPTION
**What I did**
Fixed down command, it passes empty services if specified services are not running, in this case we stops all services despite command line argument where we specify list of services we want to stop

**Related issue**
[<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->](https://github.com/docker/compose/issues/12163)

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/161c7fa4-6452-40f0-8ef3-8edf64c622ac)

