### PR TITLE
docs: fix docker compose down usage syntax

### DIFF
--- a/docs/reference/docker_compose_down.yaml
+++ b/docs/reference/docker_compose_down.yaml
@@ -14,7 +14,7 @@ long: |-
     Anonymous volumes are not removed by default. However, as they don’t have a stable name, they are not automatically
     mounted by a subsequent `up`. For data that needs to persist between updates, use explicit paths as bind mounts or
     named volumes.
-usage: docker compose down [OPTIONS] [SERVICES]
+usage: docker compose down [OPTIONS]
 pname: docker compose
 plink: docker_compose.yaml
 options:


### PR DESCRIPTION
What changed:
- Removed the invalid [SERVICES] argument from the `docker compose down` usage definition.

Why:
- `docker compose down` does not accept service names, and the generated CLI documentation was incorrect.

Related issue:
- docker/docs#23407
