### PR TITLE
don't use progress to render restart, which hides logs

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -527,7 +527,7 @@ func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Pr
 		pathMappings[i] = batch[i].PathMapping
 	}
 
-	writeWatchSyncMessage(options.LogTo, serviceName, pathMappings)
+	writeWatchSyncMessage(options.LogTo, serviceName, pathMappings, restartService)
 
 	service, err := project.GetService(serviceName)
 	if err != nil {
@@ -537,17 +537,28 @@ func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Pr
 		return err
 	}
 	if restartService {
-		return s.Restart(ctx, project.Name, api.RestartOptions{
+		err = s.restart(ctx, project.Name, api.RestartOptions{
 			Services: []string{serviceName},
 			Project:  project,
 			NoDeps:   false,
 		})
+		if err != nil {
+			return err
+		}
+		options.LogTo.Log(
+			api.WatchLogger,
+			fmt.Sprintf("service %q restarted", serviceName))
+
 	}
 	return nil
 }
 
 // writeWatchSyncMessage prints out a message about the sync for the changed paths.
-func writeWatchSyncMessage(log api.LogConsumer, serviceName string, pathMappings []sync.PathMapping) {
+func writeWatchSyncMessage(log api.LogConsumer, serviceName string, pathMappings []sync.PathMapping, restart bool) {
+	action := "Syncing"
+	if restart {
+		action = "Syncing and restarting"
+	}
 	if logrus.IsLevelEnabled(logrus.DebugLevel) {
 		hostPathsToSync := make([]string, len(pathMappings))
 		for i := range pathMappings {
@@ -556,7 +567,8 @@ func writeWatchSyncMessage(log api.LogConsumer, serviceName string, pathMappings
 		log.Log(
 			api.WatchLogger,
 			fmt.Sprintf(
-				"Syncing %q after changes were detected: %s",
+				"%s service %q after changes were detected: %s",
+				action,
 				serviceName,
 				strings.Join(hostPathsToSync, ", "),
 			),
@@ -564,7 +576,7 @@ func writeWatchSyncMessage(log api.LogConsumer, serviceName string, pathMappings
 	} else {
 		log.Log(
 			api.WatchLogger,
-			fmt.Sprintf("Syncing service %q after %d changes were detected", serviceName, len(pathMappings)),
+			fmt.Sprintf("%s service %q after %d changes were detected", action, serviceName, len(pathMappings)),
 		)
 	}
 }

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -290,8 +290,7 @@ func doTest(t *testing.T, svcName string) {
 			return poll.Continue("%v", r.Combined())
 		}
 	}
-	poll.WaitOn(t, checkRestart(fmt.Sprintf("%s-1  Restarting", svcName)))
-	poll.WaitOn(t, checkRestart(fmt.Sprintf("%s-1  Started", svcName)))
+	poll.WaitOn(t, checkRestart(fmt.Sprintf("service %q restarted", svcName)))
 	poll.WaitOn(t, checkFileContents("/app/config/file.config", "This is an updated config file"))
 
 	testComplete.Store(true)


### PR DESCRIPTION
**What I did**

minor update to watch UX:
as a service is restarted 
1. watch message to let user know service is going to be restarted
2. don't use progress, so service logs are still piped to terminal during the restart sequence, which may take up to 10s (see example with `ping` which has to be killed)

```
$ docker compose up --watch
[+] Running 1/0
 ✔ Container truc-test-1  Created                                                                                           0.0s 
        ⦿ Watch enabled
Attaching to test-1
test-1  | PING localhost (::1): 56 data bytes
test-1  | 64 bytes from ::1: seq=9 ttl=64 time=0.233 ms
test-1  | 64 bytes from ::1: seq=10 ttl=64 time=0.068 ms
        ⦿ Syncing and restarting service "test" after 1 changes were detected
test-1  | 64 bytes from ::1: seq=11 ttl=64 time=0.269 ms
test-1  | 64 bytes from ::1: seq=12 ttl=64 time=0.254 ms
test-1  | 64 bytes from ::1: seq=13 ttl=64 time=0.202 ms
test-1  | 64 bytes from ::1: seq=14 ttl=64 time=0.247 ms
test-1  | 64 bytes from ::1: seq=15 ttl=64 time=0.286 ms
test-1  | 64 bytes from ::1: seq=16 ttl=64 time=0.303 ms
test-1  | 64 bytes from ::1: seq=17 ttl=64 time=0.412 ms
test-1  | 64 bytes from ::1: seq=18 ttl=64 time=0.222 ms
test-1  | 64 bytes from ::1: seq=19 ttl=64 time=0.241 ms
test-1  | 64 bytes from ::1: seq=20 ttl=64 time=0.039 ms
        ⦿ service "test" restarted
test-1 exited with code 0
test-1  | 64 bytes from ::1: seq=1 ttl=64 time=0.047 ms
```

**Related issue**


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
