### PR TITLE
pkg/compose: build with bake: drop support for buildx v0.16 and lower

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -40,7 +40,6 @@ import (
 	"github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/moby/buildkit/client"
 	gitutil "github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 	"github.com/moby/buildkit/util/progress/progressui"
@@ -302,15 +301,12 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	}
 
 	args := []string{"bake", "--file", "-", "--progress", "rawjson", "--metadata-file", metadataFile}
-	mustAllow := buildx.Version != "" && versions.GreaterThanOrEqualTo(buildx.Version[1:], "0.17.0")
-	if mustAllow {
-		// FIXME we should prompt user about this, but this is a breaking change in UX
-		for _, path := range read {
-			args = append(args, "--allow", "fs.read="+path)
-		}
-		if privileged {
-			args = append(args, "--allow", "security.insecure")
-		}
+	// FIXME we should prompt user about this, but this is a breaking change in UX
+	for _, path := range read {
+		args = append(args, "--allow", "fs.read="+path)
+	}
+	if privileged {
+		args = append(args, "--allow", "security.insecure")
 	}
 	if options.SBOM != "" {
 		args = append(args, "--sbom="+options.SBOM)


### PR DESCRIPTION
[buildx v0.17][1] was released a Year ago, so any version this conditional code was accounting for would be versions before that; the latest of which being [buildx v0.16.2][2] (July 2024).

Given that those versions are long EOL and no longer supported, we can probably remove the conditional code.

[1]: https://github.com/docker/buildx/releases/tag/v0.17.0
[2]: https://github.com/docker/buildx/releases/tag/v0.16.2

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
