### PR TITLE
fix: replace docker-compose.yml with compose.yaml

### DIFF
--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -241,10 +241,10 @@ examples: |-
     For example, consider this command line:
 
     ```console
-    $ docker compose -f docker-compose.yml -f docker-compose.admin.yml run backup_db
+    $ docker compose -f compose.yaml -f compose.admin.yaml run backup_db
     ```
 
-    The `docker-compose.yml` file might specify a `webapp` service.
+    The `compose.yaml` file might specify a `webapp` service.
 
     ```yaml
     services:
@@ -255,7 +255,7 @@ examples: |-
         volumes:
           - "/data"
     ```
-    If the `docker-compose.admin.yml` also specifies this same service, any matching fields override the previous file.
+    If the `compose.admin.yaml` also specifies this same service, any matching fields override the previous file.
     New values, add to the `webapp` service configuration.
 
     ```yaml


### PR DESCRIPTION
**What I did**

Replace all references to `docker-compose.yml` with `compose.yaml` in documentation to align with the [Compose specification.](https://github.com/compose-spec/compose-spec/blob/main/03-compose-file.md)

This improves consistency with modern Docker standards and encourages best practices for new projects.