### PR TITLE
fix: Revert user-agent for docker cli client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v2/cmd/cmdtrace"
-	"github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -47,8 +46,6 @@ func pluginMain() {
 			if err := plugin.PersistentPreRunE(cmd, args); err != nil {
 				return err
 			}
-			// compose-specific initialization
-			dockerCliPostInitialize(dockerCli)
 
 			if err := cmdtrace.Setup(cmd, dockerCli, os.Args[1:]); err != nil {
 				logrus.Debugf("failed to enable tracing: %v", err)
@@ -73,22 +70,6 @@ func pluginMain() {
 			Vendor:        "Docker Inc.",
 			Version:       internal.Version,
 		})
-}
-
-// dockerCliPostInitialize performs Compose-specific configuration for the
-// command.Cli instance provided by the plugin.Run() initialization.
-//
-// NOTE: This must be called AFTER plugin.PersistentPreRunE.
-func dockerCliPostInitialize(dockerCli command.Cli) {
-	// HACK(milas): remove once docker/cli#4574 is merged; for now,
-	// set it in a rather roundabout way by grabbing the underlying
-	// concrete client and manually invoking an option on it
-	_ = dockerCli.Apply(func(cli *command.DockerCli) error {
-		if mobyClient, ok := cli.Client().(*client.Client); ok {
-			_ = client.WithUserAgent("compose/" + internal.Version)(mobyClient)
-		}
-		return nil
-	})
 }
 
 func main() {


### PR DESCRIPTION
**What I did**
Removed custom user-agent for docker cli client(that was added within this [PR](https://github.com/docker/compose/pull/11333)), because docker docker desktop's does specific logic depending on the user agent. The latest docker compose takes 3 seconds to do a request to the docker daemon.  
More details here https://github.com/docker/for-mac/issues/7575#issuecomment-2629044992

I also tried the ping method(internal/desktop/client.go:78) with the new user agent and it works fine, so decided to left it as is.

**Related issue**
https://github.com/docker/compose/issues/12511


p.s. I'm not sure should we change logic here or the docker desktop should start accepting the new user-agent, feel free to close this PR in case of the second case

@milas fyi
