### PR TITLE
gets back runtime flags when configuring models

### DIFF
--- a/pkg/compose/model.go
+++ b/pkg/compose/model.go
@@ -72,7 +72,6 @@ func (s *composeService) ensureModels(ctx context.Context, project *types.Projec
 
 type modelAPI struct {
 	path    string
-	version string // cached plugin version
 	env     []string
 	prepare func(ctx context.Context, cmd *exec.Cmd) error
 	cleanup func()


### PR DESCRIPTION
**What I did**
This pull reverts the changes of the model configuration that disabled `--runtime-args`

**Related issue**
https://github.com/docker/model-runner/issues/515
