### PR TITLE
refactor: extract API version constants to dedicated file

### DIFF
--- a/pkg/compose/api_versions.go
+++ b/pkg/compose/api_versions.go
@@ -1,0 +1,73 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+// Docker Engine API version constants.
+// These versions correspond to specific Docker Engine releases and their features.
+const (
+	// APIVersion144 represents Docker Engine API version 1.44 (Engine v25.0).
+	//
+	// New features in this version:
+	//  - Endpoint-specific MAC address configuration
+	//  - Multiple networks can be connected during container creation
+	//  - healthcheck.start_interval parameter support
+	//
+	// Before this version:
+	//  - MAC address was container-wide only
+	//  - Extra networks required post-creation NetworkConnect calls
+	//  - healthcheck.start_interval was not available
+	APIVersion144 = "1.44"
+
+	// APIVersion148 represents Docker Engine API version 1.48 (Engine v28.0).
+	//
+	// New features in this version:
+	//  - Volume mounts with type=image support
+	//
+	// Before this version:
+	//  - Only bind, volume, and tmpfs mount types were supported
+	APIVersion148 = "1.48"
+
+	// APIVersion149 represents Docker Engine API version 1.49 (Engine v28.1).
+	//
+	// New features in this version:
+	//  - Network interface_name configuration
+	//  - Platform parameter in ImageList API
+	//
+	// Before this version:
+	//  - interface_name was not configurable
+	//  - ImageList didn't support platform filtering
+	APIVersion149 = "1.49"
+)
+
+// Docker Engine version strings for user-facing error messages.
+// These should be used in error messages to provide clear version requirements.
+const (
+	// DockerEngineV25 is the major version string for Docker Engine 25.x
+	DockerEngineV25 = "v25"
+
+	// DockerEngineV28 is the major version string for Docker Engine 28.x
+	DockerEngineV28 = "v28"
+
+	// DockerEngineV28_1 is the specific version string for Docker Engine 28.1
+	DockerEngineV28_1 = "v28.1"
+)
+
+// Build tool version constants
+const (
+	// BuildxMinVersion is the minimum required version of buildx for compose build
+	BuildxMinVersion = "0.17.0"
+)

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -424,8 +424,8 @@ func (s *composeService) getBuildxPlugin() (*manager.Plugin, error) {
 		return nil, fmt.Errorf("failed to get version of buildx")
 	}
 
