### PR TITLE
Fix grammar: change 'adopted' to 'adopt' in Docker Swarm note

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once you have a Compose file, you can create and start your application with a
 single command: `docker compose up`.
 
 > **Note**: About Docker Swarm
-> Docker Swarm used to rely on the legacy compose file format but did not adopted the compose specification
+> Docker Swarm used to rely on the legacy compose file format but did not adopt the compose specification
 > so is missing some of the recent enhancements in the compose syntax. After 
 > [acquisition by Mirantis](https://www.mirantis.com/software/swarm/) swarm isn't maintained by Docker Inc, and
 > as such some Docker Compose features aren't accessible to swarm users.


### PR DESCRIPTION
**What I did**
Corrected a minor grammar issue in the README: changed 'did not adopted' to 'did not adopt'.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
N/A
**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
