### PR TITLE
Add exception details to the toComposeNetwork log.

### DIFF
--- a/pkg/compose/generate.go
+++ b/pkg/compose/generate.go
@@ -31,6 +31,8 @@ import (
 	"github.com/docker/docker/api/types/network"
 
 	"golang.org/x/exp/maps"
+
+	logrus "github.com/sirupsen/logrus"
 )
 
 func (s *composeService) Generate(ctx context.Context, options api.GenerateOptions) (*types.Project, error) {
@@ -222,6 +224,7 @@ func (s *composeService) toComposeNetwork(networks map[string]*network.EndpointS
 	for name, net := range networks {
 		inspect, err := s.apiClient().NetworkInspect(context.Background(), name, network.InspectOptions{})
 		if err != nil {
+			logrus.Warnf("Failed to inspect network %s: %v", name, err)
 			networkConfigs[name] = types.NetworkConfig{}
 		} else {
 			networkConfigs[name] = types.NetworkConfig{


### PR DESCRIPTION
### Description

When creating a compose, the latest version still frequently encounters issues where containers cannot join the network. https://github.com/docker/compose/issues/11601

### Issue

I found in the source code that when there is an exception during network allocation, an empty network is assigned directly without logging.

### Proposal

I would like to add a log message in this case to help identify and resolve the issue.
