### PR TITLE
Test commandName subcommand order

### DIFF
--- a/cmd/cmdtrace/cmd_span.go
+++ b/cmd/cmdtrace/cmd_span.go
@@ -114,13 +114,14 @@ func wrapRunE(c *cobra.Command, cmdSpan trace.Span, tracingShutdown tracing.Shut
 	}
 }
 
-// commandName returns the path components for a given command.
+// commandName returns the path components for a given command,
+// in reverse alphabetical order for consistent usage metrics.
 //
 // The root Compose command and anything before (i.e. "docker")
 // are not included.
 //
 // For example:
-//   - docker compose alpha watch -> [alpha, watch]
+//   - docker compose alpha watch -> [watch, alpha]
 //   - docker-compose up -> [up]
 func commandName(cmd *cobra.Command) []string {
 	var name []string


### PR DESCRIPTION
**What I did**

Previously, when the root CLI span `cli/<cmd>` was named, the subcommand path was returned in **reverse alphabetical order** instead of **CLI order**, contradicting the comment above the function.

**edit:** Reverted to the original sorting and updated test and function comment to clarify intended behaviour.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![w460](https://github.com/user-attachments/assets/88b1b8f8-e871-4220-85f9-a0ba8b3308ab)

