### PR TITLE
(refactoting) Move watch logic into a dedicated Watcher type

### DIFF
--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -117,9 +117,10 @@ func runWatch(ctx context.Context, dockerCli command.Cli, backend api.Service, w
 	}
 
 	consumer := formatter.NewLogConsumer(ctx, dockerCli.Out(), dockerCli.Err(), false, false, false)
-	return backend.Watch(ctx, project, services, api.WatchOptions{
-		Build: &build,
-		LogTo: consumer,
-		Prune: watchOpts.prune,
+	return backend.Watch(ctx, project, api.WatchOptions{
+		Build:    &build,
+		LogTo:    consumer,
+		Prune:    watchOpts.prune,
+		Services: services,
 	})
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -85,7 +85,7 @@ type Service interface {
 	// DryRunMode defines if dry run applies to the command
 	DryRunMode(ctx context.Context, dryRun bool) (context.Context, error)
 	// Watch services' development context and sync/notify/rebuild/restart on changes
-	Watch(ctx context.Context, project *types.Project, services []string, options WatchOptions) error
+	Watch(ctx context.Context, project *types.Project, options WatchOptions) error
 	// Viz generates a graphviz graph of the project services
 	Viz(ctx context.Context, project *types.Project, options VizOptions) (string, error)
 	// Wait blocks until at least one of the services' container exits
@@ -127,9 +127,10 @@ const WatchLogger = "#watch"
 
 // WatchOptions group options of the Watch API
 type WatchOptions struct {
-	Build *BuildOptions
-	LogTo LogConsumer
-	Prune bool
+	Build    *BuildOptions
+	LogTo    LogConsumer
+	Prune    bool
+	Services []string
 }
 
 // BuildOptions group options of the Build API

--- a/pkg/mocks/mock_docker_compose_api.go
+++ b/pkg/mocks/mock_docker_compose_api.go
@@ -513,17 +513,17 @@ func (mr *MockServiceMockRecorder) Wait(ctx, projectName, options any) *gomock.C
 }
 
 // Watch mocks base method.
-func (m *MockService) Watch(ctx context.Context, project *types.Project, services []string, options api.WatchOptions) error {
+func (m *MockService) Watch(ctx context.Context, project *types.Project, options api.WatchOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch", ctx, project, services, options)
+	ret := m.ctrl.Call(m, "Watch", ctx, project, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Watch indicates an expected call of Watch.
-func (mr *MockServiceMockRecorder) Watch(ctx, project, services, options any) *gomock.Call {
+func (mr *MockServiceMockRecorder) Watch(ctx, project, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockService)(nil).Watch), ctx, project, services, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockService)(nil).Watch), ctx, project, options)
 }
 
 // MockLogConsumer is a mock of LogConsumer interface.

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -83,10 +83,11 @@ func (d *fseventNotify) Start() error {
 
 	numberOfWatches.Add(int64(len(d.stream.Paths)))
 
-	d.stream.Start() //nolint:errcheck // FIXME(thaJeztah): should this return an error?
-
+	err := d.stream.Start()
+	if err != nil {
+		return err
+	}
 	go d.loop()
-
 	return nil
 }
 


### PR DESCRIPTION
Stop navigation menu being responsible for watch, with a dedicated `Watcher` component:
- `Watcher` holds the watch configuration and manages the start/stop lifecycle 
- `composeservice#watch()` returns:
  - an async func for caller to wait for completion and capture execution error (could also be a `chan error`)
  - an `error` for configuration/startup issues
- Navigation menu (`shortcut.go`) only knows `Start` and `Stop` functions to manage watch lifecycle
- removed use of errgroup without actual error management (probably requires some extra work)

**What I did**

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
