### PR TITLE
test: fix pull failure assertion for Docker v29

### DIFF
--- a/pkg/e2e/pull_test.go
+++ b/pkg/e2e/pull_test.go
@@ -66,7 +66,15 @@ func TestComposePull(t *testing.T) {
 
 	t.Run("Verify pull failure", func(t *testing.T) {
 		res := c.RunDockerComposeCmdNoCheck(t, "--project-directory", "fixtures/compose-pull/unknown-image", "pull")
-		res.Assert(t, icmd.Expected{ExitCode: 1, Err: "pull access denied for does_not_exists"})
+		output := res.Combined()
+
+		errMsg := "pull access denied for does_not_exists"
+		if !strings.Contains(output, errMsg) {
+			// containerd returns:
+			// failed to resolve reference "docker.io/library/does_not_exists:latest": docker.io/library/does_not_exists:latest: not found
+			errMsg = "does_not_exists:latest: not found"
+		}
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: errMsg})
 	})
 
 	t.Run("Verify ignore pull failure", func(t *testing.T) {


### PR DESCRIPTION
**What I did**

Fix pull failure assertion for Docker v29.2 

The error message comes now from containerd.

**Related issue**

https://github.com/docker/compose/issues/13565

Otherwise test fails with:

```
=== RUN   TestComposePull/Verify_pull_failure
    pull_test.go:68: Running command: /usr/lib/docker/cli-plugins/docker-compose --project-directory fixtures/compose-pull/unknown-image pull
    pull_test.go:69: assertion failed: 
        Command:  /usr/lib/docker/cli-plugins/docker-compose --project-directory fixtures/compose-pull/unknown-image pull
        ExitCode: 1
        Error:    exit status 1
        Stdout:   
        Stderr:    Image does_not_exists Pulling 
         Image doesn_t_exists_either Pulling 
         Image alpine:3.15 Pulling 
         Image alpine:3.15 Pulled 
         Image doesn_t_exists_either failed to resolve reference "docker.io/library/doesn_t_exists_either:latest": docker.io/library/doesn_t_exists_either:latest: not found 
         Image does_not_exists Error failed to resolve reference "docker.io/library/does_not_exists:latest": docker.io/library/does_not_exists:latest: not found
        time="2026-01-30T08:23:20-05:00" level=warning msg="WARNING: Some service image(s) must be built from source by running:\n    docker compose build can_build"
        Error response from daemon: failed to resolve reference "docker.io/library/does_not_exists:latest": docker.io/library/does_not_exists:latest: not found
        
        
        Failures:
        Expected stderr to contain "pull access denied for does_not_exists"
    --- FAIL: TestComposePull/Verify_pull_failure (0.92s)
FAIL pkg/e2e.TestComposePull/Verify_pull_failure (0.92s)
```