### PR TITLE
remove obsolete containers first on scale down

### DIFF
--- a/pkg/e2e/fixtures/scale/Dockerfile
+++ b/pkg/e2e/fixtures/scale/Dockerfile
@@ -1,0 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM nginx:alpine
+ARG FOO
+LABEL FOO=$FOO

--- a/pkg/e2e/fixtures/scale/build.yaml
+++ b/pkg/e2e/fixtures/scale/build.yaml
@@ -1,0 +1,3 @@
+services:
+  test:
+    build: .


### PR DESCRIPTION
**What I did**
As we scale down, always remove obsolete containers first, then highest-numbers.
Doing so 
1. we enforce containers added with `--no-recreate` will replace the obsolete ones (offering some kind of hand-managed rolling upgrade) - added test case to cover this scenario
2. we (try to) keep replica number low

**Related issue**
fix https://github.com/docker/compose/issues/11781

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
