### PR TITLE
Integration of SetAttributes calls

### DIFF
--- a/cmd/cmdtrace/cmd_span.go
+++ b/cmd/cmdtrace/cmd_span.go
@@ -55,8 +55,10 @@ func Setup(cmd *cobra.Command, dockerCli command.Cli, args []string) error {
 		ctx,
 		"cli/"+strings.Join(commandName(cmd), "-"),
 	)
-	cmdSpan.SetAttributes(attribute.StringSlice("cli.flags", getFlags(cmd.Flags())))
-	cmdSpan.SetAttributes(attribute.Bool("cli.isatty", dockerCli.In().IsTerminal()))
+	cmdSpan.SetAttributes(
+		attribute.StringSlice("cli.flags", getFlags(cmd.Flags())),
+		attribute.Bool("cli.isatty", dockerCli.In().IsTerminal()),
+	)
 
 	cmd.SetContext(ctx)
 	wrapRunE(cmd, cmdSpan, tracingShutdown)


### PR DESCRIPTION
## **What I did**
Within the Setup function of cmd_span.go, SetAttributes is called twice in a row to set the attributes of the span.
These have been combined into a single call.
This change makes the code more concise.

**cmd_span.go**
```diff
		ctx,
		"cli/"+strings.Join(commandName(cmd), "-"),
	)
	- cmdSpan.SetAttributes(attribute.StringSlice("cli.flags", getFlags(cmd.Flags())))
	- cmdSpan.SetAttributes(attribute.Bool("cli.isatty", dockerCli.In().IsTerminal()))
	+ cmdSpan.SetAttributes(
		+ attribute.StringSlice("cli.flags", getFlags(cmd.Flags())),
		+ attribute.Bool("cli.isatty", dockerCli.In().IsTerminal()),
	+ )

	cmd.SetContext(ctx)
	wrapRunE(cmd, cmdSpan, tracingShutdown)
```