### PR TITLE
add --wait option to start command

### DIFF
--- a/docs/reference/compose_start.md
+++ b/docs/reference/compose_start.md
@@ -5,9 +5,11 @@ Starts existing containers for a service
 
 ### Options
 
-| Name        | Type   | Default | Description                     |
-|:------------|:-------|:--------|:--------------------------------|
-| `--dry-run` | `bool` |         | Execute command in dry run mode |
+| Name             | Type   | Default | Description                                                                |
+|:-----------------|:-------|:--------|:---------------------------------------------------------------------------|
+| `--dry-run`      | `bool` |         | Execute command in dry run mode                                            |
+| `--wait`         | `bool` |         | Wait for services to be running\|healthy. Implies detached mode.           |
+| `--wait-timeout` | `int`  | `0`     | Maximum duration in seconds to wait for the project to be running\|healthy |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_start.yaml
+++ b/docs/reference/docker_compose_start.yaml
@@ -4,6 +4,28 @@ long: Starts existing containers for a service
 usage: docker compose start [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml
+options:
+    - option: wait
+      value_type: bool
+      default_value: "false"
+      description: Wait for services to be running|healthy. Implies detached mode.
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+    - option: wait-timeout
+      value_type: int
+      default_value: "0"
+      description: |
+        Maximum duration in seconds to wait for the project to be running|healthy
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool


### PR DESCRIPTION
**What I did**
expose `wait` and `waitTimeout` SDK options as CLI flags

**Related issue**
closes https://github.com/docker/compose/issues/13408

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
