### PR TITLE
add support for gw_priority, enable_ipv4 (requires docker v28.0)

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -443,6 +443,7 @@ func createEndpointSettings(p *types.Project, service types.ServiceConfig, servi
 		ipv6Address string
 		macAddress  string
 		driverOpts  types.Options
+		gwPriority  int
 	)
 	if config != nil {
 		ipv4Address = config.Ipv4Address
@@ -454,6 +455,7 @@ func createEndpointSettings(p *types.Project, service types.ServiceConfig, servi
 		}
 		macAddress = config.MacAddress
 		driverOpts = config.DriverOpts
+		gwPriority = config.GatewayPriority
 	}
 	return &network.EndpointSettings{
 		Aliases:     getAliases(p, service, serviceIndex, config, useNetworkAliases),
@@ -463,6 +465,7 @@ func createEndpointSettings(p *types.Project, service types.ServiceConfig, servi
 		IPAMConfig:  ipam,
 		MacAddress:  macAddress,
 		DriverOpts:  driverOpts,
+		GwPriority:  gwPriority,
 	}
 }
 
@@ -1325,6 +1328,7 @@ func (s *composeService) resolveOrCreateNetwork(ctx context.Context, project *ty
 		Attachable: n.Attachable,
 		IPAM:       ipam,
 		EnableIPv6: n.EnableIPv6,
+		EnableIPv4: n.EnableIPv4,
 	}
 
 	if n.Ipam.Driver != "" || len(n.Ipam.Config) > 0 {
@@ -1344,6 +1348,7 @@ func (s *composeService) resolveOrCreateNetwork(ctx context.Context, project *ty
 		}
 		createOpts.IPAM.Config = append(createOpts.IPAM.Config, config)
 	}
+
 	networkEventName := fmt.Sprintf("Network %s", n.Name)
 	w := progress.ContextWriter(ctx)
 	w.Event(progress.CreatingEvent(networkEventName))


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48936
- https://github.com/compose-spec/compose-spec/pull/552
- carries, closes https://github.com/docker/compose/pull/12564


This adds support for the GwPriority API field in API v1.48 (docker v28.0).
It can be set on both docker container run and docker network connect.

This option is used by the Engine to determine which network provides
the default gateway for a container.

It also adds support for enable_ipv4, which allows enabling (default)
or disabling IPv4 address assignment for a network.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
