### PR TITLE
Fix timeout initialization when waitTimeout is zero

### DIFF
--- a/cmd/compose/start.go
+++ b/cmd/compose/start.go
@@ -63,7 +63,10 @@ func runStart(ctx context.Context, dockerCli command.Cli, backendOptions *Backen
 		return err
 	}
 
-	timeout := time.Duration(opts.waitTimeout) * time.Second
+	var timeout time.Duration
+	if opts.waitTimeout > 0 {
+		timeout = time.Duration(opts.waitTimeout) * time.Second
+	}
 	return backend.Start(ctx, name, api.StartOptions{
 		AttachTo:    services,
 		Project:     project,

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -188,6 +188,9 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backend
 
 //nolint:gocyclo
 func validateFlags(up *upOptions, create *createOptions) error {
+	if up.waitTimeout < 0 {
+		return fmt.Errorf("--wait-timeout must be a non-negative integer")
+	}
 	if up.exitCodeFrom != "" && !up.cascadeFail {
 		up.cascadeStop = true
 	}
@@ -328,7 +331,10 @@ func runUp(
 		attach = attachSet.Elements()
 	}
 
-	timeout := time.Duration(upOptions.waitTimeout) * time.Second
+	var timeout time.Duration
+	if upOptions.waitTimeout > 0 {
+		timeout = time.Duration(upOptions.waitTimeout) * time.Second
+	}
 	return backend.Up(ctx, project, api.UpOptions{
 		Create: create,
 		Start: api.StartOptions{


### PR DESCRIPTION
**What I did**
I updated the timeout initialization logic to only set a `time.Duration` value when waitTimeout is greater than zero.

Previously, the timeout was always calculated, even when `waitTimeout` was zero or a negative value. This could unintentionally override the default behavior or result in an invalid timeout being applied.

With this change, the timeout is now explicitly guarded:
- The default behavior is preserved when `waitTimeout` is unset or zero
- Negative values are safely ignored, preventing unintended or invalid timeout configurations

This makes the behavior more explicit and defensive.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
A small guard to prevent unintended behavior 🐶
![dogs](https://github.com/user-attachments/assets/f2938eb1-8f20-42b8-87dc-fe872b492d05)

