### PR TITLE
golangci-lint: use gci formatter instead of goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,11 +79,18 @@ issues:
   max-same-issues: 0
 formatters:
   enable:
+    - gci
     - gofumpt
-    - goimports
   exclusions:
     generated: lax
     paths:
       - third_party$
       - builtin$
       - examples$
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+      custom-order: true # make the section order the same as the order of "sections".

--- a/cmd/cmdtrace/cmd_span.go
+++ b/cmd/cmdtrace/cmd_span.go
@@ -26,14 +26,15 @@ import (
 
 	dockercli "github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	commands "github.com/docker/compose/v5/cmd/compose"
-	"github.com/docker/compose/v5/internal/tracing"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	commands "github.com/docker/compose/v5/cmd/compose"
+	"github.com/docker/compose/v5/internal/tracing"
 )
 
 // Setup should be called as part of the command's PersistentPreRunE

--- a/cmd/cmdtrace/cmd_span_test.go
+++ b/cmd/cmdtrace/cmd_span_test.go
@@ -20,9 +20,10 @@ import (
 	"reflect"
 	"testing"
 
-	commands "github.com/docker/compose/v5/cmd/compose"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+
+	commands "github.com/docker/compose/v5/cmd/compose"
 )
 
 func TestGetFlags(t *testing.T) {

--- a/cmd/compose/attach.go
+++ b/cmd/compose/attach.go
@@ -20,9 +20,10 @@ import (
 	"context"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type attachOpts struct {

--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -26,11 +26,11 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
 	cliopts "github.com/docker/cli/opts"
-	"github.com/docker/compose/v5/cmd/display"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/compose/v5/cmd/display"
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type buildOptions struct {

--- a/cmd/compose/commit.go
+++ b/cmd/compose/commit.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type commitOptions struct {

--- a/cmd/compose/completion.go
+++ b/cmd/compose/completion.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 // validArgsFn defines a completion func to be returned to fetch completion options

--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -39,6 +39,11 @@ import (
 	"github.com/docker/cli/cli-plugins/metadata"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/pkg/kvfile"
+	"github.com/morikuni/aec"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/docker/compose/v5/cmd/display"
 	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/docker/compose/v5/internal/tracing"
@@ -46,10 +51,6 @@ import (
 	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/docker/compose/v5/pkg/remote"
 	"github.com/docker/compose/v5/pkg/utils"
-	"github.com/morikuni/aec"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const (

--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -30,10 +30,10 @@ import (
 	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
 )

--- a/cmd/compose/cp.go
+++ b/cmd/compose/cp.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type copyOptions struct {

--- a/cmd/compose/create.go
+++ b/cmd/compose/create.go
@@ -26,12 +26,12 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type createOptions struct {

--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/docker/compose/v5/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 type downOptions struct {

--- a/cmd/compose/events.go
+++ b/cmd/compose/events.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-
-	"github.com/spf13/cobra"
 )
 
 type eventsOpts struct {

--- a/cmd/compose/exec.go
+++ b/cmd/compose/exec.go
@@ -25,11 +25,12 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type execOpts struct {

--- a/cmd/compose/export.go
+++ b/cmd/compose/export.go
@@ -20,10 +20,10 @@ import (
 	"context"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type exportOptions struct {

--- a/cmd/compose/generate.go
+++ b/cmd/compose/generate.go
@@ -22,9 +22,10 @@ import (
 	"os"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type generateOptions struct {

--- a/cmd/compose/images.go
+++ b/cmd/compose/images.go
@@ -27,13 +27,13 @@ import (
 
 	"github.com/containerd/platforms"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type imageOptions struct {

--- a/cmd/compose/kill.go
+++ b/cmd/compose/kill.go
@@ -23,10 +23,10 @@ import (
 	"os"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/docker/compose/v5/pkg/utils"
 )
 

--- a/cmd/compose/list.go
+++ b/cmd/compose/list.go
@@ -23,13 +23,12 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/cmd/formatter"
-	"github.com/docker/compose/v5/pkg/compose"
-
 	"github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type lsOptions struct {

--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type logsOptions struct {

--- a/cmd/compose/options.go
+++ b/cmd/compose/options.go
@@ -30,6 +30,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
+
 	"github.com/docker/compose/v5/cmd/display"
 	"github.com/docker/compose/v5/cmd/prompt"
 	"github.com/docker/compose/v5/internal/tracing"

--- a/cmd/compose/options_test.go
+++ b/cmd/compose/options_test.go
@@ -28,9 +28,10 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/streams"
-	"github.com/docker/compose/v5/pkg/mocks"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/docker/compose/v5/pkg/mocks"
 )
 
 func TestApplyPlatforms_InferFromRuntime(t *testing.T) {

--- a/cmd/compose/pause.go
+++ b/cmd/compose/pause.go
@@ -20,10 +20,10 @@ import (
 	"context"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type pauseOptions struct {

--- a/cmd/compose/port.go
+++ b/cmd/compose/port.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type portOptions struct {

--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -24,14 +24,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/docker/compose/v5/cmd/formatter"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/compose"
-
 	"github.com/docker/cli/cli/command"
 	cliformatter "github.com/docker/cli/cli/command/formatter"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/compose/v5/cmd/formatter"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type psOptions struct {

--- a/cmd/compose/publish.go
+++ b/cmd/compose/publish.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type publishOptions struct {

--- a/cmd/compose/pull.go
+++ b/cmd/compose/pull.go
@@ -24,11 +24,11 @@ import (
 	"github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/morikuni/aec"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type pullOptions struct {

--- a/cmd/compose/push.go
+++ b/cmd/compose/push.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type pushOptions struct {

--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type removeOptions struct {

--- a/cmd/compose/restart.go
+++ b/cmd/compose/restart.go
@@ -21,10 +21,10 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type restartOptions struct {

--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -25,20 +25,19 @@ import (
 	composecli "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/dotenv"
 	"github.com/compose-spec/compose-go/v2/format"
-	"github.com/docker/compose/v5/cmd/display"
-	"github.com/docker/compose/v5/pkg/compose"
-	xprogress "github.com/moby/buildkit/util/progress/progressui"
-	"github.com/sirupsen/logrus"
-
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
 	"github.com/mattn/go-shellwords"
+	xprogress "github.com/moby/buildkit/util/progress/progressui"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/docker/cli/cli"
+	"github.com/docker/compose/v5/cmd/display"
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/docker/compose/v5/pkg/utils"
 )
 

--- a/cmd/compose/scale.go
+++ b/cmd/compose/scale.go
@@ -26,9 +26,10 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type scaleOptions struct {

--- a/cmd/compose/start.go
+++ b/cmd/compose/start.go
@@ -21,9 +21,10 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type startOptions struct {

--- a/cmd/compose/stop.go
+++ b/cmd/compose/stop.go
@@ -21,10 +21,10 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type stopOptions struct {

--- a/cmd/compose/top.go
+++ b/cmd/compose/top.go
@@ -25,10 +25,10 @@ import (
 	"text/tabwriter"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type topOptions struct {

--- a/cmd/compose/top_test.go
+++ b/cmd/compose/top_test.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 var topTestCases = []struct {

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -26,15 +26,15 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/cmd/display"
-	"github.com/docker/compose/v5/pkg/compose"
 	xprogress "github.com/moby/buildkit/util/progress/progressui"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/docker/compose/v5/cmd/display"
 	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/docker/compose/v5/pkg/utils"
 )
 

--- a/cmd/compose/version.go
+++ b/cmd/compose/version.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/cmd/formatter"
-
 	"github.com/spf13/cobra"
 
+	"github.com/docker/compose/v5/cmd/formatter"
 	"github.com/docker/compose/v5/internal"
 )
 

--- a/cmd/compose/version_test.go
+++ b/cmd/compose/version_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 
 	"github.com/docker/cli/cli/streams"
-	"github.com/docker/compose/v5/internal"
-	"github.com/docker/compose/v5/pkg/mocks"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/internal"
+	"github.com/docker/compose/v5/pkg/mocks"
 )
 
 func TestVersionCommand(t *testing.T) {

--- a/cmd/compose/viz.go
+++ b/cmd/compose/viz.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type vizOptions struct {

--- a/cmd/compose/volumes.go
+++ b/cmd/compose/volumes.go
@@ -24,9 +24,10 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/flags"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type volumesOptions struct {

--- a/cmd/compose/wait.go
+++ b/cmd/compose/wait.go
@@ -22,9 +22,10 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/spf13/cobra"
 )
 
 type waitOptions struct {

--- a/cmd/compose/watch.go
+++ b/cmd/compose/watch.go
@@ -21,14 +21,14 @@ import (
 	"fmt"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/cmd/formatter"
-	"github.com/docker/compose/v5/pkg/compose"
-
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/internal/locker"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/compose/v5/cmd/formatter"
+	"github.com/docker/compose/v5/internal/locker"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 )
 
 type watchOptions struct {

--- a/cmd/display/json_test.go
+++ b/cmd/display/json_test.go
@@ -21,8 +21,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func TestJsonWriter_Event(t *testing.T) {

--- a/cmd/display/tty.go
+++ b/cmd/display/tty.go
@@ -24,11 +24,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/compose/v5/pkg/api"
-
 	"github.com/buger/goterm"
 	"github.com/docker/go-units"
 	"github.com/morikuni/aec"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 // Full creates an EventProcessor that render advanced UI within a terminal.

--- a/cmd/formatter/container.go
+++ b/cmd/formatter/container.go
@@ -23,10 +23,11 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-units"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 const (

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -26,8 +26,9 @@ import (
 	"time"
 
 	"github.com/buger/goterm"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/pkg/jsonmessage"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 // LogConsumer consume logs from services and format them

--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -28,10 +28,11 @@ import (
 
 	"github.com/buger/goterm"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/internal/tracing"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/eiannone/keyboard"
 	"github.com/skratchdot/open-golang/open"
+
+	"github.com/docker/compose/v5/internal/tracing"
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 const DISPLAY_ERROR_TIME = 10

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,13 +23,13 @@ import (
 	"github.com/docker/cli/cli-plugins/metadata"
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/cmd/cmdtrace"
-	"github.com/docker/compose/v5/cmd/prompt"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/compose/v5/cmd/cmdtrace"
 	"github.com/docker/compose/v5/cmd/compatibility"
 	commands "github.com/docker/compose/v5/cmd/compose"
+	"github.com/docker/compose/v5/cmd/prompt"
 	"github.com/docker/compose/v5/internal"
 	"github.com/docker/compose/v5/pkg/compose"
 )

--- a/cmd/prompt/prompt.go
+++ b/cmd/prompt/prompt.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/docker/cli/cli/streams"
+
 	"github.com/docker/compose/v5/pkg/utils"
 )
 

--- a/docs/yaml/main/generate.go
+++ b/docs/yaml/main/generate.go
@@ -23,8 +23,9 @@ import (
 
 	clidocstool "github.com/docker/cli-docs-tool"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/cmd/compose"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/compose/v5/cmd/compose"
 )
 
 func generateDocs(opts *options) error {

--- a/internal/desktop/client.go
+++ b/internal/desktop/client.go
@@ -25,9 +25,10 @@ import (
 	"net/http"
 	"strings"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
 	"github.com/docker/compose/v5/internal"
 	"github.com/docker/compose/v5/internal/memnet"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // identify this client in the logs

--- a/internal/oci/push.go
+++ b/internal/oci/push.go
@@ -29,10 +29,11 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	pusherrors "github.com/containerd/containerd/v2/core/remotes/errors"
 	"github.com/distribution/reference"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 const (

--- a/internal/oci/resolver.go
+++ b/internal/oci/resolver.go
@@ -29,9 +29,10 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/config/configfile"
-	"github.com/docker/compose/v5/internal/registry"
 	"github.com/moby/buildkit/util/contentutil"
 	spec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/docker/compose/v5/internal/registry"
 )
 
 // NewResolver setup an OCI Resolver based on docker/cli config to provide registry credentials

--- a/internal/tracing/docker_context.go
+++ b/internal/tracing/docker_context.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/context/store"
-	"github.com/docker/compose/v5/internal/memnet"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/docker/compose/v5/internal/memnet"
 )
 
 const otelConfigFieldName = "otel"

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -23,19 +23,19 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/compose/v5/internal"
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/buildkit/util/tracing/detect"
 	_ "github.com/moby/buildkit/util/tracing/env" //nolint:blank-imports
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+
+	"github.com/docker/compose/v5/internal"
 )
 
 func init() {

--- a/pkg/api/labels_test.go
+++ b/pkg/api/labels_test.go
@@ -19,9 +19,10 @@ package api
 import (
 	"testing"
 
-	"github.com/docker/compose/v5/internal"
 	"github.com/hashicorp/go-version"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/internal"
 )
 
 func TestComposeVersionInitialization(t *testing.T) {

--- a/pkg/bridge/convert.go
+++ b/pkg/bridge/convert.go
@@ -30,14 +30,15 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/command"
 	cli "github.com/docker/cli/cli/command/container"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/utils"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
 	"gopkg.in/yaml.v3"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 type ConvertOptions struct {

--- a/pkg/compose/attach_service.go
+++ b/pkg/compose/attach_service.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command/container"
+
 	"github.com/docker/compose/v5/pkg/api"
 )
 

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/containerd/platforms"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+
 	"github.com/docker/compose/v5/internal/tracing"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/utils"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func (s *composeService) Build(ctx context.Context, project *types.Project, options api.BuildOptions) error {

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -39,7 +39,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/cli/cli/streams"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/google/uuid"
 	"github.com/moby/buildkit/client"
@@ -48,6 +47,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func buildWithBake(dockerCli command.Cli) (bool, error) {

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -29,7 +29,6 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command/image/build"
-	"github.com/docker/compose/v5/pkg/api"
 	buildtypes "github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
@@ -40,6 +39,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) doBuildClassic(ctx context.Context, project *types.Project, serviceToBuild types.Services, options api.BuildOptions) (map[string]string, error) {

--- a/pkg/compose/commit.go
+++ b/pkg/compose/commit.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Commit(ctx context.Context, projectName string, options api.CommitOptions) error {

--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -31,7 +31,6 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/streams"
-	"github.com/docker/compose/v5/pkg/dryrun"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -42,6 +41,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/dryrun"
 )
 
 type Option func(service *composeService) error

--- a/pkg/compose/containers.go
+++ b/pkg/compose/containers.go
@@ -24,9 +24,10 @@ import (
 	"strconv"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 // Containers is a set of moby Container

--- a/pkg/compose/cp.go
+++ b/pkg/compose/cp.go
@@ -25,12 +25,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/go-archive"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 type copyDirection int

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -24,18 +24,16 @@ import (
 	"testing"
 
 	composeloader "github.com/compose-spec/compose-go/v2/loader"
+	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
+	mountTypes "github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 
 	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/docker/api/types/network"
-
-	composetypes "github.com/compose-spec/compose-go/v2/types"
-	mountTypes "github.com/docker/docker/api/types/mount"
-
-	"gotest.tools/v3/assert"
 )
 
 func TestBuildBindMount(t *testing.T) {

--- a/pkg/compose/dependencies.go
+++ b/pkg/compose/dependencies.go
@@ -24,8 +24,9 @@ import (
 	"sync"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/pkg/api"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 // ServiceStatus indicates the status of a service

--- a/pkg/compose/dependencies_test.go
+++ b/pkg/compose/dependencies_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/pkg/utils"
 	testify "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 func createTestProject() *types.Project {

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -24,14 +24,15 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/containerd/errdefs"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/utils"
 	containerType "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	imageapi "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 type downOp func() error

--- a/pkg/compose/exec.go
+++ b/pkg/compose/exec.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command/container"
-	"github.com/docker/compose/v5/pkg/api"
 	containerType "github.com/docker/docker/api/types/container"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Exec(ctx context.Context, projectName string, options api.RunOptions) (int, error) {

--- a/pkg/compose/export.go
+++ b/pkg/compose/export.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/sys/atomicwriter"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Export(ctx context.Context, projectName string, options api.ExportOptions) error {

--- a/pkg/compose/filters.go
+++ b/pkg/compose/filters.go
@@ -19,8 +19,9 @@ package compose
 import (
 	"fmt"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/filters"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func projectFilter(projectName string) filters.KeyValuePair {

--- a/pkg/compose/generate.go
+++ b/pkg/compose/generate.go
@@ -24,11 +24,12 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Generate(ctx context.Context, options api.GenerateOptions) (*types.Project, error) {

--- a/pkg/compose/hook.go
+++ b/pkg/compose/hook.go
@@ -23,10 +23,11 @@ import (
 	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/utils"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 func (s composeService) runHook(ctx context.Context, ctr container.Summary, service types.ServiceConfig, hook types.ServiceHook, listener api.ContainerEventListener) error {

--- a/pkg/compose/loader.go
+++ b/pkg/compose/loader.go
@@ -25,6 +25,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/remote"
 )

--- a/pkg/compose/loader_test.go
+++ b/pkg/compose/loader_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/cli"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func TestLoadProject_Basic(t *testing.T) {

--- a/pkg/compose/ls.go
+++ b/pkg/compose/ls.go
@@ -23,10 +23,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/sirupsen/logrus"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) List(ctx context.Context, opts api.ListOptions) ([]api.Stack, error) {

--- a/pkg/compose/ls_test.go
+++ b/pkg/compose/ls_test.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
-
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func TestContainersToStacks(t *testing.T) {

--- a/pkg/compose/model.go
+++ b/pkg/compose/model.go
@@ -29,10 +29,11 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli-plugins/manager"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) ensureModels(ctx context.Context, project *types.Project, quietPull bool) error {

--- a/pkg/compose/plugins.go
+++ b/pkg/compose/plugins.go
@@ -33,9 +33,10 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/config"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 type JsonMessage struct {

--- a/pkg/compose/port.go
+++ b/pkg/compose/port.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Port(ctx context.Context, projectName string, service string, port uint16, options api.PortOptions) (string, int, error) {

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -32,13 +32,14 @@ import (
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/distribution/reference"
-	"github.com/docker/compose/v5/internal/oci"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/compose/transform"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+
+	"github.com/docker/compose/v5/internal/oci"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose/transform"
 )
 
 func (s *composeService) Publish(ctx context.Context, project *types.Project, repository string, options api.PublishOptions) error {

--- a/pkg/compose/publish_test.go
+++ b/pkg/compose/publish_test.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/internal"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/internal"
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func Test_createLayers(t *testing.T) {

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Remove(ctx context.Context, projectName string, options api.RemoveOptions) error {

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -21,10 +21,11 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/utils"
 	"github.com/docker/docker/api/types/container"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 func (s *composeService) Restart(ctx context.Context, projectName string, options api.RestartOptions) error {

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -27,8 +27,9 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli"
 	cmd "github.com/docker/cli/cli/command/container"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/pkg/stringid"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts api.RunOptions) (int, error) {

--- a/pkg/compose/scale.go
+++ b/pkg/compose/scale.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/docker/compose/v5/internal/tracing"
 	"github.com/docker/compose/v5/pkg/api"
 )

--- a/pkg/compose/shellout.go
+++ b/pkg/compose/shellout.go
@@ -26,10 +26,11 @@ import (
 	"github.com/docker/cli/cli-plugins/metadata"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
-	"github.com/docker/compose/v5/internal"
 	"github.com/docker/docker/client"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+
+	"github.com/docker/compose/v5/internal"
 )
 
 // prepareShellOut prepare a shell-out command to be ran by Compose

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/compose/v5/pkg/api"
-	containerType "github.com/docker/docker/api/types/container"
-
 	"github.com/compose-spec/compose-go/v2/types"
+	containerType "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Start(ctx context.Context, projectName string, options api.StartOptions) error {

--- a/pkg/compose/top.go
+++ b/pkg/compose/top.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Top(ctx context.Context, projectName string, services []string) ([]api.ContainerProcSummary, error) {

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -30,12 +30,13 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
-	"github.com/docker/compose/v5/cmd/formatter"
-	"github.com/docker/compose/v5/internal/tracing"
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/eiannone/keyboard"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/cmd/formatter"
+	"github.com/docker/compose/v5/internal/tracing"
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Up(ctx context.Context, project *types.Project, options api.UpOptions) error { //nolint:gocyclo

--- a/pkg/compose/viz.go
+++ b/pkg/compose/viz.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/docker/compose/v5/pkg/api"
 )
 

--- a/pkg/compose/volumes.go
+++ b/pkg/compose/volumes.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"slices"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Volumes(ctx context.Context, project string, options api.VolumesOptions) ([]api.VolumesSummary, error) {

--- a/pkg/compose/volumes_test.go
+++ b/pkg/compose/volumes_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func TestVolumes(t *testing.T) {

--- a/pkg/compose/wait.go
+++ b/pkg/compose/wait.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func (s *composeService) Wait(ctx context.Context, projectName string, options api.WaitOptions) (int64, error) {

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -29,14 +29,6 @@ import (
 	gsync "sync"
 	"time"
 
-	pathutil "github.com/docker/compose/v5/internal/paths"
-	"github.com/docker/compose/v5/internal/sync"
-	"github.com/docker/compose/v5/internal/tracing"
-	"github.com/docker/compose/v5/pkg/api"
-	cutils "github.com/docker/compose/v5/pkg/utils"
-	"github.com/docker/compose/v5/pkg/watch"
-	"github.com/moby/buildkit/util/progress/progressui"
-
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/compose-spec/compose-go/v2/utils"
 	ccli "github.com/docker/cli/cli/command/container"
@@ -44,8 +36,16 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+
+	pathutil "github.com/docker/compose/v5/internal/paths"
+	"github.com/docker/compose/v5/internal/sync"
+	"github.com/docker/compose/v5/internal/tracing"
+	"github.com/docker/compose/v5/pkg/api"
+	cutils "github.com/docker/compose/v5/pkg/utils"
+	"github.com/docker/compose/v5/pkg/watch"
 )
 
 type WatchFunc func(ctx context.Context, project *types.Project, options api.WatchOptions) (func() error, error)

--- a/pkg/compose/watch_test.go
+++ b/pkg/compose/watch_test.go
@@ -23,10 +23,6 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/streams"
-	"github.com/docker/compose/v5/internal/sync"
-	"github.com/docker/compose/v5/pkg/api"
-	"github.com/docker/compose/v5/pkg/mocks"
-	"github.com/docker/compose/v5/pkg/watch"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -34,6 +30,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/internal/sync"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/mocks"
+	"github.com/docker/compose/v5/pkg/watch"
 )
 
 type testWatcher struct {

--- a/pkg/e2e/cancel_test.go
+++ b/pkg/e2e/cancel_test.go
@@ -27,9 +27,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/compose/v5/pkg/utils"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 func TestComposeCancel(t *testing.T) {

--- a/pkg/e2e/logs_test.go
+++ b/pkg/e2e/logs_test.go
@@ -26,9 +26,8 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/poll"
-
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/poll"
 )
 
 func TestLocalComposeLogs(t *testing.T) {

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -28,10 +28,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/compose/v5/pkg/utils"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 func TestUpServiceUnhealthy(t *testing.T) {

--- a/pkg/e2e/wait_test.go
+++ b/pkg/e2e/wait_test.go
@@ -21,9 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/v3/icmd"
-
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
 )
 
 func TestWaitOnFaster(t *testing.T) {

--- a/pkg/remote/git.go
+++ b/pkg/remote/git.go
@@ -32,9 +32,10 @@ import (
 	"github.com/compose-spec/compose-go/v2/loader"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose/v5/pkg/api"
 	gitutil "github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 	"github.com/sirupsen/logrus"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 const GIT_REMOTE_ENABLED = "COMPOSE_EXPERIMENTAL_GIT_REMOTE"

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -30,9 +30,10 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/command"
+	spec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/docker/compose/v5/internal/oci"
 	"github.com/docker/compose/v5/pkg/api"
-	spec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (

--- a/pkg/watch/debounce.go
+++ b/pkg/watch/debounce.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/docker/compose/v5/pkg/utils"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 const QuietPeriod = 500 * time.Millisecond

--- a/pkg/watch/dockerignore.go
+++ b/pkg/watch/dockerignore.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/docker/compose/v5/internal/paths"
 	"github.com/moby/patternmatcher"
 	"github.com/moby/patternmatcher/ignorefile"
+
+	"github.com/docker/compose/v5/internal/paths"
 )
 
 type dockerPathMatcher struct {

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -24,8 +24,9 @@ import (
 	"path/filepath"
 	"time"
 
-	pathutil "github.com/docker/compose/v5/internal/paths"
 	"github.com/fsnotify/fsevents"
+
+	pathutil "github.com/docker/compose/v5/internal/paths"
 )
 
 // A file watcher optimized for Darwin.

--- a/pkg/watch/watcher_naive.go
+++ b/pkg/watch/watcher_naive.go
@@ -26,9 +26,10 @@ import (
 	"runtime"
 	"strings"
 
-	pathutil "github.com/docker/compose/v5/internal/paths"
 	"github.com/sirupsen/logrus"
 	"github.com/tilt-dev/fsnotify"
+
+	pathutil "github.com/docker/compose/v5/internal/paths"
 )
 
 // A naive file watcher that uses the plain fsnotify API.


### PR DESCRIPTION
Most files already grouped imports into "stdlib -> other -> local", but some files didn't. The gci formatter is similar to goimports, but has better options to make sure imports are grouped in the expected order (and to make sure no additional groups are present).

This formatter has a 'fix' function, so code can be re-formatted auto- matically;

    golangci-lint run -v --fix

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
