### PR TITLE
can't render progress concurrently with buildkit

### DIFF
--- a/pkg/progress/tty.go
+++ b/pkg/progress/tty.go
@@ -167,7 +167,7 @@ func (w *ttyWriter) print() { //nolint:gocyclo
 		_, _ = fmt.Fprint(w.out, aec.Show)
 	}()
 
-	firstLine := fmt.Sprintf("[+] %s %d/%d", w.progressTitle, numDone(w.events), w.numLines)
+	firstLine := fmt.Sprintf("[+] %s %d/%d", w.progressTitle, numDone(w.events), len(w.events))
 	if w.numLines != 0 && numDone(w.events) == w.numLines {
 		firstLine = DoneColor(firstLine)
 	}


### PR DESCRIPTION
**What I did**
removed "building" events are the progress UX collides with buildkit on terminal
only keep "built" events after all images have been built as a general status after build succeeded

**Related issue**
fixes https://github.com/docker/compose/issues/12370

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
