### PR TITLE
monitor must watch events even when context is cancelled

### DIFF
--- a/pkg/compose/monitor.go
+++ b/pkg/compose/monitor.go
@@ -79,7 +79,7 @@ func (c *monitor) Start(ctx context.Context) error {
 	}
 	restarting := utils.Set[string]{}
 
-	evtCh, errCh := c.api.Events(ctx, events.ListOptions{
+	evtCh, errCh := c.api.Events(context.Background(), events.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("type", "container"),
 			projectFilter(c.project)),
@@ -89,8 +89,6 @@ func (c *monitor) Start(ctx context.Context) error {
 			return nil
 		}
 		select {
-		case <-ctx.Done():
-			return nil
 		case err := <-errCh:
 			return err
 		case event := <-evtCh:

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -111,6 +111,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	eg.Go(func() error {
 		first := true
 		gracefulTeardown := func() {
+			first = false
 			tui.ApplicationTermination()
 			eg.Go(func() error {
 				return progress.RunWithLog(context.WithoutCancel(ctx), func(ctx context.Context) error {
@@ -121,7 +122,6 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 				}, s.stdinfo(), logConsumer)
 			})
 			isTerminated.Store(true)
-			first = false
 		}
 
 		for {
@@ -238,7 +238,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	})
 
 	eg.Go(func() error {
-		err := monitor.Start(ctx)
+		err := monitor.Start(context.Background())
 		// Signal for the signal-handler goroutines to stop
 		close(doneCh)
 		return err


### PR DESCRIPTION
**What I did**
fix: after `monitor` has been introduced, I noticed we don't support the second Ctrl+C to kill the compose app
Actually, monitor returned too early, as ctx is cancelled, and stopped collecting docker events

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
