### PR TITLE
fix scale completion

### DIFF
--- a/cmd/compose/completion.go
+++ b/cmd/compose/completion.go
@@ -90,3 +90,13 @@ func completeProfileNames(dockerCli command.Cli, p *ProjectOptions) validArgsFn 
 		return values, cobra.ShellCompDirectiveNoFileComp
 	}
 }
+
+func completeScaleArgs(cli command.Cli, p *ProjectOptions) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		completions, directive := completeServiceNames(cli, p)(cmd, args, toComplete)
+		for i, completion := range completions {
+			completions[i] = completion + "="
+		}
+		return completions, directive
+	}
+}

--- a/cmd/compose/scale.go
+++ b/cmd/compose/scale.go
@@ -51,7 +51,7 @@ func scaleCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 			}
 			return runScale(ctx, dockerCli, backend, opts, serviceTuples)
 		}),
-		ValidArgsFunction: completeServiceNames(dockerCli, p),
+		ValidArgsFunction: completeScaleArgs(dockerCli, p),
 	}
 	flags := scaleCmd.Flags()
 	flags.BoolVar(&opts.noDeps, "no-deps", false, "Don't start linked services")


### PR DESCRIPTION
**What I did**

`scale` argument is `SERVICENAME=REPLICAS`. Completion to append `=` prevents user to misuse this command

**Related issue**
based on https://github.com/docker/cli/pull/5968

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
