### PR TITLE
Add a space character to separate the timestamp from the log message

### DIFF
--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -122,7 +122,7 @@ func (l *logConsumer) write(w io.Writer, container, message string) {
 	timestamp := time.Now().Format(jsonmessage.RFC3339NanoFixed)
 	for _, line := range strings.Split(message, "\n") {
 		if l.timestamp {
-			_, _ = fmt.Fprintf(w, "%s%s%s\n", p.prefix, timestamp, line)
+			_, _ = fmt.Fprintf(w, "%s%s %s\n", p.prefix, timestamp, line)
 		} else {
 			_, _ = fmt.Fprintf(w, "%s%s\n", p.prefix, line)
 		}


### PR DESCRIPTION
**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
