### PR TITLE
image can be set to a local ID, that isn't a valid docker ref

### DIFF
--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -94,12 +94,12 @@ func (s *composeService) getImageSummaries(ctx context.Context, repoTags []strin
 			tag := ""
 			repository := ""
 			ref, err := reference.ParseDockerRef(repoTag)
-			if err != nil {
-				return err
-			}
-			repository = reference.FamiliarName(ref)
-			if tagged, ok := ref.(reference.Tagged); ok {
-				tag = tagged.Tag()
+			if err == nil {
+				// ParseDockerRef will reject a local image ID
+				repository = reference.FamiliarName(ref)
+				if tagged, ok := ref.(reference.Tagged); ok {
+					tag = tagged.Tag()
+				}
 			}
 			l.Lock()
 			summary[repoTag] = api.ImageSummary{

--- a/pkg/e2e/fixtures/simple-composefile/id.yaml
+++ b/pkg/e2e/fixtures/simple-composefile/id.yaml
@@ -1,0 +1,3 @@
+services:
+  test:
+    image: ${ID:?ID variable must be set}

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -191,3 +191,18 @@ func TestUpProfile(t *testing.T) {
 	assert.Assert(t, strings.Contains(res.Combined(), `Container foo_c  Created`), res.Combined())
 	assert.Assert(t, !strings.Contains(res.Combined(), `Container bar_c  Created`), res.Combined())
 }
+
+func TestUpImageID(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "compose-e2e-up-image-id"
+
+	digest := strings.TrimSpace(c.RunDockerCmd(t, "image", "inspect", "alpine", "-f", "{{ .ID }}").Stdout())
+	_, id, _ := strings.Cut(digest, ":")
+
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "-v")
+	})
+
+	c = NewCLI(t, WithEnv(fmt.Sprintf("ID=%s", id)))
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/id.yaml", "--project-name", projectName, "up")
+}


### PR DESCRIPTION
**What I did**
`ParseDockerRef` rejects a 64-digits local image ID, whenever one can execute `docker run <ID>` without such a reference being rejected

**Related issue**
fixes https://github.com/docker/compose/issues/12443

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
