### PR TITLE
compose-go clean volume target to avoid ambiguous comparisons

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -888,7 +887,6 @@ func buildContainerMountOptions(p types.Project, s types.ServiceConfig, img moby
 			if m.Type == "volume" {
 				src = m.Name
 			}
-			m.Destination = path.Clean(m.Destination)
 
 			if img.Config != nil {
 				if _, ok := img.Config.Volumes[m.Destination]; ok {
@@ -1111,8 +1109,6 @@ func buildMount(project types.Project, volume types.ServiceVolumeConfig) (mount.
 	}
 
 	bind, vol, tmpfs := buildMountOptions(volume)
-
-	volume.Target = path.Clean(volume.Target)
 
 	if bind != nil {
 		volume.Type = types.VolumeTypeBind


### PR DESCRIPTION
**What I did**
use cleaned paths as volume target so we can't safely retrieve volume by target

**Related issue**
requires https://github.com/compose-spec/compose-go/pull/697
fix https://github.com/docker/compose/issues/11345

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
