### PR TITLE
pkg/compose: build: remove permissions warning on Windows

### DIFF
--- a/pkg/api/dryrunclient.go
+++ b/pkg/api/dryrunclient.go
@@ -218,8 +218,7 @@ func (d *DryRunClient) ImageBuild(ctx context.Context, reader io.Reader, options
 	rc := io.NopCloser(bytes.NewReader(jsonMessage))
 
 	return build.ImageBuildResponse{
-		Body:   rc,
-		OSType: "",
+		Body: rc,
 	}, nil
 }
 

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -195,18 +194,6 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 		}
 		return "", err
 	}
-
-	// Windows: show error message about modified file permissions if the
-	// daemon isn't running Windows.
-	if response.OSType != "windows" && runtime.GOOS == "windows" {
-		// if response.OSType != "windows" && runtime.GOOS == "windows" && !options.quiet {
-		_, _ = fmt.Fprintln(s.stdout(), "SECURITY WARNING: You are building a Docker "+
-			"image from Windows against a non-Windows Docker host. All files and "+
-			"directories added to build context will have '-rwxr-xr-x' permissions. "+
-			"It is recommended to double check and reset permissions for sensitive "+
-			"files and directories.")
-	}
-
 	return imageID, nil
 }
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6432
- relates to https://github.com/docker/compose/pull/13078


This warning was added in [moby@4a8b3ca] to print a warning when building Linux images from a Windows client. Window's filesystem does not have an "executable" bit, which mean that, for example, copying a shell script to an image during build would lose the executable bit. So for Windows clients, the executable bit would be set on all files, unconditionally.

Originally this was detected in the client, which had direct access to the API response headers, but when refactoring the client to use a common library in [moby@535c4c9], this was refactored into a `ImageBuildResponse` wrapper, deconstructing the API response into an `io.Reader` and a string field containing only the `OSType` header.

This was the only use and only purpose of the `OSType` field, and now that BuildKit is the default builder for Linux images, this warning didn't get printed unless BuildKit was explicitly disabled.

This patch removes the warning, so that we can potentially remove the field, or the `ImageBuildResponse` type altogether.

[moby@4a8b3ca]: https://github.com/moby/moby/commit/4a8b3cad6096854027151dfbcfb4b2cd8841ad95
[moby@535c4c9]: https://github.com/moby/moby/commit/535c4c9a59b1e58c897677d6948a595cb3d28639

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
