### PR TITLE
only check volume mounts for updated config

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -384,6 +384,9 @@ func checkExpectedNetworks(expected types.ServiceConfig, actual moby.Container, 
 func checkExpectedVolumes(expected types.ServiceConfig, actual moby.Container, volumes map[string]string) bool {
 	// check container's volume mounts and search for the expected ones
 	for _, vol := range expected.Volumes {
+		if vol.Type != string(mmount.TypeVolume) {
+			continue
+		}
 		id := volumes[vol.Source]
 		found := false
 		for _, mount := range actual.Mounts {


### PR DESCRIPTION
**What I did**
Compose uses a config hash to detect service need to be recreated, but as compose file uses reference names for volumes (which may be != volume name), we have to check if service volume is actually used to mount the desired volume.
This only has to apply to `volume` mounts, where this reference ambiguity exisrts - otherwise we detect a false positive and recreate container while it's up-to-date.

**Related issue**
fixes https://github.com/docker/compose/issues/12383

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![468959073_1221260192696349_5555675514319708470_n](https://github.com/user-attachments/assets/bd0a07ee-e0fc-42db-bdbd-9d97611b0749)
