### PR TITLE
resolve secrets based on env var before executing bake

### DIFF
--- a/pkg/e2e/fixtures/build-test/secrets/.env
+++ b/pkg/e2e/fixtures/build-test/secrets/.env
@@ -1,0 +1,1 @@
+ANOTHER_SECRET=zot

--- a/pkg/e2e/fixtures/build-test/secrets/Dockerfile
+++ b/pkg/e2e/fixtures/build-test/secrets/Dockerfile
@@ -24,3 +24,7 @@ RUN diff /tmp/expected /tmp/actual
 RUN echo "bar" > /tmp/expected
 RUN --mount=type=secret,id=build_secret cat /run/secrets/build_secret > tmp/actual
 RUN diff --ignore-all-space /tmp/expected /tmp/actual
+
+RUN echo "zot" > /tmp/expected
+RUN --mount=type=secret,id=dotenvsecret cat /run/secrets/dotenvsecret > tmp/actual
+RUN diff --ignore-all-space /tmp/expected /tmp/actual

--- a/pkg/e2e/fixtures/build-test/secrets/compose.yml
+++ b/pkg/e2e/fixtures/build-test/secrets/compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       secrets:
         - mysecret
+        - dotenvsecret
         - source: envsecret
           target: build_secret
 
@@ -13,3 +14,5 @@ secrets:
     file: ./secret.txt
   envsecret:
     environment: SOME_SECRET
+  dotenvsecret:
+    environment: ANOTHER_SECRET


### PR DESCRIPTION
**What I did**
Use a temp folder to store all secrets set from environment variable before running bake child process. This allows to run bake without having to set environment with all values from `.env` which may collide with bake own configuration variables

**Related issue**
fix https://github.com/docker/compose/issues/13235

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
