### PR TITLE
Fix invalid path error when using OCI artifacts on Windows

### DIFF
--- a/cmd/compose/compose_oci_test.go
+++ b/cmd/compose/compose_oci_test.go
@@ -1,0 +1,76 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/mocks"
+)
+
+func TestSetEnvWithDotEnv_WithOCIArtifact(t *testing.T) {
+	// Test that setEnvWithDotEnv doesn't fail when using OCI artifacts
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	cli := mocks.NewMockCli(ctrl)
+
+	opts := ProjectOptions{
+		ConfigPaths: []string{"oci://docker.io/dockersamples/welcome-to-docker"},
+		ProjectDir:  "",
+		EnvFiles:    []string{},
+	}
+
+	err := setEnvWithDotEnv(opts, cli)
+	assert.NilError(t, err, "setEnvWithDotEnv should not fail with OCI artifact path")
+}
+
+func TestSetEnvWithDotEnv_WithGitRemote(t *testing.T) {
+	// Test that setEnvWithDotEnv doesn't fail when using Git remotes
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	cli := mocks.NewMockCli(ctrl)
+
+	opts := ProjectOptions{
+		ConfigPaths: []string{"https://github.com/docker/compose.git"},
+		ProjectDir:  "",
+		EnvFiles:    []string{},
+	}
+
+	err := setEnvWithDotEnv(opts, cli)
+	assert.NilError(t, err, "setEnvWithDotEnv should not fail with Git remote path")
+}
+
+func TestSetEnvWithDotEnv_WithLocalPath(t *testing.T) {
+	// Test that setEnvWithDotEnv still works with local paths
+	// This will fail if the file doesn't exist, but it should not panic
+	// or produce invalid paths
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	cli := mocks.NewMockCli(ctrl)
+
+	opts := ProjectOptions{
+		ConfigPaths: []string{"compose.yaml"},
+		ProjectDir:  "",
+		EnvFiles:    []string{},
+	}
+
+	// This may error if files don't exist, but should not panic
+	_ = setEnvWithDotEnv(opts, cli)
+}


### PR DESCRIPTION
Resolves #13572 

And AI disclaimer - Claude performed the troubleshooting and fix in this PR.

I have built the Compose binary locally and validated the fix does work on my Windows machine.

## Problem                                 
                                                                                                                                                                                                                      
When using Docker Compose with an OCI artifact on Windows (e.g., `docker compose -f oci://dockersamples/welcome-to-docker up`), the following error occurred:                                                      
                                                                                                                                                                                                                    
```                                                                                                                                                                                                                
CreateFile C:\Users\username\oci:\dockersamples\.env: The filename, directory name, or volume label syntax is incorrect.                                                                                           
```                                                                                                                                                                                                                
                                                                                                                                                                                                                    
This error was introduced between v5.0.0 and v5.0.1, specifically by commit 6c043929a which fixed error handling in `setEnvWithDotEnv`. The bug existed in v5.0.0 but was silently ignored due to improper error   
handling.                                                                                                                                                                                                         
                                                                                                                                                                                                                    
## Root Cause                                                                                                                                                                                                      
                                                                                                                                                                                                                    
The issue occurred in the `setEnvWithDotEnv` function in `cmd/compose/compose.go`:                                                                                                                                 
                                                                                                                                                                                                                    
1. When `setEnvWithDotEnv` is called with an OCI artifact path, it creates ProjectOptions without registering any remote loaders                                                                                   
2. The compose-go library's `GetWorkingDir()` method doesn't recognize the path as a remote resource                                                                                                               
3. It tries to treat the OCI reference as a local file path by calling `filepath.Abs()` on it                                                                                                                      
4. On Windows, `filepath.Abs("oci://dockersamples/...")` produces an invalid path like `C:\Users\username\oci:\dockersamples`                                                                                      
5. When trying to load `.env` files, it appends to this malformed path, resulting in: `C:\Users\username\oci:\dockersamples\.env`                                                                                  
6. Windows rejects this path because colons are only valid after drive letters                                                                                                                                     
                                                                                                                                                                                                                    
