### PR TITLE
Add `provenance: max` shorthand for per-service build attestations

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -473,6 +473,8 @@ func toBakeAttest(build types.BuildConfig) []string {
 	if build.Provenance != "" {
 		if build.Provenance == "true" {
 			attests = append(attests, "type=provenance")
+		} else if build.Provenance == "max" {
+			attests = append(attests, "type=provenance,mode=max")
 		} else if build.Provenance != "false" {
 			attests = append(attests, fmt.Sprintf("type=provenance,%s", build.Provenance))
 		}

--- a/pkg/compose/build_test.go
+++ b/pkg/compose/build_test.go
@@ -55,3 +55,47 @@ func Test_addBuildDependencies(t *testing.T) {
 	slices.Sort(expected)
 	assert.DeepEqual(t, services, expected)
 }
+
+func Test_toBakeAttest(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    types.BuildConfig
+		expected []string
+	}{
+		{
+			name:     "no attestations",
+			build:    types.BuildConfig{},
+			expected: nil,
+		},
+		{
+			name:     "provenance",
+			build:    types.BuildConfig{Provenance: "true"},
+			expected: []string{"type=provenance"},
+		},
+		{
+			name:     "max provenance",
+			build:    types.BuildConfig{Provenance: "max"},
+			expected: []string{"type=provenance,mode=max"},
+		},
+		{
+			name:     "sbom",
+			build:    types.BuildConfig{SBOM: "true"},
+			expected: []string{"type=sbom"},
+		},
+		{
+			name: "max provenance and sbom",
+			build: types.BuildConfig{
+				Provenance: "max",
+				SBOM:       "true",
+			},
+			expected: []string{"type=provenance,mode=max", "type=sbom"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toBakeAttest(tt.build)
+			assert.DeepEqual(t, result, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
**What I did**

Added a more readable `provenance: max` syntax as an alternative to the existing `provenance: "mode=max"`. Less verbose to encourage its use, since max is the default mode for docker/build-push-action on public GitHub repos. Follows the same pattern as other boolean/string configs (eg. pull: true/always), so hopefully it isn't against the spec.

Also added tests.

## Example Usage

```yaml
# compose.yaml
services:
  app:
    build:
      provenance: max # shorthand for "mode=max"
```
```sh
./bin/build/docker-compose build --print

...

"attest": [
    "type=provenance,mode=max"
]
```
