### PR TITLE
Fix potential nil pointer dereference in container event monitoring

### DIFF
--- a/pkg/compose/monitor.go
+++ b/pkg/compose/monitor.go
@@ -147,7 +147,7 @@ func (c *monitor) Start(ctx context.Context) error {
 					return err
 				}
 
-				if inspect.State != nil && inspect.State.Restarting || inspect.State.Running {
+				if inspect.State != nil && (inspect.State.Restarting || inspect.State.Running) {
 					// State.Restarting is set by engine when container is configured to restart on exit
 					// on ContainerRestart it doesn't (see https://github.com/moby/moby/issues/45538)
 					// container state still is reported as "running"


### PR DESCRIPTION
## Summary

- Fix incorrect operator precedence in nil check that could cause panic

## Description

The condition for checking container restart state in `monitor.go` had incorrect operator precedence.

The expression:
```go
inspect.State != nil && inspect.State.Restarting || inspect.State.Running
```

is evaluated as:
```go
(inspect.State != nil && inspect.State.Restarting) || inspect.State.Running
```

This means if `inspect.State` is `nil`, the `inspect.State.Running` check would be evaluated (because the left side of `||` could be false), causing a nil pointer dereference panic.

The fix adds explicit parentheses to ensure the nil check guards both state fields:
```go
inspect.State != nil && (inspect.State.Restarting || inspect.State.Running)
```

## Reproduction Scenario

This bug could be triggered when:
1. A container dies (triggers the `events.ActionDie` case)
2. `ContainerInspect` returns successfully but with `State: nil` (rare edge case)
3. The container is not restarting (`inspect.State.Restarting` would panic before even checking)

While Docker typically always populates the `State` field, defensive programming dictates that after checking for nil, both conditions should be guarded.

## Testing

- All unit tests pass
- Build completes successfully