### PR TITLE
format code with gofumpt

### DIFF
--- a/cmd/cmdtrace/cmd_span_test.go
+++ b/cmd/cmdtrace/cmd_span_test.go
@@ -60,5 +60,4 @@ func TestGetFlags(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -348,7 +348,6 @@ func runHash(ctx context.Context, dockerCli command.Cli, opts configOptions) err
 		}
 
 		hash, err := compose.ServiceHash(s)
-
 		if err != nil {
 			return err
 		}

--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -195,7 +195,9 @@ func applyScaleOpts(project *types.Project, opts []string) error {
 }
 
 func (opts createOptions) isPullPolicyValid() bool {
-	pullPolicies := []string{types.PullPolicyAlways, types.PullPolicyNever, types.PullPolicyBuild,
-		types.PullPolicyMissing, types.PullPolicyIfNotPresent}
+	pullPolicies := []string{
+		types.PullPolicyAlways, types.PullPolicyNever, types.PullPolicyBuild,
+		types.PullPolicyMissing, types.PullPolicyIfNotPresent,
+	}
 	return slices.Contains(pullPolicies, opts.Pull)
 }

--- a/cmd/compose/scale.go
+++ b/cmd/compose/scale.go
@@ -92,7 +92,6 @@ func parseServicesReplicasArgs(args []string) (map[string]int, error) {
 			return nil, fmt.Errorf("invalid scale specifier: %s", arg)
 		}
 		intValue, err := strconv.Atoi(val)
-
 		if err != nil {
 			return nil, fmt.Errorf("invalid scale specifier: can't parse replica value as int: %v", arg)
 		}

--- a/cmd/compose/up_test.go
+++ b/cmd/compose/up_test.go
@@ -47,5 +47,4 @@ func TestApplyScaleOpt(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, *bar.Scale, 3)
 	assert.Equal(t, *bar.Deploy.Replicas, 3)
-
 }

--- a/cmd/formatter/ansi.go
+++ b/cmd/formatter/ansi.go
@@ -27,42 +27,49 @@ var disableAnsi bool
 func ansi(code string) string {
 	return fmt.Sprintf("\033%s", code)
 }
+
 func SaveCursor() {
 	if disableAnsi {
 		return
 	}
 	fmt.Print(ansi("7"))
 }
+
 func RestoreCursor() {
 	if disableAnsi {
 		return
 	}
 	fmt.Print(ansi("8"))
 }
+
 func HideCursor() {
 	if disableAnsi {
 		return
 	}
 	fmt.Print(ansi("[?25l"))
 }
+
 func ShowCursor() {
 	if disableAnsi {
 		return
 	}
 	fmt.Print(ansi("[?25h"))
 }
+
 func MoveCursor(y, x int) {
 	if disableAnsi {
 		return
 	}
 	fmt.Print(ansi(fmt.Sprintf("[%d;%dH", y, x)))
 }
+
 func MoveCursorX(pos int) {
 	if disableAnsi {
 		return
 	}
 	fmt.Print(ansi(fmt.Sprintf("[%dG", pos)))
 }
