### PR TITLE
Improved improper use of os.Exit

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -18,7 +18,6 @@ package compatibility
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/docker/compose/v2/cmd/compose"
@@ -52,7 +51,7 @@ func getStringFlags() []string {
 }
 
 // Convert transforms standalone docker-compose args into CLI plugin compliant ones
-func Convert(args []string) []string {
+func Convert(args []string) ([]string, error) {
 	var rootFlags []string
 	command := []string{compose.PluginName}
 	l := len(args)
@@ -87,8 +86,7 @@ ARGS:
 			if arg == flag {
 				i++
 				if i >= l {
-					fmt.Fprintf(os.Stderr, "flag needs an argument: '%s'\n", arg)
-					os.Exit(1)
+					return nil, fmt.Errorf("flag needs an argument: '%s'", arg)
 				}
 				rootFlags = append(rootFlags, arg, args[i])
 				continue ARGS
@@ -103,7 +101,7 @@ ARGS:
 		}
 		command = append(command, arg)
 	}
-	return append(rootFlags, command...)
+	return append(rootFlags, command...), nil
 }
 
 func contains(array []string, needle string) bool {

--- a/cmd/compatibility/convert_test.go
+++ b/cmd/compatibility/convert_test.go
@@ -17,9 +17,6 @@
 package compatibility
 
 import (
-	"errors"
-	"os"
-	"os/exec"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -110,21 +107,11 @@ func Test_convert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			got, err := Convert(tt.args)
 			if tt.wantErr {
-				if os.Getenv("BE_CRASHER") == "1" {
-					Convert(tt.args)
-					return
-				}
-				cmd := exec.Command(os.Args[0], "-test.run=^"+t.Name()+"$")
-				cmd.Env = append(os.Environ(), "BE_CRASHER=1")
-				err := cmd.Run()
-				var e *exec.ExitError
-				if errors.As(err, &e) && !e.Success() {
-					return
-				}
-				t.Fatalf("process ran with err %v, want exit status 1", err)
+				assert.Assert(t, err != nil)
 			} else {
-				got := Convert(tt.args)
+				assert.NilError(t, err)
 				assert.DeepEqual(t, tt.want, got)
 			}
 		})


### PR DESCRIPTION
## Problem
Within the Convert function, os.Exit(1) is called directly when a flag with missing arguments is detected.
