### PR TITLE
Unquote volume names in creation events

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1623,7 +1623,7 @@ func (s *composeService) removeDivergedVolume(ctx context.Context, name string, 
 }
 
 func (s *composeService) createVolume(ctx context.Context, volume types.VolumeConfig) error {
-	eventName := fmt.Sprintf("Volume %q", volume.Name)
+	eventName := fmt.Sprintf("Volume %s", volume.Name)
 	w := progress.ContextWriter(ctx)
 	w.Event(progress.CreatingEvent(eventName))
 	hash, err := VolumeHash(volume)

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -175,7 +175,7 @@ func TestUpWithAllResources(t *testing.T) {
 	})
 
 	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/resources/compose.yaml", "--all-resources", "--project-name", projectName, "up")
-	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf(`Volume "%s_my_vol"  Created`, projectName)), res.Combined())
+	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf(`Volume %s_my_vol  Created`, projectName)), res.Combined())
 	assert.Assert(t, strings.Contains(res.Combined(), fmt.Sprintf(`Network %s_my_net  Created`, projectName)), res.Combined())
 }
 


### PR DESCRIPTION
Volumes are the only resources that are quoted, and only on creation.

**What I did**

For UX/consistency, remove quotes to make things visually consistent.

**Related issue**

Fixes #13187 
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

Not sure this PR is worthy of a cute animal...
