### PR TITLE
Replace tabbed indentation in sdk.md

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -28,8 +28,8 @@ import (
     "context"
     "log"
 
-	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/flags"
+    "github.com/docker/cli/cli/command"
+    "github.com/docker/cli/cli/flags"
     "github.com/docker/compose/v5/pkg/api"
     "github.com/docker/compose/v5/pkg/compose"
 )
@@ -37,15 +37,15 @@ import (
 func main() {
     ctx := context.Background()
 
-	dockerCLI, err := command.NewDockerCli()
-	if err != nil {
-		log.Fatalf("Failed to create docker CLI: %v", err)
-	}
-	err = dockerCLI.Initialize(&flags.ClientOptions{})
-	if err != nil {
-		log.Fatalf("Failed to initialize docker CLI: %v", err)
-	}
-	
+    dockerCLI, err := command.NewDockerCli()
+    if err != nil {
+        log.Fatalf("Failed to create docker CLI: %v", err)
+    }
+    err = dockerCLI.Initialize(&flags.ClientOptions{})
+    if err != nil {
+        log.Fatalf("Failed to initialize docker CLI: %v", err)
+    }
+
     // Create a new Compose service instance
     service, err := compose.NewComposeService(dockerCLI)
     if err != nil {


### PR DESCRIPTION
**What I did**
Replaced tabs with spaces that were mixed in the example code, it didn't indent cleanly in the github preview.

