### PR TITLE
log configuration error as a watch log event

### DIFF
--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -304,10 +304,15 @@ func (lk *LogKeyboard) StartWatch(ctx context.Context, doneCh chan bool, project
 				lk.Watch.newContext(ctx)
 				buildOpts := *options.Create.Build
 				buildOpts.Quiet = true
-				return lk.Watch.WatchFn(lk.Watch.Ctx, doneCh, project, options.Start.Services, api.WatchOptions{
+				err := lk.Watch.WatchFn(lk.Watch.Ctx, doneCh, project, options.Start.Services, api.WatchOptions{
 					Build: &buildOpts,
 					LogTo: options.Start.Attach,
 				})
+				if err != nil {
+					lk.Watch.switchWatching()
+					options.Start.Attach.Err(api.WatchLogger, err.Error())
+				}
+				return err
 			}))
 	}
 }


### PR DESCRIPTION
**What I did**
As watch is enabled hitting `w` key from interactive menu, user don't get warned about configuration error and watch not being actually enabled

this PR adds error being logged as a watch log event
```
$ avatars docker compose up
[+] Running 2/2
 ✔ Container avatars-api-1  Created                                                                                                                                                                                                            0.2s 
 ✔ Container avatars-web-1  Created                                                                                                                                                                                                            0.2s 
Attaching to api-1, web-1
api-1  |  * Serving Flask app './api/app.py' (lazy loading)
api-1  |  * Environment: development
api-1  |  * Debug mode: on
web-1  | yarn run v1.22.22
web-1  | $ vite
api-1  |  * Debugger is active!
        ⦿ can't watch service "web" with action rebuild without a build context
```

**Related issue**


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
