### PR TITLE
Fixed grammatical errors and improve clarity in code.

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -185,7 +185,7 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backen
 				}
 			} else if !cmd.Flags().Changed("no-TTY") && !cmd.Flags().Changed("interactive") && !dockerCli.In().IsTerminal() {
 				// while `docker run` requires explicit `-it` flags, Compose enables interactive mode and TTY by default
-				// but when compose is used from a scripr has stdin piped from another command, we just can't
+				// but when compose is used from a script that has stdin piped from another command, we just can't
 				// Here, we detect we run "by default" (user didn't passed explicit flags) and disable TTY allocation if
 				// we don't have an actual terminal to attach to for interactive mode
 				options.noTty = true

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -38,7 +38,7 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 		return 0, err
 	}
 
-	// remove cancellable context signal handler so we can forward signals to container without compose to exit
+	// remove cancellable context signal handler so we can forward signals to container without compose from exiting
 	signal.Reset()
 
 	sigc := make(chan os.Signal, 128)

--- a/pkg/dryrun/dryrunclient.go
+++ b/pkg/dryrun/dryrunclient.go
@@ -313,7 +313,7 @@ func (d *DryRunClient) ContainerExecStart(ctx context.Context, execID string, co
 	return nil
 }
 
-// Functions delegated to original APIClient (not used by Compose or not modifying the Compose stack
+// Functions delegated to original APIClient (not used by Compose or not modifying the Compose stack)
 
 func (d *DryRunClient) ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error) {
 	return d.apiClient.ConfigList(ctx, options)


### PR DESCRIPTION
**What I did**


This commit addresses several grammatical errors and improves the clarity of comments in the codebase. 

Specifically, it fixes a missing closing parenthesis in a comment in dryrunclient.go, corrects "compose to exit" to "compose from exiting" in run.go, and fixes a typo from "scripr" to "script" in cmd/compose/run.go. 

These changes enhance code readability and maintainability.



**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

![9743e3fa41cf44e79624f3c80b998d3b](https://github.com/user-attachments/assets/b1fce331-58e1-4e1e-a678-705f809e5780)

