### PR TITLE
sanitize service name so they can be used as bake targets

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -148,7 +148,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	)
 
 	// produce a unique ID for service used as bake target
-	for serviceName := range serviceToBeBuild {
+	for serviceName := range project.Services {
 		t := strings.ReplaceAll(serviceName, ".", "_")
 		for {
 			if _, ok := targets[serviceName]; !ok {
@@ -159,7 +159,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		}
 	}
 
-	for serviceName, service := range serviceToBeBuild {
+	for serviceName, service := range project.Services {
 		if service.Build == nil {
 			continue
 		}
@@ -230,7 +230,14 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			Outputs: outputs,
 			Call:    call,
 		}
-		group.Targets = append(group.Targets, target)
+	}
+
+	// create a bake group with targets for services to build
+	for serviceName, service := range serviceToBeBuild {
+		if service.Build == nil {
+			continue
+		}
+		group.Targets = append(group.Targets, targets[serviceName])
 	}
 
 	cfg.Groups["default"] = group


### PR DESCRIPTION
**What I did**
sanitize service name so they can be used as bake targets
replace `.` (not allowed as bake target) with `_``
append a `_` if target conflicts with another one

build with a bake group for required images to build, but include all service definitions so cross-services dependencies are met

**Related issue**
closes https://github.com/docker/compose/issues/12919
closes https://github.com/docker/compose/issues/12923

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
