### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/compose/top_test.go
+++ b/cmd/compose/top_test.go
@@ -321,7 +321,7 @@ func TestRunTopCore(t *testing.T) {
 
 func trim(s string) string {
 	var out bytes.Buffer
-	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(s), "\n") {
 		out.WriteString(strings.TrimSpace(line))
 		out.WriteRune('\n')
 	}

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -119,7 +119,7 @@ func (l *logConsumer) write(w io.Writer, container, message string) {
 	}
 	p := l.getPresenter(container)
 	timestamp := time.Now().Format(jsonmessage.RFC3339NanoFixed)
-	for _, line := range strings.Split(message, "\n") {
+	for line := range strings.SplitSeq(message, "\n") {
 		if l.timestamp {
 			_, _ = fmt.Fprintf(w, "%s%s %s\n", p.prefix, timestamp, line)
 		} else {

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -386,7 +386,7 @@ func (s *composeService) projectFromName(containers Containers, projectName stri
 		dependencies := service.Labels[api.DependenciesLabel]
 		if dependencies != "" {
 			service.DependsOn = types.DependsOnConfig{}
-			for _, dc := range strings.Split(dependencies, ",") {
+			for dc := range strings.SplitSeq(dependencies, ",") {
 				dcArr := strings.Split(dc, ":")
 				condition := ServiceConditionRunningOrHealthy
 				// Let's restart the dependency by default if we don't have the info stored in the label

--- a/pkg/compose/ls.go
+++ b/pkg/compose/ls.go
@@ -73,7 +73,7 @@ func combinedConfigFiles(containers []container.Summary) (string, error) {
 			return "", fmt.Errorf("no label %q set on container %q of compose project", api.ConfigFilesLabel, c.ID)
 		}
 
-		for _, f := range strings.Split(files, ",") {
+		for f := range strings.SplitSeq(files, ",") {
 			if !slices.Contains(configFiles, f) {
 				configFiles = append(configFiles, f)
 			}

--- a/pkg/e2e/scale_test.go
+++ b/pkg/e2e/scale_test.go
@@ -169,8 +169,8 @@ func TestScaleDownRemovesObsolete(t *testing.T) {
 
 func checkServiceContainer(t *testing.T, stdout, containerName, containerState string, count int) {
 	found := 0
-	lines := strings.Split(stdout, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(stdout, "\n")
+	for line := range lines {
 		if strings.Contains(line, containerName) && strings.Contains(line, containerState) {
 			found++
 		}


### PR DESCRIPTION
**What I did**

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![874cf9b11a22f2c26fdc07cdee841391](https://github.com/user-attachments/assets/2f174a8d-be30-47b8-ac51-bb43ca281e63)

