### PR TITLE
bugfix; change log level of "No services to build" warning log

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -91,7 +91,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opti
 	}
 
 	if len(serviceToBuild) == 0 {
-		logrus.Warn("No services to build")
+		logrus.Debug("No services to build")
 		return imageIDs, nil
 	}
 


### PR DESCRIPTION
**What I did**

suppress docker compose log "No services to build" by changing its level from `Warn` to `Debug`.

this situation is rather common when a stack is deployed on production systems with all images pulled from registry and no presense of `build:` block in `docker-compose.yml`. it is not something that needs to be 'warned'.

**Related issue**

#13484

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
