### PR TITLE
Up build depends

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -158,13 +158,13 @@ func (o *ProjectOptions) WithProject(fn ProjectFunc, dockerCli command.Cli) func
 
 // WithServices creates a cobra run command from a ProjectFunc based on configured project options and selected services
 func (o *ProjectOptions) WithServices(dockerCli command.Cli, fn ProjectServicesFunc) func(cmd *cobra.Command, args []string) error {
-	return Adapt(func(ctx context.Context, args []string) error {
+	return Adapt(func(ctx context.Context, services []string) error {
 		backend, err := compose.NewComposeService(dockerCli)
 		if err != nil {
 			return err
 		}
 
-		project, metrics, err := o.ToProject(ctx, dockerCli, backend, args, cli.WithoutEnvironmentResolution)
+		project, metrics, err := o.ToProject(ctx, dockerCli, backend, services, cli.WithoutEnvironmentResolution)
 		if err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ func (o *ProjectOptions) WithServices(dockerCli command.Cli, fn ProjectServicesF
 			return err
 		}
 
-		return fn(ctx, project, args)
+		return fn(ctx, project, services)
 	})
 }
 

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -263,7 +263,7 @@ func runUp(
 		if err != nil {
 			return err
 		}
-		bo.Services = services
+		bo.Services = project.ServiceNames()
 		bo.Deps = !upOptions.noDeps
 		build = &bo
 	}


### PR DESCRIPTION
**What I did**

buildOptions set for `up` must select all involved services to ensure we get target services and dependencies. As project has been set by `WithEnabledServices`, we can rely on `ServiceNames` to get explicitly selected services + dependencies

**Related issue**
fixes https://github.com/docker/compose/issues/13338

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
