### PR TITLE
only monitor attached services on up command

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -168,7 +168,8 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	if len(options.Start.Services) > 0 {
 		monitor.withServices(options.Start.Services)
 	} else {
-		monitor.withServices(project.ServiceNames())
+		// Start.AttachTo have been already curated with only the services to monitor
+		monitor.withServices(options.Start.AttachTo)
 	}
 	monitor.withListener(printer.HandleEvent)
 


### PR DESCRIPTION
**What I did**
Only pass the list of attached services to the logs monitor

**Related issue**
Fixes #13113 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/c26944c8-7e4d-4de4-9670-a67aae226116" />
