### PR TITLE
Support Dockerfile-specific ignore-file with watch

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -136,7 +136,7 @@ func (s *composeService) watch(ctx context.Context, syncChannel chan bool, proje
 		service.PullPolicy = types.PullPolicyBuild
 		project.Services[i] = service
 
-		dockerIgnores, err := watch.LoadDockerIgnore(service.Build.Context)
+		dockerIgnores, err := watch.LoadDockerIgnore(service.Build)
 		if err != nil {
 			return err
 		}

--- a/pkg/watch/dockerignore.go
+++ b/pkg/watch/dockerignore.go
@@ -18,10 +18,12 @@ package watch
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v2/internal/paths"
 	"github.com/moby/patternmatcher"
 	"github.com/moby/patternmatcher/ignorefile"
@@ -61,13 +63,28 @@ func (i dockerPathMatcher) MatchesEntireDir(f string) (bool, error) {
 	return true, nil
 }
 
-func LoadDockerIgnore(repoRoot string) (*dockerPathMatcher, error) {
+func LoadDockerIgnore(build *types.BuildConfig) (*dockerPathMatcher, error) {
+	repoRoot := build.Context
 	absRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	patterns, err := readDockerignorePatterns(absRoot)
+	// first try Dockerfile-specific ignore-file
+	f, err := os.Open(filepath.Join(repoRoot, build.Dockerfile+".dockerignore"))
+	if os.IsNotExist(err) {
+		// defaults to a global .dockerignore
+		f, err = os.Open(filepath.Join(repoRoot, ".dockerignore"))
+		if os.IsNotExist(err) {
+			return NewDockerPatternMatcher(repoRoot, nil)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	patterns, err := readDockerignorePatterns(f)
 	if err != nil {
 		return nil, err
 	}
@@ -122,19 +139,8 @@ func NewDockerPatternMatcher(repoRoot string, patterns []string) (*dockerPathMat
 	}, nil
 }
 
-func readDockerignorePatterns(repoRoot string) ([]string, error) {
-	var excludes []string
-
-	f, err := os.Open(filepath.Join(repoRoot, ".dockerignore"))
-	switch {
-	case os.IsNotExist(err):
-		return excludes, nil
-	case err != nil:
-		return nil, err
-	}
-	defer func() { _ = f.Close() }()
-
-	patterns, err := ignorefile.ReadAll(f)
+func readDockerignorePatterns(r io.Reader) ([]string, error) {
+	patterns, err := ignorefile.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("error reading .dockerignore: %w", err)
 	}


### PR DESCRIPTION
**What I did**
Follow https://docs.docker.com/reference/dockerfile/#dockerignore-file and first consider a Dockerfile-specific ignore file when computing exclude patterns for watch. 

**Related issue**
closes https://github.com/docker/compose/issues/12191

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
