### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+The maintainers of Docker Compose take security seriously. If you discover
+a security issue, please bring it to their attention right away!
+
+## Reporting a Vulnerability
+
+Please **DO NOT** file a public issue, instead send your report privately
+to [security@docker.com](mailto:security@docker.com).
+
+Reporter(s) can expect a response within 72 hours, acknowledging the issue was
+received.
+
+## Review Process
+
+After receiving the report, an initial triage and technical analysis is
+performed to confirm the report and determine its scope. We may request
+additional information in this stage of the process.
+
+Once a reviewer has confirmed the relevance of the report, a draft security
+advisory will be created on GitHub. The draft advisory will be used to discuss
+the issue with maintainers, the reporter(s), and where applicable, other
+affected parties under embargo.
+
+If the vulnerability is accepted, a timeline for developing a patch, public
+disclosure, and patch release will be determined. If there is an embargo period
+on public disclosure before the patch release, the reporter(s) are expected to
+participate in the discussion of the timeline and abide by agreed upon dates
+for public disclosure.
+
+## Accreditation
+
+Security reports are greatly appreciated and we will publicly thank you,
+although we will keep your name confidential if you request it. We also like to
+send gifts - if you're into swag, make sure to let us know. We do not currently
+offer a paid security bounty program at this time.
+
+## Supported Versions
+
+This project docs not provide long-term supported versions, and only the current
+release and `main` branch are actively maintained. Docker Compose v1, and the
+corresponding [v1 branch](https://github.com/docker/compose/tree/v1) reached
+EOL and are no longer supported. 
+


### PR DESCRIPTION
Add a security policy to inform users where to report security issues, and to make the OpenSSF scorecard slightly happier; https://securityscorecards.dev/viewer/?uri=github.com/docker/compose

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

- Similar to https://github.com/moby/moby/pull/48280

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
