### PR TITLE
define pull and no_cache from either service or flags values when building with bake

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -226,6 +226,9 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		image := api.GetImageNameOrDefault(service, project.Name)
 		expectedImages[serviceName] = image
 
+		pull := service.Build.Pull || options.Pull
+		noCache := service.Build.NoCache || options.NoCache
+
 		target := targets[serviceName]
 		cfg.Targets[target] = bakeTarget{
 			Context:          build.Context,
@@ -243,8 +246,8 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			Target:       build.Target,
 			Secrets:      toBakeSecrets(project, build.Secrets),
 			SSH:          toBakeSSH(append(build.SSH, options.SSHs...)),
-			Pull:         options.Pull,
-			NoCache:      options.NoCache,
+			Pull:         pull,
+			NoCache:      noCache,
 			ShmSize:      build.ShmSize,
 			Ulimits:      toBakeUlimits(build.Ulimits),
 			Entitlements: entitlements,


### PR DESCRIPTION
**What I did**
Choose the appropriate values fro `pull` and `no_cache` options, either from service definition or CLI flags, when building with `bake`

**Related issue**
fixes #13117

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1920" height="1275" alt="image" src="https://github.com/user-attachments/assets/3e6e6c28-fa7d-4dc8-aa6c-05e9bc393ec7" />
