### PR TITLE
document (hidden) --tty --interactive flags

### DIFF
--- a/docs/reference/compose_exec.md
+++ b/docs/reference/compose_exec.md
@@ -6,6 +6,12 @@ This is the equivalent of `docker exec` targeting a Compose service.
 With this subcommand, you can run arbitrary commands in your services. Commands allocate a TTY by default, so
 you can use a command such as `docker compose exec web sh` to get an interactive prompt.
 
+By default, Compose will enter container in interactive mode and allocate a TTY, while the equivalent `docker exec`
+command requires passing `--interactive --tty` flags to get the same behavior. Compose also support those two flags
+to offer a smooth migration between commands, whenever they are no-op by default. Still, `interactive` can be used to
+force disabling interactive mode (`--interactive=false`), typically when `docker compose exec` command is used inside
+a script.
+
 ### Options
 
 | Name              | Type          | Default | Description                                                                      |
@@ -28,3 +34,9 @@ This is the equivalent of `docker exec` targeting a Compose service.
 
 With this subcommand, you can run arbitrary commands in your services. Commands allocate a TTY by default, so
 you can use a command such as `docker compose exec web sh` to get an interactive prompt.
+
+By default, Compose will enter container in interactive mode and allocate a TTY, while the equivalent `docker exec` 
+command requires passing `--interactive --tty` flags to get the same behavior. Compose also support those two flags
+to offer a smooth migration between commands, whenever they are no-op by default. Still, `interactive` can be used to 
+force disabling interactive mode (`--interactive=false`), typically when `docker compose exec` command is used inside 
+a script.

--- a/docs/reference/docker_compose_exec.yaml
+++ b/docs/reference/docker_compose_exec.yaml
@@ -5,6 +5,12 @@ long: |-
 
     With this subcommand, you can run arbitrary commands in your services. Commands allocate a TTY by default, so
     you can use a command such as `docker compose exec web sh` to get an interactive prompt.
+
+    By default, Compose will enter container in interactive mode and allocate a TTY, while the equivalent `docker exec`
+    command requires passing `--interactive --tty` flags to get the same behavior. Compose also support those two flags
+    to offer a smooth migration between commands, whenever they are no-op by default. Still, `interactive` can be used to
+    force disabling interactive mode (`--interactive=false`), typically when `docker compose exec` command is used inside
+    a script.
 usage: docker compose exec [OPTIONS] SERVICE COMMAND [ARGS...]
 pname: docker compose
 plink: docker_compose.yaml


### PR DESCRIPTION
**What I did**

Those flags are hidden as they are no-op flags introduced to align with docker/cli. Still, there are a few relevant usages, typically when it comes to use Compose in a shell script

**Related issue**
close https://github.com/docker/docs/issues/23352

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
