### PR TITLE
publish Compose application as compose.yaml + images

### DIFF
--- a/cmd/compose/publish.go
+++ b/cmd/compose/publish.go
@@ -34,6 +34,7 @@ type publishOptions struct {
 	ociVersion          string
 	withEnvironment     bool
 	assumeYes           bool
+	app                 bool
 }
 
 func publishCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Service) *cobra.Command {
@@ -53,6 +54,7 @@ func publishCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Servic
 	flags.StringVar(&opts.ociVersion, "oci-version", "", "OCI image/artifact specification version (automatically determined by default)")
 	flags.BoolVar(&opts.withEnvironment, "with-env", false, "Include environment variables in the published OCI artifact")
 	flags.BoolVarP(&opts.assumeYes, "yes", "y", false, `Assume "yes" as answer to all prompts`)
+	flags.BoolVar(&opts.app, "app", false, "Published compose application (includes referenced images)")
 	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		// assumeYes was introduced by mistake as `--y`
 		if name == "y" {
@@ -76,7 +78,8 @@ func runPublish(ctx context.Context, dockerCli command.Cli, backend api.Service,
 	}
 
 	return backend.Publish(ctx, project, repository, api.PublishOptions{
-		ResolveImageDigests: opts.resolveImageDigests,
+		ResolveImageDigests: opts.resolveImageDigests || opts.app,
+		Application:         opts.app,
 		OCIVersion:          api.OCIVersion(opts.ociVersion),
 		WithEnvironment:     opts.withEnvironment,
 		AssumeYes:           opts.assumeYes,

--- a/docs/reference/compose_publish.md
+++ b/docs/reference/compose_publish.md
@@ -7,6 +7,7 @@ Publish compose application
 
 | Name                      | Type     | Default | Description                                                                    |
 |:--------------------------|:---------|:--------|:-------------------------------------------------------------------------------|
+| `--app`                   | `bool`   |         | Published compose application (includes referenced images)                     |
 | `--dry-run`               | `bool`   |         | Execute command in dry run mode                                                |
 | `--oci-version`           | `string` |         | OCI image/artifact specification version (automatically determined by default) |
 | `--resolve-image-digests` | `bool`   |         | Pin image tags to digests                                                      |

--- a/docs/reference/docker_compose_alpha_publish.yaml
+++ b/docs/reference/docker_compose_alpha_publish.yaml
@@ -5,6 +5,16 @@ usage: docker compose alpha publish [OPTIONS] REPOSITORY[:TAG]
 pname: docker compose alpha
 plink: docker_compose_alpha.yaml
 options:
+    - option: app
+      value_type: bool
+      default_value: "false"
+      description: Published compose application (includes referenced images)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: oci-version
       value_type: string
       description: |

--- a/docs/reference/docker_compose_publish.yaml
+++ b/docs/reference/docker_compose_publish.yaml
@@ -5,6 +5,16 @@ usage: docker compose publish [OPTIONS] REPOSITORY[:TAG]
 pname: docker compose
 plink: docker_compose.yaml
 options:
+    - option: app
+      value_type: bool
+      default_value: "false"
+      description: Published compose application (includes referenced images)
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: oci-version
       value_type: string
       description: |

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -444,9 +444,10 @@ const (
 // PublishOptions group options of the Publish API
 type PublishOptions struct {
 	ResolveImageDigests bool
+	Application         bool
 	WithEnvironment     bool
-	AssumeYes           bool
 
+	AssumeYes  bool
 	OCIVersion OCIVersion
 }
 


### PR DESCRIPTION
**What I did**

Introduce option to publish a Compose application as compose.yaml artifact + references to images

In addition to the compose.yaml file(s) stored in OCI artifact, command creates an OCI index for all images used by the compose application. This index is linked to compose artifact using an OCI `Subject`

```mermaid
flowchart TD
    TAG --> A
    A[Compose OCI Artifact] -->|layer| B(compose.yaml)
    A -->|layer| C(image-digests.yaml)
    I[Index] -->|Subject| A
    I -->|Manifest| R1[image]
    I -->|Manifest| R2[image]
```

```
# Publish compose application
#
$ docker compose --progress=plain publish --app nicolasdeloof582/bidule:chose
...
 nicolasdeloof582/bidule:chose published 

# Search for referrers for published OCI artifact
#
$ regctl artifact list nicolasdeloof582/bidule:chose
Subject:                        docker.io/nicolasdeloof582/bidule@sha256:1eb94ed3a7261bef470b21af724e0b925df9986d4a4aa1db052c35c154361da4
                                
Referrers:                      
                                
  Name:                         docker.io/nicolasdeloof582/bidule@sha256:f335c03f80b2915a4d978e4e9ea315058ff170db7e457a97b851eceea8e83622
  Digest:                       sha256:f335c03f80b2915a4d978e4e9ea315058ff170db7e457a97b851eceea8e83622
  MediaType:                    application/vnd.oci.image.index.v1+json
  Annotations:                  
    com.docker.compose.version: 2.39.4

# Inspect the referrer manifest
#
$ regctl manifest get docker.io/nicolasdeloof582/bidule@sha256:f335c03f80b2915a4d978e4e9ea315058ff170db7e457a97b851eceea8e83622
time=2025-10-01T17:22:45.360+02:00 level=WARN msg="Changing login user for registry" orig=nicolasdeloof582 new=ndeloof host=docker.io
Name:                                            docker.io/nicolasdeloof582/bidule@sha256:f335c03f80b2915a4d978e4e9ea315058ff170db7e457a97b851eceea8e83622
MediaType:                                       application/vnd.oci.image.index.v1+json
Digest:                                          sha256:f335c03f80b2915a4d978e4e9ea315058ff170db7e457a97b851eceea8e83622
Annotations:                                     
  com.docker.compose.version:                    2.39.4
                                                 
Manifests:                                       
                                                 
  Name:                                          docker.io/nicolasdeloof582/bidule@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
  Digest:                                        sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
  MediaType:                                     application/vnd.oci.image.index.v1+json
  Annotations:                                   
    containerd.io/distribution.source.docker.io: library/alpine

# 4bcff639.. is actually alpine/latest, mounted in compose artifact repository
#
```


**Related issue**
see https://github.com/docker/compose/issues/13238
see https://github.com/docker-archive-public/docker.app

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1024" height="1536" alt="image" src="https://github.com/user-attachments/assets/5147f5f1-71c2-47c8-9bc2-f5af4a331853" />
