### PR TITLE
use containerd registry client

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -16,22 +16,28 @@
 
 package registry
 
-import "github.com/distribution/reference"
-
 const (
+	// DefaultNamespace is the default namespace
+	DefaultNamespace = "docker.io"
+	// DefaultRegistryHost is the hostname for the default (Docker Hub) registry
+	// used for pushing and pulling images. This hostname is hard-coded to handle
+	// the conversion from image references without registry name (e.g. "ubuntu",
+	// or "ubuntu:latest"), as well as references using the "docker.io" domain
+	// name, which is used as canonical reference for images on Docker Hub, but
+	// does not match the domain-name of Docker Hub's registry.
+	DefaultRegistryHost = "registry-1.docker.io"
 	// IndexHostname is the index hostname, used for authentication and image search.
 	IndexHostname = "index.docker.io"
 	// IndexServer is used for user auth and image search
-	IndexServer = "https://index.docker.io/v1/"
+	IndexServer = "https://" + IndexHostname + "/v1/"
 	// IndexName is the name of the index
 	IndexName = "docker.io"
 )
 
 // GetAuthConfigKey special-cases using the full index address of the official
 // index as the AuthConfig key, and uses the (host)name[:port] for private indexes.
-func GetAuthConfigKey(reposName reference.Named) string {
-	indexName := reference.Domain(reposName)
-	if indexName == IndexName || indexName == IndexHostname {
+func GetAuthConfigKey(indexName string) string {
+	if indexName == IndexName || indexName == IndexHostname || indexName == DefaultRegistryHost {
 		return IndexServer
 	}
 	return indexName

--- a/pkg/compose/publish_test.go
+++ b/pkg/compose/publish_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v2/internal/ocipush"
 	"github.com/docker/compose/v2/pkg/api"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -58,17 +57,15 @@ services:
 
 	b, err := os.ReadFile("testdata/publish/common.yaml")
 	assert.NilError(t, err)
-	assert.DeepEqual(t, []ocipush.Pushable{
+	assert.DeepEqual(t, []v1.Descriptor{
 		{
-			Descriptor: v1.Descriptor{
-				MediaType: "application/vnd.docker.compose.file+yaml",
-				Digest:    "sha256:d3ba84507b56ec783f4b6d24306b99a15285f0a23a835f0b668c2dbf9c59c241",
-				Size:      32,
-				Annotations: map[string]string{
-					"com.docker.compose.extends": "true",
-					"com.docker.compose.file":    "f8f9ede3d201ec37d5a5e3a77bbadab79af26035e53135e19571f50d541d390c.yaml",
-					"com.docker.compose.version": api.ComposeVersion,
-				},
+			MediaType: "application/vnd.docker.compose.file+yaml",
+			Digest:    "sha256:d3ba84507b56ec783f4b6d24306b99a15285f0a23a835f0b668c2dbf9c59c241",
+			Size:      32,
+			Annotations: map[string]string{
+				"com.docker.compose.extends": "true",
+				"com.docker.compose.file":    "f8f9ede3d201ec37d5a5e3a77bbadab79af26035e53135e19571f50d541d390c.yaml",
+				"com.docker.compose.version": api.ComposeVersion,
 			},
 			Data: b,
 		},

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -280,7 +280,7 @@ func ImageDigestResolver(ctx context.Context, file *configfile.ConfigFile, apiCl
 }
 
 func encodedAuth(ref reference.Named, configFile driver.Auth) (string, error) {
-	authConfig, err := configFile.GetAuthConfig(registry.GetAuthConfigKey(ref))
+	authConfig, err := configFile.GetAuthConfig(registry.GetAuthConfigKey(reference.Domain(ref)))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/compose/push.go
+++ b/pkg/compose/push.go
@@ -90,7 +90,7 @@ func (s *composeService) pushServiceImage(ctx context.Context, tag string, confi
 		return err
 	}
 
-	authConfig, err := configFile.GetAuthConfig(registry.GetAuthConfigKey(ref))
+	authConfig, err := configFile.GetAuthConfig(registry.GetAuthConfigKey(reference.Domain(ref)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What I did**
replace use of buildx's imagetool with direct use of containerd's registry client
this is related to https://github.com/docker/compose/pull/13056, removing compose use of buildx codebase

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
