### PR TITLE
introduce --insecure-registry, reserved for testing purpose

### DIFF
--- a/cmd/compose/publish.go
+++ b/cmd/compose/publish.go
@@ -36,6 +36,7 @@ type publishOptions struct {
 	withEnvironment     bool
 	assumeYes           bool
 	app                 bool
+	insecureRegistry    bool
 }
 
 func publishCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *BackendOptions) *cobra.Command {
@@ -56,6 +57,7 @@ func publishCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Ba
 	flags.BoolVar(&opts.withEnvironment, "with-env", false, "Include environment variables in the published OCI artifact")
 	flags.BoolVarP(&opts.assumeYes, "yes", "y", false, `Assume "yes" as answer to all prompts`)
 	flags.BoolVar(&opts.app, "app", false, "Published compose application (includes referenced images)")
+	flags.BoolVar(&opts.insecureRegistry, "insecure-registry", false, "Use insecure registry")
 	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		// assumeYes was introduced by mistake as `--y`
 		if name == "y" {
@@ -64,6 +66,8 @@ func publishCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Ba
 		}
 		return pflag.NormalizedName(name)
 	})
+	// Should **only** be used for testing purpose, we don't want to promote use of insecure registries
+	_ = flags.MarkHidden("insecure-registry")
 
 	return cmd
 }
@@ -92,5 +96,6 @@ func runPublish(ctx context.Context, dockerCli command.Cli, backendOptions *Back
 		Application:         opts.app,
 		OCIVersion:          api.OCIVersion(opts.ociVersion),
 		WithEnvironment:     opts.withEnvironment,
+		InsecureRegistry:    opts.insecureRegistry,
 	})
 }

--- a/docs/reference/docker_compose.yaml
+++ b/docs/reference/docker_compose.yaml
@@ -139,6 +139,17 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: insecure-registry
+      value_type: stringArray
+      default_value: '[]'
+      description: |
+        Use insecure registry to pull Compose OCI artifacts. Doesn't apply to images
+      deprecated: false
+      hidden: true
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: no-ansi
       value_type: bool
       default_value: "false"

--- a/docs/reference/docker_compose_alpha_publish.yaml
+++ b/docs/reference/docker_compose_alpha_publish.yaml
@@ -15,6 +15,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: insecure-registry
+      value_type: bool
+      default_value: "false"
+      description: Use insecure registry
+      deprecated: false
+      hidden: true
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: oci-version
       value_type: string
       description: |

--- a/docs/reference/docker_compose_publish.yaml
+++ b/docs/reference/docker_compose_publish.yaml
@@ -15,6 +15,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: insecure-registry
+      value_type: bool
+      default_value: "false"
+      description: Use insecure registry
+      deprecated: false
+      hidden: true
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: oci-version
       value_type: string
       description: |

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -69,6 +69,12 @@ type ProjectLoadOptions struct {
 	// All registered listeners will be notified of events.
 	// This is optional - pass nil or empty slice if not needed.
 	LoadListeners []LoadListener
+
+	OCI OCIOptions
+}
+
+type OCIOptions struct {
+	InsecureRegistries []string
 }
 
 // Compose is the API interface one can use to programmatically use docker/compose in a third-party software
@@ -484,8 +490,9 @@ type PublishOptions struct {
 	ResolveImageDigests bool
 	Application         bool
 	WithEnvironment     bool
-
-	OCIVersion OCIVersion
+	OCIVersion          OCIVersion
+	// Use plain HTTP to access registry. Should only be used for testing purpose
+	InsecureRegistry bool
 }
 
 func (e Event) String() string {

--- a/pkg/compose/loader.go
+++ b/pkg/compose/loader.go
@@ -33,7 +33,7 @@ import (
 // It loads and validates a Compose project from configuration files.
 func (s *composeService) LoadProject(ctx context.Context, options api.ProjectLoadOptions) (*types.Project, error) {
 	// Setup remote loaders (Git, OCI)
-	remoteLoaders := s.createRemoteLoaders(options.Offline)
+	remoteLoaders := s.createRemoteLoaders(options)
 
 	projectOptions, err := s.buildProjectOptions(options, remoteLoaders)
 	if err != nil {
@@ -66,12 +66,12 @@ func (s *composeService) LoadProject(ctx context.Context, options api.ProjectLoa
 }
 
 // createRemoteLoaders creates Git and OCI remote loaders if not in offline mode
-func (s *composeService) createRemoteLoaders(offline bool) []loader.ResourceLoader {
-	if offline {
+func (s *composeService) createRemoteLoaders(options api.ProjectLoadOptions) []loader.ResourceLoader {
+	if options.Offline {
 		return nil
 	}
-	git := remote.NewGitRemoteLoader(s.dockerCli, offline)
-	oci := remote.NewOCIRemoteLoader(s.dockerCli, offline)
+	git := remote.NewGitRemoteLoader(s.dockerCli, options.Offline)
+	oci := remote.NewOCIRemoteLoader(s.dockerCli, options.Offline, options.OCI)
 	return []loader.ResourceLoader{git, oci}
 }
 

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -89,7 +89,12 @@ func (s *composeService) publish(ctx context.Context, project *types.Project, re
 			return err
 		}
 
-		resolver := oci.NewResolver(s.configFile())
+		var insecureRegistries []string
+		if options.InsecureRegistry {
+			insecureRegistries = append(insecureRegistries, reference.Domain(named))
+		}
+
+		resolver := oci.NewResolver(s.configFile(), insecureRegistries...)
 
 		descriptor, err := oci.PushManifest(ctx, resolver, named, layers, options.OCIVersion)
 		if err != nil {


### PR DESCRIPTION
**What I did**
introduce `--insecure-registry` flag, should only be used for testing purpose so marked hidden.
Need to find how we can get this excluded from docs generation

**Related issue**
fixes https://github.com/docker/compose/issues/13352

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
