### PR TITLE
pkg/compose: remove redundant uses of strslice.StrSlice

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -36,7 +36,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/api/types/versions"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
@@ -181,15 +180,12 @@ func (s *composeService) getCreateConfigs(ctx context.Context,
 		return createConfigs{}, err
 	}
 
-	var (
-		runCmd     strslice.StrSlice
-		entrypoint strslice.StrSlice
-	)
+	var runCmd, entrypoint []string
 	if service.Command != nil {
-		runCmd = strslice.StrSlice(service.Command)
+		runCmd = service.Command
 	}
 	if service.Entrypoint != nil {
-		entrypoint = strslice.StrSlice(service.Entrypoint)
+		entrypoint = service.Entrypoint
 	}
 
 	var (
@@ -286,8 +282,8 @@ func (s *composeService) getCreateConfigs(ctx context.Context,
 		Annotations:    service.Annotations,
 		Binds:          binds,
 		Mounts:         mounts,
-		CapAdd:         strslice.StrSlice(service.CapAdd),
-		CapDrop:        strslice.StrSlice(service.CapDrop),
+		CapAdd:         service.CapAdd,
+		CapDrop:        service.CapDrop,
 		NetworkMode:    networkMode,
 		Init:           service.Init,
 		IpcMode:        container.IpcMode(service.Ipc),


### PR DESCRIPTION
The strslice.StrSlice type is a string-slice with a custom JSON Unmarshal function to provide backward-compatibility with older API requests (see [moby@17d6f00] and [moby@ea4a067]).

Given that the type is assigned implicitly through the fields on HostConfig, we can just use a regular []string instead.

[moby@17d6f00]: https://github.com/moby/moby/commit/17d6f00ec2b8b9636f0bb64c55a5b3855e8f4bae
[moby@ea4a067]: https://github.com/moby/moby/commit/ea4a06740b6d4579f77507c1d7e0897a870fd72d

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
