### PR TITLE
Fix select dockerignore based on Dockerfile name set from symlink

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -436,9 +436,10 @@ func dockerFilePath(ctxName string, dockerfile string) string {
 	if !filepath.IsAbs(dockerfile) {
 		dockerfile = filepath.Join(ctxName, dockerfile)
 	}
-	symlinks, err := filepath.EvalSymlinks(dockerfile)
+	dir := filepath.Dir(dockerfile)
+	symlinks, err := filepath.EvalSymlinks(dir)
 	if err == nil {
-		return symlinks
+		return filepath.Join(symlinks, filepath.Base(dockerfile))
 	}
 	return dockerfile
 }


### PR DESCRIPTION
**What I did**
as we resolve symlink, need to preserve the Dockerfile file name as the default dockerignore file name is based on it

**Related issue**
fixes https://github.com/docker/compose/issues/13014

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
