### PR TITLE
don't warn about uid/gid not being supported while ... they are

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -976,10 +976,6 @@ func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount
 			target = configsBaseDir + config.Target
 		}
 
-		if config.UID != "" || config.GID != "" || config.Mode != nil {
-			logrus.Warn("config `uid`, `gid` and `mode` are not supported, they will be ignored")
-		}
-
 		definedConfig := p.Configs[config.Source]
 		if definedConfig.External {
 			return nil, fmt.Errorf("unsupported external config %s", definedConfig.Name)
@@ -994,6 +990,10 @@ func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount
 
 		if definedConfig.Environment != "" || definedConfig.Content != "" {
 			continue
+		}
+
+		if config.UID != "" || config.GID != "" || config.Mode != nil {
+			logrus.Warn("config `uid`, `gid` and `mode` are not supported, they will be ignored")
 		}
 
 		bindMount, err := buildMount(p, types.ServiceVolumeConfig{
@@ -1026,10 +1026,6 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 			target = secretsDir + secret.Target
 		}
 
-		if secret.UID != "" || secret.GID != "" || secret.Mode != nil {
-			logrus.Warn("secrets `uid`, `gid` and `mode` are not supported, they will be ignored")
-		}
-
 		definedSecret := p.Secrets[secret.Source]
 		if definedSecret.External {
 			return nil, fmt.Errorf("unsupported external secret %s", definedSecret.Name)
@@ -1044,6 +1040,10 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 
 		if definedSecret.Environment != "" {
 			continue
+		}
+
+		if secret.UID != "" || secret.GID != "" || secret.Mode != nil {
+			logrus.Warn("secrets `uid`, `gid` and `mode` are not supported, they will be ignored")
 		}
 
 		if _, err := os.Stat(definedSecret.File); os.IsNotExist(err) {


### PR DESCRIPTION
**What I did**
this warning only applies to bind mount. As we skip creating a bind mount when source is environment or inlined content, must be skipped.

**Related issue**
fixes https://github.com/docker/compose/issues/12010

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
