### PR TITLE
replace "pipes.quote" with equivalent "shlex.quote"

### DIFF
--- a/compose/cli/main.py
+++ b/compose/cli/main.py
@@ -2,7 +2,7 @@ import contextlib
 import functools
 import json
 import logging
-import pipes
+import shlex
 import re
 import subprocess
 import sys
@@ -1581,7 +1581,7 @@ def call_docker(args, dockeropts, environment):
         )
 
     args = [executable_path] + tls_options + args
-    log.debug(" ".join(map(pipes.quote, args)))
+    log.debug(" ".join(map(shlex.quote, args)))
 
     filtered_env = {k: v for k, v in environment.items() if v is not None}
 


### PR DESCRIPTION
**What I did**
Replaced `pipes.quote` with equivalent `shlex.quote` to maintain functionality in Python 3.13 after [removal](https://peps.python.org/pep-0594) of `pipes`.

See:
- https://github.com/cylc/cylc-flow/issues/2864
- https://stackoverflow.com/questions/26790916/python-3-backward-compatability-shlex-quote-vs-pipes-quote
- https://goldeneye2.videolan.org/Astrom/vlc/-/blob/master/extras/tools/ninja-1.11.1-replace-pipes-quote-with-shlex-quote.patch?ref_type=heads
- https://github.com/Tanguy-Boisset/bloodhound-automation/issues/20