### PR TITLE
refuse to publish compose file with local include

### DIFF
--- a/cmd/compose/publish.go
+++ b/cmd/compose/publish.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
@@ -55,9 +56,13 @@ func publishCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Servic
 }
 
 func runPublish(ctx context.Context, dockerCli command.Cli, backend api.Service, opts publishOptions, repository string) error {
-	project, _, err := opts.ToProject(ctx, dockerCli, nil)
+	project, metrics, err := opts.ToProject(ctx, dockerCli, nil)
 	if err != nil {
 		return err
+	}
+
+	if metrics.CountIncludesLocal > 0 {
+		return errors.New("cannot publish compose file with local includes")
 	}
 
 	return backend.Publish(ctx, project, repository, api.PublishOptions{

--- a/pkg/e2e/fixtures/publish/another/compose.yml
+++ b/pkg/e2e/fixtures/publish/another/compose.yml
@@ -1,0 +1,3 @@
+services:
+  foo:
+    image: bar

--- a/pkg/e2e/fixtures/publish/compose-local-include.yml
+++ b/pkg/e2e/fixtures/publish/compose-local-include.yml
@@ -1,0 +1,6 @@
+include:
+  - ./another/compose.yml
+
+services:
+  test:
+    image: test

--- a/pkg/e2e/publish_test.go
+++ b/pkg/e2e/publish_test.go
@@ -116,4 +116,10 @@ FOO=bar`), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "serviceA"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "serviceB"), res.Combined())
 	})
+
+	t.Run("refuse to publish with local include", func(t *testing.T) {
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/publish/compose-local-include.yml",
+			"-p", projectName, "alpha", "publish", "test/test", "--dry-run")
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: "cannot publish compose file with local includes"})
+	})
 }


### PR DESCRIPTION
**What I did**

Block publishing compose file with `include` using a local path. A user who want to publish a compose model MUST first publish the models it relies on

**Related issue**
https://docker.atlassian.net/browse/APCLI-879

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
