### PR TITLE
Add profile e2e test case to document in compose

### DIFF
--- a/pkg/e2e/fixtures/profiles/docker-compose.yaml
+++ b/pkg/e2e/fixtures/profiles/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  foo:
+    container_name: foo_c
+    profiles: [ test ]
+    image: alpine
+    depends_on: [ db ]
+
+  bar:
+    container_name: bar_c
+    profiles: [ test ]
+    image: alpine
+  
+  db:
+    container_name: db_c
+    image: alpine

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -179,3 +179,16 @@ func TestUpWithAllResources(t *testing.T) {
 	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf(`Volume "%s_my_vol"  Created`, projectName)), res.Combined())
 	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf(`Network %s_my_net  Created`, projectName)), res.Combined())
 }
+
+func TestUpProfile(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "compose-e2e-up-profile"
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "--profile", "test", "down", "-v")
+	})
+
+	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/profiles/docker-compose.yaml", "--project-name", projectName, "up", "foo")
+	assert.Assert(t, strings.Contains(res.Combined(), `Container db_c  Created`), res.Combined())
+	assert.Assert(t, strings.Contains(res.Combined(), `Container foo_c  Created`), res.Combined())
+	assert.Assert(t, !strings.Contains(res.Combined(), `Container bar_c  Created`), res.Combined())
+}


### PR DESCRIPTION
**What I did**
Add an e2e test on up command to document in our code base this use case.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
- https://github.com/docker/compose/issues/12244
