### PR TITLE
pkg/watch: remove unused IsWindowsShortReadError

### DIFF
--- a/pkg/watch/notify.go
+++ b/pkg/watch/notify.go
@@ -17,15 +17,11 @@
 package watch
 
 import (
-	"errors"
 	"expvar"
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
-
-	"github.com/tilt-dev/fsnotify"
 )
 
 var numberOfWatches = expvar.NewInt("watch.naive.numberOfWatches")
@@ -101,10 +97,6 @@ func DesiredWindowsBufferSize() int {
 		}
 	}
 	return defaultBufferSize
-}
-
-func IsWindowsShortReadError(err error) bool {
-	return runtime.GOOS == "windows" && !errors.Is(err, fsnotify.ErrEventOverflow)
 }
 
 type CompositePathMatcher struct {


### PR DESCRIPTION
This function was added in b3615d64e2ce7c5496e71fc51e965a6368da2ba2 but appears to be unused.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
