### PR TITLE
Publish warn display env vars

### DIFF
--- a/cmd/compose/publish.go
+++ b/cmd/compose/publish.go
@@ -30,6 +30,7 @@ type publishOptions struct {
 	resolveImageDigests bool
 	ociVersion          string
 	withEnvironment     bool
+	assumeYes           bool
 }
 
 func publishCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
@@ -48,6 +49,7 @@ func publishCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Servic
 	flags.BoolVar(&opts.resolveImageDigests, "resolve-image-digests", false, "Pin image tags to digests")
 	flags.StringVar(&opts.ociVersion, "oci-version", "", "OCI image/artifact specification version (automatically determined by default)")
 	flags.BoolVar(&opts.withEnvironment, "with-env", false, "Include environment variables in the published OCI artifact")
+	flags.BoolVarP(&opts.assumeYes, "y", "y", false, `Assume "yes" as answer to all prompts`)
 
 	return cmd
 }
@@ -62,5 +64,6 @@ func runPublish(ctx context.Context, dockerCli command.Cli, backend api.Service,
 		ResolveImageDigests: opts.resolveImageDigests,
 		OCIVersion:          api.OCIVersion(opts.ociVersion),
 		WithEnvironment:     opts.withEnvironment,
+		AssumeYes:           opts.assumeYes,
 	})
 }

--- a/docs/reference/compose_alpha_publish.md
+++ b/docs/reference/compose_alpha_publish.md
@@ -11,6 +11,7 @@ Publish compose application
 | `--oci-version`           | `string` |         | OCI image/artifact specification version (automatically determined by default) |
 | `--resolve-image-digests` | `bool`   |         | Pin image tags to digests                                                      |
 | `--with-env`              | `bool`   |         | Include environment variables in the published OCI artifact                    |
+| `-y`, `--y`               | `bool`   |         | Assume "yes" as answer to all prompts                                          |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_alpha_publish.yaml
+++ b/docs/reference/docker_compose_alpha_publish.yaml
@@ -35,6 +35,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: "y"
+      shorthand: "y"
+      value_type: bool
+      default_value: "false"
+      description: Assume "yes" as answer to all prompts
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -423,6 +423,7 @@ const (
 type PublishOptions struct {
 	ResolveImageDigests bool
 	WithEnvironment     bool
+	AssumeYes           bool
 
 	OCIVersion OCIVersion
 }

--- a/pkg/e2e/fixtures/publish/compose-multi-env-config.yml
+++ b/pkg/e2e/fixtures/publish/compose-multi-env-config.yml
@@ -1,0 +1,11 @@
+services:
+  serviceA:
+    image: "alpine:3.12"
+    environment:
+      - "FOO=bar"
+  serviceB:
+    image: "alpine:3.12"
+    env_file:
+      - publish.env
+    environment:
+      - "BAR=baz"

--- a/pkg/e2e/fixtures/publish/publish.env
+++ b/pkg/e2e/fixtures/publish/publish.env
@@ -1,1 +1,2 @@
 FOO=bar
+QUIX=

--- a/pkg/e2e/publish_test.go
+++ b/pkg/e2e/publish_test.go
@@ -31,26 +31,80 @@ func TestPublishChecks(t *testing.T) {
 	t.Run("publish error environment", func(t *testing.T) {
 		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/publish/compose-environment.yml",
 			"-p", projectName, "alpha", "publish", "test/test")
-		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `service "serviceA" has environment variable(s) declared. To avoid leaking sensitive data,`})
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `service "serviceA" has environment variable(s) declared.
+To avoid leaking sensitive data,`})
 	})
 
 	t.Run("publish error env_file", func(t *testing.T) {
 		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/publish/compose-env-file.yml",
 			"-p", projectName, "alpha", "publish", "test/test")
-		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `service "serviceA" has env_file declared. To avoid leaking sensitive data,`})
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `service "serviceA" has env_file declared.
+service "serviceA" has environment variable(s) declared.
+To avoid leaking sensitive data,`})
+	})
+
+	t.Run("publish multiple errors env_file and environment", func(t *testing.T) {
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/publish/compose-multi-env-config.yml",
+			"-p", projectName, "alpha", "publish", "test/test")
+		// we don't in which order the services will be loaded, so we can't predict the order of the error messages
+		assert.Assert(t, strings.Contains(res.Combined(), `service "serviceB" has env_file declared.`), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), `service "serviceB" has environment variable(s) declared.`), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), `service "serviceA" has environment variable(s) declared.`), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), `To avoid leaking sensitive data, you must either explicitly allow the sending of environment variables by using the --with-env flag,
+or remove sensitive data from your Compose configuration
+`), res.Combined())
 	})
 
 	t.Run("publish success environment", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/publish/compose-environment.yml",
-			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "--dry-run")
+			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "-y", "--dry-run")
 		assert.Assert(t, strings.Contains(res.Combined(), "test/test publishing"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "test/test published"), res.Combined())
 	})
 
 	t.Run("publish success env_file", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/publish/compose-env-file.yml",
-			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "--dry-run")
+			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "-y", "--dry-run")
 		assert.Assert(t, strings.Contains(res.Combined(), "test/test publishing"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "test/test published"), res.Combined())
+	})
+
+	t.Run("publish approve validation message", func(t *testing.T) {
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/publish/compose-env-file.yml",
+			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "--dry-run")
+		cmd.Stdin = strings.NewReader("y\n")
+		res := icmd.RunCmd(cmd)
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		assert.Assert(t, strings.Contains(res.Combined(), "Are you ok to publish these environment variables? [y/N]:"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "test/test publishing"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "test/test published"), res.Combined())
+	})
+
+	t.Run("publish refuse validation message", func(t *testing.T) {
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/publish/compose-env-file.yml",
+			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "--dry-run")
+		cmd.Stdin = strings.NewReader("n\n")
+		res := icmd.RunCmd(cmd)
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		assert.Assert(t, strings.Contains(res.Combined(), "Are you ok to publish these environment variables? [y/N]:"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "test/test publishing"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "test/test published"), res.Combined())
+	})
+
+	t.Run("publish list env variables", func(t *testing.T) {
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/publish/compose-multi-env-config.yml",
+			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "--dry-run")
+		cmd.Stdin = strings.NewReader("n\n")
+		res := icmd.RunCmd(cmd)
+		res.Assert(t, icmd.Expected{ExitCode: 0})
+		assert.Assert(t, strings.Contains(res.Combined(), `you are about to publish environment variables within your OCI artifact.
+please double check that you are not leaking sensitive data`), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), `Service/Config  serviceA
+FOO=bar`), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), `Service/Config  serviceB`), res.Combined())
+		// we don't know in which order the env variables will be loaded
+		assert.Assert(t, strings.Contains(res.Combined(), `FOO=bar`), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), `BAR=baz`), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), `QUIX=`), res.Combined())
 	})
 }


### PR DESCRIPTION
**What I did**
Add a warning message listing the env variables and asking for confirmation before publishing a Compose configuration with environment variables

Also added a `--force`/`-f` flag to force the publish without asking for confirmation


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

https://docker.atlassian.net/browse/COMP-875

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/bf68a709-a10c-4a0c-b0cd-5e350f8ba45d)
