### PR TITLE
bump golang to v1.23.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.23.8
+ARG GO_VERSION=1.23.10
 ARG XX_VERSION=1.6.1
 ARG GOLANGCI_LINT_VERSION=v2.0.2
 ARG ADDLICENSE_VERSION=v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/compose/v2
 
-go 1.23.8
+go 1.23.10
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Fix Vulnerability Report: GO-2025-3751

**What I did**
Bump Go to `v1.23.10`

**Related issue**
fix #13003 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/463b17a2-f359-444e-a6b5-ab3be8ffdac1)
