### PR TITLE
remove convert alias from config command

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -85,9 +85,8 @@ func configCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
 		ProjectOptions: p,
 	}
 	cmd := &cobra.Command{
-		Aliases: []string{"convert"}, // for backward compatibility with Cloud integrations
-		Use:     "config [OPTIONS] [SERVICE...]",
-		Short:   "Parse, resolve and render compose file in canonical format",
+		Use:   "config [OPTIONS] [SERVICE...]",
+		Short: "Parse, resolve and render compose file in canonical format",
 		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.quiet {
 				devnull, err := os.Open(os.DevNull)

--- a/docs/reference/compose_config.md
+++ b/docs/reference/compose_config.md
@@ -5,10 +5,6 @@
 It merges the Compose files set by `-f` flags, resolves variables in the Compose file, and expands short-notation into
 the canonical format.
 
-### Aliases
-
-`docker compose config`, `docker compose convert`
-
 ### Options
 
 | Name                      | Type     | Default | Description                                                                 |

--- a/docs/reference/docker_compose_config.yaml
+++ b/docs/reference/docker_compose_config.yaml
@@ -1,5 +1,4 @@
 command: docker compose config
-aliases: docker compose config, docker compose convert
 short: Parse, resolve and render compose file in canonical format
 long: |-
     `docker compose config` renders the actual data model to be applied on the Docker Engine.

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -242,7 +242,7 @@ func TestConfig(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("up", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose.yaml", "-p", projectName, "convert")
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose.yaml", "-p", projectName, "config")
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`name: %s
 services:
   nginx:
@@ -266,7 +266,7 @@ func TestConfigInterpolate(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("convert", func(t *testing.T) {
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose-interpolate.yaml", "-p", projectName, "convert", "--no-interpolate")
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/simple-build-test/compose-interpolate.yaml", "-p", projectName, "config", "--no-interpolate")
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`name: %s
 networks:
   default:


### PR DESCRIPTION
**What I did**
Remove the `convert` alias, as we may soon need it for something else #teasing 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/a32a65e4-2207-48d4-bd26-0102bab18f93)
