### PR TITLE
Fix edge-case bug checking path prefix in watch for bind mount volumes

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -353,8 +353,11 @@ func loadDevelopmentConfig(service types.ServiceConfig, project *types.Project) 
 
 func checkIfPathAlreadyBindMounted(watchPath string, volumes []types.ServiceVolumeConfig) bool {
 	for _, volume := range volumes {
-		if volume.Bind != nil && strings.HasPrefix(watchPath, volume.Source) {
-			return true
+		if volume.Bind != nil {
+			relPath, err := filepath.Rel(volume.Source, watchPath)
+			if err == nil && !strings.HasPrefix(relPath, "..") {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/e2e/fixtures/watch/compose.yaml
+++ b/pkg/e2e/fixtures/watch/compose.yaml
@@ -37,4 +37,7 @@ services:
         RUN mkdir -p /app/config
     init: true
     command: sleep infinity
+    volumes:
+      - ./dat:/app/dat
+      - ./data-logs:/app/data-logs
     develop: *x-dev

--- a/pkg/e2e/fixtures/watch/dat/meow.dat
+++ b/pkg/e2e/fixtures/watch/dat/meow.dat
@@ -1,0 +1,1 @@
+i am a wannabe cat

--- a/pkg/e2e/fixtures/watch/data-logs/server.log
+++ b/pkg/e2e/fixtures/watch/data-logs/server.log
@@ -1,0 +1,1 @@
+[INFO] Server started successfully on port 8080


### PR DESCRIPTION
**What I did**
I updated the condition that checks whether a bind mount volume is a prefix to a watched path.

Note: I'm not sure if the paths are cleaned already or not (especially `volume.Source`), so I did not add an instruction for this. If it is not already, `volume.Source` should be `filepath.Clean(volume.Source)` in my code to be safe.

**Related issue**
Fixes #12639.
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
Have a photo of my cat, Pepper. 💖

![image](https://github.com/user-attachments/assets/a997f8ab-ee1a-428f-8af5-5e0968ad634e)
