### PR TITLE
bump golang minimal version to 1.22 in go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.22.7
+ARG GO_VERSION=1.22.8
 ARG XX_VERSION=1.2.1
 ARG GOLANGCI_LINT_VERSION=v1.60.2
 ARG ADDLICENSE_VERSION=v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/compose/v2
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
**What I did**
Update the minimal version of golang used to build to `1.22` to be aligned with `moby/moby`

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
