### PR TITLE
add (restore) support for detach keys

### DIFF
--- a/pkg/compose/attach.go
+++ b/pkg/compose/attach.go
@@ -152,11 +152,12 @@ func (s *composeService) getContainerStreams(ctx context.Context, container stri
 	var stdout io.ReadCloser
 	var stdin io.WriteCloser
 	cnx, err := s.apiClient().ContainerAttach(ctx, container, containerType.AttachOptions{
-		Stream: true,
-		Stdin:  true,
-		Stdout: true,
-		Stderr: true,
-		Logs:   false,
+		Stream:     true,
+		Stdin:      true,
+		Stdout:     true,
+		Stderr:     true,
+		Logs:       false,
+		DetachKeys: s.configFile().DetachKeys,
 	})
 	if err == nil {
 		stdout = ContainerStdout{HijackedResponse: cnx}

--- a/pkg/compose/attach_service.go
+++ b/pkg/compose/attach_service.go
@@ -31,8 +31,13 @@ func (s *composeService) Attach(ctx context.Context, projectName string, options
 		return err
 	}
 
+	detachKeys := options.DetachKeys
+	if detachKeys == "" {
+		detachKeys = s.configFile().DetachKeys
+	}
+
 	var attach container.AttachOptions
-	attach.DetachKeys = options.DetachKeys
+	attach.DetachKeys = detachKeys
 	attach.NoStdin = options.NoStdin
 	attach.Proxy = options.Proxy
 	return container.RunAttach(ctx, s.dockerCli, target.ID, &attach)

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -49,6 +49,7 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 		OpenStdin:  !opts.Detach && opts.Interactive,
 		Attach:     !opts.Detach,
 		Containers: []string{containerID},
+		DetachKeys: s.configFile().DetachKeys,
 	})
 	var stErr cli.StatusError
 	if errors.As(err, &stErr) {

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -107,6 +107,10 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	globalCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	if navigationMenu != nil {
+		navigationMenu.EnableDetach(cancel)
+	}
+
 	var (
 		eg   errgroup.Group
 		mu   sync.Mutex

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -597,6 +597,7 @@ func (s *composeService) exec(ctx context.Context, project *types.Project, servi
 			exec.Privileged = x.Privileged
 			exec.Command = x.Command
 			exec.Workdir = x.WorkingDir
+			exec.DetachKeys = s.configFile().DetachKeys
 			for _, v := range x.Environment.ToMapping().Values() {
 				err := exec.Env.Set(v)
 				if err != nil {


### PR DESCRIPTION
**What I did**

fixed `run` and `attach` commands to handle detach keys as configured in CLI config
introduced `'d' Detach` entry in navigation menu to detach from containers.

**how to test**

```yaml
services:
  test:
    image: alpine
    command: ping localhost
```

run `docker compose up`. Hit `d` for detach menu entry. Compose should exit immediately, but container is still running:
```
$ docker ps
CONTAINER ID   IMAGE     COMMAND            CREATED          STATUS          PORTS     NAMES
b2cc5fb6988d   alpine    "ping localhost"   44 seconds ago   Up 18 seconds             truc-test-1
```

attach to container, hit detach key sequence (`"detachKeys"` in CLI config.json)
```
$ docker compose attach test
64 bytes from ::1: seq=412 ttl=64 time=0.278 ms
read escape sequence
$ 
```

check container is still running
run a one-off container, and test escape sequence:
```
$ docker compose run test
Container truc-test-run-1de59523f52e Creating 
Container truc-test-run-1de59523f52e Created 
PING localhost (::1): 56 data bytes
64 bytes from ::1: seq=0 ttl=64 time=0.024 ms
64 bytes from ::1: seq=1 ttl=64 time=0.214 ms
64 bytes from ::1: seq=2 ttl=64 time=0.199 ms
$
```

check container is still running:
```
$ docker ps
CONTAINER ID   IMAGE     COMMAND            CREATED          STATUS          PORTS     NAMES
170d8912fb3b   alpine    "ping localhost"   37 seconds ago   Up 37 seconds             truc-test-run-1de59523f52e
```


**Related issue**
fixes https://github.com/docker/compose/issues/12594

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
