### PR TITLE
Tolerate missing env file on more runtime commands

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -281,7 +281,7 @@ func (o *ProjectOptions) toProjectName(ctx context.Context, dockerCli command.Cl
 		return "", err
 	}
 
-	project, _, err := o.ToProject(ctx, dockerCli, backend, nil)
+	project, _, err := o.ToProject(ctx, dockerCli, backend, nil, cli.WithDiscardEnvFile, cli.WithoutEnvironmentResolution)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/e2e/env_file_test.go
+++ b/pkg/e2e/env_file_test.go
@@ -41,6 +41,7 @@ func TestUnusedMissingEnvFile(t *testing.T) {
 	// Runtime operations should work even with missing env file
 	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "ps")
 	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "logs")
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "exec", "serviceA", "echo", "hello")
 	c.RunDockerComposeCmd(t, "-f", "./fixtures/env_file/compose.yaml", "down")
 }
 


### PR DESCRIPTION
**What I did**

Align toProjectName (used by exec, image, etc.) with projectOrName (used by ps, logs, etc.), which already had these flags since #13156

I know, this skips compose.yaml parsing. Being pragmatic for now, as I haven't touched compose-go yet, but can probably add a function to avoid the need to call ToProject at all.

**Related issue**

Closes #13601
