### PR TITLE
Fix typo in isSwarmEnabled method name

### DIFF
--- a/pkg/compose/compose.go
+++ b/pkg/compose/compose.go
@@ -478,7 +478,7 @@ var swarmEnabled = struct {
 	err  error
 }{}
 
-func (s *composeService) isSWarmEnabled(ctx context.Context) (bool, error) {
+func (s *composeService) isSwarmEnabled(ctx context.Context) (bool, error) {
 	swarmEnabled.once.Do(func() {
 		info, err := s.apiClient().Info(ctx)
 		if err != nil {

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1524,7 +1524,7 @@ func (s *composeService) resolveExternalNetwork(ctx context.Context, n *types.Ne
 	case 1:
 		return networks[0].ID, nil
 	case 0:
-		enabled, err := s.isSWarmEnabled(ctx)
+		enabled, err := s.isSwarmEnabled(ctx)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
**What I did**
Fixed a typo in the method name `isSWarmEnabled` → `isSwarmEnabled`.
The method name had incorrect capitalization where "SW" was uppercase instead of just "S". This change corrects it to follow proper Go naming conventions for "Swarm".


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
N/A 

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
![cat](https://github.com/user-attachments/assets/464dd24a-5c9d-4d2c-a05a-3e5818f52211)

