### PR TITLE
use the 3 latest major versions of the engine to run e2e step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,9 @@ jobs:
           - plugin
           - standalone
         engine:
-          - 25.0.5
-          - 26.1.4
-          - 27.4.1
+          - 25
+          - 26
+          - 27
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
**What I did**
Use major version of engine instead of patch releases to always use the latest published versions

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
