### PR TITLE
pkg/compose: align classic builder implementation with docker/cli

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -37,10 +37,10 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/docker/docker/builder/remotecontext/urlutil"
 	"github.com/moby/buildkit/client"
 	gitutil "github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 	"github.com/moby/buildkit/util/progress/progressui"
@@ -505,7 +505,7 @@ func dockerFilePath(ctxName string, dockerfile string) string {
 	if dockerfile == "" {
 		return ""
 	}
-	if urlutil.IsGitURL(ctxName) {
+	if contextType, _ := build.DetectContextType(ctxName); contextType == build.ContextTypeGit {
 		return dockerfile
 	}
 	if !filepath.IsAbs(dockerfile) {


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/6189
- https://github.com/moby/moby/pull/50365#discussion_r2198340305


This aligns the implementation closer to the implementation in docker/cli, with the refactor done in [cli@260f1db]; this removes some direct uses of the github.com/docker/docker/builder/remotecontext/urlutil package, which won't be included in the new Moby modules.

There's still some remaining uses in the `dockerFilePath` utility (which may need to be updated to also account for remote contexts that are not "git"), so possibly we can remove the use in that utility as well.

[cli@260f1db]: https://github.com/docker/cli/commit/260f1dbebb9f3d70d2bdda67e511a6bee9fe365b

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
