### PR TITLE
fix: preserve ssh:// URL scheme when resolving Dockerfile path

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -550,7 +550,11 @@ func dockerFilePath(ctxName string, dockerfile string) string {
 	if dockerfile == "" {
 		return ""
 	}
-	if contextType, _ := build.DetectContextType(ctxName); contextType == build.ContextTypeGit {
+	contextType, _ := build.DetectContextType(ctxName)
+	if contextType == build.ContextTypeGit || contextType == build.ContextTypeRemote {
+		return dockerfile
+	}
+	if strings.Contains(ctxName, "://") {
 		return dockerfile
 	}
 	if !filepath.IsAbs(dockerfile) {

--- a/pkg/compose/build_test.go
+++ b/pkg/compose/build_test.go
@@ -24,6 +24,58 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func Test_dockerFilePath(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctxName    string
+		dockerfile string
+		expected   string
+	}{
+		{
+			name:       "empty dockerfile",
+			ctxName:    "/some/local/dir",
+			dockerfile: "",
+			expected:   "",
+		},
+		{
+			name:       "local dir with relative dockerfile",
+			ctxName:    "/some/local/dir",
+			dockerfile: "Dockerfile",
+			expected:   "/some/local/dir/Dockerfile",
+		},
+		{
+			name:       "local dir with absolute dockerfile",
+			ctxName:    "/some/local/dir",
+			dockerfile: "/absolute/path/Dockerfile",
+			expected:   "/absolute/path/Dockerfile",
+		},
+		{
+			name:       "ssh URL preserves double slash",
+			ctxName:    "ssh://git@github.com:22/docker/welcome-to-docker.git",
+			dockerfile: "Dockerfile",
+			expected:   "Dockerfile",
+		},
+		{
+			name:       "git:// URL returns dockerfile as-is",
+			ctxName:    "git://github.com/docker/compose.git",
+			dockerfile: "Dockerfile",
+			expected:   "Dockerfile",
+		},
+		{
+			name:       "https git URL returns dockerfile as-is",
+			ctxName:    "https://github.com/docker/compose.git",
+			dockerfile: "Dockerfile",
+			expected:   "Dockerfile",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := dockerFilePath(tt.ctxName, tt.dockerfile)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func Test_addBuildDependencies(t *testing.T) {
 	project := &types.Project{Services: types.Services{
 		"test": types.ServiceConfig{


### PR DESCRIPTION
- fixes #13668

When using an `ssh://` URL as build context, `filepath.Join` was silently collapsing the double slash into a single one (`ssh://` → `ssh:/`), making buildx unable to locate the Dockerfile. The fix returns the Dockerfile name as-is for any context containing a URL scheme (`://`), since buildx already knows how to resolve it relative to the remote context - the same way we already handle `git://` and `https://` contexts. Fix for the bug #13668.