### PR TITLE
Prevented incorrect progress metrics to break compose display.

### DIFF
--- a/cmd/display/tty.go
+++ b/cmd/display/tty.go
@@ -347,7 +347,12 @@ func (w *ttyWriter) lineText(t *task, pad string, terminalWidth, statusPadding i
 			}
 			total += child.total
 			current += child.current
-			completion = append(completion, percentChars[(len(percentChars)-1)*child.percent/100])
+			r := len(percentChars) - 1
+			p := child.percent
+			if p > 100 {
+				p = 100
+			}
+			completion = append(completion, percentChars[r*p/100])
 		}
 	}
 

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -416,6 +416,9 @@ func toPullProgressEvent(parent string, jm jsonmessage.JSONMessage, events api.E
 			total = jm.Progress.Total
 			if jm.Progress.Total > 0 {
 				percent = int(jm.Progress.Current * 100 / jm.Progress.Total)
+				if percent > 100 {
+					percent = 100
+				}
 			}
 		}
 	case DownloadCompletePhase, AlreadyExistsPhase, PullCompletePhase:

--- a/pkg/compose/push.go
+++ b/pkg/compose/push.go
@@ -155,6 +155,9 @@ func toPushProgressEvent(prefix string, jm jsonmessage.JSONMessage, events api.E
 			total = jm.Progress.Total
 			if jm.Progress.Total > 0 {
 				percent = int(jm.Progress.Current * 100 / jm.Progress.Total)
+				if percent > 100 {
+					percent = 100
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What I did**

**Related issue**
fixed https://github.com/docker/compose/issues/13456

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
