### PR TITLE
make sure the post_start hooks fails

### DIFF
--- a/pkg/e2e/fixtures/hooks/poststart/compose-error.yaml
+++ b/pkg/e2e/fixtures/hooks/poststart/compose-error.yaml
@@ -1,6 +1,6 @@
 services:
 
   test:
-    image: alpine
+    image: nginx
     post_start:
-      - command: sh -c 'echo env'
+      - command: sh -c 'command in error'

--- a/pkg/e2e/hooks_test.go
+++ b/pkg/e2e/hooks_test.go
@@ -33,8 +33,7 @@ func TestPostStartHookInError(t *testing.T) {
 
 	res := c.RunDockerComposeCmdNoCheck(t, "-f", "fixtures/hooks/poststart/compose-error.yaml", "--project-name", projectName, "up", "-d")
 	res.Assert(t, icmd.Expected{ExitCode: 1})
-	assert.Assert(t, strings.Contains(res.Combined(), "Error response from daemon: container"), res.Combined())
-	assert.Assert(t, strings.Contains(res.Combined(), "is not running"), res.Combined())
+	assert.Assert(t, strings.Contains(res.Combined(), "test hook exited with status 127"), res.Combined())
 }
 
 func TestPostStartHookSuccess(t *testing.T) {


### PR DESCRIPTION
before we were assuming the container will be close before the post_start will be executed

**What I did**
Changed the  `post_start` `TestPostStartHookInError` e2e test to be sure it will always failed, the previous version was flaky because the container could have been still running especially on CI nodes

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/14a145b3-5031-4bcf-a881-22bc12325c50)
