### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/cmd/compose/events.go
+++ b/cmd/compose/events.go
@@ -72,7 +72,7 @@ func runEvents(ctx context.Context, dockerCli command.Cli, backendOptions *Backe
 		Until:    opts.until,
 		Consumer: func(event api.Event) error {
 			if opts.json {
-				marshal, err := json.Marshal(map[string]interface{}{
+				marshal, err := json.Marshal(map[string]any{
 					"time":       event.Timestamp,
 					"type":       "container",
 					"service":    event.Service,

--- a/cmd/formatter/container.go
+++ b/cmd/formatter/container.go
@@ -105,7 +105,7 @@ type ContainerContext struct {
 	// used in the template. It's currently only used to detect use of the .Size
 	// field which (if used) automatically sets the '--size' option when making
 	// the API call.
-	FieldsUsed map[string]interface{}
+	FieldsUsed map[string]any
 }
 
 // NewContainerContext creates a new context for rendering containers
@@ -274,7 +274,7 @@ func (c *ContainerContext) Networks() string {
 // Size returns the container's size and virtual size (e.g. "2B (virtual 21.5MB)")
 func (c *ContainerContext) Size() string {
 	if c.FieldsUsed == nil {
-		c.FieldsUsed = map[string]interface{}{}
+		c.FieldsUsed = map[string]any{}
 	}
 	c.FieldsUsed["Size"] = struct{}{}
 	srw := units.HumanSizeWithPrecision(float64(c.c.SizeRw), 3)

--- a/cmd/formatter/formatter.go
+++ b/cmd/formatter/formatter.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Print prints formatted lists in different formats
-func Print(toJSON interface{}, format string, outWriter io.Writer, writerFn func(w io.Writer), headers ...string) error {
+func Print(toJSON any, format string, outWriter io.Writer, writerFn func(w io.Writer), headers ...string) error {
 	switch strings.ToLower(format) {
 	case TABLE, PRETTY, "":
 		return PrintPrettySection(outWriter, writerFn, headers...)

--- a/cmd/formatter/json.go
+++ b/cmd/formatter/json.go
@@ -24,12 +24,12 @@ import (
 const standardIndentation = "    "
 
 // ToStandardJSON return a string with the JSON representation of the interface{}
-func ToStandardJSON(i interface{}) (string, error) {
+func ToStandardJSON(i any) (string, error) {
 	return ToJSON(i, "", standardIndentation)
 }
 
 // ToJSON return a string with the JSON representation of the interface{}
-func ToJSON(i interface{}, prefix string, indentation string) (string, error) {
+func ToJSON(i any, prefix string, indentation string) (string, error) {
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)
 	encoder.SetEscapeHTML(false)

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -87,7 +87,7 @@ func (l *logConsumer) register(name string) *presenter {
 	l.presenters.Store(name, p)
 	l.computeWidth()
 	if l.prefix {
-		l.presenters.Range(func(key, value interface{}) bool {
+		l.presenters.Range(func(key, value any) bool {
 			p := value.(*presenter)
 			p.setPrefix(l.width)
 			return true
@@ -137,7 +137,7 @@ func (l *logConsumer) Status(container, msg string) {
 
 func (l *logConsumer) computeWidth() {
 	width := 0
-	l.presenters.Range(func(key, value interface{}) bool {
+	l.presenters.Range(func(key, value any) bool {
 		p := value.(*presenter)
 		if len(p.name) > width {
 			width = len(p.name)

--- a/internal/tracing/docker_context.go
+++ b/internal/tracing/docker_context.go
@@ -84,18 +84,18 @@ func ConfigFromDockerContext(st store.Store, name string) (OTLPConfig, error) {
 		return OTLPConfig{}, err
 	}
 
-	var otelCfg interface{}
+	var otelCfg any
 	switch m := meta.Metadata.(type) {
 	case command.DockerContext:
 		otelCfg = m.AdditionalFields[otelConfigFieldName]
-	case map[string]interface{}:
+	case map[string]any:
 		otelCfg = m[otelConfigFieldName]
 	}
 	if otelCfg == nil {
 		return OTLPConfig{}, nil
 	}
 
-	otelMap, ok := otelCfg.(map[string]interface{})
+	otelMap, ok := otelCfg.(map[string]any)
 	if !ok {
 		return OTLPConfig{}, fmt.Errorf(
 			"unexpected type for field %q: %T (expected: %T)",
@@ -115,7 +115,7 @@ func ConfigFromDockerContext(st store.Store, name string) (OTLPConfig, error) {
 // valueOrDefault returns the type-cast value at the specified key in the map
 // if present and the correct type; otherwise, it returns the default value for
 // T.
-func valueOrDefault[T any](m map[string]interface{}, key string) T {
+func valueOrDefault[T any](m map[string]any, key string) T {
 	if v, ok := m[key].(T); ok {
 		return v
 	}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 var testStoreCfg = store.NewConfig(
-	func() interface{} {
-		return &map[string]interface{}{}
+	func() any {
+		return &map[string]any{}
 	},
 )
 
@@ -44,13 +44,13 @@ func TestExtractOtelFromContext(t *testing.T) {
 		Name: "test",
 		Metadata: command.DockerContext{
 			Description: t.Name(),
-			AdditionalFields: map[string]interface{}{
-				"otel": map[string]interface{}{
+			AdditionalFields: map[string]any{
+				"otel": map[string]any{
 					"OTEL_EXPORTER_OTLP_ENDPOINT": "localhost:1234",
 				},
 			},
 		},
-		Endpoints: make(map[string]interface{}),
+		Endpoints: make(map[string]any),
 	})
 	require.NoError(t, err)
 

--- a/pkg/e2e/assert.go
+++ b/pkg/e2e/assert.go
@@ -29,7 +29,7 @@ import (
 func RequireServiceState(t testing.TB, cli *CLI, service string, state string) {
 	t.Helper()
 	psRes := cli.RunDockerComposeCmd(t, "ps", "--all", "--format=json", service)
-	var svc map[string]interface{}
+	var svc map[string]any
 	require.NoError(t, json.Unmarshal([]byte(psRes.Stdout()), &svc),
 		"Invalid `compose ps` JSON: command output: %s",
 		psRes.Combined())

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -37,7 +37,7 @@ type fseventNotify struct {
 	errors chan error
 	stop   chan struct{}
 
-	pathsWereWatching map[string]interface{}
+	pathsWereWatching map[string]any
 }
 
 func (d *fseventNotify) loop() {
@@ -71,7 +71,7 @@ func (d *fseventNotify) initAdd(name string) {
 	d.stream.Paths = append(d.stream.Paths, name)
 
 	if d.pathsWereWatching == nil {
-		d.pathsWereWatching = make(map[string]interface{})
+		d.pathsWereWatching = make(map[string]any)
 	}
 	d.pathsWereWatching[name] = struct{}{}
 }


### PR DESCRIPTION
**What I did**

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**


![872e1bdce068b6ad1756102df72adc9e](https://github.com/user-attachments/assets/aaff1099-eb21-484a-9a33-c807a0d91330)

