### PR TITLE
doc: do not mention v2 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Table of Contents
-- [Docker Compose v2](#docker-compose-v2)
+- [Docker Compose](#docker-compose)
 - [Where to get Docker Compose](#where-to-get-docker-compose)
     + [Windows and macOS](#windows-and-macos)
     + [Linux](#linux)
 - [Quick Start](#quick-start)
 - [Contributing](#contributing)
 - [Legacy](#legacy)
-# Docker Compose v2
+
+# Docker Compose
 
 [![GitHub release](https://img.shields.io/github/v/release/docker/compose.svg?style=flat-square)](https://github.com/docker/compose/releases/latest)
 [![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?style=flat-square&logo=go&logoColor=white)](https://pkg.go.dev/github.com/docker/compose/v5)


### PR DESCRIPTION
**What I did**

I updated the README because it appeared outdated after the release of the v5 version: https://github.com/docker/compose/releases/tag/v5.0.0

I found it a little bit confusing;

> <img width="670" height="125" alt="image" src="https://github.com/user-attachments/assets/b2bc9de6-ff7a-4ccb-b245-ce63ce199f12" />

**Related issue**

- https://github.com/docker/compose/pull/13375

(not mandatory) A picture of a cute animal, if possible in relation to what you did

![chat_unbothered_moisturized_happy_in_my_lane_focused_flourishing](https://github.com/user-attachments/assets/e1eb1767-4ec9-45cf-9632-4b3815e08045)


