### PR TITLE
fix(config): Print service names with --no-interpolate

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -279,6 +279,22 @@ func formatModel(model map[string]any, format string) (content []byte, err error
 }
 
 func runServices(ctx context.Context, dockerCli command.Cli, opts configOptions) error {
+	if opts.noInterpolate {
+		// we can't use ToProject, so the model we render here is only partially resolved
+		data, err := opts.ToModel(ctx, dockerCli, nil, cli.WithoutEnvironmentResolution)
+		if err != nil {
+			return err
+		}
+
+		if _, ok := data["services"]; ok {
+			for serviceName := range data["services"].(map[string]any) {
+				_, _ = fmt.Fprintln(dockerCli.Out(), serviceName)
+			}
+		}
+
+		return nil
+	}
+
 	project, err := opts.ToProject(ctx, dockerCli, nil, cli.WithoutEnvironmentResolution)
 	if err != nil {
 		return err
@@ -287,6 +303,7 @@ func runServices(ctx context.Context, dockerCli command.Cli, opts configOptions)
 		_, _ = fmt.Fprintln(dockerCli.Out(), serviceName)
 		return nil
 	})
+
 	return err
 }
 


### PR DESCRIPTION
**What I did**
Fixed `config` command with `--no-interpolate` option

**Related issue**
https://github.com/docker/compose/issues/12281

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/bb7a3d4e-e255-4190-9dac-d1bedfe06de4)
