### PR TITLE
ci(bin-image): free disk space

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -80,6 +80,15 @@ jobs:
       digest: ${{ fromJSON(steps.bake.outputs.metadata).image-cross['containerimage.digest'] }}
     steps:
       -
+        name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+      -
         name: Checkout
         uses: actions/checkout@v4
       -


### PR DESCRIPTION
relates to: https://github.com/docker/compose/actions/runs/14380532335

![image](https://github.com/user-attachments/assets/d896db56-1ba9-418e-9986-19e86fc26635)

Free up disk space in bin-image before starting the build. As follow-up we should split this job to be more efficient.