### PR TITLE
detect compose run wit --host and set DOCKER_HOST accordingly running bake

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -335,6 +335,12 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	if err != nil {
 		return nil, err
 	}
+	endpoint, cleanup, err := s.propagateDockerEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Env = append(cmd.Env, endpoint...)
+	defer cleanup()
 
 	cmd.Stdout = s.stdout()
 	cmd.Stdin = bytes.NewBuffer(b)


### PR DESCRIPTION
**What I did**

enforce child process uses the same docker host as compose by setting DOCKER_* variables

** note **: after docker/cli processed flags we can't get the original source for TLS keys, so create a temporary cert folder.

**Related issue**
fix https://github.com/docker/compose/issues/13134

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
