### PR TITLE
images command should display image Created time or N/A if not available

### DIFF
--- a/cmd/compose/images.go
+++ b/cmd/compose/images.go
@@ -95,21 +95,19 @@ func runImages(ctx context.Context, dockerCli command.Cli, backendOptions *Backe
 	if opts.Format == "json" {
 
 		type img struct {
-			ID            string    `json:"ID"`
-			ContainerName string    `json:"ContainerName"`
-			Repository    string    `json:"Repository"`
-			Tag           string    `json:"Tag"`
-			Platform      string    `json:"Platform"`
-			Size          int64     `json:"Size"`
-			LastTagTime   time.Time `json:"LastTagTime"`
+			ID            string     `json:"ID"`
+			ContainerName string     `json:"ContainerName"`
+			Repository    string     `json:"Repository"`
+			Tag           string     `json:"Tag"`
+			Platform      string     `json:"Platform"`
+			Size          int64      `json:"Size"`
+			Created       *time.Time `json:"Created,omitempty"`
+			LastTagTime   time.Time  `json:"LastTagTime,omitzero"`
 		}
 		// Convert map to slice
 		var imageList []img
 		for ctr, i := range images {
 			lastTagTime := i.LastTagTime
-			if lastTagTime.IsZero() {
-				lastTagTime = i.Created
-			}
 			imageList = append(imageList, img{
 				ContainerName: ctr,
 				ID:            i.ID,
@@ -117,6 +115,7 @@ func runImages(ctx context.Context, dockerCli command.Cli, backendOptions *Backe
 				Tag:           i.Tag,
 				Platform:      platforms.Format(i.Platform),
 				Size:          i.Size,
+				Created:       i.Created,
 				LastTagTime:   lastTagTime,
 			})
 		}
@@ -142,7 +141,10 @@ func runImages(ctx context.Context, dockerCli command.Cli, backendOptions *Backe
 				if tag == "" {
 					tag = "<none>"
 				}
-				created := units.HumanDuration(time.Now().UTC().Sub(img.LastTagTime)) + " ago"
+				created := "N/A"
+				if img.Created != nil {
+					created = units.HumanDuration(time.Now().UTC().Sub(*img.Created)) + " ago"
+				}
 				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 					container, repo, tag, platforms.Format(img.Platform), id, size, created)
 			}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -603,7 +603,7 @@ type ImageSummary struct {
 	Tag         string
 	Platform    platforms.Platform
 	Size        int64
-	Created     time.Time
+	Created     *time.Time
 	LastTagTime time.Time
 }
 

--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -91,9 +91,13 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 				}
 			}
 
-			created, err := time.Parse(time.RFC3339Nano, image.Created)
-			if err != nil {
-				return err
+			var created *time.Time
+			if image.Created != "" {
+				t, err := time.Parse(time.RFC3339Nano, image.Created)
+				if err != nil {
+					return err
+				}
+				created = &t
 			}
 
 			mux.Lock()

--- a/pkg/compose/images_test.go
+++ b/pkg/compose/images_test.go
@@ -66,21 +66,21 @@ func TestImages(t *testing.T) {
 			Repository: "foo",
 			Tag:        "1",
 			Size:       12345,
-			Created:    created1,
+			Created:    &created1,
 		},
 		"456": {
 			ID:         "image2",
 			Repository: "bar",
 			Tag:        "2",
 			Size:       67890,
-			Created:    created2,
+			Created:    &created2,
 		},
 		"789": {
 			ID:         "image1",
 			Repository: "foo",
 			Tag:        "1",
 			Size:       12345,
-			Created:    created1,
+			Created:    &created1,
 		},
 	}
 	assert.NilError(t, err)


### PR DESCRIPTION
**What I did**
`compose images` should displays image Created time (time it was built) not time it was tagged (pulled locally)
Created time may not be available (see https://github.com/moby/moby/issues/47368), so display `N/A`
This introduce a breaking change in `ImageSummary` type, hopefully v5.0.0 was not yet released :)

**Related issue**
fixes https://github.com/docker/compose/issues/13374

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
