### PR TITLE
display interpolation variables and their values when running a remote stack

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -224,6 +224,10 @@ func runRun(ctx context.Context, backend api.Service, project *types.Project, op
 		return err
 	}
 
+	if err := checksForRemoteStack(ctx, dockerCli, project, buildOpts, createOpts.AssumeYes, []string{}); err != nil {
+		return err
+	}
+
 	err = progress.Run(ctx, func(ctx context.Context) error {
 		var buildForDeps *api.BuildOptions
 		if !createOpts.noBuild {


### PR DESCRIPTION
**What I did**
Display a message showing the interpolation variables and their values before running a OCI or GIT Compose stack 

```
$ docker compose -e REGISTRY=myregistry.com up

Found the following variables in configuration:
VARIABLE     VALUE                SOURCE        REQUIRED    DEFAULT
REGISTRY     myregistry.com      command-line  yes         
TAG          v1.0                environment    no          latest
DOCKERFILE   Dockerfile          default        no          Dockerfile
API_KEY      <unset>            none           no          

Do you want to proceed with these variables? [Y/n]:
```

**Related issue**
https://docker.atlassian.net/browse/APCLI-874

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/2a8b4fde-2565-4a78-a63b-0cbd84968e02)
