### PR TITLE
add Streams Comment

### DIFF
--- a/pkg/api/io.go
+++ b/pkg/api/io.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/cli/cli/streams"
 )
 
+// Streams defines the standard streams (stdin, stdout, stderr) used by the CLI.
 type Streams interface {
 	Out() *streams.Out
 	Err() *streams.Out


### PR DESCRIPTION
## Problem:
Lack of documentation: 
The Streams interface does not have a comment explaining its role; Go's practice is to strongly encourage exported types (in this case interfaces) to have a documentation comment explaining their purpose. This way, when other developers read the code, they will immediately understand what this interface is for.

## Fix:
To improve this, GoDoc-style comments have been added to the Streams interface