### PR TITLE
use bake by default

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -34,7 +33,6 @@ import (
 	"github.com/docker/buildx/util/buildflags"
 	xprogress "github.com/docker/buildx/util/progress"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/hints"
 	cliopts "github.com/docker/cli/opts"
 	"github.com/docker/compose/v2/internal/tracing"
 	"github.com/docker/compose/v2/pkg/api"
@@ -70,10 +68,6 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 			})(ctx)
 	}, s.stdinfo(), "Building")
 }
-
-const bakeSuggest = "Compose can now delegate builds to bake for better performance.\n To do so, set COMPOSE_BAKE=true."
-
-var suggest sync.Once
 
 //nolint:gocyclo
 func (s *composeService) build(ctx context.Context, project *types.Project, options api.BuildOptions, localImages map[string]api.ImageSummary) (map[string]string, error) {
@@ -156,11 +150,6 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		w     *xprogress.Printer
 	)
 	if buildkitEnabled {
-		if hints.Enabled() && progress.Mode != progress.ModeQuiet && progress.Mode != progress.ModeJSON {
-			suggest.Do(func() {
-				fmt.Fprintln(s.dockerCli.Out(), bakeSuggest) //nolint:errcheck
-			})
-		}
 		builderName := options.Builder
 		if builderName == "" {
 			builderName = os.Getenv("BUILDX_BUILDER")

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -51,12 +51,7 @@ import (
 func buildWithBake(dockerCli command.Cli) (bool, error) {
 	b, ok := os.LookupEnv("COMPOSE_BAKE")
 	if !ok {
-		if dockerCli.ConfigFile().Plugins["compose"]["build"] == "bake" {
-			b, ok = "true", true
-		}
-	}
-	if !ok {
-		return false, nil
+		b = "true"
 	}
 	bake, err := strconv.ParseBool(b)
 	if err != nil {
@@ -72,6 +67,7 @@ func buildWithBake(dockerCli command.Cli) (bool, error) {
 	}
 	if !enabled {
 		logrus.Warnf("Docker Compose is configured to build using Bake, but buildkit isn't enabled")
+		return false, nil
 	}
 
 	_, err = manager.GetPlugin("buildx", dockerCli, &cobra.Command{})

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -284,7 +284,7 @@ func TestBuildImageDependencies(t *testing.T) {
 
 	t.Run("BuildKit by dependency order", func(t *testing.T) {
 		cli := NewCLI(t, WithEnv(
-			"DOCKER_BUILDKIT=1",
+			"DOCKER_BUILDKIT=1", "COMPOSE_BAKE=0",
 			"COMPOSE_FILE=./fixtures/build-dependencies/classic.yaml",
 		))
 		doTest(t, cli, "build")
@@ -293,7 +293,7 @@ func TestBuildImageDependencies(t *testing.T) {
 
 	t.Run("BuildKit by additional contexts", func(t *testing.T) {
 		cli := NewCLI(t, WithEnv(
-			"DOCKER_BUILDKIT=1",
+			"DOCKER_BUILDKIT=1", "COMPOSE_BAKE=0",
 			"COMPOSE_FILE=./fixtures/build-dependencies/compose.yaml",
 		))
 		doTest(t, cli, "build")


### PR DESCRIPTION
user can still opt-out by `COMPOSE_BAKE=false`
a future change will deprecate this option, so that we can remove the buildkit builder and fully rely on buildx