-	if versions.LessThan(buildx.Version[1:], "0.17.0") {
-		return nil, fmt.Errorf("compose build requires buildx 0.17 or later")
+	if versions.LessThan(buildx.Version[1:], BuildxMinVersion) {
+		return nil, fmt.Errorf("compose build requires buildx %s or later", BuildxMinVersion)
 	}
 
 	return buildx, nil

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -743,7 +743,7 @@ func (s *composeService) createMobyContainer(ctx context.Context, project *types
 	}
 	// Starting API version 1.44, the ContainerCreate API call takes multiple networks
 	// so we include all the configurations there and can skip the one-by-one calls here
-	if versions.LessThan(apiVersion, "1.44") {
+	if versions.LessThan(apiVersion, APIVersion144) {
 		// the highest-priority network is the primary and is included in the ContainerCreate API
 		// call via container.NetworkMode & network.NetworkingConfig
 		// any remaining networks are connected one-by-one here after creation (but before start)

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -353,7 +353,7 @@ func TestCreateMobyContainer(t *testing.T) {
 		// force `RuntimeVersion` to fetch fresh version
 		runtimeVersion = runtimeVersionCache{}
 		apiClient.EXPECT().ServerVersion(gomock.Any()).Return(moby.Version{
-			APIVersion: "1.44",
+			APIVersion: APIVersion144,
 		}, nil).AnyTimes()
 
 		service := types.ServiceConfig{

--- a/pkg/compose/convert.go
+++ b/pkg/compose/convert.go
@@ -73,8 +73,8 @@ func (s *composeService) ToMobyHealthCheck(ctx context.Context, check *compose.H
 		if err != nil {
 			return nil, err
 		}
-		if versions.LessThan(version, "1.44") {
-			return nil, errors.New("can't set healthcheck.start_interval as feature require Docker Engine v25 or later")
+		if versions.LessThan(version, APIVersion144) {
+			return nil, fmt.Errorf("can't set healthcheck.start_interval as feature require Docker Engine %s or later", DockerEngineV25)
 		} else {
 			startInterval = time.Duration(*check.StartInterval)
 		}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -360,7 +360,7 @@ func (s *composeService) prepareContainerMACAddress(ctx context.Context, service
 	if macAddress != "" && mainNw != nil && mainNw.MacAddress != "" && mainNw.MacAddress != macAddress {
 		return "", fmt.Errorf("the service-level mac_address should have the same value as network %s", nwName)
 	}
-	if versions.GreaterThanOrEqualTo(version, "1.44") {
+	if versions.GreaterThanOrEqualTo(version, APIVersion144) {
 		if mainNw != nil && mainNw.MacAddress == "" {
 			mainNw.MacAddress = macAddress
 		}
@@ -374,7 +374,7 @@ func (s *composeService) prepareContainerMACAddress(ctx context.Context, service
 		}
 
 		if len(withMacAddress) > 1 {
-			return "", fmt.Errorf("a MAC address is specified for multiple networks (%s), but this feature requires Docker Engine v25 or later", strings.Join(withMacAddress, ", "))
+			return "", fmt.Errorf("a MAC address is specified for multiple networks (%s), but this feature requires Docker Engine %s or later", strings.Join(withMacAddress, ", "), DockerEngineV25)
 		}
 
 		if mainNw != nil && mainNw.MacAddress != "" {
@@ -527,7 +527,7 @@ func defaultNetworkSettings(project *types.Project,
 	// so we can pass all the extra networks we want the container to be connected to
 	// in the network configuration instead of connecting the container to each extra
 	// network individually after creation.
-	if versions.GreaterThanOrEqualTo(version, "1.44") {
+	if versions.GreaterThanOrEqualTo(version, APIVersion144) {
 		if len(service.Networks) > 1 {
 			serviceNetworks := service.NetworksByPriority()
 			for _, networkKey := range serviceNetworks[1:] {
@@ -541,10 +541,10 @@ func defaultNetworkSettings(project *types.Project,
 		}
 	}
 
-	if versions.LessThan(version, "1.49") {
+	if versions.LessThan(version, APIVersion149) {
 		for _, config := range service.Networks {
 			if config != nil && config.InterfaceName != "" {
-				return "", nil, fmt.Errorf("interface_name requires Docker Engine v28.1 or later")
+				return "", nil, fmt.Errorf("interface_name requires Docker Engine %s or later", DockerEngineV28_1)
 			}
 		}
 	}
@@ -861,8 +861,8 @@ func (s *composeService) buildContainerVolumes(
 			if err != nil {
 				return nil, nil, err
 			}
-			if versions.LessThan(version, "1.48") {
-				return nil, nil, fmt.Errorf("volume with type=image require Docker Engine v28 or later")
+			if versions.LessThan(version, APIVersion148) {
+				return nil, nil, fmt.Errorf("volume with type=image require Docker Engine %s or later", DockerEngineV28)
 			}
 		}
 		mounts = append(mounts, m)

--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -61,7 +61,7 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 	if err != nil {
 		return nil, err
 	}
-	withPlatform := versions.GreaterThanOrEqualTo(version, "1.49")
+	withPlatform := versions.GreaterThanOrEqualTo(version, APIVersion149)
 
 	summary := map[string]api.ImageSummary{}
 	var mux sync.Mutex


### PR DESCRIPTION
**What I did**

Extracted hardcoded Docker Engine API version strings into a new `pkg/compose/api_versions.go` file with well-documented constants.

**Changes:**
- Created `api_versions.go` with constants: `APIVersion144`, `APIVersion148`, `APIVersion149`, `DockerEngineV25`, `DockerEngineV28`, `DockerEngineV28_1`, `BuildxMinVersion`
- Replaced magic strings in 6 files (13 locations total)

**Benefits:**
- Centralized version management
- Better code readability (`APIVersion144` vs `"1.44"`)
- Each constant documents its corresponding features

**Related issue**

N/A


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
