### PR TITLE
Add support for --label flag to docker compose up

### DIFF
--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -152,6 +152,7 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backend
 	flags.StringVar(&create.Pull, "pull", "policy", `Pull image before running ("always"|"missing"|"never")`)
 	flags.BoolVar(&create.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file")
 	flags.StringArrayVar(&create.scale, "scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
+	flags.StringArrayVar(&create.labels, "label", []string{}, "Add or override labels on services, networks and volumes")
 	flags.BoolVar(&up.noColor, "no-color", false, "Produce monochrome output")
 	flags.BoolVar(&up.noPrefix, "no-log-prefix", false, "Don't print prefix in logs")
 	flags.BoolVar(&create.forceRecreate, "force-recreate", false, "Recreate containers even if their configuration and image haven't changed")


### PR DESCRIPTION
### What I did

Added support for the `--label` flag to `docker compose up`, allowing users to add or override labels on all services when starting a Compose stack.

This brings `compose up` in line with existing behavior from other commands (such as `compose run` and `compose create`), making it possible to attach arbitrary metadata to a full Compose stack at runtime.

The provided labels are applied before container creation, ensuring they are correctly propagated to all created containers.

### Related issue

Fixes #13436

### (not mandatory) A picture of a cute animal, if possible in relation to what you did

🐜 An ant carefully tagging everything in its path — just like Compose now labels all services when bringing a stack up.

### Notes

- Adds `--label` flag support to `docker compose up`
- Allows labeling all services in a stack at startup
- Reuses existing label parsing and application logic
- No behavior change when the flag is not used
- Fully backward compatible

## Screenshot (Test) 

<img width="1870" height="811" alt="Image" src="https://github.com/user-attachments/assets/42d0453a-2120-4d1f-a4f7-f188ab8b6715" />