### PR TITLE
Fix config --variables not honoring the --format flag

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -416,7 +416,7 @@ func runVariables(ctx context.Context, dockerCli command.Cli, opts configOptions
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(result))
+		fmt.Print(string(result))
 		return nil
 	}
 

--- a/docs/reference/compose_config.md
+++ b/docs/reference/compose_config.md
@@ -15,7 +15,7 @@ the canonical format.
 |:--------------------------|:---------|:--------|:----------------------------------------------------------------------------|
 | `--dry-run`               | `bool`   |         | Execute command in dry run mode                                             |
 | `--environment`           | `bool`   |         | Print environment used for interpolation.                                   |
-| `--format`                | `string` | `yaml`  | Format the output. Values: [yaml \| json]                                   |
+| `--format`                | `string` |         | Format the output. Values: [yaml \| json]                                   |
 | `--hash`                  | `string` |         | Print the service config hash, one per line.                                |
 | `--images`                | `bool`   |         | Print the image names, one per line.                                        |
 | `--no-consistency`        | `bool`   |         | Don't check model consistency - warning: may produce invalid Compose output |

--- a/docs/reference/docker_compose_config.yaml
+++ b/docs/reference/docker_compose_config.yaml
@@ -21,7 +21,6 @@ options:
       swarm: false
     - option: format
       value_type: string
-      default_value: yaml
       description: 'Format the output. Values: [yaml | json]'
       deprecated: false
       hidden: false

--- a/pkg/e2e/config_test.go
+++ b/pkg/e2e/config_test.go
@@ -46,4 +46,25 @@ func TestLocalComposeConfig(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/compose.yaml", "--project-name", projectName, "config", "--no-interpolate")
 		res.Assert(t, icmd.Expected{Out: `- ${PORT:-8080}:80`})
 	})
+
+	t.Run("--variables --format json", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/compose.yaml", "--project-name", projectName, "config", "--variables", "--format", "json")
+		res.Assert(t, icmd.Expected{Out: `{
+    "PORT": {
+        "Name": "PORT",
+        "DefaultValue": "8080",
+        "PresenceValue": "",
+        "Required": false
+    }
+}`})
+	})
+
+	t.Run("--variables --format yaml", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/compose.yaml", "--project-name", projectName, "config", "--variables", "--format", "yaml")
+		res.Assert(t, icmd.Expected{Out: `PORT:
+    name: PORT
+    defaultvalue: "8080"
+    presencevalue: ""
+    required: false`})
+	})
 }


### PR DESCRIPTION
**What I did**

Added missing format option to the formatter.Print function.
Handling the `yaml` case separately, as it's not supported by the formatter.Print function. Maybe we can extend that function by adding support for yaml?

Before:
```text
NAME                   REQUIRED            DEFAULT VALUE          ALTERNATE VALUE
DOCKER_REGISTRY_BASE   false               ubuntu/ubuntu:latest
BIND_PORT              false               8100
BIND_ADDRESS           false               127.0.0.1
```

After:
```json
{
    "BIND_ADDRESS": {
        "Name": "BIND_ADDRESS",
        "DefaultValue": "127.0.0.1",
        "PresenceValue": "",
        "Required": false
    },
    "BIND_PORT": {
        "Name": "BIND_PORT",
        "DefaultValue": "8100",
        "PresenceValue": "",
        "Required": false
    },
    "DOCKER_REGISTRY_BASE": {
        "Name": "DOCKER_REGISTRY_BASE",
        "DefaultValue": "ubuntu/ubuntu:latest",
        "PresenceValue": "",
        "Required": false
    }
}
```

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
closes #12808

I've noticed that all the other flags that produce some kind of output like `--services` don't honor the --format flag.
Most of them just return a raw fmt.Println.

When diving deeper into the fix, I've noticed that the format flag defaults to `yaml`, even when not explicitly provided, and is used only by the default config command without any flags.

I've opted to change the default value to an empty string and override that if we are going to execute the `runConfig` func. This shouldn't break the old behavior, but I could be wrong here.

<details><summary>Cute animal photo</summary>
<p>

![cute-animal](https://github.com/user-attachments/assets/d1e5e791-9a53-4fad-8120-30101894e825)


</p>
</details> 