### PR TITLE
fix up --build with additional_context dependency

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -260,6 +260,7 @@ func runUp(
 		if err != nil {
 			return err
 		}
+		bo.Services = services
 		build = &bo
 	}
 


### PR DESCRIPTION
**What I did**
`BuildOptions` must be configured with same services as `CreateOptions` to detect the need for additional services resolution

**Related issue**
closes https://github.com/docker/compose/issues/12861

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
