### PR TITLE
also (re)start dependent services after watch rebuilt image

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -578,7 +578,7 @@ func (s *composeService) rebuild(ctx context.Context, project *types.Project, se
 		return err
 	}
 
-	p, err := project.WithSelectedServices(services)
+	p, err := project.WithSelectedServices(services, types.IncludeDependents)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What I did**

watch rebuild recreates container, which stops dependent ones declared with `restart: true` (implicitly or explicitly)
later call to `start` must run with `IncludeDependents` policy to restart those

**Related issue**
fixes https://github.com/docker/compose/issues/12814

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
