### PR TITLE
Fix runtime operations failing when env file is missing

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -245,7 +245,7 @@ func (o *ProjectOptions) projectOrName(ctx context.Context, dockerCli command.Cl
 	name := o.ProjectName
 	var project *types.Project
 	if len(o.ConfigPaths) > 0 || o.ProjectName == "" {
-		p, _, err := o.ToProject(ctx, dockerCli, services, cli.WithDiscardEnvFile)
+		p, _, err := o.ToProject(ctx, dockerCli, services, cli.WithDiscardEnvFile, cli.WithoutEnvironmentResolution)
 		if err != nil {
 			envProjectName := os.Getenv(ComposeProjectName)
 			if envProjectName != "" {

--- a/pkg/e2e/env_file_test.go
+++ b/pkg/e2e/env_file_test.go
@@ -37,6 +37,11 @@ func TestUnusedMissingEnvFile(t *testing.T) {
 	defer c.cleanupWithDown(t, "unused_dotenv")
 
 	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "up", "-d", "serviceA")
+
+	// Runtime operations should work even with missing env file
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "ps")
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "logs")
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "down")
 }
 
 func TestRunEnvFile(t *testing.T) {


### PR DESCRIPTION
**What I did**

Closes #13135

Tolerate missing env file on runtime commands that should only depend on container labels like down, ps, logs, etc.

When an env file is deleted while a container is running, or an unused env file is declared by another service, most Compose commands fail, including `docker compose down`. Containers become unmanageable by Compose, and you must use `docker down` directly or recreate env files to bring containers down.

Note: This pattern likely affects other file dependencies like `secrets.file` and `configs.file`.

## Steps to Reproduce

```bash
cat > compose.yaml << 'EOF'
services:
  app:
    image: alpine
    env_file: deleteme.env
EOF

touch deleteme.env

docker compose up -d

rm deleteme.env

docker compose ps
# env file /Users/max/dev/repro/compose-13135/deleteme.env not found: stat /Users/max/dev/repro/compose-13135/deleteme.env: no such file or directory

docker compose down
# env file /Users/max/dev/repro/compose-13135/deleteme.env not found: stat /Users/max/dev/repro/compose-13135/deleteme.env: no such file or directory
```
