### PR TITLE
add global flag to define download directory for remote configuration (oci & git)

### DIFF
--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -102,6 +102,15 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: download-dir
+      value_type: string
+      description: Directory to store OCI or GIT Compose configurations
+      deprecated: false
+      hidden: true
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: dry-run
       value_type: bool
       default_value: "false"

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -118,3 +118,23 @@ func EncompassingPaths(paths []string) []string {
 	}
 	return result
 }
+
+func GetAbsPath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, path[1:]), nil
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(wd, path), nil
+}


### PR DESCRIPTION
**What I did**
Add a `--download-dir` flag to choose the directory were remote configurations (OCI or git) will be downloaded
This flag throws an error if there is no `-f` or `--file` mentioning `oci://` or `git://` resources. 

The flag is hidden for now

**Related issue**
https://docker.atlassian.net/browse/APCLI-881

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/b81fdbf8-d14f-471e-ab21-86b900bf84ea)
