### PR TITLE
add completions for the --progress flag

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -661,6 +661,10 @@ func RootCommand(dockerCli command.Cli, backend Backend) *cobra.Command { //noli
 		"profile",
 		completeProfileNames(dockerCli, &opts),
 	)
+	c.RegisterFlagCompletionFunc( //nolint:errcheck
+		"progress",
+		cobra.FixedCompletions(printerModes, cobra.ShellCompDirectiveNoFileComp),
+	)
 
 	c.Flags().StringVar(&ansi, "ansi", "auto", `Control when to print ANSI control characters ("never"|"always"|"auto")`)
 	c.Flags().IntVar(&parallel, "parallel", -1, `Control max parallelism, -1 for unlimited`)


### PR DESCRIPTION
**what i did**

added completions for the `--progress` flag.

**related issue**

no issue i could find, i didn't know if i should have opened an issue, but i thought it would probably be fine for a 3 line change

**notes**

a few lines above there are two more calls to `RegisterCompletionFunc`, that pass in a `func`, that manually does the same as my call to `cobra.FixedCompletions`. i thought of changing those to the `cobra.FixedCompletions`, but i didn't want to change unrelated code without asking first, so here i am. if you like those manual functions more, i can also ditch my cal to `cobra.FixedCompletions` if you prefer.

(couldn't think of an animal in relation to what i did, so here's a least weasel)
<img width="1024" height="969" alt="image" src="https://github.com/user-attachments/assets/0f000d28-2674-4fa4-b965-a1c5fdeed6ca" />
