### PR TITLE
fix: initialize and pass envFiles map in processExtends

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -197,8 +197,9 @@ func (s *composeService) createLayers(ctx context.Context, project *types.Projec
 func processExtends(ctx context.Context, project *types.Project, extFiles map[string]string) ([]v1.Descriptor, error) {
 	var layers []v1.Descriptor
 	moreExtFiles := map[string]string{}
+	envFiles := map[string]string{}
 	for xf, hash := range extFiles {
-		data, err := processFile(ctx, xf, project, moreExtFiles, nil)
+		data, err := processFile(ctx, xf, project, moreExtFiles, envFiles)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Title:** fix: initialize envFiles map in processExtends to handle env_file during publish

**Description:**

**What I did**

Initialize `envFiles` as an empty map in `processExtends` and pass it to `processFile` instead of `nil`.

**Why**

When running `docker compose publish` on a project that uses `extends` with services referencing `env_file`, `processFile` attempts to assign entries into the `envFiles` map. Since `nil` was passed, this caused a panic:
```
panic: assignment to entry in nil map
goroutine 1 [running]:
github.com/docker/compose/v5/pkg/compose.processFile(...)
    github.com/docker/compose/v5/pkg/compose/publish.go:255 +0x651
```
Fixes #13671 