### PR TITLE
pass project.environment to bake

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -295,7 +295,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 
 	cmd := exec.CommandContext(ctx, buildx.Path, args...)
 	// Remove DOCKER_CLI_PLUGIN... variable so buildx can detect it run standalone
-	cmd.Env = filter(os.Environ(), manager.ReexecEnvvar)
+	cmd.Env = filter(project.Environment.Values(), manager.ReexecEnvvar)
 
 	// Use docker/cli mechanism to propagate termination signal to child process
 	server, err := socket.NewPluginServer(nil)


### PR DESCRIPTION
**What I did**
Compose project.Environment is not only os.Env but a combination of .Env and interpolation.
Pass Project.Environment to bake to enforce a consistent environment


**Related issue**


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
