### PR TITLE
fix sigint/sigterm support in logs --follow

### DIFF
--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -104,6 +104,7 @@ func (s *composeService) Logs(
 			}
 		})
 		eg.Go(func() error {
+			// pass ctx so monitor will immediately stop on SIGINT
 			return monitor.Start(ctx)
 		})
 	}

--- a/pkg/compose/monitor.go
+++ b/pkg/compose/monitor.go
@@ -79,7 +79,7 @@ func (c *monitor) Start(ctx context.Context) error {
 	}
 	restarting := utils.Set[string]{}
 
-	evtCh, errCh := c.api.Events(context.Background(), events.ListOptions{
+	evtCh, errCh := c.api.Events(ctx, events.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("type", "container"),
 			projectFilter(c.project)),
@@ -89,6 +89,8 @@ func (c *monitor) Start(ctx context.Context) error {
 			return nil
 		}
 		select {
+		case <-ctx.Done():
+			return nil
 		case err := <-errCh:
 			return err
 		case event := <-evtCh:


### PR DESCRIPTION
**What I did**

use command ctx to run monitor on `logs` command, so monitor will stop on SIGINT

**Related issue**
fix https://github.com/docker/compose/issues/13118
alternative to https://github.com/docker/compose/pull/13132

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
