### PR TITLE
report error (re)creating container

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -208,7 +208,6 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 		w.Event(progress.Event{
 			ID:         service.Name,
 			Status:     progress.Warning,
-			Text:       "Warning",
 			StatusText: "Interrupted",
 		})
 		return "", nil


### PR DESCRIPTION
**What I did**

As an error occurs (re)creating container, update progress with cause, but only for the culprit container - others will get context cancelled and report the same error as cause

```
$ docker compose up
[+] Running 2/2
 ✔ hello-arm64 Pulled                                                                                                                                                              1.1s 
 ✔ hello-amd64 Pulled                                                                                                                                                              1.1s 
[+] Running 1/2
 ✘ Container truc-hello-arm64-1               Error response from daemon: image with reference debian was found but its platform (linux/amd64) d...                                0.0s 
 ⠋ Container 445577bb3fe3_truc-hello-amd64-1  Recreate                                                                                                                             0.0s 
Error response from daemon: image with reference debian was found but its platform (linux/amd64) does not match the specified platform (linux/arm64)

```

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
