### PR TITLE
 Add E2E tests for self-referencing variable expansion in .env files  

### DIFF
--- a/pkg/e2e/fixtures/environment/env-self-reference/.env
+++ b/pkg/e2e/fixtures/environment/env-self-reference/.env
@@ -1,0 +1,4 @@
+REGISTRY_URL=gcr.io/myproject
+IMAGE_NAME=myapp
+FULL_IMAGE=${REGISTRY_URL}/${IMAGE_NAME}:latest
+BASE_URL=${REGISTRY_URL}/subpath

--- a/pkg/e2e/fixtures/environment/env-self-reference/compose.yaml
+++ b/pkg/e2e/fixtures/environment/env-self-reference/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  test:
+    image: bash
+    environment:
+      FULL_IMAGE: ${FULL_IMAGE}
+      BASE_URL: ${BASE_URL}
+    command: echo "ok"


### PR DESCRIPTION
 Summary

  - Adds E2E test coverage for self-referencing variable expansion within .env files (relates to #13591)
  - Verifies that variables defined earlier in .env can be referenced by later entries (e.g. FULL_IMAGE=${REGISTRY_URL}/${IMAGE_NAME}:latest)
  - Verifies that OS environment overrides cascade correctly through dependent variables

  Context

  Issue #13591 reports that Docker Compose doesn't support variable expansion within .env files. Investigation shows that compose-go's dotenv parser already handles this correctly — parser.go processes lines sequentially, accumulating each variable into the lookup map before parsing the next line. However, the existing test TestEnvInterpolation always sets the base variable via OS env, so it never actually exercises pure .env-internal self-reference.

  This PR closes the test gap by adding an explicit E2E test that relies solely on variables defined within the .env file, with no OS env assistance.

  Changes

  - New fixture pkg/e2e/fixtures/environment/env-self-reference/ — .env file with chained variable references and a minimal compose.yaml that consumes them
  - New test TestEnvSelfReference with two sub-tests: \
  a. Pure .env self-reference — no OS env set, asserts FULL_IMAGE: gcr.io/myproject/myapp:latest and BASE_URL: gcr.io/myproject/subpath
    b. OS env override cascade — sets REGISTRY_URL=override.io in OS env, asserts that dependent variables pick up the override

