### PR TITLE
remove ArtifactType from Config in OCI v1.1 definition of the artifact

### DIFF
--- a/internal/ocipush/push.go
+++ b/internal/ocipush/push.go
@@ -178,7 +178,6 @@ func generateManifest(layers []v1.Descriptor, ociCompat api.OCIVersion) ([]Pusha
 	case api.OCIVersion1_1:
 		config = v1.DescriptorEmptyJSON
 		artifactType = ComposeProjectArtifactType
-		config.ArtifactType = artifactType
 		// N.B. the descriptor has the data embedded in it
 		toPush = append(toPush, Pushable{Descriptor: config, Data: make([]byte, len(config.Data))})
 	default:


### PR DESCRIPTION
**What I did**
Remove the unnecessary `ArtifactType` from `Config` in Manifest Config for OCI v1.1 declaration of the Compose Artifact 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/06da4c2b-42bb-41e0-89e0-623a4dd24fa5)
