### PR TITLE
go.mod: remove exclude rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,12 +155,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-exclude (
-	// FIXME(thaJeztah): remove this once kubernetes updated their dependencies to no longer need this.
-	//
-	// For additional details, see this PR and links mentioned in that PR:
-	// https://github.com/kubernetes-sigs/kustomize/pull/5830#issuecomment-2569960859
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
-)


### PR DESCRIPTION
- relates to https://github.com/docker/compose/pull/12755

Commit 640c7deae0ea892024004b310bb54951825cb5d4 added these exclude rules as a temporary workaround until these transitive dependency versions would be gone;

> downgrade go-difflib and go-spew to tagged releases
>
> These dependencies were updated to "master" in some modules we depend on,
> but have no code-changes since their last release. Unfortunately, this also
> causes a ripple effect, forcing all users of the containerd module to also
> update these dependencies to an unrelease / un-tagged version.
>
> Both these dependencies will unlikely do a new release in the near future,
> so exclude these versions so that we can downgrade to the current release.

Kubernetes, and other dependencies have reverted those bumps, so these exclude rules are no longer needed.

This reverts commit 640c7deae0ea892024004b310bb54951825cb5d4.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
