### PR TITLE
exclude provider services from the list of dependencies that Compose should wait for

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -563,6 +563,9 @@ func shouldWaitForDependency(serviceName string, dependencyConfig types.ServiceD
 	} else if service.GetScale() == 0 {
 		// don't wait for the dependency which configured to have 0 containers running
 		return false, nil
+	} else if service.Provider != nil {
+		// don't wait for provider services
+		return false, nil
 	}
 	return true, nil
 }


### PR DESCRIPTION
**What I did**
Explicitly exclude provider services from the list of dependencies to check when `--wait` is used

**Related issue**
Fix #12953 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/b1530f77-b4b1-4e28-a2c8-cdf74aab6fd9)
