### PR TITLE
fix: return clear error when COMPOSE_FILE points to a directory

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -298,11 +298,43 @@ func (o *ProjectOptions) ToModel(ctx context.Context, dockerCli command.Cli, ser
 		return nil, err
 	}
 
+	if err := checkConfigPathsNotDirectories(options.ConfigPaths, remotes); err != nil {
+		return nil, err
+	}
+
 	if o.Compatibility || utils.StringToBool(options.Environment[ComposeCompatibility]) {
 		api.Separator = "_"
 	}
 
 	return options.LoadModel(ctx)
+}
+
+// checkConfigPathsNotDirectories returns an error if any local config path is a
+// directory rather than a file. Remote resource paths and stdin ("-") are skipped.
+//
+// This guards against COMPOSE_FILE being set to a directory (e.g. COMPOSE_FILE=""
+// which filepath.Abs resolves to the working directory).
+func checkConfigPathsNotDirectories(configPaths []string, remoteLoaders []loader.ResourceLoader) error {
+	for _, configPath := range configPaths {
+		if configPath == "-" {
+			continue
+		}
+		isRemote := false
+		for _, r := range remoteLoaders {
+			if r.Accept(configPath) {
+				isRemote = true
+				break
+			}
+		}
+		if isRemote {
+			continue
+		}
+		if info, err := os.Stat(configPath); err == nil && info.IsDir() {
+			return fmt.Errorf("path %q is a directory, not a Compose file; "+
+				"check the COMPOSE_FILE environment variable or the -f flag", configPath)
+		}
+	}
+	return nil
 }
 
 // ToProject loads a Compose project using the LoadProject API.

--- a/pkg/compose/loader.go
+++ b/pkg/compose/loader.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -31,6 +32,36 @@ import (
 	"github.com/docker/compose/v5/pkg/utils"
 )
 
+// checkConfigPathsForDirectories returns an error if any config path in configPaths
+// is a local directory instead of a file. Remote paths (accepted by remoteLoaders)
+// and the special "-" (stdin) value are skipped.
+//
+// This provides a clear error when COMPOSE_FILE is set to a directory path (e.g.,
+// "COMPOSE_FILE=" resolves to the working directory via filepath.Abs("")).
+func checkConfigPathsForDirectories(configPaths []string, remoteLoaders []loader.ResourceLoader) error {
+	for _, configPath := range configPaths {
+		if configPath == "-" {
+			continue
+		}
+		isRemote := false
+		for _, r := range remoteLoaders {
+			if r.Accept(configPath) {
+				isRemote = true
+				break
+			}
+		}
+		if isRemote {
+			continue
+		}
+		info, err := os.Stat(configPath)
+		if err == nil && info.IsDir() {
+			return fmt.Errorf("path %q is a directory, not a Compose file; "+
+				"check the COMPOSE_FILE environment variable or the -f flag", configPath)
+		}
+	}
+	return nil
+}
+
 // LoadProject implements api.Compose.LoadProject
 // It loads and validates a Compose project from configuration files.
 func (s *composeService) LoadProject(ctx context.Context, options api.ProjectLoadOptions) (*types.Project, error) {
@@ -39,6 +70,10 @@ func (s *composeService) LoadProject(ctx context.Context, options api.ProjectLoa
 
 	projectOptions, err := s.buildProjectOptions(options, remoteLoaders)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := checkConfigPathsForDirectories(projectOptions.ConfigPaths, remoteLoaders); err != nil {
 		return nil, err
 	}
 

--- a/pkg/compose/loader_test.go
+++ b/pkg/compose/loader_test.go
@@ -320,3 +320,25 @@ func TestLoadProject_MissingComposeFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, project)
 }
+
+func TestLoadProject_DirectoryAsComposeFile(t *testing.T) {
+	// Reproduce the misleading error described in https://github.com/docker/compose/issues/13649:
+	// when COMPOSE_FILE is set to a directory (e.g. COMPOSE_FILE="" resolves to the working
+	// directory via filepath.Abs("")), the error "read <dir>: is a directory" was shown.
+	// The fix should return a clear error message instead.
+	tmpDir := t.TempDir()
+
+	service, err := NewComposeService(nil)
+	require.NoError(t, err)
+
+	project, err := service.LoadProject(t.Context(), api.ProjectLoadOptions{
+		ConfigPaths: []string{tmpDir},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, project)
+	assert.Contains(t, err.Error(), "is a directory")
+	assert.Contains(t, err.Error(), "Compose file")
+	// Ensure the old opaque error message is NOT present
+	assert.NotContains(t, err.Error(), "read "+tmpDir+": is a directory")
+}


### PR DESCRIPTION
## What does this PR fix?

Fixes #13649

When `COMPOSE_FILE` is set to an empty string (or any value that resolves to a directory via `filepath.Abs`), running `docker compose up -d` produces the cryptic OS-level error:

```
read <path>: is a directory
```

This happens because `compose-go`'s `ReadConfigFiles` calls `os.ReadFile` on the resolved path, which returns `EISDIR` when the path is a directory. The error surfaced as a raw syscall message with no guidance for the user.

## What changed?

Added an explicit pre-check in two places that are responsible for loading project config:

- **`pkg/compose/loader.go`** – in `LoadProject`, before delegating to `compose-go`
- **`cmd/compose/compose.go`** – in `ToModel`, used by commands like `docker compose config`

The check iterates the resolved `ConfigPaths` and, for any path that is not stdin (`-`) or a remote resource (git/OCI), verifies it is not a directory. If it is, a clear actionable error is returned:

```
path "<path>" is a directory, not a Compose file; check the COMPOSE_FILE environment variable or the -f flag
```

## Testing

- Added unit test `TestLoadProject_DirectoryAsComposeFile` in `pkg/compose/loader_test.go` that:
  - passes a temp directory as a config path
  - asserts the new human-readable error is returned
  - asserts the old `read <path>: is a directory` message is **not** present
- All existing `TestLoadProject_*` tests continue to pass
- Linted with `golangci-lint v2.11.3` (project-pinned version) – **0 issues**

## Before / After

| Scenario | Before | After |
|---|---|---|
| `COMPOSE_FILE=""` in empty dir | `read /path/to/dir: is a directory` | `path "/path/to/dir" is a directory, not a Compose file; check the COMPOSE_FILE environment variable or the -f flag` |
| `docker compose -f /some/dir up` | same cryptic error | same clear error |
| Normal empty dir (no config) | `no configuration file provided: not found` | unchanged |