### PR TITLE
force plain displaymode if stdout isn't a terminal

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -127,7 +127,12 @@ type buildStatus struct {
 func (s *composeService) doBuildBake(ctx context.Context, project *types.Project, serviceToBeBuild types.Services, options api.BuildOptions) (map[string]string, error) { //nolint:gocyclo
 	eg := errgroup.Group{}
 	ch := make(chan *client.SolveStatus)
-	display, err := progressui.NewDisplay(os.Stdout, progressui.DisplayMode(options.Progress))
+	out := s.dockerCli.Out()
+	displayMode := progressui.DisplayMode(options.Progress)
+	if !out.IsTerminal() {
+		displayMode = progressui.PlainMode
+	}
+	display, err := progressui.NewDisplay(out, displayMode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What I did**
When compose stdout is redirected, buildkit progressui.Display can't run in TTY mode (fails with `failed to get console: provided file is not a console`).

**Related issue**
fix https://github.com/docker/compose/issues/13072

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
