### PR TITLE
prompt default implementation to prevent a panic

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -37,6 +37,7 @@ import (
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/compose/v2/pkg/api"
 )
@@ -62,6 +63,13 @@ func NewComposeService(dockerCli command.Cli, options ...Option) api.Compose {
 	}
 	for _, option := range options {
 		option(s)
+	}
+	if s.prompt == nil {
+		s.prompt = func(message string, defaultValue bool) (bool, error) {
+			fmt.Println(message)
+			logrus.Warning("Compose is running without a 'prompt' component to interact with user")
+			return defaultValue, nil
+		}
 	}
 	return s
 }


### PR DESCRIPTION
**What I did**

if no `prompt` implementation has been configured, assume we run programmatically without possibility to interact with user: show message, assume default value. log a warning about missing 'prompt' component

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
