### PR TITLE
do not forgot to remove the bake metadata file

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -236,6 +236,9 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = os.Remove(metadata.Name())
+	}()
 
 	buildx, err := manager.GetPlugin("buildx", s.dockerCli, &cobra.Command{})
 	if err != nil {


### PR DESCRIPTION
few DD e2e tests failed on Windows due to permission issues

**What I did**
Add a defer function to remove the bake metadata file we create in the temp directory
When the e2e test framework of Docker Desktop try to cleanup resource created during a test it failed as Compose created this one 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
