### PR TITLE
connect to external networks by name

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1363,7 +1363,6 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 
 	switch len(networks) {
 	case 1:
-		n.Name = networks[0].ID
 		return nil
 	case 0:
 		enabled, err := s.isSWarmEnabled(ctx)

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -99,9 +99,8 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 				errors)
 	}, 30*time.Second, 1*time.Second)
 
-	n := c.RunDockerCmd(t, "network", "inspect", networkName, "-f", "{{ .Id }}")
 	pn := c.RunDockerCmd(t, "inspect", containerName, "-f", "{{ .HostConfig.NetworkMode }}")
-	assert.Equal(t, pn.Stdout(), n.Stdout())
+	assert.Equal(t, strings.TrimSpace(pn.Stdout()), networkName)
 
 	t.Log("create a dotenv file that will be used to trigger the rebuild")
 	err = os.WriteFile(dotEnvFilepath, []byte("HELLO=WORLD\nTEST=REBUILD"), 0o666)
@@ -119,9 +118,8 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 		return true, fmt.Sprintf("container %s was rebuilt", containerName)
 	}, 30*time.Second, 1*time.Second)
 
-	n2 := c.RunDockerCmd(t, "network", "inspect", networkName, "-f", "{{ .Id }}")
 	pn2 := c.RunDockerCmd(t, "inspect", containerName, "-f", "{{ .HostConfig.NetworkMode }}")
-	assert.Equal(t, pn2.Stdout(), n2.Stdout())
+	assert.Equal(t, strings.TrimSpace(pn2.Stdout()), networkName)
 
 	assert.Check(t, !strings.Contains(r.Combined(), "Application failed to start after update"))
 


### PR DESCRIPTION
**What I did**

Network ID changes after a system restart, so better **not** resolve external network name into ID
This was introduced by https://github.com/docker/compose/commit/1bd8a773a783512b93de6b938173959a4886a081 to prevent risk of collision with network name not being guaranteed unique. the code still detect such a collision during container creation, I would assume the race condition to get duplicated network name won't take place on a system restart.

**Related issue**
fixes https://github.com/docker/compose/issues/11524

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
