### PR TITLE
support additional_context reference to another service

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -68,17 +68,16 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 		uiMode = "rawjson"
 	}
 	return api.BuildOptions{
-		Pull:          opts.pull,
-		Push:          opts.push,
-		Progress:      uiMode,
-		Args:          types.NewMappingWithEquals(opts.args),
-		NoCache:       opts.noCache,
-		Quiet:         opts.quiet,
-		Services:      services,
-		Deps:          opts.deps,
-		SSHs:          SSHKeys,
-		Builder:       builderName,
-		Compatibility: opts.Compatibility,
+		Pull:     opts.pull,
+		Push:     opts.push,
+		Progress: uiMode,
+		Args:     types.NewMappingWithEquals(opts.args),
+		NoCache:  opts.noCache,
+		Quiet:    opts.quiet,
+		Services: services,
+		Deps:     opts.deps,
+		SSHs:     SSHKeys,
+		Builder:  builderName,
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.4.7
+	github.com/compose-spec/compose-go/v2 v2.4.8-0.20250130174723-77ab539e4f3f
 	github.com/containerd/containerd/v2 v2.0.2
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.4.7 h1:WNpz5bIbKG+G+w9pfu72B1ZXr+Og9jez8TMEo8ecXPk=
-github.com/compose-spec/compose-go/v2 v2.4.7/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
+github.com/compose-spec/compose-go/v2 v2.4.8-0.20250130174723-77ab539e4f3f h1:turCjSVHj+0P+G6kuRsJfhhYzp1ULfTv7GVzv1dgIHQ=
+github.com/compose-spec/compose-go/v2 v2.4.8-0.20250130174723-77ab539e4f3f/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
 github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGDJ9kip0=
 github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2WzJmticMgVuz0=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -155,8 +155,6 @@ type BuildOptions struct {
 	Memory int64
 	// Builder name passed in the command line
 	Builder string
-	// Compatibility let compose run with best backward compatibility
-	Compatibility bool
 }
 
 // Apply mutates project according to build options

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -271,14 +271,30 @@ func TestBuildImageDependencies(t *testing.T) {
 	t.Run("ClassicBuilder", func(t *testing.T) {
 		cli := NewCLI(t, WithEnv(
 			"DOCKER_BUILDKIT=0",
+			"COMPOSE_FILE=./fixtures/build-dependencies/classic.yaml",
+		))
+		doTest(t, cli)
+	})
+
+	t.Run("BuildKit by dependency order", func(t *testing.T) {
+		cli := NewCLI(t, WithEnv(
+			"DOCKER_BUILDKIT=1",
+			"COMPOSE_FILE=./fixtures/build-dependencies/classic.yaml",
+		))
+		doTest(t, cli)
+	})
+
+	t.Run("BuildKit by additional contexts", func(t *testing.T) {
+		cli := NewCLI(t, WithEnv(
+			"DOCKER_BUILDKIT=1",
 			"COMPOSE_FILE=./fixtures/build-dependencies/compose.yaml",
 		))
 		doTest(t, cli)
 	})
 
-	t.Run("BuildKit", func(t *testing.T) {
+	t.Run("Bake by additional contexts", func(t *testing.T) {
 		cli := NewCLI(t, WithEnv(
-			"DOCKER_BUILDKIT=1",
+			"DOCKER_BUILDKIT=1", "COMPOSE_BAKE=1",
 			"COMPOSE_FILE=./fixtures/build-dependencies/compose.yaml",
 		))
 		doTest(t, cli)

--- a/pkg/e2e/fixtures/build-dependencies/classic.yaml
+++ b/pkg/e2e/fixtures/build-dependencies/classic.yaml
@@ -7,8 +7,8 @@ services:
       dockerfile: base.dockerfile
   service:
     init: true
+    depends_on:
+      - base
     build:
       context: .
-      additional_contexts:
-        base: "service:base"
       dockerfile: service.dockerfile


### PR DESCRIPTION
- classic builder doesn't support additional context
- buildkit builder detects `service:` prefix in contexts and builds images in order (in addition to runtime dependencies, to preserve backward compatibility)
- bake builder delegates to `buildx bake` with a named context for service's target

```
$ COMPOSE_BAKE=false docker compose build
INFO[0000] additional_context with "service:"" is better supported when delegating build go bake. Set COMPOSE_BAKE=true 
[+] Building 2.0s (16/16) FINISHED                                                                                                       docker:desktop-linux
 => [a internal] load build definition from Dockerfile.a                                                                                                 0.0s
...
 => => naming to docker.io/library/b:latest                                                                                                              0.0s
 => => unpacking to docker.io/library/b:latest                                                                                                           0.0s
 => [b] resolving provenance for metadata file                                                                                                           0.0s
[+] Building 2/2
 ✔ a  Built                                                                                                                                              0.0s 
 ✔ b  Built  
```