### PR TITLE
Set watch option --prune=true as default

### DIFF
--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -59,7 +59,7 @@ func watchCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 	}
 
 	cmd.Flags().BoolVar(&buildOpts.quiet, "quiet", false, "hide build output")
-	cmd.Flags().BoolVar(&watchOpts.prune, "prune", false, "Prune dangling images on rebuild")
+	cmd.Flags().BoolVar(&watchOpts.prune, "prune", true, "Prune dangling images on rebuild")
 	cmd.Flags().BoolVar(&watchOpts.noUp, "no-up", false, "Do not build & start services before watching")
 	return cmd
 }

--- a/docs/reference/compose_watch.md
+++ b/docs/reference/compose_watch.md
@@ -9,7 +9,7 @@ Watch build context for service and rebuild/refresh containers when files are up
 |:------------|:-------|:--------|:----------------------------------------------|
 | `--dry-run` | `bool` |         | Execute command in dry run mode               |
 | `--no-up`   | `bool` |         | Do not build & start services before watching |
-| `--prune`   | `bool` |         | Prune dangling images on rebuild              |
+| `--prune`   | `bool` | `true`  | Prune dangling images on rebuild              |
 | `--quiet`   | `bool` |         | hide build output                             |
 
 

--- a/docs/reference/docker_compose_watch.yaml
+++ b/docs/reference/docker_compose_watch.yaml
@@ -19,7 +19,7 @@ options:
       swarm: false
     - option: prune
       value_type: bool
-      default_value: "false"
+      default_value: "true"
       description: Prune dangling images on rebuild
       deprecated: false
       hidden: false


### PR DESCRIPTION
**What I did**
Prune images by default when watching. This also has the effect of enabling pruning when using `up --watch`. It's still possible to disable pruning with `watch --prune=false`.

Replaces [previous approach](https://github.com/docker/compose/pull/12642).

**Related issue**
#11073

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/6f1da81d-de46-48a6-8b5f-795ff15bd26e)
