### PR TITLE
test: Make tests runnable on SELinux enabled daemon

### DIFF
--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -87,7 +87,7 @@ func TestLocalComposeRun(t *testing.T) {
 	t.Run("compose run --volumes", func(t *testing.T) {
 		wd, err := os.Getwd()
 		assert.NilError(t, err)
-		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--volumes", wd+":/foo",
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/run-test/compose.yaml", "run", "--volumes", wd+":/foo:z",
 			"back", "/bin/sh", "-c", "ls /foo")
 		res.Assert(t, icmd.Expected{Out: "compose_run_test.go"})
 

--- a/pkg/e2e/fixtures/bridge/compose.yaml
+++ b/pkg/e2e/fixtures/bridge/compose.yaml
@@ -9,6 +9,8 @@ services:
     configs:
       - source: my-config
         target: /etc/my-config1.txt
+    security_opt:
+      - label=disable
   serviceB:
     image: alpine
     build: .
@@ -19,6 +21,8 @@ services:
     networks:
       - private-network
       - public-network
+    security_opt:
+      - label=disable
 configs:
   my-config:
     file: my-config.txt

--- a/pkg/e2e/fixtures/configs/compose.yaml
+++ b/pkg/e2e/fixtures/configs/compose.yaml
@@ -4,18 +4,24 @@ services:
     configs:
       - source: from_env
     command: cat /from_env
+    security_opt:
+      - label=disable
 
   from_file:
     image: alpine
     configs:
       - source: from_file
     command: cat /from_file
+    security_opt:
+      - label=disable
 
   inlined:
     image: alpine
     configs:
       - source: inlined
     command: cat /inlined
+    security_opt:
+      - label=disable
 
   target:
     image: alpine
@@ -23,6 +29,8 @@ services:
       - source: inlined
         target: /target
     command: cat /target
+    security_opt:
+      - label=disable
 
 configs:
   from_env:

--- a/pkg/e2e/fixtures/hooks/compose.yaml
+++ b/pkg/e2e/fixtures/hooks/compose.yaml
@@ -2,7 +2,7 @@ services:
   sample:
     image: nginx
     volumes:
-      - data:/data
+      - "data:/data:z"
     pre_stop:
       - command: sh -c 'echo "In the pre-stop" >> /data/log.txt'
   test:

--- a/pkg/e2e/fixtures/logs-test/cat.yaml
+++ b/pkg/e2e/fixtures/logs-test/cat.yaml
@@ -3,4 +3,4 @@ services:
     image: alpine
     command: cat /text_file.txt
     volumes:
-      - ${FILE}:/text_file.txt
+      - "${FILE}:/text_file.txt:z"

--- a/pkg/e2e/fixtures/project-volume-bind-test/docker-compose.yml
+++ b/pkg/e2e/fixtures/project-volume-bind-test/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: frontend
     volumes:
       - project-data:/data
+    security_opt:
+      - label=disable
 
 volumes:
   project-data:

--- a/pkg/e2e/fixtures/recreate-volumes/compose.yaml
+++ b/pkg/e2e/fixtures/recreate-volumes/compose.yaml
@@ -2,7 +2,7 @@ services:
   app:
     image: alpine
     volumes:
-      - my_vol:/my_vol
+      - "my_vol:/my_vol:z"
 
 volumes:
   my_vol:

--- a/pkg/e2e/fixtures/run-test/compose.yaml
+++ b/pkg/e2e/fixtures/run-test/compose.yaml
@@ -12,6 +12,8 @@ services:
       - backnet
     volumes:
       - data:/test
+    security_opt:
+      - label=disable
   front:
     image: nginx:alpine
     networks:

--- a/pkg/e2e/fixtures/stdout-stderr/compose.yaml
+++ b/pkg/e2e/fixtures/stdout-stderr/compose.yaml
@@ -4,4 +4,4 @@ services:
     init: true
     command: /bin/ash /log_to_stderr.sh
     volumes:
-           - ./log_to_stderr.sh:/log_to_stderr.sh
+           - "./log_to_stderr.sh:/log_to_stderr.sh:z"

--- a/pkg/e2e/fixtures/switch-volumes/compose.yaml
+++ b/pkg/e2e/fixtures/switch-volumes/compose.yaml
@@ -2,7 +2,7 @@ services:
   app:
     image: alpine
     volumes:
-      - my_vol:/my_vol
+      - "my_vol:/my_vol:z"
 
 volumes:
   my_vol:

--- a/pkg/e2e/fixtures/volume-test/compose.yaml
+++ b/pkg/e2e/fixtures/volume-test/compose.yaml
@@ -2,22 +2,24 @@ services:
   nginx:
     build: nginx-build
     volumes:
-      - ./static:/usr/share/nginx/html
+      - "./static:/usr/share/nginx/html:z"
     ports:
       - 8090:80
 
   nginx2:
     build: nginx-build
     volumes:
-      - staticVol:/usr/share/nginx/html:ro
+      - "staticVol:/usr/share/nginx/html:ro,z"
       - /usr/src/app/node_modules
-      - otherVol:/usr/share/nginx/test
+      - "otherVol:/usr/share/nginx/test:z"
     ports:
       - 9090:80
     configs:
       - myconfig
     secrets:
       - mysecret
+    security_opt:
+      - label=disable
 
 volumes:
   staticVol:

--- a/pkg/e2e/fixtures/volumes/compose.yaml
+++ b/pkg/e2e/fixtures/volumes/compose.yaml
@@ -8,3 +8,5 @@ services:
         target: /mnt/image
         image:
           subpath: usr/share/nginx/html/
+    security_opt:
+      - label=disable

--- a/pkg/e2e/fixtures/watch/compose.yaml
+++ b/pkg/e2e/fixtures/watch/compose.yaml
@@ -38,6 +38,6 @@ services:
     init: true
     command: sleep infinity
     volumes:
-      - ./dat:/app/dat
-      - ./data-logs:/app/data-logs
+      - "./dat:/app/dat:z"
+      - "./data-logs:/app/data-logs:z"
     develop: *x-dev


### PR DESCRIPTION
Make tests runnable on SELinux enabled daemon.  

Otherwise I get error message like these:
- https://openqa.opensuse.org/tests/5393787/file/docker_compose-e2e-compose.txt

Needs `chcon -Rt svirt_sandbox_file_t ./pkg/e2e/fixtures`.