### PR TITLE
Making the American/British spellings consistent to the error messages

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -742,7 +742,7 @@ const (
 	ContainerEventRecreated
 	// ContainerEventExited is a ContainerEvent of type exit. ExitCode is set
 	ContainerEventExited
-	// UserCancel user cancelled compose up, we are stopping containers
+	// UserCancel user canceled compose up, we are stopping containers
 	HookEventLog
 )
 


### PR DESCRIPTION
**What I did**
In the error messages + most of the code base it uses American English spelling of "canceled". However, in some parts of the code, seemingly random, the British English spelling of "cancelled" is used. As this is used in client facing code I just made it more consistent.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/91c7d0b5-52e3-40a0-84e4-6f0efbd492bc" />

