### PR TITLE
add support of develop.watch.initial_sync attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,3 +209,5 @@ exclude (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 )
+
+replace github.com/compose-spec/compose-go/v2 => github.com/compose-spec/compose-go/v2 v2.8.3-0.20250917164343-9a11fcb1e362

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 h1:lkAMpLVBDaj17e
 github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.8.2 h1:A1iVoZJUex7buGv1CpnC5uwNuyTMBYpDAmBnAQmia9Q=
-github.com/compose-spec/compose-go/v2 v2.8.2/go.mod h1:Oky9AZGTRB4E+0VbTPZTUu4Kp+oEMMuwZXZtPPVT1iE=
+github.com/compose-spec/compose-go/v2 v2.8.3-0.20250917164343-9a11fcb1e362 h1:FeJRGYVKTB5l6UVeoilkIJ3iAtBBdDMP/IaxOwSLc2s=
+github.com/compose-spec/compose-go/v2 v2.8.3-0.20250917164343-9a11fcb1e362/go.mod h1:Oky9AZGTRB4E+0VbTPZTUu4Kp+oEMMuwZXZtPPVT1iE=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -231,15 +231,11 @@ func (s *composeService) watch(ctx context.Context, project *types.Project, opti
 			if isSync(trigger) && checkIfPathAlreadyBindMounted(trigger.Path, service.Volumes) {
 				logrus.Warnf("path '%s' also declared by a bind mount volume, this path won't be monitored!\n", trigger.Path)
 				continue
-			} else {
-				var initialSync bool
-				success, err := trigger.Extensions.Get("x-initialSync", &initialSync)
-				if err == nil && success && initialSync && isSync(trigger) {
-					// Need to check initial files are in container that are meant to be synced from watch action
-					err := s.initialSync(ctx, project, service, trigger, syncer)
-					if err != nil {
-						return nil, err
-					}
+			} else if trigger.InitialSync && isSync(trigger) {
+				// Need to check initial files are in container that are meant to be synced from watch action
+				err := s.initialSync(ctx, project, service, trigger, syncer)
+				if err != nil {
+					return nil, err
 				}
 			}
 			paths = append(paths, trigger.Path)

--- a/pkg/e2e/fixtures/watch/x-initialSync.yaml
+++ b/pkg/e2e/fixtures/watch/x-initialSync.yaml
@@ -9,7 +9,7 @@ services:
       watch:
         - path: .
           target: /data
-          initial_sync: true
           action: sync+exec
           exec:
             command: echo "SUCCESS"
+          x-initialSync: true


### PR DESCRIPTION
**What I did**
Replace `x-initialSync` extension attribute by `initial_sync` one.

**Related issue**
https://github.com/docker/docs/issues/23345

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/63540a8c-b0d2-4e12-996e-b4c5466e22e1" />
