### PR TITLE
pkg/e2e: Update busybox version

### DIFF
--- a/pkg/e2e/fixtures/dependencies/Dockerfile
+++ b/pkg/e2e/fixtures/dependencies/Dockerfile
@@ -12,5 +12,5 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM busybox:1.35.0
+FROM busybox:1.36.1
 RUN echo "hello"


### PR DESCRIPTION
**What I did**

Update busybox version

The current version dumps core:

https://openqa.opensuse.org/tests/5286317#downloads