### PR TITLE
only force plain mode build if progress is set to auto

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -138,7 +138,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	displayMode := progressui.DisplayMode(options.Progress)
 	out := options.Out
 	if out == nil {
-		if !s.dockerCli.Out().IsTerminal() {
+		if displayMode == progress.ModeAuto && !s.dockerCli.Out().IsTerminal() {
 			displayMode = progressui.PlainMode
 		}
 		out = os.Stdout // should be s.dockerCli.Out(), but NewDisplay require access to the underlying *File


### PR DESCRIPTION
**What I did**
we force progress output to plain mode when out isn't a TTY, otherwise progressUI fails. But this must only apply when user didn't explicitly requested a progress mode to be set

**Related issue**
fix https://github.com/docker/compose/issues/13164

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
