### PR TITLE
gha: add docker engine v28.x to the test-matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
         engine:
           - 26
           - 27
+          - 28
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
currently v28.0.0-rc.1; https://github.com/moby/moby/releases/tag/v28.0.0-rc.1

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
