### PR TITLE
test: Set stop_signal to SIGTERM

### DIFF
--- a/pkg/e2e/fixtures/dependencies/recreate-no-deps.yaml
+++ b/pkg/e2e/fixtures/dependencies/recreate-no-deps.yaml
@@ -9,6 +9,7 @@ services:
 
   nginx:
     image: nginx:alpine
+    stop_signal: SIGTERM
     healthcheck:
       test:     "echo | nc -w 5 localhost:80"
       interval: 2s

--- a/pkg/e2e/fixtures/restart-test/compose-depends-on.yaml
+++ b/pkg/e2e/fixtures/restart-test/compose-depends-on.yaml
@@ -3,6 +3,7 @@ services:
     image: nginx:alpine
     init: true
     command: tail -f /dev/null
+    stop_signal: SIGTERM
     depends_on:
       nginx: {condition: service_healthy, restart: true}
 
@@ -10,6 +11,7 @@ services:
     image: nginx:alpine
     init: true
     command: tail -f /dev/null
+    stop_signal: SIGTERM
     depends_on:
       nginx: { condition: service_healthy }
 
@@ -17,6 +19,7 @@ services:
     image: nginx:alpine
     labels:
       TEST: ${LABEL:-test}
+    stop_signal: SIGTERM
     healthcheck:
       test:     "echo | nc -w 5 localhost:80"
       interval: 2s


### PR DESCRIPTION
**What I did**

The official nginx images set STOPSIGNAL to SIGQUIT which dumps core. Set it to SIGTERM to avoid dumping core on e2e tests.

