### PR TITLE
e2e test for start_interval

### DIFF
--- a/pkg/compose/convert.go
+++ b/pkg/compose/convert.go
@@ -78,6 +78,10 @@ func (s *composeService) ToMobyHealthCheck(ctx context.Context, check *compose.H
 		} else {
 			startInterval = time.Duration(*check.StartInterval)
 		}
+		if check.StartPeriod == nil {
+			// see https://github.com/moby/moby/issues/48874
+			return nil, errors.New("healthcheck.start_interval requires healthcheck.start_period to be set")
+		}
 	}
 	return &container.HealthConfig{
 		Test:          test,

--- a/pkg/e2e/fixtures/start_interval/compose.yaml
+++ b/pkg/e2e/fixtures/start_interval/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  test:
+    image: "nginx"
+    healthcheck:
+      interval: 30s
+      start_period: 10s
+      start_interval: 1s
+      test: "/bin/true"
+
+  error:
+    image: "nginx"
+    healthcheck:
+      interval: 30s
+      start_interval: 1s
+      test: "/bin/true"

--- a/pkg/e2e/healthcheck_test.go
+++ b/pkg/e2e/healthcheck_test.go
@@ -1,0 +1,54 @@
+/*
+   Copyright 2023 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+)
+
+func TestStartInterval(t *testing.T) {
+	c := NewParallelCLI(t)
+	const projectName = "e2e-start-interval"
+
+	t.Cleanup(func() {
+		c.cleanupWithDown(t, projectName)
+	})
+
+	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/start_interval/compose.yaml", "--project-name", projectName, "up", "--wait", "-d", "error")
+	res.Assert(t, icmd.Expected{ExitCode: 1, Err: "healthcheck.start_interval requires healthcheck.start_period to be set"})
+
+	timeout := time.After(30 * time.Second)
+	done := make(chan bool)
+	go func() {
+		res := c.RunDockerComposeCmd(t, "-f", "fixtures/start_interval/compose.yaml", "--project-name", projectName, "up", "--wait", "-d", "test")
+		out := res.Combined()
+		assert.Assert(t, strings.Contains(out, "Healthy"), out)
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("test did not finish in time")
+	case <-done:
+		break
+	}
+}


### PR DESCRIPTION
**What I did**
`start_interval` requires `start_period` to be set.

**Related issue**
fix https://github.com/docker/compose/issues/12782
