### PR TITLE
Fix build slowdown when OpenTelemetry Exporter env variables are present

### DIFF
--- a/pkg/compose/shellout.go
+++ b/pkg/compose/shellout.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"os/exec"
+	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli-plugins/metadata"
@@ -33,6 +34,13 @@ func (s *composeService) prepareShellOut(gctx context.Context, env types.Mapping
 	env = env.Clone()
 	// remove DOCKER_CLI_PLUGIN... variable so a docker-cli plugin will detect it run standalone
 	delete(env, metadata.ReexecEnvvar)
+
+	// Remove OpenTelemetry env variables so buildx doesn't attempt to init exporter and timeout
+	for k := range env {
+		if strings.HasPrefix(k, "OTEL_") {
+			delete(env, k)
+		}
+	}
 
 	// propagate opentelemetry context to child process, see https://github.com/open-telemetry/oteps/blob/main/text/0258-env-context-baggage-carriers.md
 	carrier := propagation.MapCarrier{}


### PR DESCRIPTION
Closes #13157

Fixes a 10s slowdown on `docker compose build`, including cached builds, when `OTEL_EXPORTER_*` or `OTEL_*_EXPORTER` env variables are present. Scrubs OpenTelemetry env variables when shelling out to bake.

Bake was called with the full project environment. When a user's .env file include OpenTelemetry exporter env variables (eg. `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`), these were passed to buildx, which attempted to init its OTLP exporter and connect to an unreachable collector, making the process wait for a network timeout. For the user, this was during the "resolving provenance for metadata file" step visually.

This is a short-term hotfix for the immediate issue, before more projects opt-out of Compose bake with `COMPOSE_BAKE=false`. A better long term solution might be to sanitize the bake env with a minimal allowlist (eg. DOCKER_, BUILDX_, etc.) or update hasOtelEndpointInEnv detection in internal/tracing.

## Steps to reproduce

```bash
cat > Dockerfile <<EOF
FROM alpine
EOF

cat > compose.yaml <<EOF
services:
  app:
    build: .
EOF

cat > .env <<EOF
OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
EOF

echo "--- Slow ---"
time docker compose build
# 11 seconds

echo "--- Fast ---"
time COMPOSE_BAKE=false docker compose build
# 0.5 seconds

echo "--- Fast ---"
rm .env
time docker compose build
# 0.5 seconds
```
