### PR TITLE
pkg/compose: simplify getting auth-config key

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,38 @@
+/*
+   Copyright 2023 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package registry
+
+import "github.com/distribution/reference"
+
+const (
+	// IndexHostname is the index hostname, used for authentication and image search.
+	IndexHostname = "index.docker.io"
+	// IndexServer is used for user auth and image search
+	IndexServer = "https://index.docker.io/v1/"
+	// IndexName is the name of the index
+	IndexName = "docker.io"
+)
+
+// GetAuthConfigKey special-cases using the full index address of the official
+// index as the AuthConfig key, and uses the (host)name[:port] for private indexes.
+func GetAuthConfigKey(reposName reference.Named) string {
+	indexName := reference.Domain(reposName)
+	if indexName == IndexName || indexName == IndexHostname {
+		return IndexServer
+	}
+	return indexName
+}

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -34,11 +34,11 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/docker/docker/registry"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/go-digest"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/docker/compose/v2/internal/registry"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
 )
@@ -281,13 +281,7 @@ func ImageDigestResolver(ctx context.Context, file *configfile.ConfigFile, apiCl
 }
 
 func encodedAuth(ref reference.Named, configFile driver.Auth) (string, error) {
-	repoInfo, err := registry.ParseRepositoryInfo(ref)
-	if err != nil {
-		return "", err
-	}
-
-	key := registry.GetAuthConfigKey(repoInfo.Index)
-	authConfig, err := configFile.GetAuthConfig(key)
+	authConfig, err := configFile.GetAuthConfig(registry.GetAuthConfigKey(ref))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
relates to;

- https://github.com/docker/cli/pull/2819
- https://github.com/moby/moby/commit/7bfb804dbe8e536238c01e588e49506b2f18bc91 / https://github.com/moby/moby/pull/50446


Rewrite to remove the `github.com/docker/docker/registry` dependency, which will not be included in the upcoming "api" and "client" modules, and will not be a public package in the module used for the daemon itself.

## 1. don't call "/info" API endpoint to get default registry

The `IndexServerAddress` in the `/info` endpoint was added as part of the initial Windows implementation of the engine. For legal reasons, Microsoft Windows (and thus Docker images based on Windows) were not allowed to be distributed through non-Microsoft infrastructure. As a temporary solution, a dedicated "registry-win-tp3.docker.io" registry was created to serve Windows images.

Using separate registries was not an ideal solution, and a more permanent solution was created by introducing "foreign image layers" in the distribution spec, after which the "registry-win-tp3.docker.io" ceased to exist, and removed from the engine through docker/docker PR 21100.

However, the `ElectAuthServer` was left in place, quoting from that PR;

> make the client check which default registry the daemon uses is still
> more correct than leaving it up to the client, even if it won't technically
> matter after this PR. There may be some backward compatibility scenarios
> where `ElectAuthServer` [sic] is still helpful.

That comment was 10 Years ago, and the CLI stopped using this information, as the default registry is not configurable, so in practice was a static value. (see https://github.com/docker/cli/commit/b4ca1c7368daeead400fcc1b8f2d61951a0d9d1e).

## 2. replace `ParseRepositoryInfo` and `GetAuthConfigKey` with local implementation

The `ParseRepositoryInfo` function was originally implemented for use by the daemon itself. It returns a `RepositoryInfo` struct that holds information about the repository and the registry the repository can be found in.

As it was written for use by the daemon, it also was designed to be used in combination with the daemon's configuration (such as mirrors, and insecure registries). If no daemon configuration is present, which would be the case when used in a CLI, it uses fallback logic as used in the daemon to detect if the registry is running on a localhost / loopback address, because such addresses are allowed to be "insecure" by default; this includes resolving the IP-address of the host (if it's not an IP-address).

Unfortunately, these functions (and related types) were reused in the CLI and many other places, which resulted in those types to be deeply ingrained in interfaces and (external) code.

For compose; it was only used to get the "auth-config key" to use for looking up auth information from the credentials store, which still needs special handling for the "default" (docker hub) domain, which unlike other image references doesn't use the hostname included in the image reference for the actual registry (and key for storing auth).

For those that want to follow along;

First, note that `GetAuthConfig` only requires a `registry.IndexInfo`, so not the whole `RepositoryInfo` struct;
https://github.com/moby/moby/blob/v28.3.3/registry/types.go#L8-L24

From the `registry.IndexInfo` it only uses the `IsOfficial` and `Name` fields; https://github.com/moby/moby/blob/v28.3.3/registry/config.go#L390-L395

But to get the `IndexInfo`, `ParseRepositoryInfo` is needed, which first takes the image reference's "domain name" (e.g. `docker.io`); https://github.com/moby/moby/blob/v28.3.3/registry/config.go#L421

This gets "normalized" for some cases where the `info.IndexServerAddress` was incorrectly assumed to be the canonical domain for Docker Hub registry, and which _does_ happen to also be accessible as a "v2" registry. https://github.com/moby/moby/blob/v28.3.3/registry/config.go#L334-L341

After normalizing, it checks if it's a docker hub address ("docker.io" after normalizing); Docker Hub is always required to use a secure connection, so no detection happens, and the `Official` field is set to indicate it's Docker Hub (this code path was already simplified as historically it would try to find daemon configuration (or otherwise use a default) for Mirror configuration;
https://github.com/moby/moby/blob/v28.3.3/registry/config.go#L420-L443

For non-Docker Hub registries, it also sets the name, and attempts to detect if the registry is allowed to be "insecure"; https://github.com/moby/moby/blob/v28.3.3/registry/config.go#L435-L442

Which (as mentioned) involves parsing the address and, if needed, resolving the hostname
https://github.com/moby/moby/blob/v28.3.3/registry/config.go#L445-L481

As `Insecure` is not used for looking up the auth-config key, all of the above can be reduced to;

- Is the hostname obtained from the image reference "docker.io" (after normalizing)?
- If so, use the special `https://index.docker.io/v1/` as auth-config key (another horrible remnant)
- Otherwise use the hostname obtained from the image reference as-is

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
