### PR TITLE
add support of 'debug' messages in the communication between Compose …

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -54,8 +54,9 @@ JSON messages MUST include a `type` and a `message` attribute.
 
 `type` can be either:
 - `info`: Reports status updates to the user. Compose will render message as the service state in the progress UI
-- `error`: Lest the user know something went wrong with details about the error. Compose will render the message as the reason for the service failure.
+- `error`: Let's the user know something went wrong with details about the error. Compose will render the message as the reason for the service failure.
 - `setenv`: Let's the plugin tell Compose how dependent services can access the created resource. See next section for further details.
+- `debug`: Those messages could help debugging the provider, but are not rendered to the user by default. They are rendered when Compose is started with `--verbose` flag.
 
 ```mermaid
 sequenceDiagram

--- a/pkg/compose/plugins.go
+++ b/pkg/compose/plugins.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/socket"
 	"github.com/docker/compose/v2/pkg/progress"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -44,6 +45,7 @@ const (
 	ErrorType  = "error"
 	InfoType   = "info"
 	SetEnvType = "setenv"
+	DebugType  = "debug"
 )
 
 func (s *composeService) runPlugin(ctx context.Context, project *types.Project, service types.ServiceConfig, command string) error {
@@ -123,6 +125,8 @@ func (s *composeService) executePlugin(ctx context.Context, cmd *exec.Cmd, comma
 				return nil, fmt.Errorf("invalid response from plugin: %s", msg.Message)
 			}
 			variables[key] = val
+		case DebugType:
+			logrus.Debugf("%s: %s", service.Name, msg.Message)
 		default:
 			return nil, fmt.Errorf("invalid response from plugin: %s", msg.Type)
 		}


### PR DESCRIPTION
…and provider binaries

**What I did**
Add the support of a `debug` message type between provider binaries and Compose, those message won't be displayed by default but could be enabled using `--debug` flag during the development process of a new provider or for debugging purpose.

**Related issue**
N/A
**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/0519923e-0ec1-4778-aff1-26fea4588ed9)
