### PR TITLE
Filter services in config --no-interpolate to respect [SERVICE...] argument

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -271,6 +271,20 @@ func runConfigNoInterpolate(ctx context.Context, dockerCli command.Cli, opts con
 		return nil, err
 	}
 
+	if len(services) > 0 {
+		if svcs, ok := model["services"].(map[string]any); ok {
+			filtered := make(map[string]any, len(services))
+			for _, name := range services {
+				if svc, exists := svcs[name]; exists {
+					filtered[name] = svc
+				} else {
+					return nil, fmt.Errorf("no such service: %s", name)
+				}
+			}
+			model["services"] = filtered
+		}
+	}
+
 	if opts.resolveImageDigests {
 		err = resolveImageDigests(ctx, dockerCli, model)
 		if err != nil {

--- a/pkg/e2e/config_test.go
+++ b/pkg/e2e/config_test.go
@@ -17,8 +17,10 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
 
@@ -45,6 +47,13 @@ func TestLocalComposeConfig(t *testing.T) {
 	t.Run("--no-interpolate", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/compose.yaml", "--project-name", projectName, "config", "--no-interpolate")
 		res.Assert(t, icmd.Expected{Out: `- ${PORT:-8080}:80`})
+	})
+
+	t.Run("--no-interpolate with service filter", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config-filter/compose.yaml", "--project-name", projectName, "config", "--no-interpolate", "example1")
+		res.Assert(t, icmd.Expected{Out: `example1`})
+		// example2 should NOT appear in the output when only example1 is requested
+		assert.Assert(t, !strings.Contains(res.Stdout(), "example2"), "expected example2 to be filtered out")
 	})
 
 	t.Run("--variables --format json", func(t *testing.T) {

--- a/pkg/e2e/fixtures/config-filter/compose.yaml
+++ b/pkg/e2e/fixtures/config-filter/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  example1:
+    container_name: example1
+    image: example/example
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      TZ: ${TZ:-Etc/UTC}
+
+  example2:
+    container_name: example2
+    image: example/example
+    restart: unless-stopped
+    ports:
+      - "3002:3000"
+    environment:
+      TZ: ${TZ:-Etc/UTC}


### PR DESCRIPTION
## What I did

When using `docker compose config --no-interpolate` with specific service names
(e.g., `docker compose config --no-interpolate example1`), the `[SERVICE...]`
argument was being ignored and all services were output.

The root cause is that `runConfigNoInterpolate()` calls `ToModel()` which
returns the full model without filtering by service names. Added service
filtering after model loading to match the behavior of the interpolated
code path.

## Related issue

Fixes #13614

## How I tested

- Added an e2e test with a multi-service compose file that verifies only
  the requested service is output when using `--no-interpolate` with a
  service name filter
- Verified the build compiles and existing unit tests pass