### PR TITLE
fix(push): Fix unexpected EOF on alpha publish

### DIFF
--- a/internal/ocipush/push.go
+++ b/internal/ocipush/push.go
@@ -179,7 +179,7 @@ func generateManifest(layers []v1.Descriptor, ociCompat api.OCIVersion) ([]Pusha
 		config = v1.DescriptorEmptyJSON
 		artifactType = ComposeProjectArtifactType
 		// N.B. the descriptor has the data embedded in it
-		toPush = append(toPush, Pushable{Descriptor: config, Data: nil})
+		toPush = append(toPush, Pushable{Descriptor: config, Data: make([]byte, len(config.Data))})
 	default:
 		return nil, fmt.Errorf("unsupported OCI version: %s", ociCompat)
 	}


### PR DESCRIPTION
**What I did**
Initialized `Data` slice for `v1.DescriptorEmptyJSON` to avoid `unexpected EOF`.  
Here `docker/buildx/util/imagetools/create.go:210` we pass `bytes.NewReader(dt)`, but the `dt` is nil(`internal/ocipush/push.go:182`), because of that it can't copy data `docker/buildx/util/imagetools/create.go:210` into the empty slice.   


**Related issue**
#12167 
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/dc72bb92-8af4-492f-a7f9-87b9d8e65ddb)

