### PR TITLE
Remove feature flag integration with Docker Desktop for ComposeUI and ComposeNav

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -580,7 +580,7 @@ func RootCommand(dockerCli command.Cli, backend Backend) *cobra.Command { //noli
 	}
 
 	c.AddCommand(
-		upCommand(&opts, dockerCli, backend, experiments),
+		upCommand(&opts, dockerCli, backend),
 		downCommand(&opts, dockerCli, backend),
 		startCommand(&opts, dockerCli, backend),
 		restartCommand(&opts, dockerCli, backend),

--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -106,7 +106,6 @@ type LogKeyboard struct {
 	Watch                 KeyboardWatch
 	IsDockerDesktopActive bool
 	IsWatchConfigured     bool
-	IsDDComposeUIActive   bool
 	logLevel              KEYBOARD_LOG_LEVEL
 	signalChannel         chan<- os.Signal
 }
@@ -114,7 +113,7 @@ type LogKeyboard struct {
 var KeyboardManager *LogKeyboard
 var eg multierror.Group
 
-func NewKeyboardManager(ctx context.Context, isDockerDesktopActive, isWatchConfigured, isDockerDesktopConfigActive bool,
+func NewKeyboardManager(ctx context.Context, isDockerDesktopActive, isWatchConfigured bool,
 	sc chan<- os.Signal,
 	watchFn func(ctx context.Context,
 		doneCh chan bool,
@@ -126,7 +125,6 @@ func NewKeyboardManager(ctx context.Context, isDockerDesktopActive, isWatchConfi
 	km := LogKeyboard{}
 	km.IsDockerDesktopActive = isDockerDesktopActive
 	km.IsWatchConfigured = isWatchConfigured
-	km.IsDDComposeUIActive = isDockerDesktopConfigActive
 	km.logLevel = INFO
 
 	km.Watch.Watching = false
@@ -200,9 +198,10 @@ func (lk *LogKeyboard) navigationMenu() string {
 	if openDDInfo != "" {
 		openDDUI = navColor("   ")
 	}
-	if lk.IsDDComposeUIActive {
+	if lk.IsDockerDesktopActive {
 		openDDUI = openDDUI + shortcutKeyColor("o") + navColor(" View Config")
 	}
+
 	var watchInfo string
 	if openDDInfo != "" || openDDUI != "" {
 		watchInfo = navColor("   ")
@@ -246,7 +245,7 @@ func (lk *LogKeyboard) openDockerDesktop(ctx context.Context, project *types.Pro
 }
 
 func (lk *LogKeyboard) openDDComposeUI(ctx context.Context, project *types.Project) {
-	if !lk.IsDDComposeUIActive {
+	if !lk.IsDockerDesktopActive {
 		return
 	}
 	eg.Go(tracing.EventWrapFuncForErrGroup(ctx, "menu/gui/composeview", tracing.SpanOptions{},
@@ -319,8 +318,8 @@ func (lk *LogKeyboard) HandleKeyEvents(event keyboard.KeyEvent, ctx context.Cont
 		lk.openDockerDesktop(ctx, project)
 	case 'w':
 		if !lk.IsWatchConfigured {
-			if lk.IsDDComposeUIActive {
-				// we try to open watch docs
+			// we try to open watch docs if DD is installed
+			if lk.IsDockerDesktopActive {
 				lk.openDDWatchDocs(ctx, project)
 			}
 			// either way we mark menu/watch as an error

--- a/internal/experimental/experimental.go
+++ b/internal/experimental/experimental.go
@@ -66,20 +66,3 @@ func (s *State) Load(ctx context.Context, client *desktop.Client) error {
 	s.desktopValues = desktopValues
 	return nil
 }
-
-func (s *State) NavBar() bool {
-	return s.determineFeatureState("ComposeNav")
-}
-
-func (s *State) ComposeUI() bool {
-	return s.determineFeatureState("ComposeUIView")
-}
-
-func (s *State) determineFeatureState(name string) bool {
-	if s == nil || !s.active || s.desktopValues == nil {
-		return false
-	}
-	// TODO(milas): we should add individual environment variable overrides
-	// 	per-experiment in a generic way here
-	return s.desktopValues[name].Enabled
-}

--- a/internal/tracing/keyboard_metrics.go
+++ b/internal/tracing/keyboard_metrics.go
@@ -22,17 +22,14 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func KeyboardMetrics(ctx context.Context, enabled, isDockerDesktopActive, isWatchConfigured, isDockerDesktopComposeUI bool) {
+func KeyboardMetrics(ctx context.Context, enabled, isDockerDesktopActive, isWatchConfigured bool) {
 	commandAvailable := []string{}
 	if isDockerDesktopActive {
 		commandAvailable = append(commandAvailable, "gui")
+		commandAvailable = append(commandAvailable, "gui/composeview")
 	}
 	if isWatchConfigured {
 		commandAvailable = append(commandAvailable, "watch")
-	}
-
-	if isDockerDesktopComposeUI {
-		commandAvailable = append(commandAvailable, "gui/composeview")
 	}
 
 	AddAttributeToSpan(ctx,

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -324,10 +324,3 @@ func (s *composeService) RuntimeVersion(ctx context.Context) (string, error) {
 func (s *composeService) isDesktopIntegrationActive() bool {
 	return s.desktopCli != nil
 }
-
-func (s *composeService) isDesktopUIEnabled() bool {
-	if !s.isDesktopIntegrationActive() {
-		return false
-	}
-	return s.experiments.ComposeUI()
-}

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -98,10 +98,9 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 				defer keyboard.Close() //nolint:errcheck
 				isWatchConfigured := s.shouldWatch(project)
 				isDockerDesktopActive := s.isDesktopIntegrationActive()
-				isDockerDesktopComposeUI := s.isDesktopUIEnabled()
-				tracing.KeyboardMetrics(ctx, options.Start.NavigationMenu, isDockerDesktopActive, isWatchConfigured, isDockerDesktopComposeUI)
+				tracing.KeyboardMetrics(ctx, options.Start.NavigationMenu, isDockerDesktopActive, isWatchConfigured)
 
-				formatter.NewKeyboardManager(ctx, isDockerDesktopActive, isWatchConfigured, isDockerDesktopComposeUI, signalChan, s.watch)
+				formatter.NewKeyboardManager(ctx, isDockerDesktopActive, isWatchConfigured, signalChan, s.watch)
 				if options.Start.Watch {
 					formatter.KeyboardManager.StartWatch(ctx, doneCh, project, options)
 				}


### PR DESCRIPTION
**What I did**
Remove integration with feature flags ComposeUI and ComposeNav from Docker Desktop

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/52b53891-daa2-49ae-92ba-2a9006dc70e1)
