### PR TITLE
Fix incorrect usage of errgroup.WithContext

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -121,7 +121,7 @@ func (c *convergence) ensureService(ctx context.Context, project *types.Project,
 	actual := len(containers)
 	updated := make(Containers, expected)
 
-	eg, _ := errgroup.WithContext(ctx)
+	eg, ctx := errgroup.WithContext(ctx)
 
 	err = c.resolveServiceReferences(&service)
 	if err != nil {
@@ -451,7 +451,7 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 		defer cancelFunc()
 		ctx = withTimeout
 	}
-	eg, _ := errgroup.WithContext(ctx)
+	eg, ctx := errgroup.WithContext(ctx)
 	for dep, config := range dependencies {
 		if shouldWait, err := shouldWaitForDependency(dep, config, project); err != nil {
 			return err

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -119,7 +119,7 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 		logrus.Warnf("Warning: No resource found to remove for project %q.", projectName)
 	}
 
-	eg, _ := errgroup.WithContext(ctx)
+	eg, ctx := errgroup.WithContext(ctx)
 	for _, op := range ops {
 		eg.Go(op)
 	}
@@ -335,7 +335,7 @@ func (s *composeService) stopContainers(ctx context.Context, serv *types.Service
 }
 
 func (s *composeService) removeContainers(ctx context.Context, containers []containerType.Summary, service *types.ServiceConfig, timeout *time.Duration, volumes bool) error {
-	eg, _ := errgroup.WithContext(ctx)
+	eg, ctx := errgroup.WithContext(ctx)
 	for _, ctr := range containers {
 		eg.Go(func() error {
 			return s.stopAndRemoveContainer(ctx, ctr, service, timeout, volumes)


### PR DESCRIPTION
**What I did**
- Fixed several call sites that were using `errgroup.WithContext` but discarding the derived context.
- Updated goroutines to consistently use the context returned by `errgroup.WithContext`, allowing cancellation to properly propagate when one task fails.

In cases where cancellation via context is not intended, using a plain `errgroup.Group`
(e.g. `var eg errgroup.Group`) would make the intent clearer than calling `WithContext`
and ignoring the derived context.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
