### PR TITLE
bump golang to 1.23.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.23.10
+ARG GO_VERSION=1.23.12
 ARG XX_VERSION=1.6.1
 ARG GOLANGCI_LINT_VERSION=v2.0.2
 ARG ADDLICENSE_VERSION=v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/compose/v2
 
-go 1.23.10
+go 1.23.12
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
**What I did**

bumps the golang version used to 1.23.12

> go1.23.11 (released 2025-07-08) includes security fixes to the go command, as well as bug fixes to the compiler, the linker, and the runtime. See the [Go 1.23.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.11+label%3ACherryPickApproved) on our issue tracker for details.

> go1.23.12 (released 2025-08-06) includes security fixes to the database/sql and os/exec packages, as well as bug fixes to the runtime. See the [Go 1.23.12 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.12+label%3ACherryPickApproved) on our issue tracker for details.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
