### PR TITLE
Introduced `include` to filter files considered by `watch`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.4.9-0.20250225151507-331db8fefcb7
+	github.com/compose-spec/compose-go/v2 v2.4.9-0.20250302154753-e508c724a35f
 	github.com/containerd/containerd/v2 v2.0.2
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.4.9-0.20250225151507-331db8fefcb7 h1:7NlxAsQcWvLpFlEHsBo80sJ1UMMs84kkf0yXGs6de2k=
-github.com/compose-spec/compose-go/v2 v2.4.9-0.20250225151507-331db8fefcb7/go.mod h1:6k5l/0TxCg0/2uLEhRVEsoBWBprS2uvZi32J7xub3lo=
+github.com/compose-spec/compose-go/v2 v2.4.9-0.20250302154753-e508c724a35f h1:kbmTPhf7d9kTnmH0ghAQTqxs1zenKnwKczJlC4z5WSc=
+github.com/compose-spec/compose-go/v2 v2.4.9-0.20250302154753-e508c724a35f/go.mod h1:6k5l/0TxCg0/2uLEhRVEsoBWBprS2uvZi32J7xub3lo=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=

--- a/pkg/e2e/fixtures/watch/include.yaml
+++ b/pkg/e2e/fixtures/watch/include.yaml
@@ -1,0 +1,12 @@
+services:
+  a:
+    build:
+      dockerfile_inline: |
+        FROM nginx
+        RUN mkdir /data/
+    develop:
+      watch:
+        - path: .
+          include: A.*
+          target: /data/
+          action: sync

--- a/pkg/watch/notify.go
+++ b/pkg/watch/notify.go
@@ -68,6 +68,15 @@ type PathMatcher interface {
 	MatchesEntireDir(file string) (bool, error)
 }
 
+// AnyMatcher is a PathMatcher to match any path
+type AnyMatcher struct{}
+
+func (AnyMatcher) Matches(f string) (bool, error)          { return true, nil }
+func (AnyMatcher) MatchesEntireDir(f string) (bool, error) { return true, nil }
+
+var _ PathMatcher = AnyMatcher{}
+
+// EmptyMatcher is a PathMatcher to match no path
 type EmptyMatcher struct{}
 
 func (EmptyMatcher) Matches(f string) (bool, error)          { return false, nil }


### PR DESCRIPTION
**What I did**

Introduce `include` to only select a subset of files in source path for watch command. 
Illustration example:
```yaml
services:
  base:
    build:
      context: .
      dockerfile_inline: |
        FROM nginx
    develop:
      watch:
        - path: .
          include: "*.txt" # can also be an array
          action: rebuild
```

**Related issue**
closes https://github.com/docker/compose/issues/12544
see https://github.com/compose-spec/compose-go/pull/747

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
