### PR TITLE
abstract model-cli commands execution with a model (pseudo) API

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -301,7 +301,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	}
 	cmd := exec.CommandContext(ctx, buildx.Path, args...)
 
-	err = s.prepareShellOut(ctx, project, cmd)
+	err = s.prepareShellOut(ctx, project.Environment, cmd)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compose/plugins.go
+++ b/pkg/compose/plugins.go
@@ -197,7 +197,7 @@ func (s *composeService) setupPluginCommand(ctx context.Context, project *types.
 
 	cmd := exec.CommandContext(ctx, path, args...)
 
-	err := s.prepareShellOut(ctx, project, cmd)
+	err := s.prepareShellOut(ctx, project.Environment, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (s *composeService) setupPluginCommand(ctx context.Context, project *types.
 
 func (s *composeService) getPluginMetadata(path, command string, project *types.Project) ProviderMetadata {
 	cmd := exec.Command(path, "compose", "metadata")
-	err := s.prepareShellOut(context.Background(), project, cmd)
+	err := s.prepareShellOut(context.Background(), project.Environment, cmd)
 	if err != nil {
 		logrus.Debugf("failed to prepare plugin metadata command: %v", err)
 		return ProviderMetadata{}

--- a/pkg/compose/shellout.go
+++ b/pkg/compose/shellout.go
@@ -29,10 +29,8 @@ import (
 )
 
 // prepareShellOut prepare a shell-out command to be ran by Compose
-func (s *composeService) prepareShellOut(gctx context.Context, project *types.Project, cmd *exec.Cmd) error {
-	// exec command with same environment Compose is running
-	env := types.NewMapping(project.Environment.Values())
-
+func (s *composeService) prepareShellOut(gctx context.Context, env types.Mapping, cmd *exec.Cmd) error {
+	env = env.Clone()
 	// remove DOCKER_CLI_PLUGIN... variable so a docker-cli plugin will detect it run standalone
 	delete(env, manager.ReexecEnvvar)
 


### PR DESCRIPTION
**What I did**
created a pseudo-API for model management, waiting for https://github.com/docker/model-cli/issues/113 so we can actually use `modelAPI.PullImage` in compose pull

**Related issue**


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
