### PR TITLE
Write error to watcher error channel if Start() fails

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -89,6 +89,9 @@ func (w *Watcher) Start(ctx context.Context) error {
 	w.stopFn = cancelFunc
 	wait, err := w.watchFn(ctx, w.project, w.options)
 	if err != nil {
+		go func() {
+			w.errCh <- err
+		}()
 		return err
 	}
 	go func() {


### PR DESCRIPTION
**What I did**
Current main fails to properly abort with `--watch` on permission issues because:
- `up.go:Up()` notices `globalCtx` is done, calls `watcher.Stop()`
- `watch.go:Stop()` reads from `w.errCh`
- `watch.go:Stop()` is deadlocked because `watch.go:Start` has not and will not write to `w.errCh`

The fix is simple: Ensure `watch.go:Start()` writes the error from `watchFn` into `w.errCh`.

**Related issue**
Fixes https://github.com/docker/compose/issues/13262
