### PR TITLE
Properly handle "builtin" seccomp profile

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -486,7 +486,7 @@ func parseSecurityOpts(p *types.Project, securityOpts []string) ([]string, bool,
 				return securityOpts, false, fmt.Errorf("Invalid security-opt: %q", opt)
 			}
 		}
-		if con[0] == "seccomp" && con[1] != "unconfined" {
+		if con[0] == "seccomp" && con[1] != "unconfined" && con[1] != "builtin" {
 			f, err := os.ReadFile(p.RelativePath(con[1]))
 			if err != nil {
 				return securityOpts, false, fmt.Errorf("opening seccomp profile (%s) failed: %w", con[1], err)


### PR DESCRIPTION
Like in CLI [1] the "builtin" seccomp profile should be handled the same
as "unconfined".

[1] https://github.com/docker/cli/blob/f4a68da19595d64c50b0bbc2b1f15e645943ed82/cli/command/container/opts.go#L929
