### PR TITLE
gha: set default permissions to "contents: read"

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -2,6 +2,15 @@
 # to check if yaml reference docs used in this repo are valid
 name: docs-upstream
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# If any permission is set, any permission not included in the list is
+# implicitly set to "none".
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,14 @@
 name: 'Close stale issues'
+
+# Default to 'contents: read', which grants actions to read commits.
+#
+# If any permission is set, any permission not included in the list is
+# implicitly set to "none".
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 0 * * 0,3' # at midnight UTC every Sunday and Wednesday


### PR DESCRIPTION
make the OpenSSF scorecard slightly happier;
https://securityscorecards.dev/viewer/?uri=github.com/docker/compose

    Warn: jobLevel 'contents' permission set to 'write': .github/workflows/ci.yml:256: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/ci.yml/main?enable=permissions
    Warn: no topLevel permission defined: .github/workflows/docs-upstream.yml:1: update your workflow using https://app.stepsecurity.io/secureworkflow/docker/compose/docs-upstream.yml/main?enable=permissions

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
