### PR TITLE
Add filtering logic for services

### DIFF
--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -52,6 +52,18 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 		}
 	}
 
+	if len(options.Services) > 0 {
+		var err error
+		if options.NoDeps {
+			project, err = project.WithSelectedServices(options.Services, types.IgnoreDependencies)
+		} else {
+			project, err = project.WithSelectedServices(options.Services, types.IncludeDependencies)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
 	// use an independent context tied to the errgroup for background attach operations
 	// the primary context is still used for other operations
 	// this means that once any attach operation fails, all other attaches are cancelled,


### PR DESCRIPTION
## Proposal:
The current start function loops through all services in the project, even if the service to start is specified in api.StartOptions. Also, the NoDeps option is not taken into account.

This can lead to unnecessary processing and performance degradation, especially in projects with a large number of services.
It is also inconsistent with the behavior of other commands with similar options, such as the create command.

## Fix:
Added logic to filter projects based on options.Services and options.NoDeps before calling InDependencyOrder, similar to the implementation of the create command

This change ensures that only the target service and its dependencies are processed.

## Benefits:
This change will improve the following

- **Performance**: Unnecessary iterations in projects with a large number of services will be eliminated and startup will be faster.

- **Consistency**: Behavior will be consistent with other commands, such as the create command.

- **Functionality**: The NoDeps option now works correctly.
