### PR TITLE
add cli.isatty attribute to spans generated by compose

### DIFF
--- a/cmd/cmdtrace/cmd_span.go
+++ b/cmd/cmdtrace/cmd_span.go
@@ -56,6 +56,7 @@ func Setup(cmd *cobra.Command, dockerCli command.Cli, args []string) error {
 		"cli/"+strings.Join(commandName(cmd), "-"),
 	)
 	cmdSpan.SetAttributes(attribute.StringSlice("cli.flags", getFlags(cmd.Flags())))
+	cmdSpan.SetAttributes(attribute.Bool("cli.isatty", dockerCli.In().IsTerminal()))
 
 	cmd.SetContext(ctx)
 	wrapRunE(cmd, cmdSpan, tracingShutdown)


### PR DESCRIPTION
**What I did**

Added a `cli.isatty` attribute to otel spans from compose, roughly matching [what docker cli does](https://github.com/docker/cli/blob/2d74733942be353bc7730c8722ae2414f368b732/cli/command/telemetry_utils.go#L107). This allows otel span processors to drop spans that are generated from non-tty invocations, which are likely to be automated, numerous, and uninteresting for analysis.

1. This PR does not include tests. I didn't see any tests in the repo for the sibling `cli.flags` attribute or otel in general and am  unsure whether it'd be worth the time to scaffold that all up at the moment. For now, I've manually tested with `bin/build/docker-compose ps` had the attribute set to true and `sh -c 'bin/build/docker-compose ps' < /dev/null` had it set to false.
2. I'm unaware of any naming convention and have no strong opinion on whether this should be `cli.isatty` or just `isatty`.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
