### PR TITLE
from Compose CLI, we know the streams used to configure LogConsumer

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -296,8 +296,7 @@ func runUp(
 	var consumer api.LogConsumer
 	var attach []string
 	if !upOptions.Detach {
-		outStream, errStream, _ := backend.GetConfiguredStreams()
-		consumer = formatter.NewLogConsumer(ctx, outStream, errStream, !upOptions.noColor, !upOptions.noPrefix, upOptions.timestamp)
+		consumer = formatter.NewLogConsumer(ctx, dockerCli.Out(), dockerCli.Err(), !upOptions.noColor, !upOptions.noPrefix, upOptions.timestamp)
 
 		var attachSet utils.Set[string]
 		if len(upOptions.attach) != 0 {

--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -122,8 +122,7 @@ func runWatch(ctx context.Context, dockerCli command.Cli, backendOptions *Backen
 		}
 	}
 
-	outStream, errStream, _ := backend.GetConfiguredStreams()
-	consumer := formatter.NewLogConsumer(ctx, outStream, errStream, false, false, false)
+	consumer := formatter.NewLogConsumer(ctx, dockerCli.Out(), dockerCli.Err(), false, false, false)
 	return backend.Watch(ctx, project, api.WatchOptions{
 		Build:    &build,
 		LogTo:    consumer,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -140,9 +140,6 @@ type Compose interface {
 	Generate(ctx context.Context, options GenerateOptions) (*types.Project, error)
 	// Volumes executes the equivalent to a `docker volume ls`
 	Volumes(ctx context.Context, project string, options VolumesOptions) ([]VolumesSummary, error)
-	// GetConfiguredStreams returns the configured I/O streams (stdout, stderr, stdin).
-	// If no custom streams were configured, it returns the dockerCli streams.
-	GetConfiguredStreams() (stdout io.Writer, stderr io.Writer, stdin io.Reader)
 	// LoadProject loads and validates a Compose project from configuration files.
 	LoadProject(ctx context.Context, options ProjectLoadOptions) (*types.Project, error)
 }

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -285,11 +285,6 @@ func (s *composeService) stdinfo() *streams.Out {
 	return s.stderr()
 }
 
-// GetConfiguredStreams returns the configured I/O streams (implements api.Compose interface)
-func (s *composeService) GetConfiguredStreams() (io.Writer, io.Writer, io.Reader) {
-	return s.stdout(), s.stderr(), s.stdin()
-}
-
 // readCloserAdapter adapts io.Reader to io.ReadCloser
 type readCloserAdapter struct {
 	r io.Reader

--- a/pkg/mocks/mock_docker_compose_api.go
+++ b/pkg/mocks/mock_docker_compose_api.go
@@ -11,7 +11,6 @@ package mocks
 
 import (
 	context "context"
-	io "io"
 	reflect "reflect"
 
 	types "github.com/compose-spec/compose-go/v2/types"
@@ -182,22 +181,6 @@ func (m *MockCompose) Generate(ctx context.Context, options api.GenerateOptions)
 func (mr *MockComposeMockRecorder) Generate(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockCompose)(nil).Generate), ctx, options)
-}
-
-// GetConfiguredStreams mocks base method.
-func (m *MockCompose) GetConfiguredStreams() (io.Writer, io.Writer, io.Reader) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfiguredStreams")
-	ret0, _ := ret[0].(io.Writer)
-	ret1, _ := ret[1].(io.Writer)
-	ret2, _ := ret[2].(io.Reader)
-	return ret0, ret1, ret2
-}
-
-// GetConfiguredStreams indicates an expected call of GetConfiguredStreams.
-func (mr *MockComposeMockRecorder) GetConfiguredStreams() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguredStreams", reflect.TypeOf((*MockCompose)(nil).GetConfiguredStreams))
 }
 
 // Images mocks base method.


### PR DESCRIPTION
SDK clients who wants to collect logs will need to create a `LogConsumer`. Either they will just rely on those from DockerCli, or want to use custom ones, but then as they have to set `WithStreams` they already have references to streams, we don't need those exposed by the SDK