### PR TITLE
Introduced a build tag to select watcher implementation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ ifeq ($(DETECTED_OS),Windows)
 	BINARY_EXT=.exe
 endif
 
+ifeq ($(DETECTED_OS),Darwin)
+	GO_BUILDTAGS += fsnotify
+endif
+
 BUILD_FLAGS?=
 TEST_FLAGS?=
 E2E_TEST?=
@@ -62,11 +66,11 @@ build:
 
 .PHONY: binary
 binary:
-	$(BUILDX_CMD) bake binary
+	BUILD_TAGS="$(GO_BUILDTAGS)" $(BUILDX_CMD) bake binary
 
 .PHONY: binary-with-coverage
 binary-with-coverage:
-	$(BUILDX_CMD) bake binary-with-coverage
+	BUILD_TAGS="$(GO_BUILDTAGS)" $(BUILDX_CMD) bake binary-with-coverage
 
 .PHONY: install
 install: binary

--- a/pkg/watch/watcher_darwin.go
+++ b/pkg/watch/watcher_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build fsnotify
 
 /*
    Copyright 2020 Docker Compose CLI authors

--- a/pkg/watch/watcher_naive.go
+++ b/pkg/watch/watcher_naive.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !fsnotify
 
 /*
    Copyright 2020 Docker Compose CLI authors


### PR DESCRIPTION
**What I did**

Watcher implementation is selected based on a build tag. This one used to be set by OS, but this brings a constraining requirement to use CGO for users of the compose SDK, even if they don't rely on this feature.
=> Switched to a specific build tag, set by makefile when running on MacOS
Also fixed `GO_BUILDTAGS` not being passed to bake

**Related issue**
closes https://github.com/docker/compose/issues/13448

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
