### PR TITLE
display the location of OCI or GIT Compose stack download

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -372,7 +372,7 @@ func (o *ProjectOptions) remoteLoaders(dockerCli command.Cli) []loader.ResourceL
 	if o.Offline {
 		return nil
 	}
-	git := remote.NewGitRemoteLoader(o.Offline)
+	git := remote.NewGitRemoteLoader(dockerCli, o.Offline)
 	oci := remote.NewOCIRemoteLoader(dockerCli, o.Offline)
 	return []loader.ResourceLoader{git, oci}
 }

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -301,6 +301,7 @@ func runUp(
 		attachSet.RemoveAll(upOptions.noAttach...)
 		attach = attachSet.Elements()
 	}
+	displayLocationRemoteStack(dockerCli, project, buildOptions)
 
 	timeout := time.Duration(upOptions.waitTimeout) * time.Second
 	return backend.Up(ctx, project, api.UpOptions{
@@ -328,4 +329,19 @@ func setServiceScale(project *types.Project, name string, replicas int) error {
 	service.SetScale(replicas)
 	project.Services[name] = service
 	return nil
+}
+
+func displayLocationRemoteStack(dockerCli command.Cli, project *types.Project, options buildOptions) {
+	if len(options.ProjectOptions.ConfigPaths) == 0 {
+		return
+	}
+	mainComposeFile := options.ProjectOptions.ConfigPaths[0]
+	if ui.Mode != ui.ModeQuiet && ui.Mode != ui.ModeJSON {
+		for _, loader := range options.ProjectOptions.remoteLoaders(dockerCli) {
+			if loader.Accept(mainComposeFile) {
+				_, _ = fmt.Fprintf(dockerCli.Out(), "Your compose stack %q is stored in %q\n", mainComposeFile, project.WorkingDir)
+				return
+			}
+		}
+	}
 }

--- a/pkg/remote/git.go
+++ b/pkg/remote/git.go
@@ -28,6 +28,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/moby/buildkit/util/gitutil"
 )
@@ -45,16 +46,18 @@ func gitRemoteLoaderEnabled() (bool, error) {
 	return false, nil
 }
 
-func NewGitRemoteLoader(offline bool) loader.ResourceLoader {
+func NewGitRemoteLoader(dockerCli command.Cli, offline bool) loader.ResourceLoader {
 	return gitRemoteLoader{
-		offline: offline,
-		known:   map[string]string{},
+		dockerCli: dockerCli,
+		offline:   offline,
+		known:     map[string]string{},
 	}
 }
 
 type gitRemoteLoader struct {
-	offline bool
-	known   map[string]string
+	dockerCli command.Cli
+	offline   bool
+	known     map[string]string
 }
 
 func (g gitRemoteLoader) Accept(path string) bool {

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -34,7 +34,10 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-const OCI_REMOTE_ENABLED = "COMPOSE_EXPERIMENTAL_OCI_REMOTE"
+const (
+	OCI_REMOTE_ENABLED = "COMPOSE_EXPERIMENTAL_OCI_REMOTE"
+	OciPrefix          = "oci://"
+)
 
 func ociRemoteLoaderEnabled() (bool, error) {
 	if v := os.Getenv(OCI_REMOTE_ENABLED); v != "" {
@@ -61,10 +64,8 @@ type ociRemoteLoader struct {
 	known     map[string]string
 }
 
-const prefix = "oci://"
-
 func (g ociRemoteLoader) Accept(path string) bool {
-	return strings.HasPrefix(path, prefix)
+	return strings.HasPrefix(path, OciPrefix)
 }
 
 func (g ociRemoteLoader) Load(ctx context.Context, path string) (string, error) {
@@ -82,7 +83,7 @@ func (g ociRemoteLoader) Load(ctx context.Context, path string) (string, error) 
 
 	local, ok := g.known[path]
 	if !ok {
-		ref, err := reference.ParseDockerRef(path[len(prefix):])
+		ref, err := reference.ParseDockerRef(path[len(OciPrefix):])
 		if err != nil {
 			return "", err
 		}
@@ -121,7 +122,6 @@ func (g ociRemoteLoader) Load(ctx context.Context, path string) (string, error) 
 		}
 		g.known[path] = local
 	}
-
 	return filepath.Join(local, "compose.yaml"), nil
 }
 


### PR DESCRIPTION
**What I did**
Display a message with the location where the OCI artifact or GIT Compose stack were downloaded

**Related issue**
https://docker.atlassian.net/browse/APCLI-881

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/41d9c503-25c1-44d8-8c0b-c2a9cc8dd5e8)
