### PR TITLE
introduce config --no-env-resolution

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -47,6 +47,7 @@ type configOptions struct {
 	noInterpolate       bool
 	noNormalize         bool
 	noResolvePath       bool
+	noResolveEnv        bool
 	services            bool
 	volumes             bool
 	profiles            bool
@@ -135,6 +136,7 @@ func configCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
 	flags.BoolVar(&opts.noNormalize, "no-normalize", false, "Don't normalize compose model")
 	flags.BoolVar(&opts.noResolvePath, "no-path-resolution", false, "Don't resolve file paths")
 	flags.BoolVar(&opts.noConsistency, "no-consistency", false, "Don't check model consistency - warning: may produce invalid Compose output")
+	flags.BoolVar(&opts.noResolveEnv, "no-env-resolution", false, "Don't resolve service env files")
 
 	flags.BoolVar(&opts.services, "services", false, "Print the service names, one per line.")
 	flags.BoolVar(&opts.volumes, "volumes", false, "Print the volume names, one per line.")
@@ -185,6 +187,13 @@ func runConfigInterpolate(ctx context.Context, dockerCli command.Cli, opts confi
 
 	if opts.resolveImageDigests {
 		project, err = project.WithImagesResolved(compose.ImageDigestResolver(ctx, dockerCli.ConfigFile(), dockerCli.Client()))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !opts.noResolveEnv {
+		project, err = project.WithServicesEnvironmentResolved(true)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/reference/compose_config.md
+++ b/docs/reference/compose_config.md
@@ -19,6 +19,7 @@ the canonical format.
 | `--hash`                  | `string` |         | Print the service config hash, one per line.                                |
 | `--images`                | `bool`   |         | Print the image names, one per line.                                        |
 | `--no-consistency`        | `bool`   |         | Don't check model consistency - warning: may produce invalid Compose output |
+| `--no-env-resolution`     | `bool`   |         | Don't resolve service env files                                             |
 | `--no-interpolate`        | `bool`   |         | Don't interpolate environment variables                                     |
 | `--no-normalize`          | `bool`   |         | Don't normalize compose model                                               |
 | `--no-path-resolution`    | `bool`   |         | Don't resolve file paths                                                    |

--- a/docs/reference/docker_compose_config.yaml
+++ b/docs/reference/docker_compose_config.yaml
@@ -59,6 +59,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: no-env-resolution
+      value_type: bool
+      default_value: "false"
+      description: Don't resolve service env files
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: no-interpolate
       value_type: bool
       default_value: "false"

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -151,6 +151,9 @@ func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts 
 			v, ok := envResolver(project.Environment)(s)
 			return v, ok
 		}).RemoveEmpty()
+		if service.Environment == nil {
+			service.Environment = types.MappingWithEquals{}
+		}
 		service.Environment.OverrideBy(serviceOverrideEnv)
 	}
 	for k, v := range opts.Labels {


### PR DESCRIPTION
**What I did**
introduce `config --no-env-resolution` but resolve env_file by default
also fix a potential nil map assignment (can't reproduce, but better safe than sorry)

**Related issue**
closes https://github.com/docker/compose/issues/12659

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
