### PR TITLE
add 'configured' event at the end of model configuration phase

### DIFF
--- a/pkg/api/event.go
+++ b/pkg/api/event.go
@@ -67,6 +67,8 @@ const (
 	StatusExported         = "Exported"
 	StatusDownloading      = "Downloading"
 	StatusDownloadComplete = "Download complete"
+	StatusConfiguring      = "Configuring"
+	StatusConfigured       = "Configured"
 )
 
 // Resource represents status change and progress for a compose resource.

--- a/pkg/compose/model.go
+++ b/pkg/compose/model.go
@@ -107,7 +107,7 @@ func (m *modelAPI) PullModel(ctx context.Context, model types.ModelConfig, quiet
 	events.On(api.Resource{
 		ID:     model.Name,
 		Status: api.Working,
-		Text:   "Pulling",
+		Text:   api.StatusPulling,
 	})
 
 	cmd := exec.CommandContext(ctx, m.path, "pull", model.Model)
@@ -161,7 +161,7 @@ func (m *modelAPI) ConfigureModel(ctx context.Context, config types.ModelConfig,
 	events.On(api.Resource{
 		ID:     config.Name,
 		Status: api.Working,
-		Text:   "Configuring",
+		Text:   api.StatusConfiguring,
 	})
 	// configure [--context-size=<n>] MODEL
 	args := []string{"configure"}
@@ -174,7 +174,17 @@ func (m *modelAPI) ConfigureModel(ctx context.Context, config types.ModelConfig,
 	if err != nil {
 		return err
 	}
-	return cmd.Run()
+	err = cmd.Run()
+	if err != nil {
+		events.On(errorEvent(config.Name, err.Error()))
+		return err
+	}
+	events.On(api.Resource{
+		ID:     config.Name,
+		Status: api.Done,
+		Text:   api.StatusConfigured,
+	})
+	return nil
 }
 
 func (m *modelAPI) SetModelVariables(ctx context.Context, project *types.Project) error {


### PR DESCRIPTION
Currently when using models, the final message is 'confugiring' which could let users think the DMR configuration is still pending

**What I did**
Add new Status messages for the model life cycle and add a `Done` event with `configured` message

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b26e169c-c2ac-4147-947c-4cdcb712c53f" />
