### PR TITLE
block the publication of an OCI artifact if one or more services contain only a build section

### DIFF
--- a/pkg/e2e/fixtures/publish/Dockerfile
+++ b/pkg/e2e/fixtures/publish/Dockerfile
@@ -1,0 +1,15 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM alpine:latest

--- a/pkg/e2e/fixtures/publish/compose-build-only.yml
+++ b/pkg/e2e/fixtures/publish/compose-build-only.yml
@@ -1,0 +1,9 @@
+services:
+  serviceA:
+    build:
+      context: .
+      dockerfile: Dockerfile
+  serviceB:
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/pkg/e2e/publish_test.go
+++ b/pkg/e2e/publish_test.go
@@ -107,4 +107,13 @@ FOO=bar`), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), `BAR=baz`), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), `QUIX=`), res.Combined())
 	})
+
+	t.Run("refuse to publish with build section only", func(t *testing.T) {
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/publish/compose-build-only.yml",
+			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "-y", "--dry-run")
+		res.Assert(t, icmd.Expected{ExitCode: 1})
+		assert.Assert(t, strings.Contains(res.Combined(), "your Compose stack cannot be published as it only contains a build section for service(s):"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "serviceA"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "serviceB"), res.Combined())
+	})
 }


### PR DESCRIPTION
**What I did**
As we don't want to push source/build code into the OCI artifact published on Docker Hub, we added a pre-check blocking the publish process if one or more service are only defined by a `build` section.

**Related issue**
https://docker.atlassian.net/browse/APCLI-880

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/2d941612-c7c3-4092-ad9d-09860aa05bc7)
