### PR TITLE
ensure build dependencies are enabled

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -85,11 +85,17 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 		policy = types.IncludeDependencies
 	}
 
+	var err error
 	if len(options.Services) > 0 {
 		// As user requested some services to be built, also include those used as additional_contexts
 		options.Services = addBuildDependencies(options.Services, project)
+		// Some build dependencies we just introduced may not be enabled
+		project, err = project.WithServicesEnabled(options.Services...)
+		if err != nil {
+			return nil, err
+		}
 	}
-	project, err := project.WithSelectedServices(options.Services)
+	project, err = project.WithSelectedServices(options.Services)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What I did**

ensure dependent services identified by the build execution (which may not be runtime dependencies) are enabled

**Related issue**
fixes https://github.com/docker/compose/issues/12822
fixes https://github.com/docker/compose/issues/12825

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
