### PR TITLE
fix: make "publish" push all compose files addressed in "extends" statements when using "profiles".

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -50,6 +50,10 @@ func (s *composeService) Publish(ctx context.Context, project *types.Project, re
 
 //nolint:gocyclo
 func (s *composeService) publish(ctx context.Context, project *types.Project, repository string, options api.PublishOptions) error {
+	project, err := project.WithProfiles([]string{"*"})
+	if err != nil {
+		return err
+	}
 	accept, err := s.preChecks(project, options)
 	if err != nil {
 		return err
@@ -251,11 +255,7 @@ func processFile(ctx context.Context, file string, project *types.Project, extFi
 }
 
 func (s *composeService) generateImageDigestsOverride(ctx context.Context, project *types.Project) ([]byte, error) {
-	project, err := project.WithProfiles([]string{"*"})
-	if err != nil {
-		return nil, err
-	}
-	project, err = project.WithImagesResolved(ImageDigestResolver(ctx, s.configFile(), s.apiClient()))
+	project, err := project.WithImagesResolved(ImageDigestResolver(ctx, s.configFile(), s.apiClient()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What I did**
 - in `processFile()`, load the compose file selecting the profiles from `project.Profiles` in the `loader.Options`.
 - make the command fail if publishing a compose app with no service:
   - Not sure about this one:
     - Let me know if this is better to remove it
     - I thought also about enforcing all profiles by default in `cmd/compose/publish.go` as if `--profile '*'` was passed but this is not consistent with the other commands, I guess.

**Related issue**
 - Fix for #13276 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
