### PR TITLE
use fixed version of compose bridge transformer images

### DIFF
--- a/pkg/e2e/bridge_test.go
+++ b/pkg/e2e/bridge_test.go
@@ -17,6 +17,7 @@
 package e2e
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -28,12 +29,13 @@ func TestConvertAndTransformList(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	const projectName = "bridge"
+	const bridgeImageVersion = "v0.0.3"
 	tmpDir := t.TempDir()
 
 	t.Run("kubernetes manifests", func(t *testing.T) {
 		kubedir := filepath.Join(tmpDir, "kubernetes")
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/bridge/compose.yaml", "--project-name", projectName, "bridge", "convert",
-			"--output", kubedir)
+			"--output", kubedir, "--transformation", fmt.Sprintf("docker/compose-bridge-kubernetes:%s", bridgeImageVersion))
 		assert.NilError(t, res.Error)
 		assert.Equal(t, res.ExitCode, 0)
 		res = c.RunCmd(t, "diff", "-r", kubedir, "./fixtures/bridge/expected-kubernetes")
@@ -43,7 +45,7 @@ func TestConvertAndTransformList(t *testing.T) {
 	t.Run("helm charts", func(t *testing.T) {
 		helmDir := filepath.Join(tmpDir, "helm")
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/bridge/compose.yaml", "--project-name", projectName, "bridge", "convert",
-			"--output", helmDir, "--transformation", "docker/compose-bridge-helm")
+			"--output", helmDir, "--transformation", fmt.Sprintf("docker/compose-bridge-helm:%s", bridgeImageVersion))
 		assert.NilError(t, res.Error)
 		assert.Equal(t, res.ExitCode, 0)
 		res = c.RunCmd(t, "diff", "-r", helmDir, "./fixtures/bridge/expected-helm")


### PR DESCRIPTION
to avoid CI issue on Compose when a new version is released and change the outputs

**What I did**
Use explicit version of Compose Bridge Transformer images for transformation e2e tests 

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/3af3aa45-c0ff-4385-97f3-550f3e03dc87" />
