### PR TITLE
go.mod: remove toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/docker/compose/v2
 
 go 1.22.10
 
-toolchain go1.23.4
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
looks to have accidentally made its way in https://github.com/docker/compose/commit/a42a04dfe8d2837a9efc500a34748f48cc2d40be

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
