### PR TITLE
prefer application container vs one-off running `exec` without index

### DIFF
--- a/pkg/compose/containers.go
+++ b/pkg/compose/containers.go
@@ -100,7 +100,7 @@ func (s *composeService) getSpecifiedContainer(ctx context.Context, projectName 
 		IsOneOffLabelTrueX := containers[i].Labels[api.OneoffLabel] == "True"
 		IsOneOffLabelTrueY := containers[j].Labels[api.OneoffLabel] == "True"
 
-		if numberLabelX == numberLabelY {
+		if IsOneOffLabelTrueX || IsOneOffLabelTrueY {
 			return !IsOneOffLabelTrueX && IsOneOffLabelTrueY
 		}
 

--- a/pkg/e2e/exec_test.go
+++ b/pkg/e2e/exec_test.go
@@ -1,0 +1,47 @@
+/*
+   Copyright 2023 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/v3/icmd"
+)
+
+func TestExec(t *testing.T) {
+	const projectName = "e2e-exec"
+	c := NewParallelCLI(t)
+
+	cleanup := func() {
+		c.RunDockerComposeCmd(t, "--project-name", projectName, "down", "--timeout=0", "--remove-orphans")
+	}
+	t.Cleanup(cleanup)
+	cleanup()
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/exec/compose.yaml", "--project-name", projectName, "run", "-d", "test", "cat")
+
+	res := c.RunDockerComposeCmdNoCheck(t, "--project-name", projectName, "exec", "--index=1", "test", "ps")
+	res.Assert(t, icmd.Expected{Err: "service \"test\" is not running container #1", ExitCode: 1})
+
+	res = c.RunDockerComposeCmd(t, "--project-name", projectName, "exec", "test", "ps")
+	res.Assert(t, icmd.Expected{Out: "cat"}) // one-off container was selected
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/exec/compose.yaml", "--project-name", projectName, "up", "-d")
+
+	res = c.RunDockerComposeCmd(t, "--project-name", projectName, "exec", "test", "ps")
+	res.Assert(t, icmd.Expected{Out: "tail"}) // service container was selected
+}

--- a/pkg/e2e/fixtures/exec/compose.yaml
+++ b/pkg/e2e/fixtures/exec/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  test:
+    image: alpine
+    command: tail -f /dev/null


### PR DESCRIPTION
**What I did**
prefer application container (OneOffLabel = False) vs one-off container running `exec` without an index

**Related issue**
fix https://github.com/docker/compose/issues/13152

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
