### PR TITLE
feat: Add `continue-on-failure` option to build command

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -35,15 +35,16 @@ import (
 
 type buildOptions struct {
 	*ProjectOptions
-	quiet   bool
-	pull    bool
-	push    bool
-	args    []string
-	noCache bool
-	memory  cliopts.MemBytes
-	ssh     string
-	builder string
-	deps    bool
+	quiet             bool
+	pull              bool
+	push              bool
+	args              []string
+	noCache           bool
+	memory            cliopts.MemBytes
+	ssh               string
+	builder           string
+	deps              bool
+	continueOnFailure bool
 }
 
 func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions, error) {
@@ -68,16 +69,17 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 		uiMode = "rawjson"
 	}
 	return api.BuildOptions{
-		Pull:     opts.pull,
-		Push:     opts.push,
-		Progress: uiMode,
-		Args:     types.NewMappingWithEquals(opts.args),
-		NoCache:  opts.noCache,
-		Quiet:    opts.quiet,
-		Services: services,
-		Deps:     opts.deps,
-		SSHs:     SSHKeys,
-		Builder:  builderName,
+		Pull:              opts.pull,
+		Push:              opts.push,
+		Progress:          uiMode,
+		Args:              types.NewMappingWithEquals(opts.args),
+		NoCache:           opts.noCache,
+		Quiet:             opts.quiet,
+		Services:          services,
+		Deps:              opts.deps,
+		SSHs:              SSHKeys,
+		Builder:           builderName,
+		ContinueOnFailure: opts.continueOnFailure,
 	}, nil
 }
 
@@ -118,6 +120,7 @@ func buildCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 	flags.StringVar(&opts.ssh, "ssh", "", "Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)")
 	flags.StringVar(&opts.builder, "builder", "", "Set builder to use")
 	flags.BoolVar(&opts.deps, "with-dependencies", false, "Also build dependencies (transitively)")
+	flags.BoolVar(&opts.continueOnFailure, "continue-on-failure", false, "If any service build fails, continue building the remaining services")
 
 	flags.Bool("parallel", true, "Build images in parallel. DEPRECATED")
 	flags.MarkHidden("parallel") //nolint:errcheck

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -13,18 +13,19 @@ run `docker compose build` to rebuild it.
 
 ### Options
 
-| Name                  | Type          | Default | Description                                                                                                 |
-|:----------------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
-| `--build-arg`         | `stringArray` |         | Set build-time variables for services                                                                       |
-| `--builder`           | `string`      |         | Set builder to use                                                                                          |
-| `--dry-run`           | `bool`        |         | Execute command in dry run mode                                                                             |
-| `-m`, `--memory`      | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
-| `--no-cache`          | `bool`        |         | Do not use cache when building the image                                                                    |
-| `--pull`              | `bool`        |         | Always attempt to pull a newer version of the image                                                         |
-| `--push`              | `bool`        |         | Push service images                                                                                         |
-| `-q`, `--quiet`       | `bool`        |         | Don't print anything to STDOUT                                                                              |
-| `--ssh`               | `string`      |         | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
-| `--with-dependencies` | `bool`        |         | Also build dependencies (transitively)                                                                      |
+| Name                    | Type          | Default | Description                                                                                                 |
+|:------------------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
+| `--build-arg`           | `stringArray` |         | Set build-time variables for services                                                                       |
+| `--builder`             | `string`      |         | Set builder to use                                                                                          |
+| `--dry-run`             | `bool`        |         | Execute command in dry run mode                                                                             |
+| `-m`, `--memory`        | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
+| `--no-cache`            | `bool`        |         | Do not use cache when building the image                                                                    |
+| `--pull`                | `bool`        |         | Always attempt to pull a newer version of the image                                                         |
+| `--push`                | `bool`        |         | Push service images                                                                                         |
+| `-q`, `--quiet`         | `bool`        |         | Don't print anything to STDOUT                                                                              |
+| `--ssh`                 | `string`      |         | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
+| `--with-dependencies`   | `bool`        |         | Also build dependencies (transitively)                                                                      |
+| `--continue-on-failure` | `bool`        | false   | If any service build fails, continue building the remaining services                                        |
 
 
 <!---MARKER_GEN_END-->

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -150,6 +150,8 @@ type BuildOptions struct {
 	Memory int64
 	// Builder name passed in the command line
 	Builder string
+	// If any service build fails, continue building the remaining services
+	ContinueOnFailure bool
 }
 
 // Apply mutates project according to build options

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -161,6 +161,9 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		if !buildkitEnabled {
 			id, err := s.doBuildClassic(ctx, project, service, options)
 			if err != nil {
+				if options.ContinueOnFailure {
+					return nil
+				}
 				return err
 			}
 			builtDigests[getServiceIndex(name)] = id
@@ -177,11 +180,17 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 
 		buildOptions, err := s.toBuildOptions(project, service, options)
 		if err != nil {
+			if options.ContinueOnFailure {
+				return nil
+			}
 			return err
 		}
 
 		digest, err := s.doBuildBuildkit(ctx, name, buildOptions, w, nodes)
 		if err != nil {
+			if options.ContinueOnFailure {
+				return nil
+			}
 			return err
 		}
 		builtDigests[getServiceIndex(name)] = digest


### PR DESCRIPTION
**What I did**
Added an option `continue-on-failure` to `build` command.
By default set to false, when set to true it prevents the build process from being interrupted when one of the services fail to build.

This is my first time contributing, please let me know if the solution is acceptable.

**Related issue**
Closes #11094 
