### PR TITLE
add warning message when a remote configuration include an another remote config

### DIFF
--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -96,6 +96,6 @@ type Pipe struct {
 func (u Pipe) Confirm(message string, defaultValue bool) (bool, error) {
 	_, _ = fmt.Fprint(u.stdout, message)
 	var answer string
-	_, _ = fmt.Scanln(&answer)
+	_, _ = fmt.Fscanln(u.stdin, &answer)
 	return utils.StringToBool(answer), nil
 }


### PR DESCRIPTION
**What I did**
If users start a OCI Compose application which includes remote resources, ask the users to confirm before starting it. 
Display links (oci and git) of the remote configurations to the users

**Related issue**
https://docker.atlassian.net/browse/APCLI-882

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/da12dd7b-3547-45c6-b4a1-986dbbcec326)
