### PR TITLE
Fix pull --parallel and --no-parallel deprecation warnings missing

### DIFF
--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -48,12 +48,15 @@ func pullCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) 
 	cmd := &cobra.Command{
 		Use:   "pull [OPTIONS] [SERVICE...]",
 		Short: "Pull service images",
-		PreRunE: Adapt(func(ctx context.Context, args []string) error {
-			if opts.noParallel {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("no-parallel") {
 				fmt.Fprint(os.Stderr, aec.Apply("option '--no-parallel' is DEPRECATED and will be ignored.\n", aec.RedF))
 			}
+			if cmd.Flags().Changed("parallel") {
+				fmt.Fprint(os.Stderr, aec.Apply("option '--parallel' is DEPRECATED and will be ignored.\n", aec.RedF))
+			}
 			return nil
-		}),
+		},
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runPull(ctx, dockerCli, backend, opts, args)
 		}),
@@ -64,7 +67,7 @@ func pullCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) 
 	cmd.Flags().BoolVar(&opts.includeDeps, "include-deps", false, "Also pull services declared as dependencies")
 	cmd.Flags().BoolVar(&opts.parallel, "parallel", true, "DEPRECATED pull multiple images in parallel")
 	flags.MarkHidden("parallel") //nolint:errcheck
-	cmd.Flags().BoolVar(&opts.parallel, "no-parallel", true, "DEPRECATED disable parallel pulling")
+	cmd.Flags().BoolVar(&opts.noParallel, "no-parallel", true, "DEPRECATED disable parallel pulling")
 	flags.MarkHidden("no-parallel") //nolint:errcheck
 	cmd.Flags().BoolVar(&opts.ignorePullFailures, "ignore-pull-failures", false, "Pull what it can and ignores images with pull failures")
 	cmd.Flags().BoolVar(&opts.noBuildable, "ignore-buildable", false, "Ignore images that can be built")


### PR DESCRIPTION
**What I did**

I believe `--no-parallel` was mistakenly bound to `opts.parallel` and as a result, the deprecation warning in the PreRunE hook was never printed. Fixed the binding, and added a matching deprecation warning for `--parallel`.

Before (No deprecation warnings in stderr):
```yaml
# compose.yaml
services:
  app:
    image: nginx:latest
```
```
$ docker compose pull --parallel=false
[+] Pulling 1/1
 ✔ app Pulled

$ docker compose pull --no-parallel
[+] Pulling 1/1
 ✔ app Pulled
```

After:
```
$ ./docker-compose pull --parallel=false
option '--parallel' is DEPRECATED and will be ignored.
[+] Pulling 1/1
 ✔ app Pulled

$ ./docker-compose pull --no-parallel
option '--no-parallel' is DEPRECATED and will be ignored.
[+] Pulling 1/1
 ✔ app Pulled
```
