### PR TITLE
fix OCI compose override support

### DIFF
--- a/internal/oci/resolver.go
+++ b/internal/oci/resolver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/containerd/containerd/v2/core/remotes"
@@ -50,6 +51,11 @@ func NewResolver(config *configfile.ConfigFile) remotes.Resolver {
 					return auth.Username, auth.Password, nil
 				}),
 			)),
+			docker.WithPlainHTTP(func(s string) (bool, error) {
+				// Used for testing **only**
+				_, b := os.LookupEnv("__TEST__INSECURE__REGISTRY__")
+				return b, nil
+			}),
 		),
 	})
 }

--- a/pkg/e2e/fixtures/publish/oci/compose-override.yaml
+++ b/pkg/e2e/fixtures/publish/oci/compose-override.yaml
@@ -1,0 +1,3 @@
+services:
+  app:
+    env_file: test.env

--- a/pkg/e2e/fixtures/publish/oci/compose.yaml
+++ b/pkg/e2e/fixtures/publish/oci/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  app:
+    extends:
+      file: extends.yaml
+      service: test

--- a/pkg/e2e/fixtures/publish/oci/extends.yaml
+++ b/pkg/e2e/fixtures/publish/oci/extends.yaml
@@ -1,0 +1,3 @@
+services:
+  test:
+    image: alpine

--- a/pkg/e2e/fixtures/publish/oci/test.env
+++ b/pkg/e2e/fixtures/publish/oci/test.env
@@ -1,0 +1,1 @@
+HELLO=WORLD

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -223,7 +223,7 @@ func writeComposeFile(layer spec.Descriptor, i int, local string, content []byte
 			return err
 		}
 	}
-	f, err := os.Create(filepath.Join(local, file))
+	f, err := os.OpenFile(filepath.Join(local, file), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What I did**

Fix support for OCI Compose artifact with multiple compose files (overrides)

Due to recent refactoring and lack of test coverage, earlier releases have broken support for overrides (need to _append_ to compose.yaml output.

Added an end-to-end test to fully cover this feature, with a full publish -> fetch cycle to confirm we fully support OCI artifact lifecycle with
- main compose.yaml
- override file
- env_file
- extends

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1300" height="956" alt="image" src="https://github.com/user-attachments/assets/6fa00dfc-2b1c-4984-bdee-872606900db7" />

