### PR TITLE
handle healthcheck.disable true in isServiceHealthy

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -833,7 +833,8 @@ func (s *composeService) isServiceHealthy(ctx context.Context, containers Contai
 			return false, fmt.Errorf("container %s exited (%d)", name, ctr.State.ExitCode)
 		}
 
-		if ctr.Config.Healthcheck == nil && fallbackRunning {
+		noHealthcheck := ctr.Config.Healthcheck == nil || (len(ctr.Config.Healthcheck.Test) > 0 && ctr.Config.Healthcheck.Test[0] == "NONE")
+		if noHealthcheck && fallbackRunning {
 			// Container does not define a health check, but we can fall back to "running" state
 			return ctr.State != nil && ctr.State.Status == container.StateRunning, nil
 		}


### PR DESCRIPTION
Closes #13522

Func `ToMobyHealthCheck` converts disabled helthchecks to `[]string{"NONE"}`.
Made changes in isServiceHealthy, to also consider the above as "no healthecheck", as it will never be `nil`

```go
	if check.Disable {
		test = []string{"NONE"}
	}
```

Additionally added some unit tests. To be honest, the tests **ONLY** were generated by AI.

Related downstream issue: https://github.com/getarcaneapp/arcane/issues/1338

---
I used the following code to test. Before my changes it would fail, after my changes, not.

```yaml
services:
  whoami:
    image: ghcr.io/traefik/whoami:v1.11.0@sha256:200689790a0a0ea48ca45992e0450bc26ccab5307375b41c84dfc4f2475937ab

  another:
    image: ghcr.io/traefik/whoami:v1.11.0@sha256:200689790a0a0ea48ca45992e0450bc26ccab5307375b41c84dfc4f2475937ab
    healthcheck:
      disable: true
```


```go
package main

import (
	"context"
	"fmt"
	"os"
	"os/signal"
	"path/filepath"
	"syscall"
	"time"

	"github.com/docker/cli/cli/command"
	"github.com/docker/cli/cli/flags"
	"github.com/docker/compose/v5/pkg/api"
	"github.com/docker/compose/v5/pkg/compose"
)

func main() {
	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
	defer cancel()

	// Create Docker CLI
	dockerCli, err := command.NewDockerCli()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Failed to create Docker CLI: %v\n", err)
		os.Exit(1)
	}

	// Initialize Docker CLI
	if err := dockerCli.Initialize(flags.NewClientOptions()); err != nil {
		fmt.Fprintf(os.Stderr, "Failed to initialize Docker CLI: %v\n", err)
		os.Exit(1)
	}

	// Create compose service
	service, err := compose.NewComposeService(dockerCli)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Failed to create compose service: %v\n", err)
		os.Exit(1)
	}

	// Get absolute path to compose file
	composeFile, err := filepath.Abs("test-compose.yaml")
	if err != nil {
		fmt.Fprintf(os.Stderr, "Failed to get absolute path: %v\n", err)
		os.Exit(1)
	}

	workingDir := filepath.Dir(composeFile)

	// Load project
	fmt.Printf("Loading project from %s\n", composeFile)
	project, err := service.LoadProject(ctx, api.ProjectLoadOptions{
		ConfigPaths: []string{composeFile},
		WorkingDir:  workingDir,
		ProjectName: "test",
	})
	if err != nil {
		fmt.Fprintf(os.Stderr, "Failed to load project: %v\n", err)
		os.Exit(1)
	}

	fmt.Printf("Project loaded: %s\n", project.Name)
	fmt.Printf("Services: %v\n", project.ServiceNames())

	// Start services
	fmt.Println("Starting services...")
	err = service.Up(ctx, project, api.UpOptions{
		Create: api.CreateOptions{
			Services:             project.ServiceNames(),
			RemoveOrphans:        true,
			Recreate:             api.RecreateDiverged,
			RecreateDependencies: api.RecreateDiverged,
		},
		Start: api.StartOptions{
			Project:     project,
			Services:    project.ServiceNames(),
			Wait:        true,
			WaitTimeout: 2 * time.Minute,
			OnExit:      api.CascadeFail,
		},
	})
	if err != nil {
		fmt.Fprintf(os.Stderr, "Failed to start services: %v\n", err)
		os.Exit(1)
	}

	fmt.Println("Services started successfully!")
	fmt.Println("\nPress Ctrl+C to stop services...")

	// Wait for signal
	<-ctx.Done()

	fmt.Println("\nStopping services...")
	stopCtx := context.Background()
	err = service.Down(stopCtx, project.Name, api.DownOptions{
		RemoveOrphans: true,
	})
	if err != nil {
		fmt.Fprintf(os.Stderr, "Failed to stop services: %v\n", err)
		os.Exit(1)
	}

	fmt.Println("Services stopped successfully!")
}
```