### PR TITLE
introduce `build --print` to dump equivalent bakefile

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -44,6 +44,7 @@ type buildOptions struct {
 	ssh     string
 	builder string
 	deps    bool
+	print   bool
 }
 
 func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions, error) {
@@ -76,6 +77,8 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 		Quiet:    opts.quiet,
 		Services: services,
 		Deps:     opts.deps,
+		Memory:   int64(opts.memory),
+		Print:    opts.print,
 		SSHs:     SSHKeys,
 		Builder:  builderName,
 	}, nil
@@ -131,6 +134,7 @@ func buildCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 	flags.VarP(&opts.memory, "memory", "m", "Set memory limit for the build container. Not supported by BuildKit.")
 	flags.StringVar(&p.Progress, "progress", string(buildkit.AutoMode), fmt.Sprintf(`Set type of ui output (%s)`, strings.Join(printerModes, ", ")))
 	flags.MarkHidden("progress") //nolint:errcheck
+	flags.BoolVar(&opts.print, "print", false, "Print equivalent bake file")
 
 	return cmd
 }
@@ -150,6 +154,5 @@ func runBuild(ctx context.Context, dockerCli command.Cli, backend api.Service, o
 		return err
 	}
 
-	apiBuildOptions.Memory = int64(opts.memory)
 	return backend.Build(ctx, project, apiBuildOptions)
 }

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -20,6 +20,7 @@ run `docker compose build` to rebuild it.
 | `--dry-run`           | `bool`        |         | Execute command in dry run mode                                                                             |
 | `-m`, `--memory`      | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
 | `--no-cache`          | `bool`        |         | Do not use cache when building the image                                                                    |
+| `--print`             | `bool`        |         | Print equivalent bake file                                                                                  |
 | `--pull`              | `bool`        |         | Always attempt to pull a newer version of the image                                                         |
 | `--push`              | `bool`        |         | Push service images                                                                                         |
 | `-q`, `--quiet`       | `bool`        |         | Don't print anything to STDOUT                                                                              |

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -96,6 +96,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: print
+      value_type: bool
+      default_value: "false"
+      description: Print equivalent bake file
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: progress
       value_type: string
       default_value: auto

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -155,6 +155,8 @@ type BuildOptions struct {
 	Memory int64
 	// Builder name passed in the command line
 	Builder string
+	// Print don't actually run builder but print equivalent build config
+	Print bool
 }
 
 // Apply mutates project according to build options

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -105,7 +105,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 	if err != nil {
 		return nil, err
 	}
-	if bake {
+	if bake || options.Print {
 		trace.SpanFromContext(ctx).SetAttributes(attribute.String("builder", "bake"))
 		return s.doBuildBake(ctx, project, serviceToBuild, options)
 	}

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -219,6 +219,10 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		return nil, err
 	}
 
+	if options.Print {
+		_, err = fmt.Fprintln(s.stdinfo(), string(b))
+		return nil, err
+	}
 	logrus.Debugf("bake build config:\n%s", string(b))
 
 	metadata, err := os.CreateTemp(os.TempDir(), "compose")


### PR DESCRIPTION
**What I did**
introduce `--print` so the `build` command dump equivalent bakefile. 
Can be useful to diagnose build issues when using bake build delegation

**Related issue**
closes https://github.com/docker/compose/issues/12654

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
