### PR TITLE
build(deps): bump buildx v0.30.0, buildkit v0.26.0, otel v1.38.0, otel/contrib v0.63.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/distribution/reference v0.6.0
-	github.com/docker/buildx v0.29.1
+	github.com/docker/buildx v0.30.0
 	github.com/docker/cli v28.5.2+incompatible
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/docker v28.5.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/buildx v0.29.1 h1:58hxM5Z4mnNje3G5NKfULT9xCr8ooM8XFtlfUK9bKaA=
-github.com/docker/buildx v0.29.1/go.mod h1:J4EFv6oxlPiV1MjO0VyJx2u5tLM7ImDEl9zyB8d4wPI=
+github.com/docker/buildx v0.30.0 h1:Fz7LzHqEmnE8JNpDPxLWVSKUdD5ysXn2bq8JOpRpvAY=
+github.com/docker/buildx v0.30.0/go.mod h1:m7/CUbSd2skvugtGYENwn96mk5Ffar28xmLmeAVMc4c=
 github.com/docker/cli v28.5.2+incompatible h1:XmG99IHcBmIAoC1PPg9eLBZPlTrNUAijsHLm8PjhBlg=
 github.com/docker/cli v28.5.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli-docs-tool v0.10.0 h1:bOD6mKynPQgojQi3s2jgcUWGp/Ebqy1SeCr9VfKQLLU=


### PR DESCRIPTION
- relates to https://github.com/docker/compose/pull/13078


### build(deps): bump go.opentelemetry.io/otel v1.38.0, go.opentelemetry.io/contrib v0.63.0

### build(deps): bump github.com/moby/buildkit from v0.25.2 to v0.26.0

full diff: https://github.com/moby/buildkit/compare/v0.25.2...v0.26.0

### build(deps): bump github.com/docker/buildx from v0.29.1 to v0.30.0

full diff: https://github.com/docker/buildx/compare/v0.29.1...v0.30.0



**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
