### PR TITLE
make CTRL+Z a no-op operation on Windows

### DIFF
--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -322,7 +322,7 @@ func (lk *LogKeyboard) HandleKeyEvents(ctx context.Context, event keyboard.KeyEv
 		// will notify main thread to kill and will handle gracefully
 		lk.signalChannel <- syscall.SIGINT
 	case keyboard.KeyCtrlZ:
-		_ = syscall.Kill(0, syscall.SIGSTOP)
+		handleCtrlZ()
 	case keyboard.KeyEnter:
 		newLine()
 		lk.printNavigationMenu()

--- a/cmd/formatter/shortcut_unix.go
+++ b/cmd/formatter/shortcut_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+/*
+   Copyright 2024 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package formatter
+
+import "syscall"
+
+func handleCtrlZ() {
+	_ = syscall.Kill(0, syscall.SIGSTOP)
+}

--- a/cmd/formatter/shortcut_windows.go
+++ b/cmd/formatter/shortcut_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+/*
+   Copyright 2024 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package formatter
+
+// handleCtrlZ is a no-op on Windows as SIGSTOP is not supported
+func handleCtrlZ() {
+	// Windows doesn't support SIGSTOP/SIGCONT signals
+	// Ctrl+Z behavior is handled differently by the Windows terminal
+}


### PR DESCRIPTION
**What I did**
`syscall.SIGSTOP` is not supported on Windows and block Compose build process

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c43d732d-2d91-4db1-99d5-5ecce538b41f" />
