### PR TITLE
use log API for containers we didn't attached to

### DIFF
--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/sync/errgroup"
 )
 
 func (s *composeService) Start(ctx context.Context, projectName string, options api.StartOptions) error {
@@ -47,18 +46,6 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 		}
 
 		project, err = s.projectFromName(containers, projectName, options.AttachTo...)
-		if err != nil {
-			return err
-		}
-	}
-
-	// use an independent context tied to the errgroup for background attach operations
-	// the primary context is still used for other operations
-	// this means that once any attach operation fails, all other attaches are cancelled,
-	// but an attach failing won't interfere with the rest of the start
-	eg, attachCtx := errgroup.WithContext(ctx)
-	if listener != nil {
-		_, err := s.attach(attachCtx, project, listener, options.AttachTo)
 		if err != nil {
 			return err
 		}
@@ -111,7 +98,7 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 		}
 	}
 
-	return eg.Wait()
+	return nil
 }
 
 // getDependencyCondition checks if service is depended on by other services


### PR DESCRIPTION
**What I did**

`up` listen to container events so it can collect logs when a container is restarted, recreated (watch) or scaled by another compose command. To prevent collecting logs _twice_ we have to exclude the container we explicitly attached to as part of the `up` sequence.

Changes here run `attach` outside `start` so we have better control on the sequence order, and capture containers we attached to and must exclude.

**Related issue**
fixes https://github.com/docker/compose/issues/13101

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
