### PR TITLE
only stop dependent containers ... if there's some

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -226,6 +226,9 @@ func (c *convergence) ensureService(ctx context.Context, project *types.Project,
 func (c *convergence) stopDependentContainers(ctx context.Context, project *types.Project, service types.ServiceConfig) error {
 	// Stop dependent containers, so they will be restarted after service is re-created
 	dependents := project.GetDependentsForService(service)
+	if len(dependents) == 0 {
+		return nil
+	}
 	err := c.service.stop(ctx, project.Name, api.StopOptions{
 		Services: dependents,
 		Project:  project,


### PR DESCRIPTION
**What I did**

**Related issue**
With this crazy convention an empty service selection == all services, we stop all service while we only want to stop (possible) dependent ones.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
