### PR TITLE
resurrect --all flag for cp to target oneoff container

### DIFF
--- a/cmd/compose/cp.go
+++ b/cmd/compose/cp.go
@@ -66,9 +66,7 @@ func copyCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) 
 
 	flags := copyCmd.Flags()
 	flags.IntVar(&opts.index, "index", 0, "Index of the container if service has multiple replicas")
-	flags.BoolVar(&opts.all, "all", false, "Copy to all the containers of the service")
-	flags.MarkHidden("all")                                                                                                     //nolint:errcheck
-	flags.MarkDeprecated("all", "By default all the containers of the service will get the source file/directory to be copied") //nolint:errcheck
+	flags.BoolVar(&opts.all, "all", false, "Include containers created by the run command")
 	flags.BoolVarP(&opts.followLink, "follow-link", "L", false, "Always follow symbol link in SRC_PATH")
 	flags.BoolVarP(&opts.copyUIDGID, "archive", "a", false, "Archive mode (copy all uid/gid information)")
 

--- a/docs/reference/compose_cp.md
+++ b/docs/reference/compose_cp.md
@@ -7,6 +7,7 @@ Copy files/folders between a service container and the local filesystem
 
 | Name                  | Type   | Default | Description                                             |
 |:----------------------|:-------|:--------|:--------------------------------------------------------|
+| `--all`               | `bool` |         | Include containers created by the run command           |
 | `-a`, `--archive`     | `bool` |         | Archive mode (copy all uid/gid information)             |
 | `--dry-run`           | `bool` |         | Execute command in dry run mode                         |
 | `-L`, `--follow-link` | `bool` |         | Always follow symbol link in SRC_PATH                   |

--- a/docs/reference/docker_compose_cp.yaml
+++ b/docs/reference/docker_compose_cp.yaml
@@ -10,9 +10,9 @@ options:
     - option: all
       value_type: bool
       default_value: "false"
-      description: Copy to all the containers of the service
-      deprecated: true
-      hidden: true
+      description: Include containers created by the run command
+      deprecated: false
+      hidden: false
       experimental: false
       experimentalcli: false
       kubernetes: false


### PR DESCRIPTION
**What I did**
`--all` flag was deprecated just after we introduced `cp` command and isn't actually implemented in the code (no effect) so I _assume_ it's safe to reuse it for another purpose. I suggest we align with other commands and make it an opt-in flag to include one-off (`compose run`)  containers. Doing so, we can implement `docker compose cp` to target one-off containers as requested on #10384

**Related issue**
closes https://github.com/docker/compose/issues/10384

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
