### PR TITLE
Add AI-powered PR review workflow via docker/cagent-action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,44 @@
+name: PR Review
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# Serialize reviews per PR; do not cancel in-progress runs
+# so no review is silently dropped mid-execution.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    # Only run on the upstream repo (not forks) to prevent credential leaks.
+    # Skip draft PRs (ready_for_review will fire when promoted).
+    # Skip bot actors to avoid reviewing Dependabot and automation PRs.
+    # Require collaborator-level access for comment-triggered events.
+    # Only trigger on PR comments, not plain issue comments.
+    if: >-
+      github.repository == 'docker/compose' &&
+      (github.event_name != 'pull_request_target' || github.event.pull_request.draft == false) &&
+      (github.event_name == 'pull_request_target' ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+       (github.event_name == 'pull_request_review_comment' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))) &&
+      !endsWith(github.actor, '[bot]')
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@3a12dbd0c6cd7dda3d4e05f24f0143c9701456de # v1.2.13
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CAGENT_ORG_MEMBERSHIP_TOKEN: ${{ secrets.CAGENT_ORG_MEMBERSHIP_TOKEN }}
+      CAGENT_REVIEWER_APP_ID: ${{ secrets.CAGENT_REVIEWER_APP_ID }}
+      CAGENT_REVIEWER_APP_PRIVATE_KEY: ${{ secrets.CAGENT_REVIEWER_APP_PRIVATE_KEY }}
+    permissions:
+      contents: read       # to fetch code
+      pull-requests: write # to post review comments
+      issues: write        # to reply to issue/PR comments
+      checks: write        # to update check statuses


### PR DESCRIPTION
**What I did**
  Introduce a GitHub Actions workflow that triggers an AI-powered code
  review on pull requests using docker/cagent-action's reusable workflow.

  - Restrict comment-triggered runs to OWNER/MEMBER/COLLABORATOR
  - Gate on github.repository to prevent execution on forks
  - Filter out draft PRs and bot actors
  - Only trigger on PR comments, not plain issue comments
  - Serialize reviews per PR via concurrency group

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="2688" height="1792" alt="image" src="https://github.com/user-attachments/assets/5489dcb3-0a97-4c85-ae0f-628ce1af8265" />


#BackInTheGame 🐙 