### PR TITLE
provider services: use '--project-name=' notation

### DIFF
--- a/pkg/compose/plugins.go
+++ b/pkg/compose/plugins.go
@@ -186,7 +186,7 @@ func (s *composeService) setupPluginCommand(ctx context.Context, project *types.
 		return nil, err
 	}
 
-	args := []string{"compose", "--project-name", project.Name, command}
+	args := []string{"compose", fmt.Sprintf("--project-name=%s", project.Name), command}
 	for k, v := range provider.Options {
 		for _, value := range v {
 			if _, ok := currentCommandMetadata.GetParameter(k); commandMetadataIsEmpty || ok {


### PR DESCRIPTION
**What I did**
Use the `=` flag notation to pass `--project-name` to external plugin binaries

**Related issue**
[Discussion on Docker slack community channel](https://dockercommunity.slack.com/archives/C2X82D9PA/p1754031199622499)

<img width="829" height="333" alt="Screenshot 2025-09-29 at 09 45 45" src="https://github.com/user-attachments/assets/9cb26c2c-d79c-4be8-a8e7-e30cfb474a8b" />


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1600" height="1067" alt="image" src="https://github.com/user-attachments/assets/ee557ec9-943f-429a-a47d-78b056d4b807" />