+
 func ClearLine() {
 	if disableAnsi {
 		return
@@ -70,6 +77,7 @@ func ClearLine() {
 	// Does not move cursor from its current position
 	fmt.Print(ansi("[2K"))
 }
+
 func MoveCursorUp(lines int) {
 	if disableAnsi {
 		return
@@ -77,6 +85,7 @@ func MoveCursorUp(lines int) {
 	// Does not add new lines
 	fmt.Print(ansi(fmt.Sprintf("[%dA", lines)))
 }
+
 func MoveCursorDown(lines int) {
 	if disableAnsi {
 		return
@@ -84,10 +93,12 @@ func MoveCursorDown(lines int) {
 	// Does not add new lines
 	fmt.Print(ansi(fmt.Sprintf("[%dB", lines)))
 }
+
 func NewLine() {
 	// Like \n
 	fmt.Print("\012")
 }
+
 func lenAnsi(s string) int {
 	// len has into consideration ansi codes, if we want
 	// the len of the actual len(string) we need to strip

--- a/cmd/formatter/colors.go
+++ b/cmd/formatter/colors.go
@@ -104,10 +104,12 @@ func makeColorFunc(code string) colorFunc {
 	}
 }
 
-var nextColor = rainbowColor
-var rainbow []colorFunc
-var currentIndex = 0
-var mutex sync.Mutex
+var (
+	nextColor    = rainbowColor
+	rainbow      []colorFunc
+	currentIndex = 0
+	mutex        sync.Mutex
+)
 
 func rainbowColor() colorFunc {
 	mutex.Lock()

--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -110,8 +110,10 @@ type LogKeyboard struct {
 	signalChannel         chan<- os.Signal
 }
 
-var KeyboardManager *LogKeyboard
-var eg multierror.Group
+var (
+	KeyboardManager *LogKeyboard
+	eg              multierror.Group
+)
 
 func NewKeyboardManager(ctx context.Context, isDockerDesktopActive, isWatchConfigured bool,
 	sc chan<- os.Signal,
@@ -206,7 +208,7 @@ func (lk *LogKeyboard) navigationMenu() string {
 	if openDDInfo != "" || openDDUI != "" {
 		watchInfo = navColor("   ")
 	}
-	var isEnabled = " Enable"
+	isEnabled := " Enable"
 	if lk.Watch.Watching {
 		isEnabled = " Disable"
 	}
@@ -260,6 +262,7 @@ func (lk *LogKeyboard) openDDComposeUI(ctx context.Context, project *types.Proje
 		}),
 	)
 }
+
 func (lk *LogKeyboard) openDDWatchDocs(ctx context.Context, project *types.Project) {
 	eg.Go(tracing.EventWrapFuncForErrGroup(ctx, "menu/gui/watch", tracing.SpanOptions{},
 		func(ctx context.Context) error {

--- a/internal/variables.go
+++ b/internal/variables.go
@@ -16,7 +16,5 @@
 
 package internal
 
-var (
-	// Version is the version of the CLI injected in compilation time
-	Version = "dev"
-)
+// Version is the version of the CLI injected in compilation time
+var Version = "dev"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -429,7 +429,6 @@ func (e Event) String() string {
 		attr = append(attr, fmt.Sprintf("%s=%s", k, v))
 	}
 	return fmt.Sprintf("%s container %s %s (%s)\n", t, e.Status, e.Container, strings.Join(attr, ", "))
-
 }
 
 // ListOptions group options of the ls API

--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -101,7 +101,8 @@ func (d *DryRunClient) ContainerAttach(ctx context.Context, container string, op
 }
 
 func (d *DryRunClient) ContainerCreate(ctx context.Context, config *containerType.Config, hostConfig *containerType.HostConfig,
-	networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (containerType.CreateResponse, error) {
+	networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string,
+) (containerType.CreateResponse, error) {
 	d.containers = append(d.containers, moby.Container{
 		ID:     containerName,
 		Names:  []string{containerName},
@@ -229,7 +230,6 @@ func (d *DryRunClient) ImageInspectWithRaw(ctx context.Context, imageName string
 	default:
 		return d.apiClient.ImageInspectWithRaw(ctx, imageName)
 	}
-
 }
 
 func (d *DryRunClient) ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error) {

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -134,7 +134,6 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 				fmt.Sprintf("building with %q instance using %s driver", b.Name, b.Driver),
 				fmt.Sprintf("%s:%s", b.Driver, b.Name),
 			))
-
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -187,7 +187,6 @@ func (s *composeService) projectFromName(containers Containers, projectName stri
 				Image:  c.Image,
 				Labels: c.Labels,
 			}
-
 		}
 		service.Scale = increment(service.Scale)
 		set[serviceLabel] = service
@@ -321,7 +320,6 @@ func (s *composeService) RuntimeVersion(ctx context.Context) (string, error) {
 		runtimeVersion.val = version.APIVersion
 	})
 	return runtimeVersion.val, runtimeVersion.err
-
 }
 
 func (s *composeService) isDesktopIntegrationActive() bool {

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -540,11 +540,11 @@ func nextContainerNumber(containers []moby.Container) int {
 		}
 	}
 	return maxNumber + 1
-
 }
 
 func (s *composeService) createContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,
-	name string, number int, opts createOptions) (container moby.Container, err error) {
+	name string, number int, opts createOptions,
+) (container moby.Container, err error) {
 	w := progress.ContextWriter(ctx)
 	eventName := "Container " + name
 	w.Event(progress.CreatingEvent(eventName))
@@ -557,7 +557,8 @@ func (s *composeService) createContainer(ctx context.Context, project *types.Pro
 }
 
 func (s *composeService) recreateContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,
-	replaced moby.Container, inherit bool, timeout *time.Duration) (moby.Container, error) {
+	replaced moby.Container, inherit bool, timeout *time.Duration,
+) (moby.Container, error) {
 	var created moby.Container
 	w := progress.ContextWriter(ctx)
 	w.Event(progress.NewEvent(getContainerProgressName(replaced), progress.Working, "Recreate"))
@@ -626,7 +627,6 @@ func (s *composeService) createMobyContainer(ctx context.Context,
 ) (moby.Container, error) {
 	var created moby.Container
 	cfgs, err := s.getCreateConfigs(ctx, project, service, number, inherit, opts)
-
 	if err != nil {
 		return created, err
 	}
@@ -809,7 +809,8 @@ func (s *composeService) isServiceCompleted(ctx context.Context, containers Cont
 func (s *composeService) startService(ctx context.Context,
 	project *types.Project, service types.ServiceConfig,
 	containers Containers, listener api.ContainerEventListener,
-	timeout time.Duration) error {
+	timeout time.Duration,
+) error {
 	if service.Deploy != nil && service.Deploy.Replicas != nil && *service.Deploy.Replicas == 0 {
 		return nil
 	}

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -432,5 +432,4 @@ func TestCreateMobyContainer(t *testing.T) {
 		}, progress.ContextWriter(context.TODO()))
 		assert.NilError(t, err)
 	})
-
 }

--- a/pkg/compose/cp.go
+++ b/pkg/compose/cp.go
@@ -139,7 +139,6 @@ func (s *composeService) listContainersTargetedForCopy(ctx context.Context, proj
 		}
 		if direction == fromService {
 			return containers[:1], err
-
 		}
 		return containers, err
 	}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -201,7 +201,6 @@ func (s *composeService) ensureProjectVolumes(ctx context.Context, project *type
 		}
 		return nil
 	}()
-
 	if err != nil {
 		progress.ContextWriter(ctx).TailMsgf("Failed to prepare Synchronized file shares: %v", err)
 	}
@@ -255,7 +254,7 @@ func (s *composeService) getCreateConfigs(ctx context.Context,
 	if err != nil {
 		return createConfigs{}, err
 	}
-	var containerConfig = container.Config{
+	containerConfig := container.Config{
 		Hostname:        service.Hostname,
 		Domainname:      service.DomainName,
 		User:            service.User,
@@ -883,7 +882,7 @@ func requireMountAPI(bind *types.ServiceVolumeBind) bool {
 }
 
 func buildContainerMountOptions(p types.Project, s types.ServiceConfig, img moby.ImageInspect, inherit *moby.Container) ([]mount.Mount, error) {
-	var mounts = map[string]mount.Mount{}
+	mounts := map[string]mount.Mount{}
 	if inherit != nil {
 		for _, m := range inherit.Mounts {
 			if m.Type == "tmpfs" {
@@ -969,7 +968,7 @@ func fillBindMounts(p types.Project, s types.ServiceConfig, m map[string]mount.M
 }
 
 func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount.Mount, error) {
-	var mounts = map[string]mount.Mount{}
+	mounts := map[string]mount.Mount{}
 
 	configsBaseDir := "/"
 	for _, config := range s.Configs {
@@ -1019,7 +1018,7 @@ func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount
 }
 
 func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount.Mount, error) {
-	var mounts = map[string]mount.Mount{}
+	mounts := map[string]mount.Mount{}
 
 	secretsDir := "/run/secrets/"
 	for _, secret := range s.Secrets {
@@ -1383,7 +1382,6 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 	networks, err := s.apiClient().NetworkList(ctx, network.ListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", n.Name)),
 	})
-
 	if err != nil {
 		return "", err
 	}

--- a/pkg/compose/dependencies.go
+++ b/pkg/compose/dependencies.go
@@ -438,7 +438,6 @@ func (g *Graph) HasCycles() (bool, error) {
 		if !utils.StringContains(discovered, vertex.Key) && !utils.StringContains(finished, vertex.Key) {
 			var err error
 			discovered, finished, err = g.visit(vertex.Key, path, discovered, finished)
-
 			if err != nil {
 				return true, err
 			}

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -211,7 +211,8 @@ func TestDownRemoveOrphans(t *testing.T) {
 			{
 				Name:   "myProject_default",
 				Labels: map[string]string{compose.NetworkLabel: "default"},
-			}}, nil)
+			},
+		}, nil)
 
 	stopOptions := containerType.StopOptions{}
 	api.EXPECT().ContainerStop(gomock.Any(), "123", stopOptions).Return(nil)

--- a/pkg/compose/envresolver.go
+++ b/pkg/compose/envresolver.go
@@ -21,10 +21,8 @@ import (
 	"strings"
 )
 
-var (
-	// isCaseInsensitiveEnvVars is true on platforms where environment variable names are treated case-insensitively.
-	isCaseInsensitiveEnvVars = (runtime.GOOS == "windows")
-)
+// isCaseInsensitiveEnvVars is true on platforms where environment variable names are treated case-insensitively.
+var isCaseInsensitiveEnvVars = (runtime.GOOS == "windows")
 
 // envResolver returns resolver for environment variables suitable for the current platform.
 // Expected to be used with `MappingWithEquals.Resolve`.

--- a/pkg/compose/generate.go
+++ b/pkg/compose/generate.go
@@ -92,7 +92,6 @@ func (s *composeService) createProjectFromContainers(containers []moby.Container
 				Image:  c.Image,
 				Labels: c.Labels,
 			}
-
 		}
 		service.Scale = increment(service.Scale)
 
@@ -172,7 +171,8 @@ func (s *composeService) toComposeHealthCheck(healthConfig *containerType.Health
 }
 
 func (s *composeService) toComposeVolumes(volumes []moby.MountPoint) (map[string]types.VolumeConfig,
-	[]types.ServiceVolumeConfig, map[string]types.SecretConfig, []types.ServiceSecretConfig) {
+	[]types.ServiceVolumeConfig, map[string]types.SecretConfig, []types.ServiceSecretConfig,
+) {
 	volumeConfigs := make(map[string]types.VolumeConfig)
 	secretConfigs := make(map[string]types.SecretConfig)
 	var serviceVolumeConfigs []types.ServiceVolumeConfig
@@ -227,7 +227,6 @@ func (s *composeService) toComposeNetwork(networks map[string]*network.EndpointS
 			networkConfigs[name] = types.NetworkConfig{
 				Internal: inspect.Internal,
 			}
-
 		}
 		serviceNetworkConfigs[name] = &types.ServiceNetworkConfig{
 			Aliases: net.Aliases,

--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -48,7 +48,6 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 		for _, c := range allContainers {
 			if utils.StringContains(options.Services, c.Labels[api.ServiceLabel]) {
 				containers = append(containers, c)
-
 			}
 		}
 	} else {

--- a/pkg/compose/kill_test.go
+++ b/pkg/compose/kill_test.go
@@ -123,7 +123,8 @@ func containerLabels(service string, oneOff bool) map[string]string {
 		compose.ServiceLabel:     service,
 		compose.ConfigFilesLabel: composefile,
 		compose.WorkingDirLabel:  workingdir,
-		compose.ProjectLabel:     strings.ToLower(testProject)}
+		compose.ProjectLabel:     strings.ToLower(testProject),
+	}
 	if oneOff {
 		labels[compose.OneoffLabel] = "True"
 	}

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -39,7 +39,6 @@ func (s *composeService) Logs(
 	consumer api.LogConsumer,
 	options api.LogOptions,
 ) error {
-
 	var containers Containers
 	var err error
 

--- a/pkg/compose/pause.go
+++ b/pkg/compose/pause.go
@@ -54,7 +54,6 @@ func (s *composeService) pause(ctx context.Context, projectName string, options 
 			}
 			return err
 		})
-
 	})
 	return eg.Wait()
 }
@@ -86,7 +85,6 @@ func (s *composeService) unPause(ctx context.Context, projectName string, option
 			}
 			return err
 		})
-
 	})
 	return eg.Wait()
 }

