### PR TITLE
set fsnotify build tag when building for OSX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,from=osxcross,src=/osxsdk,target=/xx-sdk \
     xx-go --wrap && \
-    if [ "$(xx-info os)" == "darwin" ]; then export CGO_ENABLED=1; fi && \
+    if [ "$(xx-info os)" == "darwin" ]; then export CGO_ENABLED=1; export BUILD_TAGS=fsnotify,$BUILD_TAGS; fi && \
     make build GO_BUILDTAGS="$BUILD_TAGS" DESTDIR=/out && \
     xx-verify --static /out/docker-compose
 


### PR DESCRIPTION
**What I did**

follow-up https://github.com/docker/compose/pull/13452
during release, we use cross-compilation with GHA bake action. This updates the Dockerfile to enable fsnotify build tag when we target OSX binaries

**Related issue**
fixes https://github.com/docker/for-mac/issues/7832

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
