### PR TITLE
Show watch error message and open DD only when w is pressed

### DIFF
--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -288,19 +288,7 @@ func (lk *LogKeyboard) keyboardError(prefix string, err error) {
 
 func (lk *LogKeyboard) StartWatch(ctx context.Context, doneCh chan bool, project *types.Project, options api.UpOptions) {
 	if !lk.IsWatchConfigured {
-		if lk.IsDDComposeUIActive {
-			// we try to open watch docs
-			lk.openDDWatchDocs(ctx, project)
-		}
-		// either way we mark menu/watch as an error
-		eg.Go(tracing.EventWrapFuncForErrGroup(ctx, "menu/watch", tracing.SpanOptions{},
-			func(ctx context.Context) error {
-				err := fmt.Errorf("Watch is not yet configured. Learn more: %s", ansiColor(CYAN, "https://docs.docker.com/compose/file-watch/"))
-				lk.keyboardError("Watch", err)
-				return err
-			}))
 		return
-
 	}
 	lk.Watch.switchWatching()
 	if !lk.Watch.isWatching() {
@@ -330,6 +318,20 @@ func (lk *LogKeyboard) HandleKeyEvents(event keyboard.KeyEvent, ctx context.Cont
 	case 'v':
 		lk.openDockerDesktop(ctx, project)
 	case 'w':
+		if !lk.IsWatchConfigured {
+			if lk.IsDDComposeUIActive {
+				// we try to open watch docs
+				lk.openDDWatchDocs(ctx, project)
+			}
+			// either way we mark menu/watch as an error
+			eg.Go(tracing.EventWrapFuncForErrGroup(ctx, "menu/watch", tracing.SpanOptions{},
+				func(ctx context.Context) error {
+					err := fmt.Errorf("watch is not yet configured. Learn more: %s", ansiColor(CYAN, "https://docs.docker.com/compose/file-watch/"))
+					lk.keyboardError("Watch", err)
+					return err
+				}))
+			return
+		}
 		lk.StartWatch(ctx, doneCh, project, options)
 	case 'o':
 		lk.openDDComposeUI(ctx, project)


### PR DESCRIPTION
**What I did**
When running `docker compose up --watch`, with the menu enabled, show error message and open DD only when `w` is pressed.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/abf38b87-f36a-47dd-af0b-49b1c2779152)
