### PR TITLE
Add the `--no-build` option to `run`

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -142,6 +142,7 @@ func (options runOptions) getEnvironment(resolve func(string) (string, bool)) (t
 	return environment, nil
 }
 
+//nolint:gocyclo
 func runCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *BackendOptions) *cobra.Command {
 	options := runOptions{
 		composeOptions: &composeOptions{
@@ -189,6 +190,9 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backen
 				// Here, we detect we run "by default" (user didn't passed explicit flags) and disable TTY allocation if
 				// we don't have an actual terminal to attach to for interactive mode
 				options.noTty = true
+			}
+			if createOpts.Build && createOpts.noBuild {
+				return fmt.Errorf("--build and --no-build are incompatible")
 			}
 
 			if options.quiet {
@@ -246,6 +250,7 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backen
 	flags.BoolVar(&buildOpts.quiet, "quiet-build", false, "Suppress progress output from the build process")
 	flags.BoolVar(&options.quietPull, "quiet-pull", false, "Pull without printing progress information")
 	flags.BoolVar(&createOpts.Build, "build", false, "Build image before starting container")
+	flags.BoolVar(&createOpts.noBuild, "no-build", false, "Don't build an image, even if it's policy")
 	flags.BoolVar(&options.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
 
 	cmd.Flags().BoolVarP(&options.interactive, "interactive", "i", true, "Keep STDIN open even if not attached")

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -71,6 +71,7 @@ specified in the service configuration.
 | `-l`, `--label`         | `stringArray` |          | Add or override a label                                                          |
 | `--name`                | `string`      |          | Assign a name to the container                                                   |
 | `-T`, `--no-TTY`        | `bool`        | `true`   | Disable pseudo-TTY allocation (default: auto-detected)                           |
+| `--no-build`            | `bool`        |          | Don't build an image, even if it's policy                                        |
 | `--no-deps`             | `bool`        |          | Don't start linked services                                                      |
 | `-p`, `--publish`       | `stringArray` |          | Publish a container's port(s) to the host                                        |
 | `--pull`                | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                         |

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -169,6 +169,16 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: no-build
+      value_type: bool
+      default_value: "false"
+      description: Don't build an image, even if it's policy
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
     - option: no-deps
       value_type: bool
       default_value: "false"


### PR DESCRIPTION
**What I did**

`docker compose up` supports `--no-build` but `run` doesn't expose it, even though it has the `--build` option. Fix that omission.
