### PR TITLE
feat(run): Add --quiet and --quiet-build options for the run command

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -67,6 +67,7 @@ type runOptions struct {
 	noDeps        bool
 	ignoreOrphans bool
 	removeOrphans bool
+	quiet         bool
 	quietPull     bool
 }
 
@@ -180,6 +181,14 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *
 					options.noTty = !options.tty
 				}
 			}
+			if options.quiet {
+				progress.Mode = progress.ModeQuiet
+				devnull, err := os.Open(os.DevNull)
+				if err != nil {
+					return err
+				}
+				os.Stdout = devnull
+			}
 			createOpts.pullChanged = cmd.Flags().Changed("pull")
 			return nil
 		}),
@@ -222,6 +231,8 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *
 	flags.BoolVar(&options.useAliases, "use-aliases", false, "Use the service's network useAliases in the network(s) the container connects to")
 	flags.BoolVarP(&options.servicePorts, "service-ports", "P", false, "Run command with all service's ports enabled and mapped to the host")
 	flags.StringVar(&createOpts.Pull, "pull", "policy", `Pull image before running ("always"|"missing"|"never")`)
+	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Don't print anything to STDOUT")
+	flags.BoolVar(&buildOpts.quiet, "quiet-build", false, "Suppress progress output from the build process")
 	flags.BoolVar(&options.quietPull, "quiet-pull", false, "Pull without printing progress information")
 	flags.BoolVar(&createOpts.Build, "build", false, "Build image before starting container")
 	flags.BoolVar(&options.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -74,6 +74,8 @@ specified in the service configuration.
 | `--no-deps`             | `bool`        |          | Don't start linked services                                                      |
 | `-p`, `--publish`       | `stringArray` |          | Publish a container's port(s) to the host                                        |
 | `--pull`                | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                         |
+| `-q`, `--quiet`         | `bool`        |          | Don't print anything to STDOUT                                                   |
+| `--quiet-build`         | `bool`        |          | Suppress progress output from the build process                                  |
 | `--quiet-pull`          | `bool`        |          | Pull without printing progress information                                       |
 | `--remove-orphans`      | `bool`        |          | Remove containers for services not defined in the Compose file                   |
 | `--rm`                  | `bool`        |          | Automatically remove the container when it exits                                 |

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -200,6 +200,27 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: quiet
+      shorthand: q
+      value_type: bool
+      default_value: "false"
+      description: Don't print anything to STDOUT
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: quiet-build
+      value_type: bool
+      default_value: "false"
+      description: Suppress progress output from the build process
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet-pull
       value_type: bool
       default_value: "false"


### PR DESCRIPTION
**What I did**
Added `--quiet` and `--quiet-build` options for the `run` command to suppress all output OR just build output

**Related issue**
https://github.com/docker/compose/issues/12684

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/c808ea38-fd38-4e60-87bf-fca142839e2b)
