### PR TITLE
cmd/compose: fix minor linting issues

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -160,10 +160,10 @@ func runBuild(ctx context.Context, dockerCli command.Cli, backend api.Service, o
 	}
 
 	apiBuildOptions, err := opts.toAPIBuildOptions(services)
-	apiBuildOptions.Attestations = true
 	if err != nil {
 		return err
 	}
+	apiBuildOptions.Attestations = true
 
 	return backend.Build(ctx, project, apiBuildOptions)
 }

--- a/cmd/compose/commit.go
+++ b/cmd/compose/commit.go
@@ -79,7 +79,7 @@ func runCommit(ctx context.Context, dockerCli command.Cli, backend api.Service, 
 		return err
 	}
 
-	commitOptions := api.CommitOptions{
+	return backend.Commit(ctx, projectName, api.CommitOptions{
 		Service:   options.service,
 		Reference: options.reference,
 		Pause:     options.pause,
@@ -87,7 +87,5 @@ func runCommit(ctx context.Context, dockerCli command.Cli, backend api.Service, 
 		Author:    options.author,
 		Changes:   options.changes,
 		Index:     options.index,
-	}
-
-	return backend.Commit(ctx, projectName, commitOptions)
+	})
 }


### PR DESCRIPTION
- inline variable that shadowed package-type
- don't use apiBuildOptions if an error was returned

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
