### PR TITLE
check the assume yes publish flag command before the presence of bind mounts

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -236,6 +236,9 @@ func (s *composeService) preChecks(project *types.Project, options api.PublishOp
 	if ok, err := s.checkOnlyBuildSection(project); !ok || err != nil {
 		return false, err
 	}
+	if options.AssumeYes {
+		return true, nil
+	}
 	bindMounts := s.checkForBindMount(project)
 	if len(bindMounts) > 0 {
 		fmt.Println("you are about to publish bind mounts declaration within your OCI artifact.\n" +
@@ -250,9 +253,6 @@ func (s *composeService) preChecks(project *types.Project, options api.PublishOp
 		if ok, err := acceptPublishBindMountDeclarations(s.dockerCli); err != nil || !ok {
 			return false, err
 		}
-	}
-	if options.AssumeYes {
-		return true, nil
 	}
 	detectedSecrets, err := s.checkForSensitiveData(project)
 	if err != nil {


### PR DESCRIPTION
**What I did**
Check the value of the `-y` or `--yes` flag of the publish command before warning if bind mounts declaration will be published 

**Related issue**
#13148 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1200" height="899" alt="image" src="https://github.com/user-attachments/assets/0547f139-7003-4fb7-8d4a-1bfbbb0f9cc5" />
