### PR TITLE
show build progress during watch rebuild

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -121,7 +121,7 @@ func buildCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.push, "push", false, "Push service images")
-	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Don't print anything to STDOUT")
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress the build output")
 	flags.BoolVar(&opts.pull, "pull", false, "Always attempt to pull a newer version of the image")
 	flags.StringArrayVar(&opts.args, "build-arg", []string{}, "Set build-time variables for services")
 	flags.StringVar(&opts.ssh, "ssh", "", "Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)")

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -165,6 +165,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *c
 	flags.BoolVar(&create.recreateDeps, "always-recreate-deps", false, "Recreate dependent containers. Incompatible with --no-recreate.")
 	flags.BoolVarP(&create.noInherit, "renew-anon-volumes", "V", false, "Recreate anonymous volumes instead of retrieving data from the previous containers")
 	flags.BoolVar(&create.quietPull, "quiet-pull", false, "Pull without printing progress information")
+	flags.BoolVar(&build.quiet, "quiet-build", false, "Suppress the build output")
 	flags.StringArrayVar(&up.attach, "attach", []string{}, "Restrict attaching to the specified services. Incompatible with --attach-dependencies.")
 	flags.StringArrayVar(&up.noAttach, "no-attach", []string{}, "Do not attach (stream logs) to the specified services")
 	flags.BoolVar(&up.attachDependencies, "attach-dependencies", false, "Automatically attach to log output of dependent services")

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -25,7 +25,7 @@ run `docker compose build` to rebuild it.
 | `--provenance`        | `string`      |         | Add a provenance attestation                                                                                |
 | `--pull`              | `bool`        |         | Always attempt to pull a newer version of the image                                                         |
 | `--push`              | `bool`        |         | Push service images                                                                                         |
-| `-q`, `--quiet`       | `bool`        |         | Don't print anything to STDOUT                                                                              |
+| `-q`, `--quiet`       | `bool`        |         | Suppress the build output                                                                                   |
 | `--sbom`              | `string`      |         | Add a SBOM attestation                                                                                      |
 | `--ssh`               | `string`      |         | Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent) |
 | `--with-dependencies` | `bool`        |         | Also build dependencies (transitively)                                                                      |

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -44,6 +44,7 @@ If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the contai
 | `--no-recreate`                | `bool`        |          | If containers already exist, don't recreate them. Incompatible with --force-recreate.                                                               |
 | `--no-start`                   | `bool`        |          | Don't start the services after creating them                                                                                                        |
 | `--pull`                       | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                                                                                            |
+| `--quiet-build`                | `bool`        |          | Suppress the build output                                                                                                                           |
 | `--quiet-pull`                 | `bool`        |          | Pull without printing progress information                                                                                                          |
 | `--remove-orphans`             | `bool`        |          | Remove containers for services not defined in the Compose file                                                                                      |
 | `-V`, `--renew-anon-volumes`   | `bool`        |          | Recreate anonymous volumes instead of retrieving data from the previous containers                                                                  |

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -158,7 +158,7 @@ options:
       shorthand: q
       value_type: bool
       default_value: "false"
-      description: Don't print anything to STDOUT
+      description: Suppress the build output
       deprecated: false
       hidden: false
       experimental: false

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -211,6 +211,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: quiet-build
+      value_type: bool
+      default_value: "false"
+      description: Suppress the build output
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: quiet-pull
       value_type: bool
       default_value: "false"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 	"time"
@@ -176,6 +177,8 @@ type BuildOptions struct {
 	Provenance string
 	// SBOM generate a SBOM attestation
 	SBOM string
+	// Out is the stream to write build progress
+	Out io.Writer
 }
 
 // Apply mutates project according to build options

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -130,10 +130,14 @@ type buildStatus struct {
 func (s *composeService) doBuildBake(ctx context.Context, project *types.Project, serviceToBeBuild types.Services, options api.BuildOptions) (map[string]string, error) { //nolint:gocyclo
 	eg := errgroup.Group{}
 	ch := make(chan *client.SolveStatus)
-	out := s.dockerCli.Out()
 	displayMode := progressui.DisplayMode(options.Progress)
-	if !out.IsTerminal() {
-		displayMode = progressui.PlainMode
+	out := options.Out
+	if out == nil {
+		cout := s.dockerCli.Out()
+		if !cout.IsTerminal() {
+			displayMode = progressui.PlainMode
+		}
+		out = cout
 	}
 	display, err := progressui.NewDisplay(out, displayMode)
 	if err != nil {


### PR DESCRIPTION
**What I did**
During a watch rebuild, show build logs (plain mode) mixed with running services logs
Introduced `--quiet-build` to support the previous behavior for watch to hide build logs
(makes me wonder we should deprecate `watch` command)

https://asciinema.org/a/2LfcAifSGq8FWmfUnbShuNn9g


**Related issue**
fixes https://github.com/docker/compose/issues/13044

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
