### PR TITLE
add USER_AGENT variable to cmd when shellouting

### DIFF
--- a/pkg/compose/shellout.go
+++ b/pkg/compose/shellout.go
@@ -23,6 +23,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/context/docker"
+	"github.com/docker/compose/v2/internal"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 )
@@ -41,6 +42,7 @@ func (s *composeService) prepareShellOut(gctx context.Context, project *types.Pr
 	env.Merge(types.Mapping(carrier))
 
 	env["DOCKER_CONTEXT"] = s.dockerCli.CurrentContext()
+	env["USER_AGENT"] = "compose/" + internal.Version
 
 	metadata, err := s.dockerCli.ContextStore().GetMetadata(s.dockerCli.CurrentContext())
 	if err != nil {


### PR DESCRIPTION
**What I did**
Add `USER_AGENT` env variable to shellout commands. It will help Docker Model Runner to know it starts from a Compose context.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![image](https://github.com/user-attachments/assets/6c7b8459-63ac-4db4-96cf-c8fb152bcfc0)
