### PR TITLE
mount API is not strictly equivalent to bind

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -320,8 +320,7 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 func (s *composeService) getLocalImagesDigests(ctx context.Context, project *types.Project) (map[string]api.ImageSummary, error) {
 	imageNames := utils.Set[string]{}
 	for _, s := range project.Services {
-		imgName := api.GetImageNameOrDefault(s, project.Name)
-		imageNames.Add(imgName)
+		imageNames.Add(api.GetImageNameOrDefault(s, project.Name))
 		for _, volume := range s.Volumes {
 			if volume.Type == types.VolumeTypeImage {
 				imageNames.Add(volume.Source)

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -282,8 +282,15 @@ func (s *composeService) removeImage(ctx context.Context, image string, w progre
 
 func (s *composeService) removeVolume(ctx context.Context, id string, w progress.Writer) error {
 	resource := fmt.Sprintf("Volume %s", id)
+
+	_, err := s.apiClient().VolumeInspect(ctx, id)
+	if errdefs.IsNotFound(err) {
+		// Already gone
+		return nil
+	}
+
 	w.Event(progress.NewEvent(resource, progress.Working, "Removing"))
-	err := s.apiClient().VolumeRemove(ctx, id, true)
+	err = s.apiClient().VolumeRemove(ctx, id, true)
 	if err == nil {
 		w.Event(progress.NewEvent(resource, progress.Done, "Removed"))
 		return nil

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -254,6 +254,8 @@ func TestDownRemoveVolumes(t *testing.T) {
 		Return(volume.ListResponse{
 			Volumes: []*volume.Volume{{Name: "myProject_volume"}},
 		}, nil)
+	api.EXPECT().VolumeInspect(gomock.Any(), "myProject_volume").
+		Return(volume.Volume{}, nil)
 	api.EXPECT().NetworkList(gomock.Any(), network.ListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).
 		Return(nil, nil)
 


### PR DESCRIPTION
**What I did**
A volume mount with an actual bind (driver option `o: bind`)  must be configured using `bind` API otherwise we get some weird behavior

**Related issue**
https://docker.atlassian.net/browse/CSESC-577

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
