### PR TITLE
gha: test against docker v29, v28, and rename checks to use `stable`, `oldstable`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,15 +149,26 @@ jobs:
         if: always()
   e2e:
     runs-on: ubuntu-latest
+    name: e2e (${{ matrix.mode }}, ${{ matrix.channel }})
     strategy:
       fail-fast: false
       matrix:
-        mode:
-          - plugin
-          - standalone
-        engine:
-          - 28 # old stable (latest major - 1)
-          - 29 # current stable
+        include:
+          # current stable
+          - mode: plugin
+            engine: 29
+            channel: stable
+          - mode: standalone
+            engine: 29
+            channel: stable
+
+          # old stable (latest major - 1)
+          - mode: plugin
+            engine: 28
+            channel: oldstable
+          - mode: standalone
+            engine: 28
+            channel: oldstable
     steps:
       - name: Prepare
         run: |


### PR DESCRIPTION
### gha: test against docker v29, v28

### gha: use custom names for matrix

Manually enumerate the combinations ((plugin|standalone), (version))
so that we can assign a predictable name ("stable", "oldstable") and
prevent having to update the branch-protection rules for each update
to mark the tests as required.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
