### PR TITLE
Update ls --quiet help description

### DIFF
--- a/cmd/compose/list.go
+++ b/cmd/compose/list.go
@@ -50,7 +50,7 @@ func listCommand(dockerCli command.Cli, backend api.Service) *cobra.Command {
 		ValidArgsFunction: noCompletion(),
 	}
 	lsCmd.Flags().StringVar(&lsOpts.Format, "format", "table", "Format the output. Values: [table | json]")
-	lsCmd.Flags().BoolVarP(&lsOpts.Quiet, "quiet", "q", false, "Only display IDs")
+	lsCmd.Flags().BoolVarP(&lsOpts.Quiet, "quiet", "q", false, "Only display project names")
 	lsCmd.Flags().Var(&lsOpts.Filter, "filter", "Filter output based on conditions provided")
 	lsCmd.Flags().BoolVarP(&lsOpts.All, "all", "a", false, "Show all stopped Compose projects")
 

--- a/docs/reference/compose_ls.md
+++ b/docs/reference/compose_ls.md
@@ -11,7 +11,7 @@ Lists running Compose projects
 | `--dry-run`     | `bool`   |         | Execute command in dry run mode            |
 | `--filter`      | `filter` |         | Filter output based on conditions provided |
 | `--format`      | `string` | `table` | Format the output. Values: [table \| json] |
-| `-q`, `--quiet` | `bool`   |         | Only display IDs                           |
+| `-q`, `--quiet` | `bool`   |         | Only display project names                 |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_ls.yaml
+++ b/docs/reference/docker_compose_ls.yaml
@@ -39,7 +39,7 @@ options:
       shorthand: q
       value_type: bool
       default_value: "false"
-      description: Only display IDs
+      description: Only display project names
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
**What I did**

`docker compose ls --help` claimed that `--quiet` displays IDs, but actually prints project names. Updated the help text to accurately reflect the output.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![owl-fly-silently-5](https://github.com/user-attachments/assets/bdf2b143-6ac0-46ad-812d-25683afd3468)

