### PR TITLE
update cagent-action to latest (with better permissions)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -8,7 +8,7 @@ on:
     types: [ready_for_review, opened]
 
 permissions:
-  contents: read # Required at top-level to give `issue_comment` events access to the secrets below.
+  contents: read # Required at top level so `GITHUB_TOKEN` for `issue_comment` events can read repository contents.
 
 jobs:
   review:


### PR DESCRIPTION
**What I did**

Upgrade `docker/cagent-action` from v1.2.13 to v1.3.1 and simplify the PR review workflow.

Key changes:
- **Bump cagent-action ref** to `dba0ca51…@v1.3.1`, which handles filtering logic (draft PRs, bot actors, collaborator checks) internally — removing ~20 lines of hand-rolled `if` conditions from the workflow.
- **Switch trigger from `pull_request_target` to `pull_request`** — the new action version manages fork PR security itself, so `pull_request_target` is no longer needed. Fork PRs can still be reviewed via the `/review` comment command.
- **Add top-level `permissions: contents: read`** so `issue_comment`-triggered runs can access secrets, and scope remaining permissions to the `review` job to follow least-privilege.
- **Remove `concurrency` block** — the updated action handles review serialization internally.
- **Add inline comments** on secrets and triggers for easier onboarding.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Closes: https://github.com/docker/gordon/issues/272

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

🤖🐙 *(an AI octopus reviewing pull requests)*