### PR TITLE
report cancelled pull after another one failed

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -204,6 +204,16 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 		Platform:     platform,
 	})
 
+	if ctx.Err() != nil {
+		w.Event(progress.Event{
+			ID:         service.Name,
+			Status:     progress.Warning,
+			Text:       "Warning",
+			StatusText: "Interrupted",
+		})
+		return "", nil
+	}
+
 	// check if has error and the service has a build section
 	// then the status should be warning instead of error
 	if err != nil && service.Build != nil {


### PR DESCRIPTION
**What I did**

As a pull error occurs, concurrent pull get ctx cancelled, but http/transport returns the context.Cause (https://github.com/golang/go/blob/master/src/net/http/transport.go#L669) and we don't get a "context cancelled" error but the original error to cancel the errgroup.

As a workaround, detect context is cancelled and report pull has been interrupted

**Related issue**
fixes https://github.com/docker/compose/issues/12767

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
```
$ cat compose.yaml 
services:
  test:
    image: alpine
  fail:
    image: none

$ docker compose  pull
[+] Pulling 2/2
 ✘ fail Error   pull access denied for none, repository does not exist or may require 'docker login'                                                                   0.8s 
 ! test Warning Interrupted                                                                                                                                            0.8s 
Error response from daemon: pull access denied for none, repository does not exist or may require 'docker login'
```