### PR TITLE
Remove bind options when creating a volume type

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1067,7 +1067,7 @@ func buildMount(project types.Project, volume types.ServiceVolumeConfig) (mount.
 		}
 	}
 
-	bind, vol, tmpfs := buildMountOptions(project, volume)
+	bind, vol, tmpfs := buildMountOptions(volume)
 
 	volume.Target = path.Clean(volume.Target)
 
@@ -1087,7 +1087,7 @@ func buildMount(project types.Project, volume types.ServiceVolumeConfig) (mount.
 	}, nil
 }
 
-func buildMountOptions(project types.Project, volume types.ServiceVolumeConfig) (*mount.BindOptions, *mount.VolumeOptions, *mount.TmpfsOptions) {
+func buildMountOptions(volume types.ServiceVolumeConfig) (*mount.BindOptions, *mount.VolumeOptions, *mount.TmpfsOptions) {
 	switch volume.Type {
 	case "bind":
 		if volume.Volume != nil {
@@ -1103,11 +1103,6 @@ func buildMountOptions(project types.Project, volume types.ServiceVolumeConfig) 
 		}
 		if volume.Tmpfs != nil {
 			logrus.Warnf("mount of type `volume` should not define `tmpfs` option")
-		}
-		if v, ok := project.Volumes[volume.Source]; ok && v.DriverOpts["o"] == types.VolumeTypeBind {
-			return buildBindOption(&types.ServiceVolumeBind{
-				CreateHostPath: true,
-			}), nil, nil
 		}
 		return nil, buildVolumeOptions(volume.Volume), nil
 	case "tmpfs":


### PR DESCRIPTION
**What I did**
Cleanup to remove bind options when creating a volume type. Tried to reproduce from original issue and it seems the root cause was fixed meanwhile. 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
- [#6317](https://github.com/docker/for-mac/issues/6317)

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/4f1b7e6d-d8f9-43a0-8de5-4844d4a244e0)
