### PR TITLE
run ContainerStart sequentially

### DIFF
--- a/pkg/e2e/fixtures/port-range/compose.yaml
+++ b/pkg/e2e/fixtures/port-range/compose.yaml
@@ -4,3 +4,13 @@ services:
     scale: 5
     ports:
       - "6005-6015:80"
+
+  b:
+    image: nginx:alpine
+    ports:
+      - 80
+
+  c:
+    image: nginx:alpine
+    ports:
+      - 80


### PR DESCRIPTION
**What I did**
As compose calls ContainerStart concurrently, Docker engine sometimes fails to allocate a port in a range. This should be fixed in engine, but this preventive workaround has low impact on Compose

**Related issue**
closes https://github.com/docker/compose/issues/12846

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
