### PR TITLE
Add unit test for upOptions.OnExit method

### DIFF
--- a/cmd/compose/up_test.go
+++ b/cmd/compose/up_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func TestApplyScaleOpt(t *testing.T) {
@@ -47,4 +49,43 @@ func TestApplyScaleOpt(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, *bar.Scale, 3)
 	assert.Equal(t, *bar.Deploy.Replicas, 3)
+}
+
+func TestUpOptions_OnExit(t *testing.T) {
+	tests := []struct {
+		name string
+		args upOptions
+		want api.Cascade
+	}{
+		{
+			name: "no cascade",
+			args: upOptions{},
+			want: api.CascadeIgnore,
+		},
+		{
+			name: "cascade stop",
+			args: upOptions{cascadeStop: true},
+			want: api.CascadeStop,
+		},
+		{
+			name: "cascade fail",
+			args: upOptions{cascadeFail: true},
+			want: api.CascadeFail,
+		},
+		{
+			name: "both set - stop takes precedence",
+			args: upOptions{
+				cascadeStop: true,
+				cascadeFail: true,
+			},
+			want: api.CascadeStop,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.OnExit()
+			assert.Equal(t, got, tt.want)
+		})
+	}
 }


### PR DESCRIPTION
**What I did**

Added unit tests for the `upOptions.OnExit()` method in `cmd/compose/up_test.go`.

The new test (`TestUpOptions_OnExit`) covers all cascade behavior modes:
- `CascadeIgnore` (default behavior)
- `CascadeStop` (--abort-on-container-exit)
- `CascadeFail` (--abort-on-container-failure)
- Edge case: both flags set (stop takes precedence)

This test follows the existing test patterns in the codebase, using table-driven tests with the `args` field containing the full `upOptions` struct.

**Related issue**

N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="643" height="425" alt="image" src="https://github.com/user-attachments/assets/f49b1ed7-4401-4639-b563-0758c94450d9" />

