### PR TITLE
Fix missing error handling in setEnvWithDotEnv

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -688,7 +688,7 @@ func setEnvWithDotEnv(opts ProjectOptions) error {
 	}
 	for k, v := range envFromFile {
 		if _, ok := os.LookupEnv(k); !ok && strings.HasPrefix(k, "COMPOSE_") {
-			if err = os.Setenv(k, v); err != nil {
+			if err := os.Setenv(k, v); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
**What I did**
- Fixed missing error handling in `setEnvWithDotEnv`
- Propagated errors instead of returning nil
- Avoided reassigning the `err` variable to satisfy gocritic (`sloppyReassign`)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

**Additional notes**
If ignoring errors was intentional here, it might be worth documenting the rationale
with a comment to make the behavior explicit and easier to reason about for future maintainers.
