### PR TITLE
fix various linting issues

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -324,17 +324,16 @@ func resolveImageDigests(ctx context.Context, dockerCli command.Cli, model map[s
 func formatModel(model map[string]any, format string) (content []byte, err error) {
 	switch format {
 	case "json":
-		content, err = json.MarshalIndent(model, "", "  ")
+		return json.MarshalIndent(model, "", "  ")
 	case "yaml":
 		buf := bytes.NewBuffer([]byte{})
 		encoder := yaml.NewEncoder(buf)
 		encoder.SetIndent(2)
 		err = encoder.Encode(model)
-		content = buf.Bytes()
+		return buf.Bytes(), err
 	default:
 		return nil, fmt.Errorf("unsupported format %q", format)
 	}
-	return
 }
 
 func runServices(ctx context.Context, dockerCli command.Cli, opts configOptions) error {

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -605,10 +605,10 @@ func (s *composeService) createContainer(ctx context.Context, project *types.Pro
 				StatusText: err.Error(),
 			})
 		}
-		return
+		return ctr, err
 	}
 	s.events.On(progress.CreatedEvent(eventName))
-	return
+	return ctr, nil
 }
 
 func (s *composeService) recreateContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,

--- a/pkg/compose/cp.go
+++ b/pkg/compose/cp.go
@@ -331,7 +331,7 @@ func splitCpArg(arg string) (ctr, path string) {
 
 func resolveLocalPath(localPath string) (absPath string, err error) {
 	if absPath, err = filepath.Abs(localPath); err != nil {
-		return
+		return absPath, err
 	}
 	return archive.PreserveTrailingDotOrSeparator(absPath, localPath), nil
 }

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1449,11 +1449,11 @@ func (s *composeService) removeDivergedNetwork(ctx context.Context, project *typ
 
 func (s *composeService) disconnectNetwork(
 	ctx context.Context,
-	network string,
+	nwName string,
 	containers Containers,
 ) error {
 	for _, c := range containers {
-		err := s.apiClient().NetworkDisconnect(ctx, network, c.ID, true)
+		err := s.apiClient().NetworkDisconnect(ctx, nwName, c.ID, true)
 		if err != nil {
 			return err
 		}
@@ -1464,12 +1464,12 @@ func (s *composeService) disconnectNetwork(
 
 func (s *composeService) connectNetwork(
 	ctx context.Context,
-	network string,
+	nwName string,
 	containers Containers,
 	config *network.EndpointSettings,
 ) error {
 	for _, c := range containers {
-		err := s.apiClient().NetworkConnect(ctx, network, c.ID, config)
+		err := s.apiClient().NetworkConnect(ctx, nwName, c.ID, config)
 		if err != nil {
 			return err
 		}

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -32,6 +32,7 @@ func TestUpWait(t *testing.T) {
 	timeout := time.After(30 * time.Second)
 	done := make(chan bool)
 	go func() {
+		//nolint:nolintlint,testifylint // helper asserts inside goroutine; acceptable in this e2e test
 		res := c.RunDockerComposeCmd(t, "-f", "fixtures/dependencies/deps-completed-successfully.yaml", "--project-name", projectName, "up", "--wait", "-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "e2e-deps-wait-oneshot-1"), res.Combined())
 		done <- true

--- a/pkg/e2e/healthcheck_test.go
+++ b/pkg/e2e/healthcheck_test.go
@@ -39,6 +39,7 @@ func TestStartInterval(t *testing.T) {
 	timeout := time.After(30 * time.Second)
 	done := make(chan bool)
 	go func() {
+		//nolint:nolintlint,testifylint // helper asserts inside goroutine; acceptable in this e2e test
 		res := c.RunDockerComposeCmd(t, "-f", "fixtures/start_interval/compose.yaml", "--project-name", projectName, "up", "--wait", "-d", "test")
 		out := res.Combined()
 		assert.Assert(t, strings.Contains(out, "Healthy"), out)


### PR DESCRIPTION
Got these when running locally on a more recent version of golangci-lint:

    pkg/compose/build_bake.go:187:3: importShadow: shadow of imported from 'github.com/docker/cli/cli/command/image/build' package 'build' (gocritic)
                    build := *service.Build
                    ^
    pkg/compose/build_bake.go:526:19: importShadow: shadow of imported from 'github.com/docker/cli/cli/command/image/build' package 'build' (gocritic)
    func toBakeAttest(build types.BuildConfig) []string {
                      ^
    pkg/compose/create.go:1453:2: importShadow: shadow of imported from 'github.com/docker/docker/api/types/network' package 'network' (gocritic)
            network string,
            ^
    pkg/compose/create.go:1468:2: importShadow: shadow of imported from 'github.com/docker/docker/api/types/network' package 'network' (gocritic)
            network string,
            ^
    pkg/compose/monitor.go:42:17: importShadow: shadow of imported from 'github.com/docker/compose/v2/pkg/api' package 'api' (gocritic)
    func newMonitor(api client.APIClient, project string) *monitor {
                    ^
    cmd/compose/config.go:337:1: File is not properly formatted (gofumpt)
            return
    ^
    pkg/compose/convergence.go:608:1: File is not properly formatted (gofumpt)
                    return
    ^
    pkg/compose/cp.go:335:1: File is not properly formatted (gofumpt)
                    return
    ^
    pkg/e2e/compose_up_test.go:35:10: go-require: c.RunDockerComposeCmd contains assertions that must only be used in the goroutine running the test function (testifylint)
                    res := c.RunDockerComposeCmd(t, "-f", "fixtures/dependencies/deps-completed-successfully.yaml", "--project-name", projectName, "up", "--wait", "-d")
                           ^
    pkg/e2e/healthcheck_test.go:42:10: go-require: c.RunDockerComposeCmd contains assertions that must only be used in the goroutine running the test function (testifylint)
                    res := c.RunDockerComposeCmd(t, "-f", "fixtures/start_interval/compose.yaml", "--project-name", projectName, "up", "--wait", "-d", "test")
                           ^
    10 issues:
    * gocritic: 5
    * gofumpt: 3
    * testifylint: 2

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
