### PR TITLE
pull --quiet should not drop status message, only progress

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -42,9 +42,6 @@ import (
 )
 
 func (s *composeService) Pull(ctx context.Context, project *types.Project, options api.PullOptions) error {
-	if options.Quiet {
-		return s.pull(ctx, project, options)
-	}
 	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
 		return s.pull(ctx, project, options)
 	}, s.stdinfo(), "Pulling")
@@ -118,7 +115,7 @@ func (s *composeService) pull(ctx context.Context, project *types.Project, opts 
 
 		idx, name, service := i, name, service
 		eg.Go(func() error {
-			_, err := s.pullServiceImage(ctx, service, s.configFile(), w, false, project.Environment["DOCKER_DEFAULT_PLATFORM"])
+			_, err := s.pullServiceImage(ctx, service, s.configFile(), w, opts.Quiet, project.Environment["DOCKER_DEFAULT_PLATFORM"])
 			if err != nil {
 				pullErrors[idx] = err
 				if service.Build != nil {


### PR DESCRIPTION
**What I did**

`--quiet` is defined as "Pull without printing progress information" - but this should not drop the global status, especially when pull fails of is skipped. Users who want `pull` command to run strictly without output can either redirect to /dev/null or use `--progress=none` 

**Related issue**
closes https://github.com/docker/compose/issues/12357

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/77ef7b31-199b-4db8-9011-08d6971bb19e)
