### PR TITLE
only load env_file after services have been selected

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -170,7 +170,7 @@ func (o *ProjectOptions) WithServices(dockerCli command.Cli, fn ProjectServicesF
 	return Adapt(func(ctx context.Context, args []string) error {
 		options := []cli.ProjectOptionsFn{
 			cli.WithResolvedPaths(true),
-			cli.WithDiscardEnvFile,
+			cli.WithoutEnvironmentResolution,
 		}
 
 		project, metrics, err := o.ToProject(ctx, dockerCli, args, options...)
@@ -179,6 +179,11 @@ func (o *ProjectOptions) WithServices(dockerCli command.Cli, fn ProjectServicesF
 		}
 
 		ctx = context.WithValue(ctx, tracing.MetricsKey{}, metrics)
+
+		project, err = project.WithServicesEnvironmentResolved(true)
+		if err != nil {
+			return err
+		}
 
 		return fn(ctx, project, args)
 	})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
-	github.com/compose-spec/compose-go/v2 v2.4.9-0.20250306081139-60e14f61e9ef
+	github.com/compose-spec/compose-go/v2 v2.4.9-0.20250307154133-53320326687c
 	github.com/containerd/containerd/v2 v2.0.3
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.4.9-0.20250306081139-60e14f61e9ef h1:1PcqLEYTxUY28/oZCxtkkF4SpleCrO+Vckw8Skpymz4=
-github.com/compose-spec/compose-go/v2 v2.4.9-0.20250306081139-60e14f61e9ef/go.mod h1:6k5l/0TxCg0/2uLEhRVEsoBWBprS2uvZi32J7xub3lo=
+github.com/compose-spec/compose-go/v2 v2.4.9-0.20250307154133-53320326687c h1:2KFMBiATRqXYmm/6U1Y3WUxorVBERkdwM1ax7vJI2OQ=
+github.com/compose-spec/compose-go/v2 v2.4.9-0.20250307154133-53320326687c/go.mod h1:6k5l/0TxCg0/2uLEhRVEsoBWBprS2uvZi32J7xub3lo=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=

--- a/pkg/e2e/env_file_test.go
+++ b/pkg/e2e/env_file_test.go
@@ -30,3 +30,10 @@ func TestRawEnvFile(t *testing.T) {
 	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/dotenv/raw.yaml", "run", "test")
 	assert.Equal(t, strings.TrimSpace(res.Stdout()), "'{\"key\": \"value\"}'")
 }
+
+func TestUnusedMissingEnvFile(t *testing.T) {
+	c := NewParallelCLI(t)
+	defer c.cleanupWithDown(t, "unused_dotenv")
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "up", "-d", "serviceA")
+}

--- a/pkg/e2e/fixtures/env_file/compose.yaml
+++ b/pkg/e2e/fixtures/env_file/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  serviceA:
+    image: nginx:latest
+
+  serviceB:
+    image: nginx:latest
+    env_file:
+      - /doesnotexist/.env


### PR DESCRIPTION
**What I did**
resolve `env_file` _after_  active services have been selected, so we don't read (potentially missing) env_file for inactive ones

**Related issue**
fixes https://github.com/docker/compose/issues/8713
requires https://github.com/compose-spec/compose-go/pull/751

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
