### PR TITLE
add default compose labels to images built from bake

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -164,6 +164,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			continue
 		}
 		build := *service.Build
+		labels := getImageBuildLabels(project, service)
 
 		args := types.Mapping{}
 		for k, v := range resolveAndMergeBuildArgs(s.dockerCli, project, service, options) {
@@ -209,7 +210,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			Dockerfile:       dockerFilePath(build.Context, build.Dockerfile),
 			DockerfileInline: strings.ReplaceAll(build.DockerfileInline, "${", "$${"),
 			Args:             args,
-			Labels:           build.Labels,
+			Labels:           labels,
 			Tags:             append(build.Tags, api.GetImageNameOrDefault(service, project.Name)),
 
 			CacheFrom:    build.CacheFrom,


### PR DESCRIPTION
**What I did**
Add default Compose labels to images build from bake via Compose

**Related issue**
#13048 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="600" height="365" alt="image" src="https://github.com/user-attachments/assets/cdb2a4b2-41d5-4ff7-917e-bbf5ebd6f553" />
