### PR TITLE
track only images for services to be built

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -174,7 +174,10 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		}
 
 		image := api.GetImageNameOrDefault(service, project.Name)
-		expectedImages[serviceName] = image
+
+		if _, ok := serviceToBeBuild[serviceName]; ok {
+			expectedImages[serviceName] = image
+		}
 
 		entitlements := build.Entitlements
 		if slices.Contains(build.Entitlements, "security.insecure") {


### PR DESCRIPTION
**What I did**
Added a conditional check to verify if a service exists in `serviceToBeBuild` before adding its image to the `expectedImages` map. This prevents unintended services from being included.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes #12928 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
