### PR TITLE
add logs to container attach options

### DIFF
--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -160,7 +160,7 @@ func (s *composeService) getContainerStreams(ctx context.Context, container stri
 		Stdin:  true,
 		Stdout: true,
 		Stderr: true,
-		Logs:   false,
+		Logs:   true,
 	})
 	if err == nil {
 		stdout = ContainerStdout{HijackedResponse: cnx}


### PR DESCRIPTION
This will avoid losing first logs of containers linked to the app but created outside of Compose

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
