### PR TITLE
don't display bake suggestion when using --progress with quiet or json option

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -139,7 +139,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		w     *xprogress.Printer
 	)
 	if buildkitEnabled {
-		if hints.Enabled() {
+		if hints.Enabled() && progress.Mode != progress.ModeQuiet && progress.Mode != progress.ModeJSON {
 			suggest.Do(func() {
 				fmt.Fprintln(s.dockerCli.Out(), bakeSuggest) //nolint:errcheck
 			})


### PR DESCRIPTION
**What I did**
To avoid breaking potential json parting and respect `quiet` option of progress mode, I removed bake suggestion's print

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
