### PR TITLE
otel attribute to track builder implementation selected

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -62,8 +62,11 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 		return err
 	}
 	return progress.RunWithTitle(ctx, func(ctx context.Context) error {
-		_, err := s.build(ctx, project, options, nil)
-		return err
+		return tracing.SpanWrapFunc("project/build", tracing.ProjectOptions(ctx, project),
+			func(ctx context.Context) error {
+				_, err := s.build(ctx, project, options, nil)
+				return err
+			})(ctx)
 	}, s.stdinfo(), "Building")
 }
 


### PR DESCRIPTION
send `builder` attribute in `project/build` span so we can track the builder implementation selected by user