### PR TITLE
fix(secrets): Reverted secrets file mode 440 -> 444

### DIFF
--- a/pkg/compose/secrets.go
+++ b/pkg/compose/secrets.go
@@ -110,7 +110,7 @@ func createTar(env string, config types.FileReferenceConfig) (bytes.Buffer, erro
 	value := []byte(env)
 	b := bytes.Buffer{}
 	tarWriter := tar.NewWriter(&b)
-	mode := types.FileMode(0o440)
+	mode := types.FileMode(0o444)
 	if config.Mode != nil {
 		mode = *config.Mode
 	}


### PR DESCRIPTION
**What I did**
Reverted secrets file mode from 440 to 444. it looks like it was changed by mistake in this PR https://github.com/docker/compose/pull/12633

**Related issue**
https://github.com/docker/compose/issues/12658

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
