### PR TITLE
detect container is restarted

### DIFF
--- a/pkg/compose/monitor.go
+++ b/pkg/compose/monitor.go
@@ -136,11 +136,6 @@ func (c *monitor) Start(ctx context.Context) error {
 					listener(newContainerEvent(event.TimeNano, ctr, api.ContainerEventRestarted))
 				}
 				logrus.Debugf("container %s restarted", ctr.Name)
-			case events.ActionStop:
-				// when a container is in restarting phase, and we stop the application (abort-on-container-exit)
-				// we won't get any additional start+die events, just this stop as a proof container is down
-				logrus.Debugf("container %s stopped", ctr.Name)
-				containers.Remove(ctr.ID)
 			case events.ActionDie:
 				logrus.Debugf("container %s exited with code %d", ctr.Name, ctr.ExitCode)
 				inspect, err := c.api.ContainerInspect(ctx, event.Actor.ID)

--- a/pkg/compose/printer.go
+++ b/pkg/compose/printer.go
@@ -42,7 +42,11 @@ func newLogPrinter(consumer api.LogConsumer) logPrinter {
 func (p *printer) HandleEvent(event api.ContainerEvent) {
 	switch event.Type {
 	case api.ContainerEventExited:
-		p.consumer.Status(event.Source, fmt.Sprintf("exited with code %d", event.ExitCode))
+		if event.Restarting {
+			p.consumer.Status(event.Source, fmt.Sprintf("exited with code %d (restarting)", event.ExitCode))
+		} else {
+			p.consumer.Status(event.Source, fmt.Sprintf("exited with code %d", event.ExitCode))
+		}
 	case api.ContainerEventRecreated:
 		p.consumer.Status(event.Container.Labels[api.ContainerReplaceLabel], "has been recreated")
 	case api.ContainerEventLog, api.HookEventLog:

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -245,7 +245,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		if event.Type != api.ContainerEventStarted {
 			return
 		}
-		if slices.Contains(attached, event.ID) {
+		if slices.Contains(attached, event.ID) && !event.Restarting {
 			return
 		}
 		eg.Go(func() error {


### PR DESCRIPTION
**What I did**
detect a container is restarted. `stop` event doesn't tell us anything about container state (just, engine received a stop request) so better rely on `die` event which demonstrates container termination, then we can inspect and know container is restarting

** note ** I wish `die` event includes a `restarting` attribute so we don't even need to inspect container. I will check I can offer a contribution to moby for this purpose

**Related issue**
fixes https://github.com/docker/compose/issues/13161
supersede https://github.com/docker/compose/pull/13199

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
