### PR TITLE
Fix the generated manifest for compose artifacts

### DIFF
--- a/internal/ocipush/push.go
+++ b/internal/ocipush/push.go
@@ -105,7 +105,9 @@ func PushManifest(
 ) error {
 	// Check if we need an extra empty layer for the manifest config
 	if ociVersion == api.OCIVersion1_1 || ociVersion == "" {
-		layers = append(layers, Pushable{Descriptor: v1.DescriptorEmptyJSON, Data: []byte("{}")})
+		if err := resolver.Push(ctx, named, v1.DescriptorEmptyJSON, v1.DescriptorEmptyJSON.Data); err != nil {
+			return err
+		}
 	}
 	// prepare to push the manifest by pushing the layers
 	layerDescriptors := make([]v1.Descriptor, len(layers))


### PR DESCRIPTION
**What I did**
The generated manifests from `docker compose alpha publish` include setting the config as a layer -> [example](https://oci.dag.dev/?image=registry-1-stage.docker.io%2Fhubregistrystagetest%2Fflask-redis-compose-stack%3A1.0.0)

This PR updates this so that we will still push the empty descriptor blob (so the manifest push succeeds), but we don't set it as a layer.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
