### PR TITLE
fix(logs): keep log streaming active until containers fully stops

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -96,7 +96,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	eg.Go(func() error {
 		first := true
 		gracefulTeardown := func() {
-			printer.Cancel()
+			defer printer.Cancel()
 			_, _ = fmt.Fprintln(s.stdinfo(), "Gracefully stopping... (press Ctrl+C again to force)")
 			eg.Go(func() error {
 				err := s.Stop(context.WithoutCancel(ctx), project.Name, api.StopOptions{


### PR DESCRIPTION
Prevents loss of final log messages during SIGINT/SITERM shutdown by maintaining log collection until containers complete their stop sequence.

Fixes #12918

Signed-off-by: arithmeticmean <satyanand6996@gmail.com>
