### PR TITLE
ci: fix provenance for binaries and generate sbom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,25 @@ jobs:
         with:
           source: .
           targets: release
+          provenance: mode=max
+          sbom: true
           set: |
             *.platform=${{ matrix.platform }}
             *.cache-from=type=gha,scope=binary-${{ env.PLATFORM_PAIR }}
             *.cache-to=type=gha,scope=binary-${{ env.PLATFORM_PAIR }},mode=max
+      -
+        name: Rename provenance and sbom
+        working-directory: ./bin/release
+        run: |
+          binname=$(find . -name 'docker-compose-*')
+          filename=$(basename "$binname" | sed -E 's/\.exe$//')
+          mv "provenance.json" "${filename}.provenance.json"
+          mv "sbom-binary.spdx.json" "${filename}.sbom.json"
+          find . -name 'sbom*.json' -exec rm {} \;
+      -
+        name: List artifacts
+        run: |
+          tree -nh ./bin/release
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -283,7 +298,11 @@ jobs:
           find . -type f -print0 | sort -z | xargs -r0 shasum -a 256 -b | sed 's# \*\./# *#' > $RUNNER_TEMP/checksums.txt
           shasum -a 256 -U -c $RUNNER_TEMP/checksums.txt
           mv $RUNNER_TEMP/checksums.txt .
-          cat checksums.txt | while read sum file; do echo "$sum $file" > ${file#\*}.sha256; done
+          cat checksums.txt | while read sum file; do
+            if [[ "${file#\*}" == docker-compose-* && "${file#\*}" != *.provenance.json && "${file#\*}" != *.sbom.json ]]; then
+              echo "$sum $file" > ${file#\*}.sha256
+            fi
+          done
       -
         name: License
         run: cp packaging/* ./bin/release/


### PR DESCRIPTION
**What I did**

Generated provenance for binaries that are pushed to GitHub Releases is overriden by the last binary when merged in release job: https://github.com/docker/compose/releases/tag/v2.32.4

![image](https://github.com/user-attachments/assets/4dbb17bc-89de-4253-b7d7-0e0eb2035fd6)

There should be a provenance for each binary similar to buildx: https://github.com/docker/buildx/releases/tag/v0.19.3

![image](https://github.com/user-attachments/assets/556eb4b7-9638-4597-9957-3092ea4d82fd)

SBOM generation is also not enabled, I think this is an oversight in the workflow because we have it enabled in the Dockerfile: https://github.com/docker/compose/blob/489fe9cf021636d5b4f88e3f924a77bf6e26a6ee/Dockerfile#L181-L182

Result: https://github.com/docker/compose/actions/runs/12843628138/job/35815820312#step:6:5

```
 [4.0K]  ./bin/release
├── [ 300]  LICENSE
├── [3.3K]  checksums.txt
├── [ 60M]  docker-compose-darwin-aarch64
├── [ 49K]  docker-compose-darwin-aarch64.provenance.json
├── [358K]  docker-compose-darwin-aarch64.sbom.json
├── [  96]  docker-compose-darwin-aarch64.sha256
├── [ 62M]  docker-compose-darwin-x86_64
├── [ 49K]  docker-compose-darwin-x86_64.provenance.json
├── [358K]  docker-compose-darwin-x86_64.sbom.json
├── [  95]  docker-compose-darwin-x86_64.sha256
├── [ 60M]  docker-compose-linux-aarch64
├── [ 49K]  docker-compose-linux-aarch64.provenance.json
├── [358K]  docker-compose-linux-aarch64.sbom.json
├── [  95]  docker-compose-linux-aarch64.sha256
├── [ 58M]  docker-compose-linux-armv6
├── [ 49K]  docker-compose-linux-armv6.provenance.json
├── [358K]  docker-compose-linux-armv6.sbom.json
├── [  93]  docker-compose-linux-armv6.sha256
├── [ 58M]  docker-compose-linux-armv7
├── [ 49K]  docker-compose-linux-armv7.provenance.json
├── [358K]  docker-compose-linux-armv7.sbom.json
├── [  93]  docker-compose-linux-armv7.sha256
├── [ 62M]  docker-compose-linux-ppc64le
├── [ 49K]  docker-compose-linux-ppc64le.provenance.json
├── [358K]  docker-compose-linux-ppc64le.sbom.json
├── [  95]  docker-compose-linux-ppc64le.sha256
├── [ 59M]  docker-compose-linux-riscv64
├── [ 49K]  docker-compose-linux-riscv64.provenance.json
├── [358K]  docker-compose-linux-riscv64.sbom.json
├── [  95]  docker-compose-linux-riscv64.sha256
├── [ 66M]  docker-compose-linux-s390x
├── [ 49K]  docker-compose-linux-s390x.provenance.json
├── [358K]  docker-compose-linux-s390x.sbom.json
├── [  93]  docker-compose-linux-s390x.sha256
├── [ 62M]  docker-compose-linux-x86_64
├── [ 49K]  docker-compose-linux-x86_64.provenance.json
├── [358K]  docker-compose-linux-x86_64.sbom.json
├── [  94]  docker-compose-linux-x86_64.sha256
├── [ 60M]  docker-compose-windows-aarch64.exe
├── [ 101]  docker-compose-windows-aarch64.exe.sha256
├── [ 49K]  docker-compose-windows-aarch64.provenance.json
├── [360K]  docker-compose-windows-aarch64.sbom.json
├── [ 63M]  docker-compose-windows-x86_64.exe
├── [ 100]  docker-compose-windows-x86_64.exe.sha256
├── [ 49K]  docker-compose-windows-x86_64.provenance.json
└── [360K]  docker-compose-windows-x86_64.sbom.json
```