### PR TITLE
remove Docker EULA licensing which isn't relevant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,9 +307,6 @@ jobs:
             fi
           done
       -
-        name: License
-        run: cp packaging/* ./bin/release/
-      -
         name: List artifacts
         run: |
           tree -nh ./bin/release

--- a/packaging/LICENSE
+++ b/packaging/LICENSE
@@ -1,2 +1,0 @@
-The Docker End User License Agreement (https://www.docker.com/legal/docker-software-end-user-license-agreement) describes Docker's Terms for this software.
-By downloading, accessing, or using this software you expressly accept and agree to the Terms set out in the Docker End User License Agreement.


### PR DESCRIPTION
There's no Docker EULA anymore since Docker switched to a subscription model

fix https://github.com/docker/compose/issues/12280