### PR TITLE
Revert docker compose images JSON output to array format

### DIFF
--- a/cmd/compose/images.go
+++ b/cmd/compose/images.go
@@ -87,6 +87,14 @@ func runImages(ctx context.Context, dockerCli command.Cli, backend api.Service, 
 		}
 		return nil
 	}
+	if opts.Format == "json" {
+		// Convert map to slice
+		var imageList []api.ImageSummary
+		for _, img := range images {
+			imageList = append(imageList, img)
+		}
+		return formatter.Print(imageList, opts.Format, dockerCli.Out(), nil)
+	}
 
 	return formatter.Print(images, opts.Format, dockerCli.Out(),
 		func(w io.Writer) {


### PR DESCRIPTION
In case #12916 was decided on.
Changed  `docker compose images --format json` behaviour from json map to a json list.

```
{
    "lab_postgres": {
        "ID": "sha256:XXXXXXXX",
        "Repository": "postgres",
        ...
    "redis_ins": {
        "ID": "sha256:YYYYYYY",
        "Repository": "redis",
        ...
```
Back to:
```
{
{"ID":"sha256:XXXXXX","Repository":"research-labs-redis-ins",...},
{"ID":"sha256:YYYYY","Repository":"research-labs-test-postgres",...}
```


**Related issue**
Resolves #12916.
