### PR TITLE
Link to configuration file docs

### DIFF
--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -67,7 +67,7 @@ Define and run multi-container applications with Docker
 ## Examples
 
 ### Use `-f` to specify the name and path of one or more Compose files
-Use the `-f` flag to specify the location of a Compose configuration file.
+Use the `-f` flag to specify the location of a Compose [configuration file](/reference/compose-file/).
 
 #### Specifying multiple Compose files
 You can supply multiple `-f` configuration files. When you supply multiple files, Compose combines them into a single

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -229,7 +229,7 @@ options:
       swarm: false
 examples: |-
     ### Use `-f` to specify the name and path of one or more Compose files
-    Use the `-f` flag to specify the location of a Compose configuration file.
+    Use the `-f` flag to specify the location of a Compose [configuration file](/reference/compose-file/).
 
     #### Specifying multiple Compose files
     You can supply multiple `-f` configuration files. When you supply multiple files, Compose combines them into a single


### PR DESCRIPTION
**What I did**
Added a link from the [compose command docs](https://docs.docker.com/reference/cli/docker/compose/#examples) to the [config file docs](https://docs.docker.com/reference/compose-file/) to improve clarity and ease of finding related docs.

**Related issue**
Closes #12526 

A lynx:
![220px-Lynx_lynx_poing-1084623192](https://github.com/user-attachments/assets/6a565c4c-5d8b-4c36-8061-3a7b1214209f)

