### PR TITLE
build: write --print output to stdout

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -220,7 +220,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	}
 
 	if options.Print {
-		_, err = fmt.Fprintln(s.stdinfo(), string(b))
+		_, err = fmt.Fprintln(s.stdout(), string(b))
 		return nil, err
 	}
 	logrus.Debugf("bake build config:\n%s", string(b))


### PR DESCRIPTION
stdinfo should only be used for status/progress messages: it defaults to stderr and makes piping the output trickier.  `docker buildx bake --print` always uses stdout.