### PR TITLE
escape $ in bake.json as interpolation already has been managed by cpmpose

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -280,6 +280,9 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		return nil, err
 	}
 
+	// escape all occurrences of '$' as we interpolated everything that has to
+	b = bytes.ReplaceAll(b, []byte("$"), []byte("$$"))
+
 	if options.Print {
 		_, err = fmt.Fprintln(s.stdout(), string(b))
 		return nil, err

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -645,3 +645,11 @@ func TestBuildTLS(t *testing.T) {
 	res := icmd.RunCmd(cmd)
 	res.Assert(t, icmd.Expected{Err: "Built"})
 }
+
+func TestBuildEscaped(t *testing.T) {
+	c := NewParallelCLI(t)
+	// ensure local test run does not reuse previously build image
+	c.RunDockerOrExitError(t, "rmi", "build-test-tags")
+	res := c.RunDockerComposeCmd(t, "--project-directory", "./fixtures/build-test/escaped", "build", "--no-cache")
+	res.Assert(t, icmd.Expected{Out: "foo is ${bar}"})
+}

--- a/pkg/e2e/fixtures/build-test/escaped/Dockerfile
+++ b/pkg/e2e/fixtures/build-test/escaped/Dockerfile
@@ -1,0 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM alpine
+ARG foo
+RUN echo foo is $foo

--- a/pkg/e2e/fixtures/build-test/escaped/compose.yaml
+++ b/pkg/e2e/fixtures/build-test/escaped/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  foo:
+    build:
+      context: .
+      args:
+        foo: $${bar}


### PR DESCRIPTION
**What I did**

**Related issue**
fixes https://github.com/docker/compose/issues/13258

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
