### PR TITLE
Recreate on volume change

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -32,20 +32,21 @@ import (
 )
 
 type createOptions struct {
-	Build         bool
-	noBuild       bool
-	Pull          string
-	pullChanged   bool
-	removeOrphans bool
-	ignoreOrphans bool
-	forceRecreate bool
-	noRecreate    bool
-	recreateDeps  bool
-	noInherit     bool
-	timeChanged   bool
-	timeout       int
-	quietPull     bool
-	scale         []string
+	Build           bool
+	noBuild         bool
+	Pull            string
+	pullChanged     bool
+	removeOrphans   bool
+	ignoreOrphans   bool
+	forceRecreate   bool
+	noRecreate      bool
+	recreateDeps    bool
+	noInherit       bool
+	timeChanged     bool
+	timeout         int
+	quietPull       bool
+	scale           []string
+	recreateVolumes bool
 }
 
 func createCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -148,6 +148,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *c
 	flags.BoolVar(&create.noBuild, "no-build", false, "Don't build an image, even if it's policy")
 	flags.StringVar(&create.Pull, "pull", "policy", `Pull image before running ("always"|"missing"|"never")`)
 	flags.BoolVar(&create.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
+	flags.BoolVar(&create.recreateVolumes, "recreate-volumes", false, "Recreate volumes when volume configuration in the Compose file changes.")
 	flags.StringArrayVar(&create.scale, "scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
 	flags.BoolVar(&up.noColor, "no-color", false, "Produce monochrome output")
 	flags.BoolVar(&up.noPrefix, "no-log-prefix", false, "Don't print prefix in logs")
@@ -255,6 +256,7 @@ func runUp(
 		Inherit:              !createOptions.noInherit,
 		Timeout:              createOptions.GetTimeout(),
 		QuietPull:            createOptions.quietPull,
+		RecreateVolumes:      createOptions.recreateVolumes,
 	}
 
 	if upOptions.noStart {

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -45,6 +45,7 @@ If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the contai
 | `--no-start`                   | `bool`        |          | Don't start the services after creating them                                                                                                        |
 | `--pull`                       | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                                                                                            |
 | `--quiet-pull`                 | `bool`        |          | Pull without printing progress information                                                                                                          |
+| `--recreate-volumes`           | `bool`        |          | Recreate volumes when volume configuration in the Compose file changes.                                                                             |
 | `--remove-orphans`             | `bool`        |          | Remove containers for services not defined in the Compose file                                                                                      |
 | `-V`, `--renew-anon-volumes`   | `bool`        |          | Recreate anonymous volumes instead of retrieving data from the previous containers                                                                  |
 | `--scale`                      | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.                                                       |

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -221,6 +221,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: recreate-volumes
+      value_type: bool
+      default_value: "false"
+      description: |
+        Recreate volumes when volume configuration in the Compose file changes.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: remove-orphans
       value_type: bool
       default_value: "false"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -204,6 +204,8 @@ type CreateOptions struct {
 	Timeout *time.Duration
 	// QuietPull makes the pulling process quiet
 	QuietPull bool
+	// Allow recreate volumes when volumes configuration changes
+	RecreateVolumes bool
 }
 
 // StartOptions group options of the Start API

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -29,8 +29,10 @@ const (
 	ProjectLabel = "com.docker.compose.project"
 	// ServiceLabel allow to track resource related to a compose service
 	ServiceLabel = "com.docker.compose.service"
-	// ConfigHashLabel stores configuration hash for a compose service
+	// ConfigHashLabel stores configuration hash for a compose service or volume
 	ConfigHashLabel = "com.docker.compose.config-hash"
+	// ExternalVolumeHashLabel stores volume external configuration hash for a compose service
+	ExternalVolumeHashLabel = "com.docker.compose.external-volume-hash"
 	// ContainerNumberLabel stores the container index of a replicated service
 	ContainerNumberLabel = "com.docker.compose.container-number"
 	// VolumeLabel allow to track resource related to a compose volume

--- a/pkg/compose/kill.go
+++ b/pkg/compose/kill.go
@@ -18,7 +18,6 @@ package compose
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	moby "github.com/docker/docker/api/types"
@@ -45,6 +44,11 @@ func (s *composeService) kill(ctx context.Context, projectName string, options a
 		return err
 	}
 
+	if len(containers) == 0 {
+		w.Event(progress.SkippedEvent(strings.Join(services, ","), "No containers for selected service"))
+		return nil
+	}
+
 	project := options.Project
 	if project == nil {
 		project, err = s.getProjectWithResources(ctx, containers, projectName)
@@ -55,10 +59,6 @@ func (s *composeService) kill(ctx context.Context, projectName string, options a
 
 	if !options.RemoveOrphans {
 		containers = containers.filter(isService(project.ServiceNames()...))
-	}
-	if len(containers) == 0 {
-		_, _ = fmt.Fprintf(s.stdinfo(), "no container to kill")
-		return nil
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -82,9 +82,7 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 		return nil
 	}
 	msg := fmt.Sprintf("Going to remove %s", strings.Join(names, ", "))
-	if options.Force {
-		_, _ = fmt.Fprintln(s.stdout(), msg)
-	} else {
+	if !options.Force {
 		confirm, err := prompt.NewPrompt(s.stdin(), s.stdout()).Confirm(msg, false)
 		if err != nil {
 			return err

--- a/pkg/e2e/fixtures/recreate-volumes/compose.yaml
+++ b/pkg/e2e/fixtures/recreate-volumes/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  app:
+    image: alpine
+    volumes:
+      - my_vol:/my_vol
+
+volumes:
+  my_vol:

--- a/pkg/e2e/fixtures/recreate-volumes/compose2.yaml
+++ b/pkg/e2e/fixtures/recreate-volumes/compose2.yaml
@@ -1,0 +1,9 @@
+services:
+  app:
+    image: alpine
+    volumes:
+      - my_vol:/my_vol
+
+volumes:
+  my_vol:
+    name: cool


### PR DESCRIPTION
**What I did**
Add volumes on configuration hash in order to recreate container when `volumes` changes

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
- fixes #10060 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/be4eeda9-7d73-4a56-85d4-958afe40a1d3)
