### PR TITLE
add a default statut messsage to exec error to avoid empty line display

### DIFF
--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli"
@@ -109,8 +110,8 @@ func runExec(ctx context.Context, dockerCli command.Cli, backend api.Service, op
 
 	exitCode, err := backend.Exec(ctx, projectName, execOpts)
 	if exitCode != 0 {
-		errMsg := ""
-		if err != nil {
+		errMsg := fmt.Sprintf("exit status %d", exitCode)
+		if err != nil && err.Error() != "" {
 			errMsg = err.Error()
 		}
 		return cli.StatusError{StatusCode: exitCode, Status: errMsg}

--- a/pkg/compose/exec.go
+++ b/pkg/compose/exec.go
@@ -52,7 +52,7 @@ func (s *composeService) Exec(ctx context.Context, projectName string, options a
 	err = container.RunExec(ctx, s.dockerCli, target.ID, exec)
 	var sterr cli.StatusError
 	if errors.As(err, &sterr) {
-		return sterr.StatusCode, nil
+		return sterr.StatusCode, err
 	}
 	return 0, err
 }


### PR DESCRIPTION
**What I did**
Add the default `exit status $exit_code` message when `docker compose exec` fails and the Docker cli returns only the status code without any message. 
The status message was the one we had few releases ago

**Related issue**
fix #12962 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/815cc49b-f676-4055-a2a9-f459ab6fe3ff)
