### PR TITLE
do not require a build section but for `rebuild` action

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -119,22 +119,11 @@ func (s *composeService) watch(ctx context.Context, syncChannel chan bool, proje
 				if options.Build == nil {
 					return fmt.Errorf("--no-build is incompatible with watch action %s in service %s", types.WatchActionRebuild, service.Name)
 				}
+				// set the service to always be built - watch triggers `Up()` when it receives a rebuild event
+				service.PullPolicy = types.PullPolicyBuild
+				project.Services[i] = service
 			}
 		}
-
-		if len(services) > 0 && service.Build == nil {
-			// service explicitly selected for watch has no build section
-			return fmt.Errorf("can't watch service %q without a build context", service.Name)
-		}
-
-		if len(services) == 0 && service.Build == nil {
-			logrus.Debugf("service %q has no build context, skipping watch", service.Name)
-			continue
-		}
-
-		// set the service to always be built - watch triggers `Up()` when it receives a rebuild event
-		service.PullPolicy = types.PullPolicyBuild
-		project.Services[i] = service
 
 		dockerIgnores, err := watch.LoadDockerIgnore(service.Build)
 		if err != nil {

--- a/pkg/watch/dockerignore.go
+++ b/pkg/watch/dockerignore.go
@@ -64,7 +64,10 @@ func (i dockerPathMatcher) MatchesEntireDir(f string) (bool, error) {
 	return true, nil
 }
 
-func LoadDockerIgnore(build *types.BuildConfig) (*dockerPathMatcher, error) {
+func LoadDockerIgnore(build *types.BuildConfig) (PathMatcher, error) {
+	if build == nil {
+		return EmptyMatcher{}, nil
+	}
 	repoRoot := build.Context
 	absRoot, err := filepath.Abs(repoRoot)
 	if err != nil {


### PR DESCRIPTION
**What I did**
Watch can be used to sync local content with a container, even if no build section is declared. This one only is required when action is `rebuild`

**Related issue**
closes https://github.com/docker/compose/issues/12065

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
