### PR TITLE
Improve error message to include expected network label

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1208,7 +1208,13 @@ func (s *composeService) resolveOrCreateNetwork(ctx context.Context, n *types.Ne
 					"Set `external: true` to use an existing network", n.Name, expectedProjectLabel)
 			}
 			if inspect.Labels[api.NetworkLabel] != expectedNetworkLabel {
-				return fmt.Errorf("network %s was found but has incorrect label %s set to %q", n.Name, api.NetworkLabel, inspect.Labels[api.NetworkLabel])
+				return fmt.Errorf(
+					"network %s was found but has incorrect label %s set to %q (expected: %q)",
+					n.Name,
+					api.NetworkLabel,
+					inspect.Labels[api.NetworkLabel],
+					expectedNetworkLabel,
+				)
 			}
 			return nil
 		}


### PR DESCRIPTION
Updated the error message when a network is found with an incorrect label to also display the expected label value. This provides more context for debugging.

Should make debugging #10797 much easier.

**What I did**
```
$ docker compose --file docker-compose.yml --file docker-compose.dev.yml up
[+] Running 24/24
 ✔ mailhog 7 layers [⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                                                                                                    8.1s 
   ✔ df20fa9351a1 Pull complete                                                                                                                                                                                                                         0.5s 
   ✔ ed8968b2872e Pull complete                                                                                                                                                                                                                         0.5s 
   ✔ a92cc7c5fd73 Pull complete                                                                                                                                                                                                                         0.5s 
   ✔ f17c8f1adafb Pull complete                                                                                                                                                                                                                         4.3s 
   ✔ 03954754c53a Pull complete                                                                                                                                                                                                                         0.9s 
   ✔ 60493946972a Pull complete                                                                                                                                                                                                                         1.2s 
   ✔ 368ee3bc1dbb Pull complete                                                                                                                                                                                                                         1.5s 
 ✔ redis 15 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                                                                                            14.8s 
   ✔ 6414378b6477 Pull complete                                                                                                                                                                                                                         2.8s 
   ✔ caaf2b7eab60 Pull complete                                                                                                                                                                                                                         2.9s 
   ✔ 4f4fb700ef54 Pull complete                                                                                                                                                                                                                         3.2s 
   ✔ 86a1720f5df2 Pull complete                                                                                                                                                                                                                         3.6s 
   ✔ 7fa31013e891 Pull complete                                                                                                                                                                                                                         7.9s 
   ✔ 904fa886b986 Pull complete                                                                                                                                                                                                                         4.1s 
   ✔ c9baa17a1bc5 Pull complete                                                                                                                                                                                                                         4.3s 
   ✔ f47dc7262436 Pull complete                                                                                                                                                                                                                         5.4s 
   ✔ 4c8c88ac5d8a Pull complete                                                                                                                                                                                                                         7.7s 
   ✔ c17f3cf48586 Pull complete                                                                                                                                                                                                                         8.9s 
   ✔ 0a9cf6132a4c Pull complete                                                                                                                                                                                                                         9.2s 
   ✔ e27f0a722fd3 Pull complete                                                                                                                                                                                                                         8.4s 
   ✔ 0fae4b43eb13 Pull complete                                                                                                                                                                                                                         8.8s 
   ✔ 561bb2dc87d6 Pull complete                                                                                                                                                                                                                         9.2s 
   ✔ 79e6e2693bf3 Pull complete                                                                                                                                                                                                                         9.3s 
WARN[0014] a network with name easyad_web-network exists but was not created by compose.
Set `external: true` to use an existing network 
network easyad_web-network was found but has incorrect label com.docker.compose.network set to "web-network,com.docker.compose.project=easyad,com.docker.compose.version=2.24.6"
```
**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![IMG_20230802_005159_262](https://github.com/user-attachments/assets/1c7b2bcb-ad58-462f-9104-2fd33f2eb372)

