### PR TITLE
Compose can't create a tar with adequate uid:gid ownership

### DIFF
--- a/pkg/e2e/fixtures/env-secret/compose.yaml
+++ b/pkg/e2e/fixtures/env-secret/compose.yaml
@@ -14,23 +14,6 @@ services:
         mode: 0440
     command: cat /run/secrets/bar
 
-  bar:
-    image: alpine
-    user: "1005"
-    secrets:
-      - source: secret
-        target: bar
-    command: cat /run/secrets/bar
-
-  zot:
-    image: alpine
-    user: "1005:1005"
-    secrets:
-      - source: secret
-        target: bar
-    command: cat /run/secrets/bar
-
-
 secrets:
   secret:
     environment: SECRET

--- a/pkg/e2e/secrets_test.go
+++ b/pkg/e2e/secrets_test.go
@@ -17,7 +17,6 @@
 package e2e
 
 import (
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/icmd"
@@ -40,28 +39,6 @@ func TestSecretFromEnv(t *testing.T) {
 				cmd.Env = append(cmd.Env, "SECRET=BAR")
 			})
 		res.Assert(t, icmd.Expected{Out: "-r--r-----    1 1005     1005"})
-	})
-	t.Run("secret uid from user", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "version", "--format", "{{ .Server.Version }}")
-		if strings.HasPrefix(res.Stdout(), "27.") {
-			t.Skip("USER uid:gid is not supported")
-		}
-		res = icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/env-secret/compose.yaml", "run", "bar", "ls", "-al", "/var/run/secrets/bar"),
-			func(cmd *icmd.Cmd) {
-				cmd.Env = append(cmd.Env, "SECRET=BAR")
-			})
-		res.Assert(t, icmd.Expected{Out: "-r--r--r--    1 1005     root"})
-	})
-	t.Run("secret uid:gid from user", func(t *testing.T) {
-		res := c.RunDockerCmd(t, "version", "--format", "{{ .Server.Version }}")
-		if strings.HasPrefix(res.Stdout(), "27.") {
-			t.Skip("USER uid:gid is not supported")
-		}
-		res = icmd.RunCmd(c.NewDockerComposeCmd(t, "-f", "./fixtures/env-secret/compose.yaml", "run", "zot", "ls", "-al", "/var/run/secrets/bar"),
-			func(cmd *icmd.Cmd) {
-				cmd.Env = append(cmd.Env, "SECRET=BAR")
-			})
-		res.Assert(t, icmd.Expected{Out: "-r--r--r--    1 1005     1005"})
 	})
 }
 


### PR DESCRIPTION
**What I did**
revert https://github.com/docker/compose/issues/13287

**Related issue**
fixes https://github.com/docker/compose/issues/13296
https://github.com/docker/compose/issues/13287 can't be fixed in Compose.
the behavior described by the compose-spec as https://docs.docker.com/reference/compose-file/services/#long-syntax-5 is inherited from Swarm and can't be reproduced by Compose as we miss the required feature from Docker engine API

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
