### PR TITLE
Skip PR review workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,6 +12,10 @@ permissions:
 
 jobs:
   review:
+    if: >-
+      github.event_name == 'issue_comment' ||
+      github.event_name == 'pull_request_review_comment' ||
+      github.event.pull_request.user.login != 'dependabot[bot]'
     uses: docker/cagent-action/.github/workflows/review-pr.yml@dba0ca51938c78afb363625363c50582243218d6 # v1.3.1
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:


### PR DESCRIPTION
**What I did**
Dependabot PRs don't have access to the secrets required by the cagent-action reusable workflow, causing the org membership check to fail with "github-token not supplied".

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
