### PR TITLE
Fix: respect required: false for env_file in publish command

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -251,6 +251,9 @@ func processFile(ctx context.Context, file string, project *types.Project, extFi
 	}
 	for name, service := range base.Services {
 		for i, envFile := range service.EnvFiles {
+			if !envFile.Required {
+				continue
+			}
 			hash := fmt.Sprintf("%x.env", sha256.Sum256([]byte(envFile.Path)))
 			envFiles[envFile.Path] = hash
 			f, err = transform.ReplaceEnvFile(f, name, i, hash)
@@ -351,8 +354,11 @@ func (s *composeService) checkEnvironmentVariables(project *types.Project, optio
 	errorList := map[string][]string{}
 
 	for _, service := range project.Services {
-		if len(service.EnvFiles) > 0 {
-			errorList[service.Name] = append(errorList[service.Name], fmt.Sprintf("service %q has env_file declared.", service.Name))
+		for _, envFile := range service.EnvFiles {
+			if envFile.Required {
+				errorList[service.Name] = append(errorList[service.Name], fmt.Sprintf("service %q has env_file declared.", service.Name))
+				break
+			}
 		}
 	}
 
@@ -438,6 +444,9 @@ func (s *composeService) checkForSensitiveData(project *types.Project) ([]secret
 	for _, service := range project.Services {
 		// Check env files
 		for _, envFile := range service.EnvFiles {
+			if !envFile.Required {
+				continue
+			}
 			findings, err := scan.ScanFile(envFile.Path)
 			if err != nil {
 				return nil, fmt.Errorf("failed to scan env file %s: %w", envFile.Path, err)

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -252,7 +252,9 @@ func processFile(ctx context.Context, file string, project *types.Project, extFi
 	for name, service := range base.Services {
 		for i, envFile := range service.EnvFiles {
 			if !envFile.Required {
-				continue
+				if _, err := os.Stat(envFile.Path); os.IsNotExist(err) {
+					continue
+				}
 			}
 			hash := fmt.Sprintf("%x.env", sha256.Sum256([]byte(envFile.Path)))
 			envFiles[envFile.Path] = hash
@@ -356,7 +358,7 @@ func (s *composeService) checkEnvironmentVariables(project *types.Project, optio
 	for _, service := range project.Services {
 		for _, envFile := range service.EnvFiles {
 			if envFile.Required {
-				errorList[service.Name] = append(errorList[service.Name], fmt.Sprintf("service %q has env_file declared.", service.Name))
+				errorList[service.Name] = append(errorList[service.Name], fmt.Sprintf("service %q has required env_file declared.", service.Name))
 				break
 			}
 		}
@@ -444,8 +446,11 @@ func (s *composeService) checkForSensitiveData(project *types.Project) ([]secret
 	for _, service := range project.Services {
 		// Check env files
 		for _, envFile := range service.EnvFiles {
+			// Skip optional env files that don't exist
 			if !envFile.Required {
-				continue
+				if _, err := os.Stat(envFile.Path); os.IsNotExist(err) {
+					continue
+				}
 			}
 			findings, err := scan.ScanFile(envFile.Path)
 			if err != nil {

--- a/pkg/compose/publish_test.go
+++ b/pkg/compose/publish_test.go
@@ -121,15 +121,21 @@ func Test_createLayers_withRequiredFalse(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	assert.Equal(t, len(layers), 2)
+	assert.Equal(t, len(layers), 3)
 
 	assert.Equal(t, layers[0].Annotations["com.docker.compose.file"], "compose-required-false.yaml")
 
 	assert.Equal(t, layers[1].MediaType, "application/vnd.docker.compose.envfile")
+	assert.Equal(t, layers[2].MediaType, "application/vnd.docker.compose.envfile")
 
-	envFileHash := layers[1].Annotations["com.docker.compose.envfile"]
-	assert.Assert(t, len(envFileHash) > 0)
-	assert.Assert(t, envFileHash != "missing.env")
+	envFileHashes := []string{
+		layers[1].Annotations["com.docker.compose.envfile"],
+		layers[2].Annotations["com.docker.compose.envfile"],
+	}
+	assert.Assert(t, envFileHashes[0] != "")
+	assert.Assert(t, envFileHashes[1] != "")
+	assert.Assert(t, envFileHashes[0] != "missing.env")
+	assert.Assert(t, envFileHashes[1] != "missing.env")
 }
 
 func Test_checkEnvironmentVariables_withRequiredFalse(t *testing.T) {
@@ -143,7 +149,7 @@ func Test_checkEnvironmentVariables_withRequiredFalse(t *testing.T) {
 						Required: false,
 					},
 					{
-						Path:     "existing.env", 
+						Path:     "existing.env",
 						Required: true,
 					},
 				},
@@ -164,6 +170,6 @@ func Test_checkEnvironmentVariables_withRequiredFalse(t *testing.T) {
 
 	err := service.checkEnvironmentVariables(project, api.PublishOptions{})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), `service "test" has env_file declared.`))
+	assert.Assert(t, strings.Contains(err.Error(), `service "test" has required env_file declared.`))
 	assert.Assert(t, !strings.Contains(err.Error(), `service "test2"`))
 }

--- a/pkg/compose/publish_test.go
+++ b/pkg/compose/publish_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/loader"
@@ -99,4 +100,70 @@ services:
 	assert.DeepEqual(t, expectedLayers, layers, cmp.FilterPath(func(path cmp.Path) bool {
 		return !slices.Contains([]string{".Data", ".Digest", ".Size"}, path.String())
 	}, cmp.Ignore()))
+}
+
+func Test_createLayers_withRequiredFalse(t *testing.T) {
+	project, err := loader.LoadWithContext(t.Context(), types.ConfigDetails{
+		WorkingDir:  "testdata/publish/",
+		Environment: types.Mapping{},
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: "testdata/publish/compose-required-false.yaml",
+			},
+		},
+	})
+	assert.NilError(t, err)
+	project.ComposeFiles = []string{"testdata/publish/compose-required-false.yaml"}
+
+	service := &composeService{}
+	layers, err := service.createLayers(t.Context(), project, api.PublishOptions{
+		WithEnvironment: true,
+	})
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(layers), 2)
+
+	assert.Equal(t, layers[0].Annotations["com.docker.compose.file"], "compose-required-false.yaml")
+
+	assert.Equal(t, layers[1].MediaType, "application/vnd.docker.compose.envfile")
+
+	envFileHash := layers[1].Annotations["com.docker.compose.envfile"]
+	assert.Assert(t, len(envFileHash) > 0)
+	assert.Assert(t, envFileHash != "missing.env")
+}
+
+func Test_checkEnvironmentVariables_withRequiredFalse(t *testing.T) {
+	project := &types.Project{
+		Services: types.Services{
+			"test": {
+				Name: "test",
+				EnvFiles: []types.EnvFile{
+					{
+						Path:     "missing.env",
+						Required: false,
+					},
+					{
+						Path:     "existing.env", 
+						Required: true,
+					},
+				},
+			},
+			"test2": {
+				Name: "test2",
+				EnvFiles: []types.EnvFile{
+					{
+						Path:     "optional.env",
+						Required: false,
+					},
+				},
+			},
+		},
+	}
+
+	service := &composeService{}
+
+	err := service.checkEnvironmentVariables(project, api.PublishOptions{})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), `service "test" has env_file declared.`))
+	assert.Assert(t, !strings.Contains(err.Error(), `service "test2"`))
 }

--- a/pkg/compose/testdata/publish/compose-required-false.yaml
+++ b/pkg/compose/testdata/publish/compose-required-false.yaml
@@ -5,5 +5,7 @@ services:
     env_file:
       - path: missing.env
         required: false
+      - path: optional.env
+        required: false
       - path: existing.env
         required: true

--- a/pkg/compose/testdata/publish/compose-required-false.yaml
+++ b/pkg/compose/testdata/publish/compose-required-false.yaml
@@ -1,0 +1,9 @@
+name: test-required-false
+services:
+  test:
+    image: test
+    env_file:
+      - path: missing.env
+        required: false
+      - path: existing.env
+        required: true

--- a/pkg/compose/testdata/publish/existing.env
+++ b/pkg/compose/testdata/publish/existing.env
@@ -1,0 +1,1 @@
+EXISTING_VAR=value

--- a/pkg/compose/testdata/publish/optional.env
+++ b/pkg/compose/testdata/publish/optional.env
@@ -1,0 +1,1 @@
+OPTIONAL_VAR=value


### PR DESCRIPTION
**What I did**
Fixed docker compose publish command to respect `required: false` setting on env_file entries. Previously, the command would fail when optional env files were missing, even when explicitly marked as not required.

Changes made:
- Modified [checkForSensitiveData()](cci:1://file:///Users/makskozlov/GolandProjects/temp-scud/compose/pkg/compose/publish.go:427:0-480:1) to skip env files with `required: false`
- Updated [processFile()](cci:1://file:///Users/makskozlov/GolandProjects/temp-scud/compose/pkg/compose/publish.go:225:0-285:1) to only process required env files into publish layers  
- Fixed [checkEnvironmentVariables()](cci:1://file:///Users/makskozlov/GolandProjects/temp-scud/compose/pkg/compose/publish.go:353:0-379:1) to only consider required env files for environment warnings
- Added comprehensive tests to verify the fix works correctly

**Related issue**
fixes #13648

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**