### PR TITLE
introduce config --lock-image-digests

### DIFF
--- a/docs/reference/compose_config.md
+++ b/docs/reference/compose_config.md
@@ -14,6 +14,7 @@ the canonical format.
 | `--format`                | `string` |         | Format the output. Values: [yaml \| json]                                   |
 | `--hash`                  | `string` |         | Print the service config hash, one per line.                                |
 | `--images`                | `bool`   |         | Print the image names, one per line.                                        |
+| `--lock-image-digests`    | `bool`   |         | Produces an override file with image digests                                |
 | `--no-consistency`        | `bool`   |         | Don't check model consistency - warning: may produce invalid Compose output |
 | `--no-env-resolution`     | `bool`   |         | Don't resolve service env files                                             |
 | `--no-interpolate`        | `bool`   |         | Don't interpolate environment variables                                     |

--- a/docs/reference/docker_compose_config.yaml
+++ b/docs/reference/docker_compose_config.yaml
@@ -46,6 +46,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: lock-image-digests
+      value_type: bool
+      default_value: "false"
+      description: Produces an override file with image digests
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: no-consistency
       value_type: bool
       default_value: "false"

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -235,7 +235,7 @@ func TestCompatibility(t *testing.T) {
 }
 
 func TestConfig(t *testing.T) {
-	const projectName = "compose-e2e-convert"
+	const projectName = "compose-e2e-config"
 	c := NewParallelCLI(t)
 
 	wd, err := os.Getwd()
@@ -253,24 +253,24 @@ services:
       default: null
 networks:
   default:
-    name: compose-e2e-convert_default
+    name: compose-e2e-config_default
 `, projectName, filepath.Join(wd, "fixtures", "simple-build-test", "nginx-build")), ExitCode: 0})
 	})
 }
 
 func TestConfigInterpolate(t *testing.T) {
-	const projectName = "compose-e2e-convert-interpolate"
+	const projectName = "compose-e2e-config-interpolate"
 	c := NewParallelCLI(t)
 
 	wd, err := os.Getwd()
 	assert.NilError(t, err)
 
-	t.Run("convert", func(t *testing.T) {
+	t.Run("config", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose-interpolate.yaml", "-p", projectName, "config", "--no-interpolate")
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`name: %s
 networks:
   default:
-    name: compose-e2e-convert-interpolate_default
+    name: compose-e2e-config-interpolate_default
 services:
   nginx:
     build:


### PR DESCRIPTION
**What I did**
introduce `config --lock-image-digests`. This produces an override file with image digest locked, comparable to the one generated by `publish`

**Related issue**
fixes https://github.com/docker/compose/issues/12836

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
