### PR TITLE
Warn when unsupported deploy attribute is used in docker compose

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -307,7 +307,13 @@ func (o *ProjectOptions) ToModel(ctx context.Context, dockerCli command.Cli, ser
 
 // ToProject loads a Compose project using the LoadProject API.
 // Accepts optional cli.ProjectOptionsFn to control loader behavior.
-func (o *ProjectOptions) ToProject(ctx context.Context, dockerCli command.Cli, backend api.Compose, services []string, po ...cli.ProjectOptionsFn) (*types.Project, tracing.Metrics, error) {
+func (o *ProjectOptions) ToProject(
+	ctx context.Context,
+	dockerCli command.Cli,
+	backend api.Compose,
+	services []string,
+	po ...cli.ProjectOptionsFn,
+) (*types.Project, tracing.Metrics, error) {
 	var metrics tracing.Metrics
 	remotes := o.remoteLoaders(dockerCli)
 
@@ -356,6 +362,9 @@ func (o *ProjectOptions) ToProject(ctx context.Context, dockerCli command.Cli, b
 	if err != nil {
 		return nil, metrics, err
 	}
+
+	// Warn about unsupported attributes (e.g. deploy)
+	warnIgnoredDeployAttributes(project)
 
 	return project, metrics, nil
 }

--- a/cmd/compose/warnings.go
+++ b/cmd/compose/warnings.go
@@ -1,0 +1,86 @@
+package compose
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/sirupsen/logrus"
+)
+
+// warnIgnoredDeployAttributes emits informational warnings for deploy
+// attributes that are ignored by Docker Compose when running in
+// standalone (non-Swarm) mode.
+//
+// Note that some deploy attributes are still considered in standalone
+// mode, most notably `replicas` and device reservations (e.g. GPU requests).
+func warnIgnoredDeployAttributes(project *types.Project) {
+	for _, svc := range project.Services {
+		if svc.Deploy == nil {
+			continue
+		}
+
+		ignored := collectIgnoredDeployAttributes(svc.Deploy)
+		if len(ignored) == 0 {
+			continue
+		}
+
+		sort.Strings(ignored)
+
+		logrus.Warnf(
+			"Service %q uses deploy attributes that are ignored by Docker Compose "+
+				"in standalone (non-Swarm) mode. Some deploy attributes are still considered "+
+				"(such as replicas and device reservations), but the following will be ignored: %s",
+			svc.Name,
+			strings.Join(ignored, ", "),
+		)
+	}
+}
+
+// collectIgnoredDeployAttributes returns deploy sub-attributes
+// that are ignored by Docker Compose in standalone mode.
+//
+// This function intentionally focuses only on attributes that are
+// consistently ignored, to avoid noisy or misleading warnings.
+func collectIgnoredDeployAttributes(deploy *types.DeployConfig) []string {
+	if deploy == nil {
+		return nil
+	}
+
+	var ignored []string
+
+	// Placement — ignored in standalone mode
+	if len(deploy.Placement.Constraints) > 0 {
+		ignored = append(ignored, "placement.constraints")
+	}
+	if len(deploy.Placement.Preferences) > 0 {
+		ignored = append(ignored, "placement.preferences")
+	}
+
+	// Update / Rollback configuration — ignored
+	if deploy.UpdateConfig != nil {
+		ignored = append(ignored, "update_config")
+	}
+	if deploy.RollbackConfig != nil {
+		ignored = append(ignored, "rollback_config")
+	}
+
+	// Endpoint mode — ignored
+	if deploy.EndpointMode != "" {
+		ignored = append(ignored, "endpoint_mode")
+	}
+
+	// Mode — ignored in standalone mode (even if set to "replicated")
+	if deploy.Mode != "" {
+		ignored = append(ignored, "mode")
+	}
+
+	// Intentionally NOT warned:
+	// - deploy.replicas (supported)
+	// - deploy.resources.reservations.devices (supported, e.g. GPU requests)
+	// - deploy.restart_policy (may be used as fallback if service.restart is unset)
+	// - cpu/memory limits (runtime-dependent and partially supported)
+	// - deploy.labels (ignored but rarely used)
+
+	return ignored
+}


### PR DESCRIPTION
## What I did

Added a warning when unsupported Compose attributes are detected during project
loading. Currently this warns when the `deploy` section is used, which is
ignored by docker compose outside of Swarm mode.

This avoids silent misconfiguration and makes it clear to users why `deploy`
settings are not applied when running docker compose outside of Swarm mode.

## Related issue

Fixes #13150  
Related to #13149

### (not mandatory) A picture of a cute animal, if possible in relation to what you did

🐶 A vigilant watchdog barking loudly when something unsupported sneaks in — just like Compose now warns users when `deploy` is defined outside of Swarm mode.

###  Notes

- Emits a warning when the `deploy` attribute is present in a service definition
- Does not change runtime behavior; only adds user-facing feedback
- Keeps backward compatibility
- Introduces a small, dedicated `warnings.go` helper to keep the logic isolated
- Verified with local build and tests:
  - `go build ./cmd/compose`
  - `go test ./cmd/compose/...`

## Screenshot

_Build and tests passing locally_

<img width="975" height="89" alt="image" src="https://github.com/user-attachments/assets/7022c6b8-ffdf-4335-aa17-57421c05d88a" />

