### PR TITLE
add support for CDI device request using `devices`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	google.golang.org/grpc v1.62.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
+	tags.cncf.io/container-device-interface v0.8.0
 )
 
 require (
@@ -190,5 +191,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
-	tags.cncf.io/container-device-interface v0.8.0 // indirect
 )


### PR DESCRIPTION
**What I did**

mimic docker/cli behavior to detect `devices` path is set to a CDI string and create a device request accordingly
TBD this should be addressed in compose-go, converting such `devices` item into an actual `resources.reservations.devices` as canonical format

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
