### PR TITLE
manage `watch` applied to mulitple services

### DIFF
--- a/internal/sync/shared.go
+++ b/internal/sync/shared.go
@@ -16,8 +16,6 @@ package sync
 
 import (
 	"context"
-
-	"github.com/compose-spec/compose-go/v2/types"
 )
 
 // PathMapping contains the Compose service and modified host system path.
@@ -38,5 +36,5 @@ type PathMapping struct {
 }
 
 type Syncer interface {
-	Sync(ctx context.Context, service types.ServiceConfig, paths []PathMapping) error
+	Sync(ctx context.Context, service string, paths []*PathMapping) error
 }

--- a/internal/sync/tar.go
+++ b/internal/sync/tar.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/compose-spec/compose-go/v2/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
 )
@@ -65,8 +64,8 @@ func NewTar(projectName string, client LowLevelClient) *Tar {
 	}
 }
 
-func (t *Tar) Sync(ctx context.Context, service types.ServiceConfig, paths []PathMapping) error {
-	containers, err := t.client.ContainersForService(ctx, t.projectName, service.Name)
+func (t *Tar) Sync(ctx context.Context, service string, paths []*PathMapping) error {
+	containers, err := t.client.ContainersForService(ctx, t.projectName, service)
 	if err != nil {
 		return err
 	}
@@ -77,7 +76,7 @@ func (t *Tar) Sync(ctx context.Context, service types.ServiceConfig, paths []Pat
 		if _, err := os.Stat(p.HostPath); err != nil && errors.Is(err, fs.ErrNotExist) {
 			pathsToDelete = append(pathsToDelete, p.ContainerPath)
 		} else {
-			pathsToCopy = append(pathsToCopy, p)
+			pathsToCopy = append(pathsToCopy, *p)
 		}
 	}
 

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -162,7 +162,7 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("--quiet-pull", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/quiet-pull.yaml", "down", "--rmi", "all")
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/quiet-pull.yaml", "down", "--remove-orphans", "--rmi", "all")
 		res.Assert(t, icmd.Success)
 
 		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/quiet-pull.yaml", "run", "--quiet-pull", "backend")
@@ -171,12 +171,11 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("--pull", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/pull.yaml", "down", "--rmi", "all")
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/pull.yaml", "down", "--remove-orphans", "--rmi", "all")
 		res.Assert(t, icmd.Success)
 
 		res = c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/pull.yaml", "run", "--pull", "always", "backend")
 		assert.Assert(t, strings.Contains(res.Combined(), "backend Pulling"), res.Combined())
-		assert.Assert(t, strings.Contains(res.Combined(), "Download complete"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "backend Pulled"), res.Combined())
 	})
 }

--- a/pkg/e2e/fixtures/watch/rebuild.yaml
+++ b/pkg/e2e/fixtures/watch/rebuild.yaml
@@ -1,0 +1,31 @@
+services:
+  a:
+    build:
+      dockerfile_inline: |
+        FROM nginx
+        RUN mkdir /data
+        COPY test /data/a
+    develop:
+      watch:
+        - path: test
+          action: rebuild
+  b:
+    build:
+      dockerfile_inline: |
+        FROM nginx
+        RUN mkdir /data
+        COPY test /data/b
+    develop:
+      watch:
+        - path: test
+          action: rebuild
+  c:
+    build:
+      dockerfile_inline: |
+        FROM nginx
+        RUN mkdir /data
+        COPY test /data/c
+    develop:
+      watch:
+        - path: test
+          action: rebuild

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -93,10 +93,7 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 	t.Log("wait for watch to start watching")
 	c.WaitForCondition(t, func() (bool, string) {
 		out := r.String()
-		errors := r.String()
-		return strings.Contains(out,
-				"Watch configuration"), fmt.Sprintf("'Watch configuration' not found in : \n%s\nStderr: \n%s\n", out,
-				errors)
+		return strings.Contains(out, "Watch enabled"), "watch not started"
 	}, 30*time.Second, 1*time.Second)
 
 	pn := c.RunDockerCmd(t, "inspect", containerName, "-f", "{{ .HostConfig.NetworkMode }}")
@@ -112,7 +109,7 @@ func TestRebuildOnDotEnvWithExternalNetwork(t *testing.T) {
 	t.Log("check if the container has been rebuild")
 	c.WaitForCondition(t, func() (bool, string) {
 		out := r.String()
-		if strings.Count(out, "batch complete: service["+svcName+"]") != 1 {
+		if strings.Count(out, "batch complete") != 1 {
 			return false, fmt.Sprintf("container %s was not rebuilt", containerName)
 		}
 		return true, fmt.Sprintf("container %s was rebuilt", containerName)
@@ -283,7 +280,7 @@ func doTest(t *testing.T, svcName string) {
 			return poll.Continue("%v", r.Combined())
 		}
 	}
-	poll.WaitOn(t, checkRestart(fmt.Sprintf("service %q restarted", svcName)))
+	poll.WaitOn(t, checkRestart(fmt.Sprintf("service(s) [%q] restarted", svcName)))
 	poll.WaitOn(t, checkFileContents("/app/config/file.config", "This is an updated config file"))
 
 	testComplete.Store(true)

--- a/pkg/watch/debounce.go
+++ b/pkg/watch/debounce.go
@@ -1,0 +1,73 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/compose/v2/pkg/utils"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+)
+
+const QuietPeriod = 500 * time.Millisecond
+
+// batchDebounceEvents groups identical file events within a sliding time window and writes the results to the returned
+// channel.
+//
+// The returned channel is closed when the debouncer is stopped via context cancellation or by closing the input channel.
+func BatchDebounceEvents(ctx context.Context, clock clockwork.Clock, input <-chan FileEvent) <-chan []FileEvent {
+	out := make(chan []FileEvent)
+	go func() {
+		defer close(out)
+		seen := utils.Set[FileEvent]{}
+		flushEvents := func() {
+			if len(seen) == 0 {
+				return
+			}
+			logrus.Debugf("flush: %d events %s", len(seen), seen)
+
+			events := make([]FileEvent, 0, len(seen))
+			for e := range seen {
+				events = append(events, e)
+			}
+			out <- events
+			seen = utils.Set[FileEvent]{}
+		}
+
+		t := clock.NewTicker(QuietPeriod)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.Chan():
+				flushEvents()
+			case e, ok := <-input:
+				if !ok {
+					// input channel was closed
+					flushEvents()
+					return
+				}
+				if _, ok := seen[e]; !ok {
+					seen.Add(e)
+				}
+				t.Reset(QuietPeriod)
+			}
+		}
+	}()
+	return out
+}

--- a/pkg/watch/debounce_test.go
+++ b/pkg/watch/debounce_test.go
@@ -1,0 +1,64 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"gotest.tools/v3/assert"
+)
+
+func Test_BatchDebounceEvents(t *testing.T) {
+	ch := make(chan FileEvent)
+	clock := clockwork.NewFakeClock()
+	ctx, stop := context.WithCancel(context.Background())
+	t.Cleanup(stop)
+
+	eventBatchCh := BatchDebounceEvents(ctx, clock, ch)
+	for i := 0; i < 100; i++ {
+		path := "/a"
+		if i%2 == 0 {
+			path = "/b"
+		}
+
+		ch <- FileEvent(path)
+	}
+	// we sent 100 events + the debouncer
+	clock.BlockUntil(101)
+	clock.Advance(QuietPeriod)
+	select {
+	case batch := <-eventBatchCh:
+		slices.Sort(batch)
+		assert.Equal(t, len(batch), 2)
+		assert.Equal(t, batch[0], FileEvent("/a"))
+		assert.Equal(t, batch[1], FileEvent("/b"))
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("timed out waiting for events")
+	}
+	clock.BlockUntil(1)
+	clock.Advance(QuietPeriod)
+
+	// there should only be a single batch
+	select {
+	case batch := <-eventBatchCh:
+		t.Fatalf("unexpected events: %v", batch)
+	case <-time.After(50 * time.Millisecond):
+		// channel is empty
+	}
+}

--- a/pkg/watch/notify.go
+++ b/pkg/watch/notify.go
@@ -30,19 +30,13 @@ import (
 
 var numberOfWatches = expvar.NewInt("watch.naive.numberOfWatches")
 
-type FileEvent struct {
-	path string
-}
+type FileEvent string
 
 func NewFileEvent(p string) FileEvent {
 	if !filepath.IsAbs(p) {
 		panic(fmt.Sprintf("NewFileEvent only accepts absolute paths. Actual: %s", p))
 	}
-	return FileEvent{path: p}
-}
-
-func (e FileEvent) Path() string {
-	return e.path
+	return FileEvent(p)
 }
 
 type Notify interface {
@@ -81,8 +75,8 @@ func (EmptyMatcher) MatchesEntireDir(f string) (bool, error) { return false, nil
 
 var _ PathMatcher = EmptyMatcher{}
 
-func NewWatcher(paths []string, ignore PathMatcher) (Notify, error) {
-	return newWatcher(paths, ignore)
+func NewWatcher(paths []string) (Notify, error) {
+	return newWatcher(paths)
 }
 
 const WindowsBufferSizeEnvVar = "COMPOSE_WATCH_WINDOWS_BUFFER_SIZE"


### PR DESCRIPTION
**What I did**
`watch` used to be ran _per service_ which brings race condition when a file event has impacts on multiple services.
This PR changes the implementation so we collect file events, then check all services for watch rules matching update, and eventually apply required actions.

Updated logic is :
- create a single `watcher` for the paths declared by all services in project
- debounce raw filesystem event for batch processing
- select watch rule(s) to match updated paths; apply ignore filter _by rule_ (as distinct service may declare distinct ignores)
- apply changes to services and paths impacted

**Related issue**
closes https://github.com/docker/compose/issues/12427

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/97cf302b-8be2-4301-aaec-11be9a49cd81)
