### PR TITLE
bump golang 1.24.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG GO_VERSION=1.24.9
+ARG GO_VERSION=1.24.11
 ARG XX_VERSION=1.6.1
 ARG GOLANGCI_LINT_VERSION=v2.6.2
 ARG ADDLICENSE_VERSION=v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/compose/v5
 
-go 1.24.9
+go 1.24.11
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
**What I did**
This change bumps the Go toolchain to Go 1.24.11

> go1.24.10 (released 2025-11-05) includes fixes to the encoding/pem and net/url packages. See the [Go 1.24.10 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.10+label%3ACherryPickApproved) on our issue tracker for details.

> go1.24.11 (released 2025-12-02) includes two security fixes to the crypto/x509 package, as well as bug fixes to the runtime. See the [Go 1.24.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.11+label%3ACherryPickApproved) on our issue tracker for details.

full diff: https://github.com/golang/go/compare/go1.24.9...go1.24.11

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
