### PR TITLE
fix: clean up temporary compose files after conversion

### DIFF
--- a/pkg/bridge/convert.go
+++ b/pkg/bridge/convert.go
@@ -35,6 +35,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/go-connections/nat"
+	"github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v4"
 
 	"github.com/docker/compose/v5/pkg/api"
@@ -85,7 +86,17 @@ func convert(ctx context.Context, dockerCli command.Cli, model map[string]any, o
 		return err
 	}
 
-	dir := os.TempDir()
+	dir, err := os.MkdirTemp("", "compose-convert-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			logrus.Warnf("failed to remove temp dir %s: %v", dir, err)
+		}
+	}()
+
 	composeYaml := filepath.Join(dir, "compose.yaml")
 	err = os.WriteFile(composeYaml, raw, 0o600)
 	if err != nil {


### PR DESCRIPTION
### What I did

This PR fixes the temporary file handling in the `bridge` package during
the `compose convert` process.

Previously, the convert function used a fixed path in the system temporary
directory via `os.TempDir()`, which caused the following issues:

- Temporary `compose.yaml` files were not removed after execution
- Multiple runs could overwrite the same file
- Concurrent executions could lead to race conditions
- Sensitive project data could remain on disk unexpectedly

This change replaces the shared temp directory usage with
`os.MkdirTemp`, creating an isolated temporary directory per execution
and ensuring proper cleanup with `defer os.RemoveAll`.

---

### Related issue

fixes #13482

---

### (not mandatory) A picture of a cute animal, if possible in relation to what you did
<img width="338" height="395" alt="image" src="https://github.com/user-attachments/assets/8f183893-8c3d-4950-a6ad-6cb36c422f48" />


