### PR TITLE
add info about models usage to OpenTelemetry spans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -213,3 +213,5 @@ exclude (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 )
+
+replace github.com/compose-spec/compose-go/v2 => github.com/compose-spec/compose-go/v2 v2.8.1-0.20250724131002-0bd910723fa2

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.8.0 h1:+xkrdBkyiiXY2gBTIhJvuKPH7zoC+jvlQBjah6Gg8+U=
-github.com/compose-spec/compose-go/v2 v2.8.0/go.mod h1:veko/VB7URrg/tKz3vmIAQDaz+CGiXH8vZsW79NmAww=
+github.com/compose-spec/compose-go/v2 v2.8.1-0.20250724131002-0bd910723fa2 h1:ScueH2qQpgDxyxJ1xSun2JWCDk747v0VnG9jVWce+K0=
+github.com/compose-spec/compose-go/v2 v2.8.1-0.20250724131002-0bd910723fa2/go.mod h1:veko/VB7URrg/tKz3vmIAQDaz+CGiXH8vZsW79NmAww=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=

--- a/internal/tracing/attributes.go
+++ b/internal/tracing/attributes.go
@@ -77,11 +77,13 @@ func ProjectOptions(ctx context.Context, proj *types.Project) SpanOptions {
 		attribute.StringSlice("project.networks", proj.NetworkNames()),
 		attribute.StringSlice("project.secrets", proj.SecretNames()),
 		attribute.StringSlice("project.configs", proj.ConfigNames()),
+		attribute.StringSlice("project.models", proj.ModelNames()),
 		attribute.StringSlice("project.extensions", keys(proj.Extensions)),
 		attribute.StringSlice("project.services.active", proj.ServiceNames()),
 		attribute.StringSlice("project.services.disabled", proj.DisabledServiceNames()),
 		attribute.StringSlice("project.services.build", proj.ServicesWithBuild()),
 		attribute.StringSlice("project.services.depends_on", proj.ServicesWithDependsOn()),
+		attribute.StringSlice("project.services.models", proj.ServicesWithModels()),
 		attribute.StringSlice("project.services.capabilities", capabilities),
 		attribute.StringSlice("project.services.capabilities.gpu", gpu),
 		attribute.StringSlice("project.services.capabilities.tpu", tpu),
@@ -110,6 +112,7 @@ func ServiceOptions(service types.ServiceConfig) SpanOptions {
 		attribute.String("service.name", service.Name),
 		attribute.String("service.image", service.Image),
 		attribute.StringSlice("service.networks", keys(service.Networks)),
+		attribute.StringSlice("service.models", keys(service.Models)),
 	}
 
 	configNames := make([]string, len(service.Configs))


### PR DESCRIPTION
**What I did**
Add `models` data to OpenTelemetry spans, so we could monitor usage of this new feature

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="292" height="222" alt="image" src="https://github.com/user-attachments/assets/f8805d3a-1750-4402-8646-3e9cb9e940c3" />
