### PR TITLE
Service being declared in a profile must not trigger re-creation

### DIFF
--- a/pkg/compose/hash.go
+++ b/pkg/compose/hash.go
@@ -33,6 +33,7 @@ func ServiceHash(o types.ServiceConfig) (string, error) {
 		o.Deploy.Replicas = nil
 	}
 	o.DependsOn = nil
+	o.Profiles = nil
 
 	bytes, err := json.Marshal(o)
 	if err != nil {


### PR DESCRIPTION
**What I did**
Exclude profiles from service hash computation

**Related issue**
fixes https://github.com/docker/compose/issues/12260

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
