### PR TITLE
Allow `up --watch --prune`

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -57,6 +57,7 @@ type upOptions struct {
 	wait                  bool
 	waitTimeout           int
 	watch                 bool
+	prune                 bool
 	navigationMenu        bool
 	navigationMenuChanged bool
 }
@@ -170,6 +171,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *c
 	flags.BoolVar(&up.wait, "wait", false, "Wait for services to be running|healthy. Implies detached mode.")
 	flags.IntVar(&up.waitTimeout, "wait-timeout", 0, "Maximum duration in seconds to wait for the project to be running|healthy")
 	flags.BoolVarP(&up.watch, "watch", "w", false, "Watch source code and rebuild/refresh containers when files are updated.")
+	flags.BoolVar(&up.prune, "prune", false, "Prune dangling images on rebuild")
 	flags.BoolVar(&up.navigationMenu, "menu", false, "Enable interactive shortcuts when running attached. Incompatible with --detach. Can also be enable/disable by setting COMPOSE_MENU environment var.")
 
 	return upCmd
@@ -206,6 +208,9 @@ func validateFlags(up *upOptions, create *createOptions) error {
 	}
 	if create.noBuild && up.watch {
 		return fmt.Errorf("--no-build and --watch are incompatible")
+	}
+	if !up.watch && up.prune {
+		return fmt.Errorf("--prune can only be used with --watch")
 	}
 	return nil
 }
@@ -310,6 +315,7 @@ func runUp(
 			Wait:           upOptions.wait,
 			WaitTimeout:    timeout,
 			Watch:          upOptions.watch,
+			Prune:          upOptions.prune,
 			Services:       services,
 			NavigationMenu: upOptions.navigationMenu && ui.Mode != "plain",
 		},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -229,6 +229,7 @@ type StartOptions struct {
 	// Services passed in the command line to be started
 	Services       []string
 	Watch          bool
+	Prune          bool
 	NavigationMenu bool
 }
 

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -162,6 +162,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 			return s.watch(ctx, doneCh, project, options.Start.Services, api.WatchOptions{
 				Build: &buildOpts,
 				LogTo: options.Start.Attach,
+				Prune: options.Start.Prune,
 			})
 		})
 	}


### PR DESCRIPTION
**What I did**
Just like #11932, which added `watch --prune`, but now for the up command.

**Related issue**
#11073

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/6f1da81d-de46-48a6-8b5f-795ff15bd26e)
