### PR TITLE
(reactoring) avoid a global variable by introducing logConsumer decorator

### DIFF
--- a/internal/tracing/keyboard_metrics.go
+++ b/internal/tracing/keyboard_metrics.go
@@ -22,14 +22,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func KeyboardMetrics(ctx context.Context, enabled, isDockerDesktopActive, isWatchConfigured bool) {
+func KeyboardMetrics(ctx context.Context, enabled, isDockerDesktopActive bool) {
 	commandAvailable := []string{}
 	if isDockerDesktopActive {
 		commandAvailable = append(commandAvailable, "gui")
 		commandAvailable = append(commandAvailable, "gui/composeview")
-	}
-	if isWatchConfigured {
-		commandAvailable = append(commandAvailable, "watch")
 	}
 
 	AddAttributeToSpan(ctx,

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -55,7 +55,7 @@ type Watcher struct {
 	errCh   chan error
 }
 
-func NewWatcher(project *types.Project, options api.UpOptions, w WatchFunc) (*Watcher, error) {
+func NewWatcher(project *types.Project, options api.UpOptions, w WatchFunc, consumer api.LogConsumer) (*Watcher, error) {
 	for i := range project.Services {
 		service := project.Services[i]
 
@@ -65,7 +65,7 @@ func NewWatcher(project *types.Project, options api.UpOptions, w WatchFunc) (*Wa
 			return &Watcher{
 				project: project,
 				options: api.WatchOptions{
-					LogTo: options.Start.Attach,
+					LogTo: consumer,
 					Build: build,
 				},
 				watchFn: w,


### PR DESCRIPTION
Use a LogConsumer `Decorator` to add support for navigation menu, without logConsumer to be aware -> no more dependency to navigation menu, nor global variable

**What I did**

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
