### PR TITLE
build dependent service images when required

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -261,6 +261,7 @@ func runUp(
 			return err
 		}
 		bo.Services = services
+		bo.Deps = !upOptions.noDeps
 		build = &bo
 	}
 

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -524,3 +524,15 @@ func TestBuildEntitlements(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildDependsOn(t *testing.T) {
+	c := NewParallelCLI(t)
+
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "-f", "fixtures/build-dependencies/compose-depends_on.yaml", "down", "--rmi=local")
+	})
+
+	res := c.RunDockerComposeCmd(t, "-f", "fixtures/build-dependencies/compose-depends_on.yaml", "--progress=plain", "up", "test2")
+	out := res.Combined()
+	assert.Check(t, strings.Contains(out, "test1  Built"))
+}

--- a/pkg/e2e/fixtures/build-dependencies/compose-depends_on.yaml
+++ b/pkg/e2e/fixtures/build-dependencies/compose-depends_on.yaml
@@ -1,0 +1,15 @@
+services:
+  test1:
+    pull_policy: build
+    build:
+      dockerfile_inline: FROM alpine
+    command:
+      - echo
+      - "test 1 success"
+  test2:
+    image: alpine
+    depends_on:
+      - test1
+    command:
+      - echo
+      - "test 2 success"


### PR DESCRIPTION
**What I did**
fixed a regression when service implies by depends_on have images to be built but are not explicitly selected

**Related issue**
fix https://github.com/docker/compose/issues/12892

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
