### PR TITLE
use standard TARGETARCH for architecture suffix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,9 +188,6 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 RUN --mount=from=binary \
     mkdir -p /out && \
-    # TODO: should just use standard arch
-    TARGETARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "$TARGETARCH"); \
-    TARGETARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "$TARGETARCH"); \
     cp docker-compose* "/out/docker-compose-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}$(ls docker-compose* | sed -e 's/^docker-compose//')"
 
 FROM scratch AS release


### PR DESCRIPTION
**What I did**

use standard `TARGETARCH` for architecture suffix in released binaries
this enforces consistency with other Docker CLI plugins (buildx, buildx, scout, init ...)

note: this is a breaking change which may impact scripts downloading latest release. Anyway, this TODO is here for too long, better introduce a breaking change _once_ and get a consistent user experience across docker repositories

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
