### PR TITLE
compose: recreate container when mounted image digest changes

### DIFF
--- a/pkg/e2e/fixtures/image-volume-recreate/Dockerfile
+++ b/pkg/e2e/fixtures/image-volume-recreate/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+#
+#    Copyright 2020 Docker Compose CLI authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+FROM alpine
+WORKDIR /app
+ARG CONTENT=initial
+RUN echo "$CONTENT" > /app/content.txt

--- a/pkg/e2e/fixtures/image-volume-recreate/compose.yaml
+++ b/pkg/e2e/fixtures/image-volume-recreate/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  source:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: image-volume-source
+
+  consumer:
+    image: alpine
+    depends_on:
+      - source
+    command: ["cat", "/data/content.txt"]
+    volumes:
+      - type: image
+        source: image-volume-source
+        target: /data
+        image:
+          subpath: app


### PR DESCRIPTION
**What I did**
Until now, `mustRecreate` logic only checked for divergence in `TypeVolume` mounts but ignored `TypeImage` mounts. This inconsistency caused containers to erroneously retain stale images even after the source image was rebuilt.

This commit introduces a new label `com.docker.compose.image.mounts` that tracks the digests of images used as mounts. The convergence logic is updated to verify this label, ensuring that containers are correctly recreated whenever the underlying image mount digest changes.
**Related issue**
Fixes #13547