### PR TITLE
pkg/compose: un-export consts

### DIFF
--- a/pkg/compose/api_versions.go
+++ b/pkg/compose/api_versions.go
@@ -19,16 +19,16 @@ package compose
 // Docker Engine API version constants.
 // These versions correspond to specific Docker Engine releases and their features.
 const (
-	// APIVersion148 represents Docker Engine API version 1.48 (Engine v28.0).
+	// apiVersion148 represents Docker Engine API version 1.48 (Engine v28.0).
 	//
 	// New features in this version:
 	//  - Volume mounts with type=image support
 	//
 	// Before this version:
 	//  - Only bind, volume, and tmpfs mount types were supported
-	APIVersion148 = "1.48"
+	apiVersion148 = "1.48"
 
-	// APIVersion149 represents Docker Engine API version 1.49 (Engine v28.1).
+	// apiVersion149 represents Docker Engine API version 1.49 (Engine v28.1).
 	//
 	// New features in this version:
 	//  - Network interface_name configuration
@@ -37,14 +37,14 @@ const (
 	// Before this version:
 	//  - interface_name was not configurable
 	//  - ImageList didn't support platform filtering
-	APIVersion149 = "1.49"
+	apiVersion149 = "1.49"
 )
 
 // Docker Engine version strings for user-facing error messages.
 // These should be used in error messages to provide clear version requirements.
 const (
-	// DockerEngineV28 is the major version string for Docker Engine 28.x
-	DockerEngineV28 = "v28"
+	// dockerEngineV28 is the major version string for Docker Engine 28.x
+	dockerEngineV28 = "v28"
 
 	// DockerEngineV28_1 is the specific version string for Docker Engine 28.1
 	DockerEngineV28_1 = "v28.1"
@@ -52,6 +52,6 @@ const (
 
 // Build tool version constants
 const (
-	// BuildxMinVersion is the minimum required version of buildx for compose build
-	BuildxMinVersion = "0.17.0"
+	// buildxMinVersion is the minimum required version of buildx for compose build
+	buildxMinVersion = "0.17.0"
 )

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -424,8 +424,8 @@ func (s *composeService) getBuildxPlugin() (*manager.Plugin, error) {
 		return nil, fmt.Errorf("failed to get version of buildx")
 	}
 
-	if versions.LessThan(buildx.Version[1:], BuildxMinVersion) {
-		return nil, fmt.Errorf("compose build requires buildx %s or later", BuildxMinVersion)
+	if versions.LessThan(buildx.Version[1:], buildxMinVersion) {
+		return nil, fmt.Errorf("compose build requires buildx %s or later", buildxMinVersion)
 	}
 
 	return buildx, nil

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -528,7 +528,7 @@ func defaultNetworkSettings(project *types.Project,
 		return network.NetworkNone, nil, nil
 	}
 
-	if versions.LessThan(version, APIVersion149) {
+	if versions.LessThan(version, apiVersion149) {
 		for _, config := range service.Networks {
 			if config != nil && config.InterfaceName != "" {
 				return "", nil, fmt.Errorf("interface_name requires Docker Engine %s or later", DockerEngineV28_1)
@@ -901,8 +901,8 @@ func (s *composeService) buildContainerVolumes(
 			if err != nil {
 				return nil, nil, err
 			}
-			if versions.LessThan(version, APIVersion148) {
-				return nil, nil, fmt.Errorf("volume with type=image require Docker Engine %s or later", DockerEngineV28)
+			if versions.LessThan(version, apiVersion148) {
+				return nil, nil, fmt.Errorf("volume with type=image require Docker Engine %s or later", dockerEngineV28)
 			}
 		}
 		mounts = append(mounts, m)

--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -60,7 +60,7 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 	if err != nil {
 		return nil, err
 	}
-	withPlatform := versions.GreaterThanOrEqualTo(version, APIVersion149)
+	withPlatform := versions.GreaterThanOrEqualTo(version, apiVersion149)
 
 	summary := map[string]api.ImageSummary{}
 	var mux sync.Mutex


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/compose/pull/13580
- relates to https://github.com/docker/compose/pull/13503

### pkg/compose: un-export consts

These consts were added in b760afaf9f137edc940ceb9f4dc1e10340378150, but are only user internal in the package. 

Given that the list of consts may change over time, it's probably best to keep them internal and not part of the module's API.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
