### PR TITLE
gha: update test-matrix: remove docker 26.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,8 @@ jobs:
           - plugin
           - standalone
         engine:
-          - 26
-          - 27
-          - 28
+          - 27 # old stable (latest major - 1)
+          - 28 # current stable
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/51018

---

### gha: update test-matrix: remove docker 26.x

- Mirantis Container Runtime (MCR) 23.0 reached EOL, and the next LTS
  version of MCR is 25.x, but download.docker.com does not have 25.x
  packages for the latest Ubuntu release.
- Docker 26.x reached EOL and is no longer maintained

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
