### PR TITLE
When retrying to resolveOrCreateNetwork, retry with a valid network name

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1220,7 +1220,7 @@ func (s *composeService) ensureNetwork(ctx context.Context, project *types.Proje
 	if errdefs.IsConflict(err) {
 		// Maybe another execution of `docker compose up|run` created same network
 		// let's retry once
-		return s.resolveOrCreateNetwork(ctx, project, "", n)
+		return s.resolveOrCreateNetwork(ctx, project, name, n)
 	}
 	return id, err
 }


### PR DESCRIPTION
**What I did**

compose sometimes fail to start a basic stack with a network error 
`Network tmp_default was found but has incorrect label com.docker.compose.network set to "default" (expected "")`

The same compose file might succeed or fail randomly. Given the error message, when it fails the network name param is empty [here](https://github.com/docker/compose/blob/main/pkg/compose/create.go#L1249), that is very likely due to the retry that passes an empty string instead of the actual name, passed in the first invocation (and the error message indicates that resolution would succeed if the name `default` was passed as expected).

This PR passes the same name param when retrying as in the initial invocation (I might miss some context, if there was a specific reason to pass empty on the retry?)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![octupus](https://img.freepik.com/premium-photo/octopus-made-legos-is-made-legos_783884-284030.jpg?w=360)
