### PR TITLE
Fix bake

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -68,16 +68,17 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 		uiMode = "rawjson"
 	}
 	return api.BuildOptions{
-		Pull:     opts.pull,
-		Push:     opts.push,
-		Progress: uiMode,
-		Args:     types.NewMappingWithEquals(opts.args),
-		NoCache:  opts.noCache,
-		Quiet:    opts.quiet,
-		Services: services,
-		Deps:     opts.deps,
-		SSHs:     SSHKeys,
-		Builder:  builderName,
+		Pull:          opts.pull,
+		Push:          opts.push,
+		Progress:      uiMode,
+		Args:          types.NewMappingWithEquals(opts.args),
+		NoCache:       opts.noCache,
+		Quiet:         opts.quiet,
+		Services:      services,
+		Deps:          opts.deps,
+		SSHs:          SSHKeys,
+		Builder:       builderName,
+		Compatibility: opts.Compatibility,
 	}, nil
 }
 

--- a/cmd/compose/create_test.go
+++ b/cmd/compose/create_test.go
@@ -40,7 +40,9 @@ func TestRunCreate(t *testing.T) {
 	)
 
 	createOpts := createOptions{}
-	buildOpts := buildOptions{}
+	buildOpts := buildOptions{
+		ProjectOptions: &ProjectOptions{},
+	}
 	project := sampleProject()
 	err := runCreate(ctx, nil, backend, createOpts, buildOpts, project, nil)
 	require.NoError(t, err)
@@ -58,7 +60,9 @@ func TestRunCreate_Build(t *testing.T) {
 	createOpts := createOptions{
 		Build: true,
 	}
-	buildOpts := buildOptions{}
+	buildOpts := buildOptions{
+		ProjectOptions: &ProjectOptions{},
+	}
 	project := sampleProject()
 	err := runCreate(ctx, nil, backend, createOpts, buildOpts, project, nil)
 	require.NoError(t, err)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -155,6 +155,8 @@ type BuildOptions struct {
 	Memory int64
 	// Builder name passed in the command line
 	Builder string
+	// Compatibility let compose run with best backward compatibility
+	Compatibility bool
 }
 
 // Apply mutates project according to build options


### PR DESCRIPTION
**What I did**
fix build delegation to bake for corner-cases detected on https://github.com/docker/compose/pull/12501

ability to build service in dependency order is preserved when `--compatibility` is set, as it would be better imho to have explicit support for this by https://github.com/docker/compose/pull/12485

see tests running on https://github.com/docker/compose/pull/12501 (some will need to be fixed as output isn't the same vs buildkit)