### PR TITLE
pkg/compose: remove uses of ExecOptions.Detach

### DIFF
--- a/pkg/compose/hook.go
+++ b/pkg/compose/hook.go
@@ -48,7 +48,6 @@ func (s composeService) runHook(ctx context.Context, ctr container.Summary, serv
 		Env:          ToMobyEnv(hook.Environment),
 		WorkingDir:   hook.WorkingDir,
 		Cmd:          hook.Command,
-		Detach:       detached,
 		AttachStdout: !detached,
 		AttachStderr: !detached,
 	})


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50218

This field was added in [moby@5130fe5d38837302e], which added it for use as intermediate struct when parsing CLI flags (through `runconfig.ParseExec`) in [moby@c786a8ee5e9db8f5f].

Commit [moby@9d9dff3d0d9e92adf] rewrote the CLI to use Cobra, and as part of this introduced a separate `execOptions` type in `api/client/container`, however the ExecOptions.Detach field was still used as intermediate field to store the flag's value.

Given that the client doesn't use this field, let's remove its use to prevent giving the impression that it's used anywhere.

[moby@5130fe5d38837302e]: https://github.com/docker/docker/commit/5130fe5d38837302e72bdc5e4bd1f5fa1df72c7f
[moby@c786a8ee5e9db8f5f]: https://github.com/docker/docker/commit/c786a8ee5e9db8f5f609cf8721bd1e1513fb0043
[moby@9d9dff3d0d9e92adf]: https://github.com/docker/docker/commit/9d9dff3d0d9e92adf7c2e59f94c63766659d1d47

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
