### PR TITLE
introduce build --check

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -45,6 +45,7 @@ type buildOptions struct {
 	builder string
 	deps    bool
 	print   bool
+	check   bool
 }
 
 func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions, error) {
@@ -79,6 +80,7 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 		Deps:     opts.deps,
 		Memory:   int64(opts.memory),
 		Print:    opts.print,
+		Check:    opts.check,
 		SSHs:     SSHKeys,
 		Builder:  builderName,
 	}, nil
@@ -135,6 +137,7 @@ func buildCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 	flags.StringVar(&p.Progress, "progress", string(buildkit.AutoMode), fmt.Sprintf(`Set type of ui output (%s)`, strings.Join(printerModes, ", ")))
 	flags.MarkHidden("progress") //nolint:errcheck
 	flags.BoolVar(&opts.print, "print", false, "Print equivalent bake file")
+	flags.BoolVar(&opts.check, "check", false, "Check build configuration")
 
 	return cmd
 }

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -17,6 +17,7 @@ run `docker compose build` to rebuild it.
 |:----------------------|:--------------|:--------|:------------------------------------------------------------------------------------------------------------|
 | `--build-arg`         | `stringArray` |         | Set build-time variables for services                                                                       |
 | `--builder`           | `string`      |         | Set builder to use                                                                                          |
+| `--check`             | `bool`        |         | Check build configuration                                                                                   |
 | `--dry-run`           | `bool`        |         | Execute command in dry run mode                                                                             |
 | `-m`, `--memory`      | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
 | `--no-cache`          | `bool`        |         | Do not use cache when building the image                                                                    |

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -33,6 +33,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: check
+      value_type: bool
+      default_value: "false"
+      description: Check build configuration
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: compress
       value_type: bool
       default_value: "true"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -157,6 +157,8 @@ type BuildOptions struct {
 	Builder string
 	// Print don't actually run builder but print equivalent build config
 	Print bool
+	// Check let builder validate build configuration
+	Check bool
 }
 
 // Apply mutates project according to build options

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -300,8 +300,8 @@ func TestBuildImageDependencies(t *testing.T) {
 			"DOCKER_BUILDKIT=1", "COMPOSE_BAKE=1",
 			"COMPOSE_FILE=./fixtures/build-dependencies/compose.yaml",
 		))
-		doTest(t, cli, "build")
-		doTest(t, cli, "build", "service")
+		doTest(t, cli, "--verbose", "build")
+		doTest(t, cli, "--verbose", "build", "service")
 	})
 }
 


### PR DESCRIPTION
**What I did**

introduce build `--check` flag to let bake run with call=lint (aligned with `docker build --check`)

**Related issue**
fix https://github.com/docker/compose/issues/12749

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
