### PR TITLE
inject secrets/config just before container is started

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -756,14 +756,7 @@ func (s *composeService) createMobyContainer(ctx context.Context,
 			}
 		}
 	}
-
-	err = s.injectSecrets(ctx, project, service, created.ID)
-	if err != nil {
-		return created, err
-	}
-
-	err = s.injectConfigs(ctx, project, service, created.ID)
-	return created, err
+	return created, nil
 }
 
 // getLinks mimics V1 compose/service.py::Service::_get_links()
@@ -897,6 +890,17 @@ func (s *composeService) startService(ctx context.Context,
 		if ctr.State == ContainerRunning {
 			continue
 		}
+
+		err = s.injectSecrets(ctx, project, service, ctr.ID)
+		if err != nil {
+			return err
+		}
+
+		err = s.injectConfigs(ctx, project, service, ctr.ID)
+		if err != nil {
+			return err
+		}
+
 		eventName := getContainerProgressName(ctr)
 		w.Event(progress.StartingEvent(eventName))
 		err = s.apiClient().ContainerStart(ctx, ctr.ID, containerType.StartOptions{})

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -127,7 +127,14 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	if err != nil {
 		return "", err
 	}
-	return created.ID, nil
+
+	err = s.injectSecrets(ctx, project, service, created.ID)
+	if err != nil {
+		return created.ID, err
+	}
+
+	err = s.injectConfigs(ctx, project, service, created.ID)
+	return created.ID, err
 }
 
 func applyRunOptions(project *types.Project, service *types.ServiceConfig, opts api.RunOptions) {


### PR DESCRIPTION
**What I did**

delay injection of secrets/config after dependencies have been resolved. This allows to avoid issue when an init container is used to setup a volume, and container mounts this volume with subpath. As CopyToContainer require the container's filesystem to be all set, this can't run on `create` but must wait for init container completion

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
