### PR TITLE
use output registry when push true and load to docker store if not

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -205,7 +205,11 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		case len(service.Build.Platforms) > 1:
 			outputs = []string{fmt.Sprintf("type=image,push=%t", push)}
 		default:
-			outputs = []string{fmt.Sprintf("type=docker,load=true,push=%t", push)}
+			if push {
+				outputs = []string{"type=registry"}
+			} else {
+				outputs = []string{"type=docker"}
+			}
 		}
 
 		read = append(read, build.Context)


### PR DESCRIPTION
**What I did**
Update the way we pass image output configuration to bake

**Related issue**
https://github.com/docker/buildx/pull/3333#discussion_r2224560641

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
This panda was choose by @crazy-max 🥳 

<img width="714" height="400" alt="image" src="https://github.com/user-attachments/assets/2b8a4d55-893d-4255-b91e-be958ce544b9" />
