### PR TITLE
Fix quiet option when using COMPOSE_BAKE=1

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -261,6 +261,9 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	if options.Builder != "" {
 		args = append(args, "--builder", options.Builder)
 	}
+	if options.Quiet {
+		args = append(args, "--progress=quiet")
+	}
 
 	logrus.Debugf("Executing bake with args: %v", args)
 

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -128,6 +128,11 @@ func TestLocalComposeBuild(t *testing.T) {
 			assert.Assert(t, !strings.Contains(res.Stdout(), "failed to push"), res.Stdout())
 		})
 
+		t.Run(env+" build --quiet", func(t *testing.T) {
+			res := c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "build", "--quiet")
+			res.Assert(t, icmd.Expected{Out: ""})
+		})
+
 		t.Run(env+" cleanup build project", func(t *testing.T) {
 			c.RunDockerComposeCmd(t, "--project-directory", "fixtures/build-test", "down")
 			c.RunDockerOrExitError(t, "rmi", "-f", "build-test-nginx")


### PR DESCRIPTION
**What I did**
Add handling of the quiet option when using `COMPOSE_BAKE=1`

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Fixes #12833 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![cat-sleeping-outdoors](https://github.com/user-attachments/assets/25a3cb26-4e39-4e39-8456-c18186614239)

