### PR TITLE
do not throw an error on build with provider services

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -165,7 +165,7 @@ type BuildOptions struct {
 func (o BuildOptions) Apply(project *types.Project) error {
 	platform := project.Environment["DOCKER_DEFAULT_PLATFORM"]
 	for name, service := range project.Services {
-		if service.Image == "" && service.Build == nil {
+		if service.Provider == nil && service.Image == "" && service.Build == nil {
 			return fmt.Errorf("invalid service %q. Must specify either image or build", name)
 		}
 


### PR DESCRIPTION
**What I did**
Avoid to throw an error on build command for provider service as they don't have neither `image` or `build` attributes

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
