### PR TITLE
introduce development mode

### DIFF
--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -49,6 +49,7 @@ type createOptions struct {
 	quietPull     bool
 	scale         []string
 	AssumeYes     bool
+	Development   bool
 }
 
 func createCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
@@ -120,6 +121,7 @@ func runCreate(ctx context.Context, _ command.Cli, backend api.Service, createOp
 		Timeout:              createOpts.GetTimeout(),
 		QuietPull:            createOpts.quietPull,
 		AssumeYes:            createOpts.AssumeYes,
+		Development:          createOpts.Development,
 	})
 }
 

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -181,6 +181,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *c
 		}
 		return pflag.NormalizedName(name)
 	})
+	flags.BoolVar(&create.Development, "dev", false, "Enable development mode.")
 	return upCmd
 }
 
@@ -277,6 +278,7 @@ func runUp(
 		Timeout:              createOptions.GetTimeout(),
 		QuietPull:            createOptions.quietPull,
 		AssumeYes:            createOptions.AssumeYes,
+		Development:          createOptions.Development,
 	}
 
 	if upOptions.noStart {

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -32,6 +32,7 @@ If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the contai
 | `--attach-dependencies`        | `bool`        |          | Automatically attach to log output of dependent services                                                                                            |
 | `--build`                      | `bool`        |          | Build images before starting containers                                                                                                             |
 | `-d`, `--detach`               | `bool`        |          | Detached mode: Run containers in the background                                                                                                     |
+| `--dev`                        | `bool`        |          | Enable development mode.                                                                                                                            |
 | `--dry-run`                    | `bool`        |          | Execute command in dry run mode                                                                                                                     |
 | `--exit-code-from`             | `string`      |          | Return the exit code of the selected service container. Implies --abort-on-container-exit                                                           |
 | `--force-recreate`             | `bool`        |          | Recreate containers even if their configuration and image haven't changed                                                                           |

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -98,6 +98,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: dev
+      value_type: bool
+      default_value: "false"
+      description: Enable development mode.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: exit-code-from
       value_type: string
       description: |

--- a/go.mod
+++ b/go.mod
@@ -212,3 +212,5 @@ exclude (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 )
+
+replace github.com/compose-spec/compose-go/v2 => github.com/ndeloof/compose-go/v2 v2.0.1-0.20250708142739-c0abfc6735a4

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.7.1 h1:EUIbuaD0R/J1KA+FbJMNbcS9+jt/CVudbp5iHqUllSs=
-github.com/compose-spec/compose-go/v2 v2.7.1/go.mod h1:TmjkIB9W73fwVxkYY+u2uhMbMUakjiif79DlYgXsyvU=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
@@ -361,6 +359,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/ndeloof/compose-go/v2 v2.0.1-0.20250708142739-c0abfc6735a4 h1:k84kfjgpENwxepUBphnu7DdHve4k+J+JLgKa52+mI1Q=
+github.com/ndeloof/compose-go/v2 v2.0.1-0.20250708142739-c0abfc6735a4/go.mod h1:Zow/3eYNOnl2T4qLGZEizf8d/ht1qfy09G7WGOSzGOY=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -225,7 +225,8 @@ type CreateOptions struct {
 	// QuietPull makes the pulling process quiet
 	QuietPull bool
 	// AssumeYes assume "yes" as answer to all prompts and run non-interactively
-	AssumeYes bool
+	AssumeYes   bool
+	Development bool
 }
 
 // StartOptions group options of the Start API

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -68,6 +68,10 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, cre
 }
 
 func (s *composeService) create(ctx context.Context, project *types.Project, options api.CreateOptions) error {
+	if options.Development {
+		project = enableDevelopmentMode(project)
+	}
+
 	if len(options.Services) == 0 {
 		options.Services = project.ServiceNames()
 	}

--- a/pkg/compose/development.go
+++ b/pkg/compose/development.go
@@ -1,0 +1,34 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import "github.com/compose-spec/compose-go/v2/types"
+
+func enableDevelopmentMode(project *types.Project) *types.Project {
+	for name, service := range project.Services {
+		dev := service.Develop
+		if dev == nil {
+			continue
+		}
+		service.Ports = append(service.Ports, dev.Ports...)
+		if len(dev.Command) > 0 {
+			service.Command = dev.Command
+		}
+		project.Services[name] = service
+	}
+	return project
+}


### PR DESCRIPTION
**What I did**
`docker compose up --dev` enable development mode, which allows to publish additional ports (typically: a remote debugger, or administration UI) and override the service command (to switch to `yarn dev`)

While less powerful, this offers an alternative to a sibling compose-dev.yaml file and need to specify multiple compose files on command line

example:
```yaml
services:
  app:
     build: .
     develop:
        watch:
           - path: src
             target: /app
        command: yarn dev --port 4001
        ports:
           - 4001:4001
```

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