--- a/pkg/compose/ps_test.go
+++ b/pkg/compose/ps_test.go
@@ -55,7 +55,8 @@ func TestPs(t *testing.T) {
 	containers, err := tested.Ps(ctx, strings.ToLower(testProject), compose.PsOptions{})
 
 	expected := []compose.ContainerSummary{
-		{ID: "123", Name: "123", Names: []string{"/123"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service1",
+		{
+			ID: "123", Name: "123", Names: []string{"/123"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service1",
 			State: "running", Health: "healthy", Publishers: []compose.PortPublisher{},
 			Labels: map[string]string{
 				compose.ProjectLabel:     strings.ToLower(testProject),
@@ -64,7 +65,8 @@ func TestPs(t *testing.T) {
 				compose.ServiceLabel:     "service1",
 			},
 		},
-		{ID: "456", Name: "456", Names: []string{"/456"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service1",
+		{
+			ID: "456", Name: "456", Names: []string{"/456"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service1",
 			State: "running", Health: "",
 			Publishers: []compose.PortPublisher{{URL: "localhost", TargetPort: 90, PublishedPort: 80}},
 			Labels: map[string]string{
@@ -74,7 +76,8 @@ func TestPs(t *testing.T) {
 				compose.ServiceLabel:     "service1",
 			},
 		},
-		{ID: "789", Name: "789", Names: []string{"/789"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service2",
+		{
+			ID: "789", Name: "789", Names: []string{"/789"}, Image: "foo", Project: strings.ToLower(testProject), Service: "service2",
 			State: "exited", Health: "", ExitCode: 130, Publishers: []compose.PortPublisher{},
 			Labels: map[string]string{
 				compose.ProjectLabel:     strings.ToLower(testProject),

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -175,7 +175,8 @@ func getUnwrappedErrorMessage(err error) string {
 }
 
 func (s *composeService) pullServiceImage(ctx context.Context, service types.ServiceConfig,
-	configFile driver.Auth, w progress.Writer, quietPull bool, defaultPlatform string) (string, error) {
+	configFile driver.Auth, w progress.Writer, quietPull bool, defaultPlatform string,
+) (string, error) {
 	w.Event(progress.Event{
 		ID:     service.Name,
 		Status: progress.Working,

--- a/pkg/compose/scale.go
+++ b/pkg/compose/scale.go
@@ -31,6 +31,5 @@ func (s *composeService) Scale(ctx context.Context, project *types.Project, opti
 			return err
 		}
 		return s.start(ctx, project.Name, api.StartOptions{Project: project, Services: options.Services}, nil)
-
 	}), s.stdinfo())
 }

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -180,7 +180,8 @@ type containerWatchFn func(container moby.Container, t time.Time) error
 // watchContainers uses engine events to capture container start/die and notify ContainerEventListener
 func (s *composeService) watchContainers(ctx context.Context, //nolint:gocyclo
 	projectName string, services, required []string,
-	listener api.ContainerEventListener, containers Containers, onStart, onRecreate containerWatchFn) error {
+	listener api.ContainerEventListener, containers Containers, onStart, onRecreate containerWatchFn,
+) error {
 	if len(containers) == 0 {
 		return nil
 	}

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -69,6 +69,7 @@ func (s *composeService) getSyncImplementation(project *types.Project) (sync.Syn
 
 	return sync.NewTar(project.Name, tarDockerClient{s: s}), nil
 }
+
 func (s *composeService) shouldWatch(project *types.Project) bool {
 	var shouldWatch bool
 	for i := range project.Services {
@@ -84,6 +85,7 @@ func (s *composeService) shouldWatch(project *types.Project) bool {
 func (s *composeService) Watch(ctx context.Context, project *types.Project, services []string, options api.WatchOptions) error {
 	return s.watch(ctx, nil, project, services, options)
 }
+
 func (s *composeService) watch(ctx context.Context, syncChannel chan bool, project *types.Project, services []string, options api.WatchOptions) error { //nolint: gocyclo
 	var err error
 	if project, err = project.WithSelectedServices(services); err != nil {
@@ -538,7 +540,6 @@ func (s *composeService) rebuild(ctx context.Context, project *types.Project, se
 	// restrict the build to ONLY this service, not any of its dependencies
 	options.Build.Services = []string{serviceName}
 	imageNameToIdMap, err := s.build(ctx, project, *options.Build, nil)
-
 	if err != nil {
 		options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Build failed. Error: %v", err))
 		return err
@@ -611,7 +612,6 @@ func (s *composeService) pruneDanglingImagesOnRebuild(ctx context.Context, proje
 			filters.Arg("label", api.ProjectLabel+"="+projectName),
 		),
 	})
-
 	if err != nil {
 		logrus.Debugf("Failed to list images: %v", err)
 		return

--- a/pkg/compose/watch_test.go
+++ b/pkg/compose/watch_test.go
@@ -50,7 +50,7 @@ func TestDebounceBatching(t *testing.T) {
 	matcher := watch.EmptyMatcher{}
 	eventBatchCh := batchDebounceEvents(ctx, clock, quietPeriod, ch)
 	for i := 0; i < 100; i++ {
-		var path = "/a"
+		path := "/a"
 		if i%2 == 0 {
 			path = "/b"
 		}
@@ -121,7 +121,6 @@ func (s stdLogger) Status(container, msg string) {
 }
 
 func (s stdLogger) Register(container string) {
-
 }
 
 func TestWatch_Sync(t *testing.T) {

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestLocalComposeBuild(t *testing.T) {
-
 	for _, env := range []string{"DOCKER_BUILDKIT=0", "DOCKER_BUILDKIT=1", "DOCKER_BUILDKIT=1,COMPOSE-BAKE=1"} {
 		c := NewCLI(t, WithEnv(strings.Split(env, ",")...))
 
@@ -135,7 +134,6 @@ func TestLocalComposeBuild(t *testing.T) {
 			c.RunDockerOrExitError(t, "rmi", "-f", "custom-nginx")
 		})
 	}
-
 }
 
 func TestBuildSSH(t *testing.T) {
@@ -150,7 +148,6 @@ func TestBuildSSH(t *testing.T) {
 			ExitCode: 1,
 			Err:      "invalid empty ssh agent socket: make sure SSH_AUTH_SOCK is set",
 		})
-
 	})
 
 	t.Run("build succeed with ssh from Compose file", func(t *testing.T) {
@@ -218,7 +215,6 @@ func TestBuildTags(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	t.Run("build with tags", func(t *testing.T) {
-
 		// ensure local test run does not reuse previously build image
 		c.RunDockerOrExitError(t, "rmi", "build-test-tags")
 
@@ -318,7 +314,6 @@ func TestBuildPlatformsWithCorrectBuildxConfig(t *testing.T) {
 		assert.NilError(t, res.Error, res.Stderr())
 		res.Assert(t, icmd.Expected{Out: "I am building for linux/arm64"})
 		res.Assert(t, icmd.Expected{Out: "I am building for linux/amd64"})
-
 	})
 
 	t.Run("multi-arch multi service builds ok", func(t *testing.T) {
@@ -355,7 +350,6 @@ func TestBuildPlatformsWithCorrectBuildxConfig(t *testing.T) {
 		assert.NilError(t, res.Error, res.Stderr())
 		res.Assert(t, icmd.Expected{Out: "I am building for linux/386"})
 	})
-
 }
 
 func TestBuildPrivileged(t *testing.T) {
@@ -445,7 +439,6 @@ Switch to a different driver, or turn on the containerd image store, and try aga
 			Err:      "the classic builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use BuildKit",
 		})
 	})
-
 }
 
 func TestBuildBuilder(t *testing.T) {
@@ -472,7 +465,6 @@ func TestBuildBuilder(t *testing.T) {
 			Err:      fmt.Sprintf(`no builder %q found`, "unknown-builder"),
 		})
 	})
-
 }
 
 func TestBuildEntitlements(t *testing.T) {

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -83,7 +83,6 @@ func TestLocalComposeUp(t *testing.T) {
 	t.Run("check user labels", func(t *testing.T) {
 		res := c.RunDockerCmd(t, "inspect", projectName+"-web-1")
 		res.Assert(t, icmd.Expected{Out: `"my-label": "test"`})
-
 	})
 
 	t.Run("check healthcheck output", func(t *testing.T) {
@@ -391,7 +390,6 @@ func TestNestedDotEnv(t *testing.T) {
 		ExitCode: 0,
 		Out:      "root sub win=sub",
 	})
-
 }
 
 func TestUnnecessaryResources(t *testing.T) {

--- a/pkg/e2e/framework.go
+++ b/pkg/e2e/framework.go
@@ -133,7 +133,6 @@ func copyLocalConfig(t testing.TB, configDir string) {
 // initializePlugins copies the necessary plugin files to the temporary config
 // directory for the test.
 func initializePlugins(t testing.TB, configDir string) {
-
 	t.Cleanup(func() {
 		if t.Failed() {
 			if conf, err := os.ReadFile(filepath.Join(configDir, "config.json")); err == nil {

--- a/pkg/e2e/logs_test.go
+++ b/pkg/e2e/logs_test.go
@@ -128,6 +128,5 @@ func expectOutput(res *icmd.Result, expected string) func(t poll.LogT) poll.Resu
 			return poll.Success()
 		}
 		return poll.Continue("condition not met")
-
 	}
 }

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -142,9 +142,7 @@ func TestNetworkModes(t *testing.T) {
 	t.Run("run with service mode dependency", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-test/compose.yaml", "--project-name", projectName, "run", "-T", "mydb", "echo", "success")
 		res.Assert(t, icmd.Expected{Out: "success"})
-
 	})
-
 }
 
 func TestNetworkConfigChanged(t *testing.T) {

--- a/pkg/e2e/pull_test.go
+++ b/pkg/e2e/pull_test.go
@@ -89,5 +89,4 @@ func TestComposePull(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/compose-pull/unknown-image", "pull", "--ignore-pull-failures")
 		res.Assert(t, icmd.Expected{Err: "Some service image(s) must be built from source by running:"})
 	})
-
 }

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -152,7 +152,6 @@ func TestScaleDoesntRecreate(t *testing.T) {
 
 	res := c.RunDockerComposeCmd(t, "-f", "fixtures/simple-composefile/compose.yaml", "--project-name", projectName, "up", "--scale", "simple=2", "-d")
 	assert.Check(t, !strings.Contains(res.Combined(), "Recreated"))
-
 }
 
 func TestUpWithDependencyNotRequired(t *testing.T) {

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 func TestWatch(t *testing.T) {
-
 	services := []string{"alpine", "busybox", "debian"}
 	for _, svcName := range services {
 		t.Run(svcName, func(t *testing.T) {
@@ -133,7 +132,6 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 		}
 	})
 	testComplete.Store(true)
-
 }
 
 // NOTE: these tests all share a single Compose file but are safe to run

--- a/pkg/progress/json.go
+++ b/pkg/progress/json.go
@@ -51,7 +51,7 @@ func (p *jsonWriter) Start(ctx context.Context) error {
 }
 
 func (p *jsonWriter) Event(e Event) {
-	var message = &jsonMessage{
+	message := &jsonMessage{
 		DryRun:   p.dryRun,
 		Tail:     false,
 		ID:       e.ID,
@@ -75,7 +75,7 @@ func (p *jsonWriter) Events(events []Event) {
 }
 
 func (p *jsonWriter) TailMsgf(msg string, args ...interface{}) {
-	var message = &jsonMessage{
+	message := &jsonMessage{
 		DryRun: p.dryRun,
 		Tail:   true,
 		ID:     "",

--- a/pkg/progress/noop.go
+++ b/pkg/progress/noop.go
@@ -20,8 +20,7 @@ import (
 	"context"
 )
 
-type noopWriter struct {
-}
+type noopWriter struct{}
 
 func (p *noopWriter) Start(ctx context.Context) error {
 	return nil

--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -345,6 +345,4 @@ func lenAnsi(s string) int {
 	return length
 }
 
-var (
-	percentChars = strings.Split("⠀⡀⣀⣄⣤⣦⣶⣷⣿", "")
-)
+var percentChars = strings.Split("⠀⡀⣀⣄⣤⣦⣶⣷⣿", "")

--- a/pkg/utils/writer_test.go
+++ b/pkg/utils/writer_test.go
@@ -36,5 +36,4 @@ func TestSplitWriter(t *testing.T) {
 	w.Write([]byte("\n"))
 	w.Write([]byte("world!\n"))
 	assert.DeepEqual(t, lines, []string{"hello", "world!"})
-
 }

--- a/pkg/watch/notify.go
+++ b/pkg/watch/notify.go
@@ -28,9 +28,7 @@ import (
 	"github.com/tilt-dev/fsnotify"
 )
 
-var (
-	numberOfWatches = expvar.NewInt("watch.naive.numberOfWatches")
-)
+var numberOfWatches = expvar.NewInt("watch.naive.numberOfWatches")
 
 type FileEvent struct {
 	path string
@@ -76,8 +74,7 @@ type PathMatcher interface {
 	MatchesEntireDir(file string) (bool, error)
 }
 
-type EmptyMatcher struct {
-}
+type EmptyMatcher struct{}
 
 func (EmptyMatcher) Matches(f string) (bool, error)          { return false, nil }
 func (EmptyMatcher) MatchesEntireDir(f string) (bool, error) { return false, nil }


### PR DESCRIPTION
Format the code  with gofumpt to prevent my IDE from reformatting every time I open a file. gofumpt provides a superset of gofmt, so should not impact users that are not using gofumpt.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
