### PR TITLE
apply BUILDKIT_PROGRESS value when building with bake

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -130,6 +130,9 @@ type buildStatus struct {
 func (s *composeService) doBuildBake(ctx context.Context, project *types.Project, serviceToBeBuild types.Services, options api.BuildOptions) (map[string]string, error) { //nolint:gocyclo
 	eg := errgroup.Group{}
 	ch := make(chan *client.SolveStatus)
+	if options.Progress == progress.ModeAuto {
+		options.Progress = os.Getenv("BUILDKIT_PROGRESS")
+	}
 	displayMode := progressui.DisplayMode(options.Progress)
 	out := options.Out
 	if out == nil {


### PR DESCRIPTION
**What I did**
Setup the progress display mode if `BUILDKIT_PROGRESS` is defined and progress is defined with the `auto` value when building with `bake`

**Related issue**
fixes #13088 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/f7957447-0641-4dce-9374-120ce35009e9" />
