### PR TITLE
test digest or canonical reference, not only tag, when checking if an  image is already present

### DIFF
--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -159,12 +159,14 @@ func imageAlreadyPresent(serviceImage string, localImages map[string]api.ImageSu
 	if err != nil {
 		return false
 	}
-	tagged, ok := normalizedImage.(reference.NamedTagged)
-	if !ok {
-		return false
+	switch refType := normalizedImage.(type) {
+	case reference.NamedTagged:
+		_, ok := localImages[serviceImage]
+		return ok && refType.Tag() != "latest"
+	default:
+		_, ok := localImages[serviceImage]
+		return ok
 	}
-	_, ok = localImages[serviceImage]
-	return ok && tagged.Tag() != "latest"
 }
 
 func getUnwrappedErrorMessage(err error) string {


### PR DESCRIPTION
**What I did**
Ensure the validation includes not only tagged images, but also those referenced by digest or canonical form.

**Related issue**
fixes #12726 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1000" height="827" alt="image" src="https://github.com/user-attachments/assets/3cfe01d6-6d78-4a3e-ac77-46b4e4a54e74" />
