### PR TITLE
ci: fix bin-image job

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -136,6 +136,6 @@ jobs:
               workflow_id: 'compose-edge-integration.yml',
               ref: 'main',
               inputs: {
-                "image-tag": "${{ needs.bin-image.outputs.digest }}"
+                "image-tag": "${{ env.REPO_SLUG }}:edge"
               }
             })


### PR DESCRIPTION
relates to https://github.com/docker/compose/actions/runs/21631806154/job/62346301683#step:8:540

```
Error: meta-images is required when output is image
```

Forgot to put the dependency on bin-image :persevere:

Also fixes the bin-image edge tag being used for e2e tests.