### PR TITLE
bake parses "${}" in DockerfileInline as a variable

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -191,7 +191,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			Context:          build.Context,
 			Contexts:         additionalContexts(build.AdditionalContexts),
 			Dockerfile:       dockerFilePath(build.Context, build.Dockerfile),
-			DockerfileInline: build.DockerfileInline,
+			DockerfileInline: strings.ReplaceAll(build.DockerfileInline, "${", "$${"),
 			Args:             args,
 			Labels:           build.Labels,
 			Tags:             append(build.Tags, image),


### PR DESCRIPTION
**What I did**
escape `$` in inlined dockerfile to prevent bake for parsing `${XX}` as a variable 

**Related issue**
fixes https://github.com/docker/compose/issues/12662

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
