### PR TITLE
`publish`reject compose file with bind mounts

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -155,6 +155,15 @@ func (s *composeService) preChecks(project *types.Project, options api.PublishOp
 		}
 		return acceptPublishEnvVariables(s.dockerCli)
 	}
+
+	for name, config := range project.Services {
+		for _, volume := range config.Volumes {
+			if volume.Type == types.VolumeTypeBind {
+				return false, fmt.Errorf("cannot publish compose file: service %q relies on bind-mount. You should use volumes", name)
+			}
+		}
+	}
+
 	return true, nil
 }
 

--- a/pkg/e2e/fixtures/publish/compose-bind-mount.yml
+++ b/pkg/e2e/fixtures/publish/compose-bind-mount.yml
@@ -1,0 +1,5 @@
+services:
+  serviceA:
+    image: a
+    volumes:
+      - .:/user-data

--- a/pkg/e2e/publish_test.go
+++ b/pkg/e2e/publish_test.go
@@ -108,6 +108,12 @@ FOO=bar`), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), `QUIX=`), res.Combined())
 	})
 
+	t.Run("refuse to publish with bind mount", func(t *testing.T) {
+		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/publish/compose-bind-mount.yml",
+			"-p", projectName, "alpha", "publish", "test/test", "--dry-run")
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `cannot publish compose file: service "serviceA" relies on bind-mount. You should use volumes`})
+	})
+
 	t.Run("refuse to publish with build section only", func(t *testing.T) {
 		res := c.RunDockerComposeCmdNoCheck(t, "-f", "./fixtures/publish/compose-build-only.yml",
 			"-p", projectName, "alpha", "publish", "test/test", "--with-env", "-y", "--dry-run")


### PR DESCRIPTION
**What I did**
`publish` reject compose file with bind mounts
Compose file author should rely on volumes to prevent consumer to expose personal data to a potentially untrusted compose stack

**Related issue**
https://docker.atlassian.net/browse/APCLI-878

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
