### PR TITLE
pretend cli.Out is a containerd.File

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/buger/goterm v1.0.4
 	github.com/compose-spec/compose-go/v2 v2.9.0
+	github.com/containerd/console v1.0.5
 	github.com/containerd/containerd/v2 v2.1.4
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/platforms v1.0.0-rc.1
@@ -80,7 +81,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/containerd/console v1.0.5 // indirect
 	github.com/containerd/containerd/api v1.9.0 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect


### PR DESCRIPTION
**What I did**

buildkit NewDisplay cast stout into a containerd.File to access console. It actually never use the `Reader` feature, so while the cast fails passing a plain dockerCli.Out() stream, all required features are available
This PR creates a fake `containerd.File` from Stream so we can use buildkit display

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
