### PR TITLE
[Addresses 12236]: docker compose --watch doesn't properly handle .dockerignore whitelists

### DIFF
--- a/bug-12236/.dockerignore
+++ b/bug-12236/.dockerignore
@@ -1,0 +1,4 @@
+# ignore everything by default
+*
+# add exceptions here
+!dir1/

--- a/bug-12236/Dockerfile
+++ b/bug-12236/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+WORKDIR /app
+ENTRYPOINT ["ls", "-la"]

--- a/bug-12236/compose.yml
+++ b/bug-12236/compose.yml
@@ -1,0 +1,11 @@
+services:
+  alpine:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    develop:
+      watch:
+        - action: sync+restart
+          x-initialSync: true
+          path: ./dir1
+          target: /app/dir1

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -651,6 +651,7 @@ func (s *composeService) initialSyncFiles(ctx context.Context, project *types.Pr
 				return nil
 			}
 			if shouldIgnore(filepath.Base(path), ignore) || checkIfPathAlreadyBindMounted(path, service.Volumes) {
+				logrus.Debugf("ignoring file %s", path)
 				// By definition sync ignores bind mounted paths
 				if d.IsDir() {
 					// skip folder

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -621,7 +621,7 @@ func (s *composeService) initialSync(ctx context.Context, project *types.Project
 	if err != nil {
 		return err
 	}
-
+	logrus.Debugf("copying %d files for initial sync", len(pathsToCopy))
 	return syncer.Sync(ctx, service, pathsToCopy)
 }
 
@@ -665,6 +665,7 @@ func (s *composeService) initialSyncFiles(ctx context.Context, project *types.Pr
 			if !d.IsDir() {
 				if info.ModTime().Before(timeImageCreated) {
 					// skip file if it was modified before image creation
+					logrus.Debugf("skipping file %s; it was modified before image creation", path)
 					return nil
 				}
 				rel, err := filepath.Rel(trigger.Path, path)

--- a/pkg/watch/dockerignore.go
+++ b/pkg/watch/dockerignore.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+	
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v2/internal/paths"
 	"github.com/moby/patternmatcher"
@@ -83,7 +85,7 @@ func LoadDockerIgnore(build *types.BuildConfig) (*dockerPathMatcher, error) {
 		return nil, err
 	}
 	defer func() { _ = f.Close() }()
-
+	logrus.Debugf("Using .dockerignore file: %s", f.Name())
 	patterns, err := readDockerignorePatterns(f)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
1. `make build`
2. `cd bug-12236`
3. `../bin/build/docker-compose -D up --watch alpine`

## Expected Output:
1. Debug logs show that docker compose copies 1 file for initial sync. 
2. Docker compose copies`./dir1` from the host machine to `/app/dir1` in the created container.
3. The `ls -la` output shows `dir1`.

## Actual Output:
```
✗ ../bin/build/docker-compose -D up --watch alpine
[+] Running 1/0
 ✔ Container bug-12236-alpine-1  Created                                                                                                                                       0.0s 
Attaching to alpine-1
DEBU[0000] Using .dockerignore file: /Users/michaelhatch/compose/bug-12236/.dockerignore 
DEBU[0000] ignoring file /Users/michaelhatch/compose/bug-12236/dir1/foo.txt 
DEBU[0000] copying 0 files for initial sync             
alpine-1  | total 8
alpine-1  | drwxr-xr-x    2 root     root          4096 Oct 26 17:11 .
alpine-1  | drwxr-xr-x    1 root     root          4096 Oct 26 17:34 ..
DEBU[0000] Watch configuration for service "alpine":
  - Action sync+restart for path "/Users/michaelhatch/compose/bug-12236/dir1" 
          ⦿ Watch enabled
alpine-1 exited with code 0
          ⦿ Watch disabled
```

## Related Issue
See issue [here](https://github.com/docker/compose/issues/12236).


