### PR TITLE
don't send raw os.Args to opentelemetry but a pseudo command line

### DIFF
--- a/cmd/cmdtrace/cmd_span.go
+++ b/cmd/cmdtrace/cmd_span.go
@@ -55,7 +55,6 @@ func Setup(cmd *cobra.Command, dockerCli command.Cli, args []string) error {
 		ctx,
 		"cli/"+strings.Join(commandName(cmd), "-"),
 	)
-	cmdSpan.SetAttributes(attribute.StringSlice("cli.args", args))
 	cmdSpan.SetAttributes(attribute.StringSlice("cli.flags", getFlags(cmd.Flags())))
 
 	cmd.SetContext(ctx)


### PR DESCRIPTION
**What I did**

removed `cli.args` telemetry attribute as raw os.Args is hardly comparable between executions. We already provide compose command as `cli/command` and active flags as `cli.flags`

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
