### PR TITLE
desktop: allow this client to be identified via user-agent

### DIFF
--- a/internal/desktop/client.go
+++ b/internal/desktop/client.go
@@ -27,10 +27,14 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/docker/compose/v2/internal"
 	"github.com/docker/compose/v2/internal/memnet"
 	"github.com/r3labs/sse"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
+
+// identify this client in the logs
+var userAgent = "compose/" + internal.Version
 
 // Client for integration with Docker Desktop features.
 type Client struct {
@@ -76,6 +80,7 @@ func (c *Client) Ping(ctx context.Context) (*PingResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -105,6 +110,7 @@ func (c *Client) FeatureFlags(ctx context.Context) (FeatureFlagResponse, error) 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -135,6 +141,7 @@ func (c *Client) GetFileSharesConfig(ctx context.Context) (*GetFileSharesConfigR
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -170,6 +177,7 @@ func (c *Client) CreateFileShare(ctx context.Context, r CreateFileShareRequest) 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -212,6 +220,7 @@ func (c *Client) ListFileShares(ctx context.Context) ([]FileShareSession, error)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -236,6 +245,7 @@ func (c *Client) DeleteFileShare(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
@@ -268,6 +278,7 @@ func (c *Client) StreamFileShares(ctx context.Context) (<-chan EventMessage[[]Fi
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What I did**

Set the `User-Agent` when calling the Docker Desktop API, so it's possible to trace the server logs back to this client.

Previously the HTTP requests were sent with a generic Go-http-client user-agent which made it hard to determine where the requests are coming from. It's important that we can find clients to help debug issues (or to ensure we update clients if APIs change in future)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

Let's make it easier to see the owl:

![image](https://github.com/user-attachments/assets/52f0c379-5944-4a75-87a4-264fa02cb26c)

