### PR TITLE
add service name completion to down command

### DIFF
--- a/cmd/compose/down.go
+++ b/cmd/compose/down.go
@@ -60,7 +60,7 @@ func downCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backe
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runDown(ctx, dockerCli, backendOptions, opts, args)
 		}),
-		ValidArgsFunction: noCompletion(),
+		ValidArgsFunction: completeServiceNames(dockerCli, p),
 	}
 	flags := downCmd.Flags()
 	removeOrphans := utils.StringToBool(os.Getenv(ComposeRemoveOrphans))


### PR DESCRIPTION
**What I did**

I reused the function defined in https://github.com/docker/compose/blob/bd05d60135ad305770ae0708123dcf4ad908af96/cmd/compose/completion.go#L39
and added it to the the validation function for the down command here: https://github.com/docker/compose/blob/bd05d60135ad305770ae0708123dcf4ad908af96/cmd/compose/down.go#L63

**Related issue**
This closes the feature request #13469, purely coincidentally :) 


**A picture of a cute animal, if possible in relation to what you did**

Enjoy this very unrelated gif of my dog Sadie asking you to please approve this PR (she frequently only wants to shut down one specific one of the services in her docker compose projects):
![IMG_9848-2](https://github.com/user-attachments/assets/8c714cbe-cb11-497f-816f-ef4f5619d8c0)

