### PR TITLE
buildkit require os.Stdout to access the raw terminal

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -133,11 +133,10 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	displayMode := progressui.DisplayMode(options.Progress)
 	out := options.Out
 	if out == nil {
-		cout := s.dockerCli.Out()
-		if !cout.IsTerminal() {
+		if !s.dockerCli.Out().IsTerminal() {
 			displayMode = progressui.PlainMode
 		}
-		out = cout
+		out = os.Stdout // should be s.dockerCli.Out(), but NewDisplay require access to the underlying *File
 	}
 	display, err := progressui.NewDisplay(out, displayMode)
 	if err != nil {


### PR DESCRIPTION
**What I did**
buildkit (actually, containerd/console) requires a `*File` to access the raw terminal and render build progress UI
it actually can't just be based on a file descriptor (we can get for `dockerCli.Out().FD()`) as windows support requires an actual file 🥲
so .. we have to assume dockerCli.Out == os.Stdout, which basically makes dockerCli.Out abstraction useless 🥹

**Related issue**
fixes https://github.com/docker/compose/issues/13099

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
