### PR TITLE
PWD

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -383,11 +383,18 @@ func (o *ProjectOptions) remoteLoaders(dockerCli command.Cli) []loader.ResourceL
 }
 
 func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
 	return cli.NewProjectOptions(o.ConfigPaths,
 		append(po,
 			cli.WithWorkingDirectory(o.ProjectDir),
 			// First apply os.Environment, always win
 			cli.WithOsEnv,
+			// set PWD as this variable is not consistently supported on Windows
+			cli.WithEnv([]string{"PWD=" + pwd}),
 			// Load PWD/.env if present and no explicit --env-file has been set
 			cli.WithEnvFiles(o.EnvFiles...),
 			// read dot env file to populate project environment


### PR DESCRIPTION
**What I did**
set `PWD` variable as all Unix shell will offer this variable _but_ windows powershell.
Using `${PWD}` is such a common practice for compose users we can't pretend this isn't supported :P 

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
