### PR TITLE
 Fixes `provenance` always enabled

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -140,6 +140,7 @@ func buildCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service)
 	flags.MarkHidden("progress") //nolint:errcheck
 	flags.BoolVar(&opts.print, "print", false, "Print equivalent bake file")
 	flags.BoolVar(&opts.check, "check", false, "Check build configuration")
+	flags.BoolVar(&opts.provenance, "provenance", true, "Generate provenance attestation for built images. Shorthand for `--attest=type=provenance`.")
 
 	return cmd
 }
@@ -156,7 +157,6 @@ func runBuild(ctx context.Context, dockerCli command.Cli, backend api.Service, o
 	}
 
 	apiBuildOptions, err := opts.toAPIBuildOptions(services)
-	apiBuildOptions.Provenance = true
 	if err != nil {
 		return err
 	}

--- a/docs/reference/compose_build.md
+++ b/docs/reference/compose_build.md
@@ -22,6 +22,7 @@ run `docker compose build` to rebuild it.
 | `-m`, `--memory`      | `bytes`       | `0`     | Set memory limit for the build container. Not supported by BuildKit.                                        |
 | `--no-cache`          | `bool`        |         | Do not use cache when building the image                                                                    |
 | `--print`             | `bool`        |         | Print equivalent bake file                                                                                  |
+| `--provenance`        | `bool`        | `true`  | Generate provenance attestation for built images. Shorthand for `--attest=type=provenance`.                 |
 | `--pull`              | `bool`        |         | Always attempt to pull a newer version of the image                                                         |
 | `--push`              | `bool`        |         | Push service images                                                                                         |
 | `-q`, `--quiet`       | `bool`        |         | Don't print anything to STDOUT                                                                              |

--- a/docs/reference/docker_compose_build.yaml
+++ b/docs/reference/docker_compose_build.yaml
@@ -125,6 +125,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: provenance
+      value_type: bool
+      default_value: "true"
+      description: |
+        Generate provenance attestation for built images. Shorthand for `--attest=type=provenance`.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: pull
       value_type: bool
       default_value: "false"


### PR DESCRIPTION
## Problem:
Currently, the `build` option `Provenance` is hard-coded to true in the `runBuild` function.
```go
// cmd/compose/build.go L170-L171
func runBuild(...) {
    // ...
	apiBuildOptions, err := opts.toAPIBuildOptions(services)
	apiBuildOptions.Provenance = true // Here's the problem.
    // ...
}
```

This prevents users from disabling the generation of SLSA provenance metadata(used for software supply chain security and build traceability) at build time.

Since the provenance flag already exists in the buildOptions structure, this hard-coded value should be removed, and users should be able to control it via a command-line flag.
## Suggestion for improvement:
### Add `--provenance` flag
Introduce a new `--provenance` flag to the `build` command. This will give users explicit control over whether provenance metadata should be generated, making the tool more flexible and intuitive.

As a security best practice, the default value of this flag should be true with true as the default, so provenance is generated unless users explicitly disable it.
## Benefits
**Improved control**: Users can disable provenance generation by specifying `--provenance=false`.

**Code clarity**: Removes hard-coding and delegates control to existing `buildOptions` structure.

**Security best practice**: Enabling provenance by default supports secure software supply chains.