### PR TITLE
Fixed service: reference in additional_contexts for builds without bake

### DIFF
--- a/pkg/e2e/fixtures/build-dependencies/compose.yaml
+++ b/pkg/e2e/fixtures/build-dependencies/compose.yaml
@@ -1,6 +1,5 @@
 services:
   base:
-    image: base
     init: true
     build:
       context: .


### PR DESCRIPTION
**What I did**

Fixed additional_contexts: service:xx with bake disabled.
context is converted into an image reference after dependent service has been built by dependency order

**Related issue**
fixes https://github.com/docker/compose/issues/12579

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
