### PR TITLE
fail build if minimal required version of buildx isn't installed

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -40,6 +40,7 @@ import (
 	"github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/progress"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/google/uuid"
 	"github.com/moby/buildkit/client"
 	gitutil "github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
@@ -306,6 +307,10 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	buildx, err := manager.GetPlugin("buildx", s.dockerCli, &cobra.Command{})
 	if err != nil {
 		return nil, err
+	}
+
+	if versions.LessThan(buildx.Version[1:], "0.17.0") {
+		return nil, fmt.Errorf("compose build requires buildx 0.17 or later")
 	}
 
 	args := []string{"bake", "--file", "-", "--progress", "rawjson", "--metadata-file", metadataFile}


### PR DESCRIPTION
**What I did**

**Related issue**
see https://github.com/docker/compose/commit/ae3309afabf82c95e816fcd9da4daae917fcb582#commitcomment-168173048

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