### Code Flow                                                                                                                                                                                                      
                                                                                                                                                                                                                    
In compose-go's `cli/options.go`, the `GetWorkingDir()` method:                                                                                                                                                    
```go                                                                                                                                                                                                              
func (o *ProjectOptions) GetWorkingDir() (string, error) {                                                                                                                                                         
    if o.WorkingDir != "" {                                                                                                                                                                                        
        return filepath.Abs(o.WorkingDir)                                                                                                                                                                          
    }                                                                                                                                                                                                              
PATH:                                                                                                                                                                                                              
    for _, path := range o.ConfigPaths {                                                                                                                                                                           
        if path != "-" {                                                                                                                                                                                           
            for _, l := range o.ResourceLoaders {                                                                                                                                                                  
                if l.Accept(path) {                                                                                                                                                                                
                    break PATH  // Skip filepath.Abs for remote resources                                                                                                                                          
                }                                                                                                                                                                                                  
            }                                                                                                                                                                                                      
            absPath, err := filepath.Abs(path)  // BUG: Called for OCI paths when no loaders registered                                                                                                            
            if err != nil {                                                                                                                                                                                        
                return "", err                                                                                                                                                                                     
            }                                                                                                                                                                                                      
            return filepath.Dir(absPath), nil                                                                                                                                                                      
        }                                                                                                                                                                                                          
    }                                                                                                                                                                                                              
    return os.Getwd()                                                                                                                                                                                              
}                                                                                                                                                                                                                  
```                                                                                                                                                                                                                
                                                                                                                                                                                                                    
Without remote loaders registered, OCI paths fall through to `filepath.Abs()`, causing the issue.                                                                                                                  
                                                                                                                                                                                                                    
## Solution                                                                                                                                                                                                        
                                                                                                                                                                                                                    
Modified `setEnvWithDotEnv` to detect remote config paths and skip environment loading for them:                                                                                                                   
                                                                                                                                                                                                                    
```go                                                                                                                                                                                                              
func setEnvWithDotEnv(opts ProjectOptions) error {                                                                                                                                                                 
    // Check if we're using a remote config (OCI or Git)                                                                                                                                                           
    // If so, skip env loading as remote loaders haven't been initialized yet                                                                                                                                      
    for _, path := range opts.ConfigPaths {                                                                                                                                                                        
        if strings.HasPrefix(path, remote.OciPrefix) || strings.Contains(path, "://") {                                                                                                                            
            return nil                                                                                                                                                                                             
        }                                                                                                                                                                                                          
    }                                                                                                                                                                                                              
    // ... rest of the function unchanged                                                                                                                                                                          
}                                                                                                                                                                                                                  
```                                                                                                                                                                                                                
                                                                                                                                                                                                                    
This approach:                                                                                                                                                                                                     
- Detects remote config paths early (OCI: `oci://`, Git: URLs with `://`)                                                                                                                                          
- Skips the problematic .env loading for remote configs                                                                                                                                                            
- Allows normal processing for local compose files                                                                                                                                                                 
- Environment loading for remote configs happens later in the flow when remote loaders are properly initialized                                                                                                    
                                                                                                                                                                                                                    
## Testing                                                                                                                                                                                                         
                                                                                                                                                                                                                    
- Added tests in `cmd/compose/compose_oci_test.go` for OCI artifacts, Git remotes, and local paths                                                                                                                 
   - Verified fix works on Windows ARM64                                                                                                                                                                              
   - All existing tests pass                                                                                                                                                                                          

## Files Changed                                                                                                                                                                                                   
                                                                                                                                                                                                                      
- `cmd/compose/compose.go`: Modified `setEnvWithDotEnv` function                                                                                                                                                   
- `cmd/compose/compose_oci_test.go`: Added tests for the fix"  