### PR TITLE
Fix potential nil pointer dereference when checking container state in Remove

### DIFF
--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -64,7 +64,7 @@ func (s *composeService) Remove(ctx context.Context, projectName string, options
 		if err != nil {
 			return err
 		}
-		if !inspected.State.Running || (options.Stop && s.dryRun) {
+		if inspected.State == nil || !inspected.State.Running || (options.Stop && s.dryRun) {
 			stoppedContainers = append(stoppedContainers, ctr)
 		}
 	}


### PR DESCRIPTION
## Summary
- Add nil check for `inspected.State` before accessing `inspected.State.Running` in the `Remove` function
- Prevents potential panic if Docker returns a container without State information

## Problem
In `pkg/compose/remove.go:67`, the code accesses `inspected.State.Running` without first checking if `inspected.State` is nil:

```go
if !inspected.State.Running || (options.Stop && s.dryRun) {
```

While Docker containers typically always have State populated, this is inconsistent with nil checks done elsewhere in the codebase and could cause a panic in edge cases (race conditions, unusual Docker states, or API changes).

## Solution
Add a nil check consistent with the pattern used elsewhere in the codebase:
- `pkg/compose/convergence.go:836` - `ctr.State != nil && ctr.State.Status`
- `pkg/compose/convergence.go:862` - `ctr.State != nil && ctr.State.Status`
- `pkg/compose/monitor.go:150` - `inspect.State != nil && (inspect.State.Restarting || ...)`
- `pkg/compose/ps.go:70` - `if inspect.State != nil {`

The fix adds a nil check that treats containers with nil State as "stopped" (which is the safe default for the Remove operation).