### PR TITLE
pkg/compose: explicitly map AuthConfig fields instead of a direct cast

### DIFF
--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -154,8 +154,17 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 		return "", err
 	}
 	authConfigs := make(map[string]registry.AuthConfig, len(creds))
-	for k, auth := range creds {
-		authConfigs[k] = registry.AuthConfig(auth)
+	for k, authConfig := range creds {
+		authConfigs[k] = registry.AuthConfig{
+			Username:      authConfig.Username,
+			Password:      authConfig.Password,
+			ServerAddress: authConfig.ServerAddress,
+
+			// TODO(thaJeztah): Are these expected to be included? See https://github.com/docker/cli/pull/6516#discussion_r2387586472
+			Auth:          authConfig.Auth,
+			IdentityToken: authConfig.IdentityToken,
+			RegistryToken: authConfig.RegistryToken,
+		}
 	}
 	buildOptions := imageBuildOptions(s.dockerCli, project, service, options)
 	imageName := api.GetImageNameOrDefault(service, project.Name)


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6516
- relates to https://github.com/docker/cli/pull/6515#issuecomment-3345966610


Commit [cli@27b2797] forked the AuthConfig type from the API, and changed existing code to do a direct cast / convert of the forked type to the API type. This can cause issues if the API types diverges, such as the removal of the Email field.

This patch explicitly maps each field to the corresponding API type, but adds some TODOs, because various code-paths only included a subset of the fields, which may be intentional for fields that were meant to be handled on the daemon / registry-client only.

We should evaluate these conversions to make sure these fields should be sent from the client or not (and possibly even removed from the API type).

[cli@27b2797]: https://github.com/docker/cli/commit/27b2797f7deb3ca5b7f80371d825113deb1faca1

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
