### PR TITLE
fix oci compose configuration

### DIFF
--- a/docs/reference/compose.md
+++ b/docs/reference/compose.md
@@ -126,6 +126,19 @@ get the postgres image for the db service from anywhere by using the `-f` flag a
 $ docker compose -f ~/sandbox/rails/compose.yaml pull db
 ```
 
+#### Using OCI-published Compose configurations
+
+Docker Compose supports loading configurations directly from [OCI (Open Container Initiative) registries](https://opencontainers.org/).  
+This allows you to **share and reuse Compose applications** as OCI artifacts, the same way you distribute container images.
+
+You can reference an OCI-published Compose file by using the `oci://` scheme in place of a local path.
+
+**Example:**
+```console
+$ docker compose -f oci://ghcr.io/my-org/my-compose-config:latest up
+```
+
+
 ### Use `-p` to specify a project name
 
 Each configuration has a project name. Compose sets the project name using

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/distribution/reference v0.6.0
 	github.com/docker/buildx v0.28.0
-	github.com/docker/cli v28.5.0-rc.1+incompatible
+	github.com/docker/cli v28.5.0+incompatible
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.5.0+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/buildx v0.28.0 h1:ZnrVsZ/qQwSOQ4Fx3IgXjiurAwvocaF1YUaPbIXD89E=
 github.com/docker/buildx v0.28.0/go.mod h1:nLwx58w7xrQbLVSXiWiHpkVhY4ou4ci/hYomc139Vjk=
-github.com/docker/cli v28.5.0-rc.1+incompatible h1:QRD0LtIkBuG8XJfdZQIyUyncfdogkOqF8elzL0XAINE=
-github.com/docker/cli v28.5.0-rc.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v28.5.0+incompatible h1:crVqLrtKsrhC9c00ythRx435H8LiQnUKRtJLRR+Auxk=
+github.com/docker/cli v28.5.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.10.0 h1:bOD6mKynPQgojQi3s2jgcUWGp/Ebqy1SeCr9VfKQLLU=
 github.com/docker/cli-docs-tool v0.10.0/go.mod h1:5EM5zPnT2E7yCLERZmrDA234Vwn09fzRHP4aX1qwp1U=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=


### PR DESCRIPTION
… https://github.com/docker/compose/issues/13242)

This PR updates the docker compose reference documentation to explain
how to use and publish Compose configurations stored in OCI registries.

Fixes https://github.com/docker/compose/issues/13242.