### PR TITLE
Fix help output for "exec --no-tty" option

### DIFF
--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -82,7 +82,7 @@ func execCommand(p *ProjectOptions, dockerCli command.Cli, backend api.Compose) 
 	runCmd.Flags().IntVar(&opts.index, "index", 0, "Index of the container if service has multiple replicas")
 	runCmd.Flags().BoolVarP(&opts.privileged, "privileged", "", false, "Give extended privileges to the process")
 	runCmd.Flags().StringVarP(&opts.user, "user", "u", "", "Run the command as this user")
-	runCmd.Flags().BoolVarP(&opts.noTty, "no-tty", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.")
+	runCmd.Flags().BoolVarP(&opts.noTty, "no-tty", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-TTY allocation. By default 'docker compose exec' allocates a TTY.")
 	runCmd.Flags().StringVarP(&opts.workingDir, "workdir", "w", "", "Path to workdir directory for this command")
 
 	runCmd.Flags().BoolVarP(&opts.interactive, "interactive", "i", true, "Keep STDIN open even if not attached")

--- a/docs/reference/compose_exec.md
+++ b/docs/reference/compose_exec.md
@@ -20,7 +20,7 @@ a script.
 | `--dry-run`       | `bool`        |         | Execute command in dry run mode                                                  |
 | `-e`, `--env`     | `stringArray` |         | Set environment variables                                                        |
 | `--index`         | `int`         | `0`     | Index of the container if service has multiple replicas                          |
-| `-T`, `--no-tty`  | `bool`        | `true`  | Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY. |
+| `-T`, `--no-tty`  | `bool`        | `true`  | Disable pseudo-TTY allocation. By default 'docker compose exec' allocates a TTY. |
 | `--privileged`    | `bool`        |         | Give extended privileges to the process                                          |
 | `-u`, `--user`    | `string`      |         | Run the command as this user                                                     |
 | `-w`, `--workdir` | `string`      |         | Path to workdir directory for this command                                       |

--- a/docs/reference/docker_compose_exec.yaml
+++ b/docs/reference/docker_compose_exec.yaml
@@ -63,7 +63,7 @@ options:
       value_type: bool
       default_value: "true"
       description: |
-        Disable pseudo-TTY allocation. By default `docker compose exec` allocates a TTY.
+        Disable pseudo-TTY allocation. By default 'docker compose exec' allocates a TTY.
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
**What I did**

Replaced backticks with single quotes in the help output of `docker compose exec` for the `--no-TTY` option.

Currently the output of  `docker compose exec --help` looks like this:

```
✘ $ docker compose exec --help
Usage:  docker compose exec [OPTIONS] SERVICE COMMAND [ARGS...]

Execute a command in a running container

Options:
  -d, --detach                       Detached mode: Run command in the background
      --dry-run                      Execute command in dry run mode
  -e, --env stringArray              Set environment variables
      --index int                    Index of the container if service has multiple replicas
  -T, --no-TTY docker compose exec   Disable pseudo-TTY allocation. By default docker compose exec allocates a TTY.
      --privileged                   Give extended privileges to the process
  -u, --user string                  Run the command as this user
  -w, --workdir string               Path to workdir directory for this command
```
Note the `-T` line:

```
  -T, --no-TTY docker compose exec   Disable pseudo-TTY allocation. By default docker compose exec allocates a TTY.
```

That "docker compose exec" part after `--no-TTY` is most likely unintentional; it's there because Cobra (or more specifically, pflag) found the backticks and extracted the wrapped value via [UnquoteUsage](https://github.com/spf13/pflag/blob/6fcfbc9910e1af538fde31db820be7d1bec231e4/flag.go#L594) function.
This is a not-so-well documented behavior, see e.g. [this](https://github.com/spf13/pflag/issues/200) and [this](https://github.com/spf13/cobra/issues/2125).

After the change the output looks as expected:

```
✓ $ ./bin/build/docker-compose exec --help
Usage:  docker compose exec [OPTIONS] SERVICE COMMAND [ARGS...]

Execute a command in a running container

Options:
  -d, --detach            Detached mode: Run command in the background
      --dry-run           Execute command in dry run mode
  -e, --env stringArray   Set environment variables
      --index int         Index of the container if service has multiple replicas
  -T, --no-tty            Disable pseudo-TTY allocation. By default 'docker compose exec' allocates a TTY.
      --privileged        Give extended privileges to the process
  -u, --user string       Run the command as this user
  -w, --workdir string    Path to workdir directory for this command
```

**Note**

The `By default 'docker compose exec' allocates a TTY.` part of the output is not entirely correct, given that the default value of the flag is `!dockerCli.Out().IsTerminal()` ([source](https://github.com/docker/compose/blob/e59150baa80093000f250fa91f427d6df620a4ad/cmd/compose/exec.go#L85)). It'd be more like, "By default 'docker compose exec' allocates a TTY when the output is a terminal."
Let me know if that sounds better and I'll update it in a separate PR.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ce3dbd4e-ed3d-45c0-b97e-0bdff4ef6230" />


