### PR TITLE
Recreate container on volume configuration change

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -46,6 +46,7 @@ type createOptions struct {
 	timeout       int
 	quietPull     bool
 	scale         []string
+	AssumeYes     bool
 }
 
 func createCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
@@ -80,6 +81,7 @@ func createCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service
 	flags.BoolVar(&opts.noRecreate, "no-recreate", false, "If containers already exist, don't recreate them. Incompatible with --force-recreate.")
 	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
 	flags.StringArrayVar(&opts.scale, "scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
+	flags.BoolVarP(&opts.AssumeYes, "y", "y", false, `Assume "yes" as answer to all prompts and run non-interactively`)
 	return cmd
 }
 
@@ -107,6 +109,7 @@ func runCreate(ctx context.Context, _ command.Cli, backend api.Service, createOp
 		Inherit:              !createOpts.noInherit,
 		Timeout:              createOpts.GetTimeout(),
 		QuietPull:            createOpts.quietPull,
+		AssumeYes:            createOpts.AssumeYes,
 	})
 }
 

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -145,6 +145,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *c
 	flags := upCmd.Flags()
 	flags.BoolVarP(&up.Detach, "detach", "d", false, "Detached mode: Run containers in the background")
 	flags.BoolVar(&create.Build, "build", false, "Build images before starting containers")
+	flags.BoolVarP(&create.AssumeYes, "y", "y", false, `Assume "yes" as answer to all prompts and run non-interactively`)
 	flags.BoolVar(&create.noBuild, "no-build", false, "Don't build an image, even if it's policy")
 	flags.StringVar(&create.Pull, "pull", "policy", `Pull image before running ("always"|"missing"|"never")`)
 	flags.BoolVar(&create.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
@@ -255,6 +256,7 @@ func runUp(
 		Inherit:              !createOptions.noInherit,
 		Timeout:              createOptions.GetTimeout(),
 		QuietPull:            createOptions.quietPull,
+		AssumeYes:            createOptions.AssumeYes,
 	}
 
 	if upOptions.noStart {

--- a/docs/reference/compose_create.md
+++ b/docs/reference/compose_create.md
@@ -16,6 +16,7 @@ Creates containers for a service
 | `--quiet-pull`     | `bool`        |          | Pull without printing progress information                                                    |
 | `--remove-orphans` | `bool`        |          | Remove containers for services not defined in the Compose file                                |
 | `--scale`          | `stringArray` |          | Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present. |
+| `-y`, `--y`        | `bool`        |          | Assume "yes" as answer to all prompts and run non-interactively                               |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -53,6 +53,7 @@ If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the contai
 | `--wait`                       | `bool`        |          | Wait for services to be running\|healthy. Implies detached mode.                                                                                    |
 | `--wait-timeout`               | `int`         | `0`      | Maximum duration in seconds to wait for the project to be running\|healthy                                                                          |
 | `-w`, `--watch`                | `bool`        |          | Watch source code and rebuild/refresh containers when files are updated.                                                                            |
+| `-y`, `--y`                    | `bool`        |          | Assume "yes" as answer to all prompts and run non-interactively                                                                                     |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_create.yaml
+++ b/docs/reference/docker_compose_create.yaml
@@ -88,6 +88,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: "y"
+      shorthand: "y"
+      value_type: bool
+      default_value: "false"
+      description: Assume "yes" as answer to all prompts and run non-interactively
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -309,6 +309,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: "y"
+      shorthand: "y"
+      value_type: bool
+      default_value: "false"
+      description: Assume "yes" as answer to all prompts and run non-interactively
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -207,6 +207,8 @@ type CreateOptions struct {
 	Timeout *time.Duration
 	// QuietPull makes the pulling process quiet
 	QuietPull bool
+	// AssumeYes assume "yes" as answer to all prompts and run non-interactively
+	AssumeYes bool
 }
 
 // StartOptions group options of the Start API

--- a/pkg/compose/hash.go
+++ b/pkg/compose/hash.go
@@ -42,7 +42,20 @@ func ServiceHash(o types.ServiceConfig) (string, error) {
 	return digest.SHA256.FromBytes(bytes).Encoded(), nil
 }
 
+// NetworkHash computes the configuration hash for a network.
 func NetworkHash(o *types.NetworkConfig) (string, error) {
+	bytes, err := json.Marshal(o)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256.FromBytes(bytes).Encoded(), nil
+}
+
+// VolumeHash computes the configuration hash for a volume.
+func VolumeHash(o types.VolumeConfig) (string, error) {
+	if o.Driver == "" { // (TODO: jhrotko) This probably should be fixed in compose-go
+		o.Driver = "local"
+	}
 	bytes, err := json.Marshal(o)
 	if err != nil {
 		return "", err

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -104,7 +104,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 		Labels:            mergeLabels(service.Labels, service.CustomLabels),
 	}
 
-	err = newConvergence(project.ServiceNames(), observedState, nil, s).resolveServiceReferences(&service)
+	err = newConvergence(project.ServiceNames(), observedState, nil, nil, s).resolveServiceReferences(&service)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/e2e/fixtures/recreate-volumes/compose.yaml
+++ b/pkg/e2e/fixtures/recreate-volumes/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  app:
+    image: alpine
+    volumes:
+      - my_vol:/my_vol
+
+volumes:
+  my_vol:
+    external: true
+    name: test_external_volume

--- a/pkg/e2e/fixtures/recreate-volumes/compose2.yaml
+++ b/pkg/e2e/fixtures/recreate-volumes/compose2.yaml
@@ -1,0 +1,10 @@
+services:
+  app:
+    image: alpine
+    volumes:
+      - my_vol:/my_vol
+
+volumes:
+  my_vol:
+    external: true
+    name: test_external_volume_2


### PR DESCRIPTION
**What I did**
supersede https://github.com/docker/compose/pull/12223
- detect actual volume doesn't match configuration
- request user to confirm dropping volume before recreation, until ran with `--yes`
- recreate container if the mounted volume is not the expected one

drawbacks:
- anonymous volumes from previous container can't be re-attached to recreated one, as we have to remove container (we miss a `VolumeRename` API)

**Related issue**
fixes https://github.com/docker/compose/issues/10060

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
