### PR TITLE
Add support for COMPOSE_PROGRESS env variable

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -69,6 +69,8 @@ const (
 	ComposeEnvFiles = "COMPOSE_ENV_FILES"
 	// ComposeMenu defines if the navigation menu should be rendered. Can be also set via --menu
 	ComposeMenu = "COMPOSE_MENU"
+	// ComposeProgress defines type of progress output, if --progress isn't used
+	ComposeProgress = "COMPOSE_PROGRESS"
 )
 
 // rawEnv load a dot env file using docker/cli key=value parser, without attempt to interpolate or evaluate values
@@ -228,7 +230,7 @@ func (o *ProjectOptions) addProjectFlags(f *pflag.FlagSet) {
 	f.StringVar(&o.ProjectDir, "project-directory", "", "Specify an alternate working directory\n(default: the path of the, first specified, Compose file)")
 	f.StringVar(&o.WorkDir, "workdir", "", "DEPRECATED! USE --project-directory INSTEAD.\nSpecify an alternate working directory\n(default: the path of the, first specified, Compose file)")
 	f.BoolVar(&o.Compatibility, "compatibility", false, "Run compose in backward compatibility mode")
-	f.StringVar(&o.Progress, "progress", string(buildkit.AutoMode), fmt.Sprintf(`Set type of progress output (%s)`, strings.Join(printerModes, ", ")))
+	f.StringVar(&o.Progress, "progress", defaultStringVar(ComposeProgress, string(buildkit.AutoMode)), fmt.Sprintf(`Set type of progress output (%s)`, strings.Join(printerModes, ", ")))
 	f.BoolVar(&o.All, "all-resources", false, "Include all resources, even those not used by services")
 	_ = f.MarkHidden("workdir")
 }
@@ -238,6 +240,14 @@ func defaultStringArrayVar(env string) []string {
 	return strings.FieldsFunc(os.Getenv(env), func(c rune) bool {
 		return c == ','
 	})
+}
+
+// get default value for a command line flag from the env variable, if the env variable is not set, it returns the provided default value 'def'
+func defaultStringVar(env, def string) string {
+	if v, ok := os.LookupEnv(env); ok {
+		return v
+	}
+	return def
 }
 
 func (o *ProjectOptions) projectOrName(ctx context.Context, dockerCli command.Cli, services ...string) (*types.Project, string, error) {

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -170,6 +170,18 @@ func TestLocalComposeRun(t *testing.T) {
 		assert.Assert(t, strings.Contains(res.Combined(), "Pulled"), res.Combined())
 	})
 
+	t.Run("COMPOSE_PROGRESS quiet", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/quiet-pull.yaml", "down", "--remove-orphans", "--rmi", "all")
+		res.Assert(t, icmd.Success)
+
+		cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/run-test/quiet-pull.yaml", "run", "backend")
+		res = icmd.RunCmd(cmd, func(c *icmd.Cmd) {
+			c.Env = append(c.Env, "COMPOSE_PROGRESS=quiet")
+		})
+		assert.Assert(t, !strings.Contains(res.Combined(), "Pull complete"), res.Combined())
+		assert.Assert(t, !strings.Contains(res.Combined(), "Pulled"), res.Combined())
+	})
+
 	t.Run("--pull", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/pull.yaml", "down", "--remove-orphans", "--rmi", "all")
 		res.Assert(t, icmd.Success)

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -19,6 +19,7 @@ package progress
 import (
 	"context"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/docker/cli/cli/streams"
@@ -120,6 +121,9 @@ func NewWriter(ctx context.Context, out *streams.Out, progressTitle string) (Wri
 	dryRun, ok := ctx.Value(api.DryRunKey{}).(bool)
 	if !ok {
 		dryRun = false
+	}
+	if v, ok := os.LookupEnv("COMPOSE_PROGRESS"); ok && Mode == ModeAuto {
+		Mode = v
 	}
 	if Mode == ModeQuiet {
 		return quiet{}, nil

--- a/pkg/progress/writer.go
+++ b/pkg/progress/writer.go
@@ -19,7 +19,6 @@ package progress
 import (
 	"context"
 	"io"
-	"os"
 	"sync"
 
 	"github.com/docker/cli/cli/streams"
@@ -121,9 +120,6 @@ func NewWriter(ctx context.Context, out *streams.Out, progressTitle string) (Wri
 	dryRun, ok := ctx.Value(api.DryRunKey{}).(bool)
 	if !ok {
 		dryRun = false
-	}
-	if v, ok := os.LookupEnv("COMPOSE_PROGRESS"); ok && Mode == ModeAuto {
-		Mode = v
 	}
 	if Mode == ModeQuiet {
 		return quiet{}, nil


### PR DESCRIPTION
**What I did**
Added support for the new env variable COMPOSE_PROGRESS to suppress output.

Behaviour is similar to `docker compose --progress=<mode> ...`

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
closes #12751 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
