### PR TITLE
one-off container are not indexed, and must be ignored by exec --index command

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -506,7 +506,10 @@ func (s *composeService) prepareLabels(labels types.Labels, service types.Servic
 	}
 	labels[api.ConfigHashLabel] = hash
 
-	labels[api.ContainerNumberLabel] = strconv.Itoa(number)
+	if number > 0 {
+		// One-off containers are not indexed
+		labels[api.ContainerNumberLabel] = strconv.Itoa(number)
+	}
 
 	var dependencies []string
 	for s, d := range service.DependsOn {

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -109,7 +109,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 		return "", err
 	}
 
-	created, err := s.createContainer(ctx, project, service, service.ContainerName, 1, createOpts)
+	created, err := s.createContainer(ctx, project, service, service.ContainerName, -1, createOpts)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -62,7 +62,6 @@ func TestLocalComposeRun(t *testing.T) {
 		assert.Assert(t, runContainerID != "")
 		res = c.RunDockerCmd(t, "inspect", runContainerID)
 		res.Assert(t, icmd.Expected{Out: ` "Status": "exited"`})
-		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.container-number": "1"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": "run-test"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.oneoff": "True",`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.slug": "` + truncatedSlug})


### PR DESCRIPTION
this removes label `com.docker.compose.container-number` from one-off containers, as this index is for service replicas, not containers created by `run` command. `docker compose exec --index` will then ignore them

**What I did**

**Related issue**
closes https://github.com/docker/compose/issues/12219

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
