### PR TITLE
Eliminate magic number in init functions

### DIFF
--- a/cmd/formatter/colors.go
+++ b/cmd/formatter/colors.go
@@ -58,6 +58,9 @@ const (
 	Auto = "auto"
 )
 
+// ansiColorOffset is the offset for basic foreground colors in ANSI escape codes.
+const ansiColorOffset = 30
+
 // SetANSIMode configure formatter for colored output on ANSI-compliant console
 func SetANSIMode(streams command.Streams, ansi string) {
 	if !useAnsi(streams, ansi) {
@@ -122,8 +125,8 @@ func rainbowColor() colorFunc {
 func init() {
 	colors := map[string]colorFunc{}
 	for i, name := range names {
-		colors[name] = makeColorFunc(strconv.Itoa(30 + i))
-		colors["intense_"+name] = makeColorFunc(strconv.Itoa(30+i) + ";1")
+		colors[name] = makeColorFunc(strconv.Itoa(ansiColorOffset + i))
+		colors["intense_"+name] = makeColorFunc(strconv.Itoa(ansiColorOffset+i) + ";1")
 	}
 	rainbow = []colorFunc{
 		colors["cyan"],


### PR DESCRIPTION
## **What I did**
The number 30 used within the nit function is a magic number representing the offset of the ANSI color code.
Replacing this with a constant with a descriptive name improves code readability and maintainability.

**colors.go**
```diff
	// Auto detect terminal is a tty and can use ANSI codes
	Auto = "auto"
)

+ // ansiColorOffset is the offset for basic foreground colors in ANSI escape codes.
+ const ansiColorOffset = 30

// SetANSIMode configure formatter for colored output on ANSI-compliant console
func SetANSIMode(streams command.Streams, ansi string) {
func init() {
	colors := map[string]colorFunc{}
	for i, name := range names {
		- colors[name] = makeColorFunc(strconv.Itoa(30 + i))
		- colors["intense_"+name] = makeColorFunc(strconv.Itoa(30+i) + ";1")
		+ colors[name] = makeColorFunc(strconv.Itoa(ansiColorOffset + i))
		+ colors["intense_"+name] = makeColorFunc(strconv.Itoa(ansiColorOffset+i) + ";1")
	}
	rainbow = []colorFunc{
		colors["cyan"],
```
