### PR TITLE
docs: document how to use OCI-published Compose configurations

### DIFF
--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -138,6 +138,8 @@ You can reference an OCI-published Compose file by using the `oci://` scheme in 
 $ docker compose -f oci://ghcr.io/my-org/my-compose-config:latest up
 ```
 
+
+
 ### Use `-p` to specify a project name
 
 Each configuration has a project name. Compose sets the project name using


### PR DESCRIPTION
… #13242)

This PR updates the docker compose reference documentation to explain
how to use and publish Compose configurations stored in OCI registries.

Fixes #13242.