### PR TITLE
Condense output of `compose top`

### DIFF
--- a/cmd/compose/top.go
+++ b/cmd/compose/top.go
@@ -73,14 +73,23 @@ func runTop(ctx context.Context, dockerCli command.Cli, backend api.Service, opt
 func collectTop(containers []api.ContainerProcSummary) (topHeader, []topEntries) {
 	// map column name to its header (should keep working if backend.Top returns
 	// varying columns for different containers)
-	header := topHeader{"SERVICE": 0}
+	header := topHeader{"SERVICE": 0, "#": 1}
 
 	// assume one process per container and grow if needed
 	entries := make([]topEntries, 0, len(containers))
 
 	for _, container := range containers {
 		for _, proc := range container.Processes {
-			entry := topEntries{"SERVICE": container.Name}
+			svc := container.Name
+			if tmp, ok := container.Labels[api.ServiceLabel]; ok {
+				svc = tmp
+			}
+			replica := "-"
+			if tmp, ok := container.Labels[api.ContainerNumberLabel]; ok {
+				replica = tmp
+			}
+
+			entry := topEntries{"SERVICE": svc, "#": replica}
 
 			for i, title := range container.Titles {
 				if _, exists := header[title]; !exists {

--- a/cmd/compose/top.go
+++ b/cmd/compose/top.go
@@ -124,7 +124,7 @@ func topPrint(out io.Writer, headers topHeader, rows []topEntries) error {
 		return nil
 	}
 
-	w := tabwriter.NewWriter(out, 5, 1, 3, ' ', 0)
+	w := tabwriter.NewWriter(out, 4, 1, 2, ' ', 0)
 
 	// write headers in the order we've encountered them
 	h := make([]string, len(headers))

--- a/cmd/compose/top.go
+++ b/cmd/compose/top.go
@@ -101,6 +101,21 @@ func collectTop(containers []api.ContainerProcSummary) (topHeader, []topEntries)
 			entries = append(entries, entry)
 		}
 	}
+
+	// ensure CMD is the right-most column
+	if pos, ok := header["CMD"]; ok {
+		max := pos
+		for h, i := range header {
+			if i > max {
+				max = i
+			}
+			if i > pos {
+				header[h] = i - 1
+			}
+		}
+		header["CMD"] = max
+	}
+
 	return header, entries
 }
 

--- a/cmd/compose/top_test.go
+++ b/cmd/compose/top_test.go
@@ -39,7 +39,7 @@ var topTestCases = []struct {
 		name:    "noprocs",
 		titles:  []string{"UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"},
 		procs:   [][]string{},
-		header:  topHeader{"SERVICE": 0},
+		header:  topHeader{"SERVICE": 0, "#": 1},
 		entries: []topEntries{},
 		output:  "",
 	},
@@ -49,18 +49,20 @@ var topTestCases = []struct {
 		procs:  [][]string{{"root", "1", "1", "0", "12:00", "?", "00:00:01", "/entrypoint"}},
 		header: topHeader{
 			"SERVICE": 0,
-			"UID":     1,
-			"PID":     2,
-			"PPID":    3,
-			"C":       4,
-			"STIME":   5,
-			"TTY":     6,
-			"TIME":    7,
-			"CMD":     8,
+			"#":       1,
+			"UID":     2,
+			"PID":     3,
+			"PPID":    4,
+			"C":       5,
+			"STIME":   6,
+			"TTY":     7,
+			"TIME":    8,
+			"CMD":     9,
 		},
 		entries: []topEntries{
 			{
 				"SERVICE": "simple",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "1",
 				"PPID":    "1",
@@ -72,8 +74,8 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE   UID    PID   PPID   C    STIME   TTY   TIME       CMD
-			simple    root   1     1      0    12:00   ?     00:00:01   /entrypoint
+			SERVICE   #    UID    PID   PPID   C    STIME   TTY   TIME       CMD
+			simple    1    root   1     1      0    12:00   ?     00:00:01   /entrypoint
 		`),
 	},
 	{
@@ -82,17 +84,19 @@ var topTestCases = []struct {
 		procs:  [][]string{{"root", "1", "0", "12:00", "?", "00:00:02", "/entrypoint"}},
 		header: topHeader{
 			"SERVICE": 0,
-			"UID":     1,
-			"PID":     2,
-			"C":       3,
-			"STIME":   4,
-			"TTY":     5,
-			"TIME":    6,
-			"CMD":     7,
+			"#":       1,
+			"UID":     2,
+			"PID":     3,
+			"C":       4,
+			"STIME":   5,
+			"TTY":     6,
+			"TIME":    7,
+			"CMD":     8,
 		},
 		entries: []topEntries{
 			{
 				"SERVICE": "noppid",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "1",
 				"C":       "0",
@@ -103,8 +107,8 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE   UID    PID   C    STIME   TTY   TIME       CMD
-			noppid    root   1     0    12:00   ?     00:00:02   /entrypoint
+			SERVICE   #    UID    PID   C    STIME   TTY   TIME       CMD
+			noppid    1    root   1     0    12:00   ?     00:00:02   /entrypoint
 		`),
 	},
 	{
@@ -113,19 +117,21 @@ var topTestCases = []struct {
 		procs:  [][]string{{"root", "1", "1", "1", "0", "12:00", "?", "00:00:03", "/entrypoint"}},
 		header: topHeader{
 			"SERVICE": 0,
-			"UID":     1,
-			"GID":     2,
-			"PID":     3,
-			"PPID":    4,
-			"C":       5,
-			"STIME":   6,
-			"TTY":     7,
-			"TIME":    8,
-			"CMD":     9,
+			"#":       1,
+			"UID":     2,
+			"GID":     3,
+			"PID":     4,
+			"PPID":    5,
+			"C":       6,
+			"STIME":   7,
+			"TTY":     8,
+			"TIME":    9,
+			"CMD":     10,
 		},
 		entries: []topEntries{
 			{
 				"SERVICE": "extra-hdr",
+				"#":       "1",
 				"UID":     "root",
 				"GID":     "1",
 				"PID":     "1",
@@ -138,8 +144,8 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE     UID    GID   PID   PPID   C    STIME   TTY   TIME       CMD
-			extra-hdr   root   1     1     1      0    12:00   ?     00:00:03   /entrypoint
+			SERVICE     #    UID    GID   PID   PPID   C    STIME   TTY   TIME       CMD
+			extra-hdr   1    root   1     1     1      0    12:00   ?     00:00:03   /entrypoint
 		`),
 	},
 	{
@@ -151,18 +157,20 @@ var topTestCases = []struct {
 		},
 		header: topHeader{
 			"SERVICE": 0,
-			"UID":     1,
-			"PID":     2,
-			"PPID":    3,
-			"C":       4,
-			"STIME":   5,
-			"TTY":     6,
-			"TIME":    7,
-			"CMD":     8,
+			"#":       1,
+			"UID":     2,
+			"PID":     3,
+			"PPID":    4,
+			"C":       5,
+			"STIME":   6,
+			"TTY":     7,
+			"TIME":    8,
+			"CMD":     9,
 		},
 		entries: []topEntries{
 			{
 				"SERVICE": "multiple",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "1",
 				"PPID":    "1",
@@ -174,6 +182,7 @@ var topTestCases = []struct {
 			},
 			{
 				"SERVICE": "multiple",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "123",
 				"PPID":    "1",
@@ -185,9 +194,9 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE    UID    PID   PPID   C    STIME   TTY   TIME       CMD
-			multiple   root   1     1      0    12:00   ?     00:00:04   /entrypoint
-			multiple   root   123   1      0    12:00   ?     00:00:42   sleep infinity
+			SERVICE    #    UID    PID   PPID   C    STIME   TTY   TIME       CMD
+			multiple   1    root   1     1      0    12:00   ?     00:00:04   /entrypoint
+			multiple   1    root   123   1      0    12:00   ?     00:00:42   sleep infinity
 		`),
 	},
 }
@@ -201,9 +210,13 @@ func TestRunTopCore(t *testing.T) {
 
 	for _, tc := range topTestCases {
 		summary := api.ContainerProcSummary{
-			Name:      tc.name,
+			Name:      "not used",
 			Titles:    tc.titles,
 			Processes: tc.procs,
+			Labels: map[string]string{
+				api.ServiceLabel:         tc.name,
+				api.ContainerNumberLabel: "1",
+			},
 		}
 		all = append(all, summary)
 
@@ -224,19 +237,21 @@ func TestRunTopCore(t *testing.T) {
 		header, entries := collectTop(all)
 		assert.EqualValues(t, topHeader{
 			"SERVICE": 0,
-			"UID":     1,
-			"PID":     2,
-			"PPID":    3,
-			"C":       4,
-			"STIME":   5,
-			"TTY":     6,
-			"TIME":    7,
-			"CMD":     8,
-			"GID":     9,
+			"#":       1,
+			"UID":     2,
+			"PID":     3,
+			"PPID":    4,
+			"C":       5,
+			"STIME":   6,
+			"TTY":     7,
+			"TIME":    8,
+			"CMD":     9,
+			"GID":     10,
 		}, header)
 		assert.EqualValues(t, []topEntries{
 			{
 				"SERVICE": "simple",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "1",
 				"PPID":    "1",
@@ -247,6 +262,7 @@ func TestRunTopCore(t *testing.T) {
 				"CMD":     "/entrypoint",
 			}, {
 				"SERVICE": "noppid",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "1",
 				"C":       "0",
@@ -256,6 +272,7 @@ func TestRunTopCore(t *testing.T) {
 				"CMD":     "/entrypoint",
 			}, {
 				"SERVICE": "extra-hdr",
+				"#":       "1",
 				"UID":     "root",
 				"GID":     "1",
 				"PID":     "1",
@@ -267,6 +284,7 @@ func TestRunTopCore(t *testing.T) {
 				"CMD":     "/entrypoint",
 			}, {
 				"SERVICE": "multiple",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "1",
 				"PPID":    "1",
@@ -277,6 +295,7 @@ func TestRunTopCore(t *testing.T) {
 				"CMD":     "/entrypoint",
 			}, {
 				"SERVICE": "multiple",
+				"#":       "1",
 				"UID":     "root",
 				"PID":     "123",
 				"PPID":    "1",
@@ -292,12 +311,12 @@ func TestRunTopCore(t *testing.T) {
 		err := topPrint(&buf, header, entries)
 		require.NoError(t, err)
 		assert.Equal(t, trim(`
-			SERVICE     UID    PID   PPID   C    STIME   TTY   TIME       CMD              GID
-			simple      root   1     1      0    12:00   ?     00:00:01   /entrypoint      -
-			noppid      root   1     -      0    12:00   ?     00:00:02   /entrypoint      -
-			extra-hdr   root   1     1      0    12:00   ?     00:00:03   /entrypoint      1
-			multiple    root   1     1      0    12:00   ?     00:00:04   /entrypoint      -
-			multiple    root   123   1      0    12:00   ?     00:00:42   sleep infinity   -
+			SERVICE     #    UID    PID   PPID   C    STIME   TTY   TIME       CMD              GID
+			simple      1    root   1     1      0    12:00   ?     00:00:01   /entrypoint      -
+			noppid      1    root   1     -      0    12:00   ?     00:00:02   /entrypoint      -
+			extra-hdr   1    root   1     1      0    12:00   ?     00:00:03   /entrypoint      1
+			multiple    1    root   1     1      0    12:00   ?     00:00:04   /entrypoint      -
+			multiple    1    root   123   1      0    12:00   ?     00:00:42   sleep infinity   -
 		`), buf.String())
 
 	})

--- a/cmd/compose/top_test.go
+++ b/cmd/compose/top_test.go
@@ -74,8 +74,8 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE   #    UID    PID   PPID   C    STIME   TTY   TIME       CMD
-			simple    1    root   1     1      0    12:00   ?     00:00:01   /entrypoint
+			SERVICE  #   UID   PID  PPID  C   STIME  TTY  TIME      CMD
+			simple   1   root  1    1     0   12:00  ?    00:00:01  /entrypoint
 		`),
 	},
 	{
@@ -107,8 +107,8 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE   #    UID    PID   C    STIME   TTY   TIME       CMD
-			noppid    1    root   1     0    12:00   ?     00:00:02   /entrypoint
+			SERVICE  #   UID   PID  C   STIME  TTY  TIME      CMD
+			noppid   1   root  1    0   12:00  ?    00:00:02  /entrypoint
 		`),
 	},
 	{
@@ -144,8 +144,8 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE     #    UID    GID   PID   PPID   C    STIME   TTY   TIME       CMD
-			extra-hdr   1    root   1     1     1      0    12:00   ?     00:00:03   /entrypoint
+			SERVICE    #   UID   GID  PID  PPID  C   STIME  TTY  TIME      CMD
+			extra-hdr  1   root  1    1    1     0   12:00  ?    00:00:03  /entrypoint
 		`),
 	},
 	{
@@ -194,9 +194,9 @@ var topTestCases = []struct {
 			},
 		},
 		output: trim(`
-			SERVICE    #    UID    PID   PPID   C    STIME   TTY   TIME       CMD
-			multiple   1    root   1     1      0    12:00   ?     00:00:04   /entrypoint
-			multiple   1    root   123   1      0    12:00   ?     00:00:42   sleep infinity
+			SERVICE   #   UID   PID  PPID  C   STIME  TTY  TIME      CMD
+			multiple  1   root  1    1     0   12:00  ?    00:00:04  /entrypoint
+			multiple  1   root  123  1     0   12:00  ?    00:00:42  sleep infinity
 		`),
 	},
 }
@@ -311,12 +311,12 @@ func TestRunTopCore(t *testing.T) {
 		err := topPrint(&buf, header, entries)
 		require.NoError(t, err)
 		assert.Equal(t, trim(`
-			SERVICE     #    UID    PID   PPID   C    STIME   TTY   TIME       GID   CMD
-			simple      1    root   1     1      0    12:00   ?     00:00:01   -     /entrypoint
-			noppid      1    root   1     -      0    12:00   ?     00:00:02   -     /entrypoint
-			extra-hdr   1    root   1     1      0    12:00   ?     00:00:03   1     /entrypoint
-			multiple    1    root   1     1      0    12:00   ?     00:00:04   -     /entrypoint
-			multiple    1    root   123   1      0    12:00   ?     00:00:42   -     sleep infinity
+			SERVICE    #   UID   PID  PPID  C   STIME  TTY  TIME      GID  CMD
+			simple     1   root  1    1     0   12:00  ?    00:00:01  -    /entrypoint
+			noppid     1   root  1    -     0   12:00  ?    00:00:02  -    /entrypoint
+			extra-hdr  1   root  1    1     0   12:00  ?    00:00:03  1    /entrypoint
+			multiple   1   root  1    1     0   12:00  ?    00:00:04  -    /entrypoint
+			multiple   1   root  123  1     0   12:00  ?    00:00:42  -    sleep infinity
 		`), buf.String())
 
 	})

--- a/cmd/compose/top_test.go
+++ b/cmd/compose/top_test.go
@@ -245,8 +245,8 @@ func TestRunTopCore(t *testing.T) {
 			"STIME":   6,
 			"TTY":     7,
 			"TIME":    8,
-			"CMD":     9,
-			"GID":     10,
+			"GID":     9,
+			"CMD":     10,
 		}, header)
 		assert.EqualValues(t, []topEntries{
 			{
@@ -311,12 +311,12 @@ func TestRunTopCore(t *testing.T) {
 		err := topPrint(&buf, header, entries)
 		require.NoError(t, err)
 		assert.Equal(t, trim(`
-			SERVICE     #    UID    PID   PPID   C    STIME   TTY   TIME       CMD              GID
-			simple      1    root   1     1      0    12:00   ?     00:00:01   /entrypoint      -
-			noppid      1    root   1     -      0    12:00   ?     00:00:02   /entrypoint      -
-			extra-hdr   1    root   1     1      0    12:00   ?     00:00:03   /entrypoint      1
-			multiple    1    root   1     1      0    12:00   ?     00:00:04   /entrypoint      -
-			multiple    1    root   123   1      0    12:00   ?     00:00:42   sleep infinity   -
+			SERVICE     #    UID    PID   PPID   C    STIME   TTY   TIME       GID   CMD
+			simple      1    root   1     1      0    12:00   ?     00:00:01   -     /entrypoint
+			noppid      1    root   1     -      0    12:00   ?     00:00:02   -     /entrypoint
+			extra-hdr   1    root   1     1      0    12:00   ?     00:00:03   1     /entrypoint
+			multiple    1    root   1     1      0    12:00   ?     00:00:04   -     /entrypoint
+			multiple    1    root   123   1      0    12:00   ?     00:00:42   -     sleep infinity
 		`), buf.String())
 
 	})

--- a/cmd/compose/top_test.go
+++ b/cmd/compose/top_test.go
@@ -1,0 +1,313 @@
+/*
+   Copyright 2024 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/docker/compose/v2/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var topTestCases = []struct {
+	name   string
+	titles []string
+	procs  [][]string
+
+	header  topHeader
+	entries []topEntries
+	output  string
+}{
+	{
+		name:    "noprocs",
+		titles:  []string{"UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"},
+		procs:   [][]string{},
+		header:  topHeader{"SERVICE": 0},
+		entries: []topEntries{},
+		output:  "",
+	},
+	{
+		name:   "simple",
+		titles: []string{"UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"},
+		procs:  [][]string{{"root", "1", "1", "0", "12:00", "?", "00:00:01", "/entrypoint"}},
+		header: topHeader{
+			"SERVICE": 0,
+			"UID":     1,
+			"PID":     2,
+			"PPID":    3,
+			"C":       4,
+			"STIME":   5,
+			"TTY":     6,
+			"TIME":    7,
+			"CMD":     8,
+		},
+		entries: []topEntries{
+			{
+				"SERVICE": "simple",
+				"UID":     "root",
+				"PID":     "1",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:01",
+				"CMD":     "/entrypoint",
+			},
+		},
+		output: trim(`
+			SERVICE   UID    PID   PPID   C    STIME   TTY   TIME       CMD
+			simple    root   1     1      0    12:00   ?     00:00:01   /entrypoint
+		`),
+	},
+	{
+		name:   "noppid",
+		titles: []string{"UID", "PID", "C", "STIME", "TTY", "TIME", "CMD"},
+		procs:  [][]string{{"root", "1", "0", "12:00", "?", "00:00:02", "/entrypoint"}},
+		header: topHeader{
+			"SERVICE": 0,
+			"UID":     1,
+			"PID":     2,
+			"C":       3,
+			"STIME":   4,
+			"TTY":     5,
+			"TIME":    6,
+			"CMD":     7,
+		},
+		entries: []topEntries{
+			{
+				"SERVICE": "noppid",
+				"UID":     "root",
+				"PID":     "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:02",
+				"CMD":     "/entrypoint",
+			},
+		},
+		output: trim(`
+			SERVICE   UID    PID   C    STIME   TTY   TIME       CMD
+			noppid    root   1     0    12:00   ?     00:00:02   /entrypoint
+		`),
+	},
+	{
+		name:   "extra-hdr",
+		titles: []string{"UID", "GID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"},
+		procs:  [][]string{{"root", "1", "1", "1", "0", "12:00", "?", "00:00:03", "/entrypoint"}},
+		header: topHeader{
+			"SERVICE": 0,
+			"UID":     1,
+			"GID":     2,
+			"PID":     3,
+			"PPID":    4,
+			"C":       5,
+			"STIME":   6,
+			"TTY":     7,
+			"TIME":    8,
+			"CMD":     9,
+		},
+		entries: []topEntries{
+			{
+				"SERVICE": "extra-hdr",
+				"UID":     "root",
+				"GID":     "1",
+				"PID":     "1",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:03",
+				"CMD":     "/entrypoint",
+			},
+		},
+		output: trim(`
+			SERVICE     UID    GID   PID   PPID   C    STIME   TTY   TIME       CMD
+			extra-hdr   root   1     1     1      0    12:00   ?     00:00:03   /entrypoint
+		`),
+	},
+	{
+		name:   "multiple",
+		titles: []string{"UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"},
+		procs: [][]string{
+			{"root", "1", "1", "0", "12:00", "?", "00:00:04", "/entrypoint"},
+			{"root", "123", "1", "0", "12:00", "?", "00:00:42", "sleep infinity"},
+		},
+		header: topHeader{
+			"SERVICE": 0,
+			"UID":     1,
+			"PID":     2,
+			"PPID":    3,
+			"C":       4,
+			"STIME":   5,
+			"TTY":     6,
+			"TIME":    7,
+			"CMD":     8,
+		},
+		entries: []topEntries{
+			{
+				"SERVICE": "multiple",
+				"UID":     "root",
+				"PID":     "1",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:04",
+				"CMD":     "/entrypoint",
+			},
+			{
+				"SERVICE": "multiple",
+				"UID":     "root",
+				"PID":     "123",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:42",
+				"CMD":     "sleep infinity",
+			},
+		},
+		output: trim(`
+			SERVICE    UID    PID   PPID   C    STIME   TTY   TIME       CMD
+			multiple   root   1     1      0    12:00   ?     00:00:04   /entrypoint
+			multiple   root   123   1      0    12:00   ?     00:00:42   sleep infinity
+		`),
+	},
+}
+
+// TestRunTopCore only tests the core functionality of runTop: formatting
+// and printing of the output of (api.Service).Top().
+func TestRunTopCore(t *testing.T) {
+	t.Parallel()
+
+	all := []api.ContainerProcSummary{}
+
+	for _, tc := range topTestCases {
+		summary := api.ContainerProcSummary{
+			Name:      tc.name,
+			Titles:    tc.titles,
+			Processes: tc.procs,
+		}
+		all = append(all, summary)
+
+		t.Run(tc.name, func(t *testing.T) {
+			header, entries := collectTop([]api.ContainerProcSummary{summary})
+			assert.EqualValues(t, tc.header, header)
+			assert.EqualValues(t, tc.entries, entries)
+
+			var buf bytes.Buffer
+			err := topPrint(&buf, header, entries)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.output, buf.String())
+		})
+	}
+
+	t.Run("all", func(t *testing.T) {
+		header, entries := collectTop(all)
+		assert.EqualValues(t, topHeader{
+			"SERVICE": 0,
+			"UID":     1,
+			"PID":     2,
+			"PPID":    3,
+			"C":       4,
+			"STIME":   5,
+			"TTY":     6,
+			"TIME":    7,
+			"CMD":     8,
+			"GID":     9,
+		}, header)
+		assert.EqualValues(t, []topEntries{
+			{
+				"SERVICE": "simple",
+				"UID":     "root",
+				"PID":     "1",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:01",
+				"CMD":     "/entrypoint",
+			}, {
+				"SERVICE": "noppid",
+				"UID":     "root",
+				"PID":     "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:02",
+				"CMD":     "/entrypoint",
+			}, {
+				"SERVICE": "extra-hdr",
+				"UID":     "root",
+				"GID":     "1",
+				"PID":     "1",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:03",
+				"CMD":     "/entrypoint",
+			}, {
+				"SERVICE": "multiple",
+				"UID":     "root",
+				"PID":     "1",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:04",
+				"CMD":     "/entrypoint",
+			}, {
+				"SERVICE": "multiple",
+				"UID":     "root",
+				"PID":     "123",
+				"PPID":    "1",
+				"C":       "0",
+				"STIME":   "12:00",
+				"TTY":     "?",
+				"TIME":    "00:00:42",
+				"CMD":     "sleep infinity",
+			},
+		}, entries)
+
+		var buf bytes.Buffer
+		err := topPrint(&buf, header, entries)
+		require.NoError(t, err)
+		assert.Equal(t, trim(`
+			SERVICE     UID    PID   PPID   C    STIME   TTY   TIME       CMD              GID
+			simple      root   1     1      0    12:00   ?     00:00:01   /entrypoint      -
+			noppid      root   1     -      0    12:00   ?     00:00:02   /entrypoint      -
+			extra-hdr   root   1     1      0    12:00   ?     00:00:03   /entrypoint      1
+			multiple    root   1     1      0    12:00   ?     00:00:04   /entrypoint      -
+			multiple    root   123   1      0    12:00   ?     00:00:42   sleep infinity   -
+		`), buf.String())
+
+	})
+}
+
+func trim(s string) string {
+	var out bytes.Buffer
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		out.WriteString(strings.TrimSpace(line))
+		out.WriteRune('\n')
+	}
+	return out.String()
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -521,6 +521,7 @@ type ContainerProcSummary struct {
 	Name      string
 	Processes [][]string
 	Titles    []string
+	Labels    map[string]string
 }
 
 // ImageSummary holds container image description

--- a/pkg/compose/top.go
+++ b/pkg/compose/top.go
@@ -48,6 +48,7 @@ func (s *composeService) Top(ctx context.Context, projectName string, services [
 				Name:      getCanonicalContainerName(container),
 				Processes: topContent.Processes,
 				Titles:    topContent.Titles,
+				Labels:    container.Labels,
 			}
 			return nil
 		})


### PR DESCRIPTION
**What I did**

This changes the output format of `compose top` and inlines the service container name into the table.

Previously, `compose top` had printed something like:

    <service name>
    UID    PID   ...
    root   1     ...

Now, the output looks more like this:

    SERVICE   UID    PID   ...
    <name>    root   1     ...

**Related issue**

Closes #12381 

![image](https://github.com/user-attachments/assets/fdc1fb31-60fa-4522-9f1a-51780c5a41fb)

*Baby mountain goat on rock, CC-by-sa [Shaundd](https://commons.wikimedia.org/wiki/User:Shaundd), [WP:Commons](https://commons.wikimedia.org/wiki/File:Baby_mountain_goat_on_rock.JPG)*