### PR TITLE
Avoid starting all services on rebuild

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -512,9 +512,15 @@ func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Pr
 				return err
 			}
 
+			services := []string{serviceName}
+			p, err := project.WithSelectedServices(services)
+			if err != nil {
+				return err
+			}
 			err = s.start(ctx, project.Name, api.StartOptions{
-				Project:  project,
-				Services: []string{serviceName},
+				Project:  p,
+				Services: services,
+				AttachTo: services,
 			}, nil)
 			if err != nil {
 				options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Application failed to start after update. Error: %v", err))


### PR DESCRIPTION
**What I did**
When a service is rebuild during watch, it will trigger to start all services since the graph to start the project is built based on the selected services the project has

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
- fixes https://github.com/docker/compose/issues/12256

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img src="https://github.com/user-attachments/assets/f43f98f7-b333-4c61-b5ba-96c231d48bc8" alt="silly ball" height="600">
