### PR TITLE
Fix publish short-form port mappings

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -477,7 +477,7 @@ func composeFileAsByteReader(ctx context.Context, filePath string, project *type
 	if err != nil {
 		return nil, fmt.Errorf("failed to open compose file %s: %w", filePath, err)
 	}
-	model, err := loader.LoadModelWithContext(ctx, types.ConfigDetails{
+	configDetails := types.ConfigDetails{
 		WorkingDir:  project.WorkingDir,
 		Environment: project.Environment,
 		ConfigFiles: []types.ConfigFile{
@@ -486,18 +486,29 @@ func composeFileAsByteReader(ctx context.Context, filePath string, project *type
 				Content:  composeFile,
 			},
 		},
-	}, func(options *loader.Options) {
+	}
+	loadOptions := func(options *loader.Options) {
 		options.SkipValidation = true
 		options.SkipExtends = true
 		options.SkipConsistencyCheck = true
 		options.ResolvePaths = true
 		options.SkipInterpolation = true
 		options.SkipResolveEnvironment = true
-	})
+	}
+
+	base, err := loader.LoadWithContext(ctx, configDetails, loadOptions)
+	if err == nil {
+		in, err := base.MarshalYAML()
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewBuffer(in), nil
+	}
+
+	model, err := loader.LoadModelWithContext(ctx, configDetails, loadOptions)
 	if err != nil {
 		return nil, err
 	}
-
 	in, err := yaml.Marshal(model)
 	if err != nil {
 		return nil, err

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -184,12 +184,12 @@ func (s *composeService) createLayers(ctx context.Context, project *types.Projec
 	}
 
 	if options.ResolveImageDigests {
-		yaml, err := s.generateImageDigestsOverride(ctx, project)
+		overrideYAML, err := s.generateImageDigestsOverride(ctx, project)
 		if err != nil {
 			return nil, err
 		}
 
-		layerDescriptor := oci.DescriptorForComposeFile("image-digests.yaml", yaml)
+		layerDescriptor := oci.DescriptorForComposeFile("image-digests.yaml", overrideYAML)
 		layers = append(layers, layerDescriptor)
 	}
 	return layers, nil

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -438,6 +438,39 @@ func (s *composeService) checkForSensitiveData(ctx context.Context, project *typ
 		allFindings = append(allFindings, findings...)
 	}
 	for _, service := range project.Services {
+		if len(service.Environment) == 0 {
+			continue
+		}
+
+		environment := map[string]string{}
+		for key, value := range service.Environment {
+			if value == nil {
+				continue
+			}
+			environment[key] = *value
+		}
+		if len(environment) == 0 {
+			continue
+		}
+
+		in, err := yaml.Marshal(map[string]any{
+			"services": map[string]any{
+				service.Name: map[string]any{
+					"environment": environment,
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		findings, err := scan.ScanReader(bytes.NewReader(in))
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan environment for service %s: %w", service.Name, err)
+		}
+		allFindings = append(allFindings, findings...)
+	}
+	for _, service := range project.Services {
 		// Check env files
 		for _, envFile := range service.EnvFiles {
 			findings, err := scan.ScanFile(envFile.Path)
@@ -478,7 +511,7 @@ func composeFileAsByteReader(ctx context.Context, filePath string, project *type
 	if err != nil {
 		return nil, fmt.Errorf("failed to open compose file %s: %w", filePath, err)
 	}
-	configDetails := types.ConfigDetails{
+	model, err := loader.LoadModelWithContext(ctx, types.ConfigDetails{
 		WorkingDir:  project.WorkingDir,
 		Environment: project.Environment,
 		ConfigFiles: []types.ConfigFile{
@@ -487,26 +520,14 @@ func composeFileAsByteReader(ctx context.Context, filePath string, project *type
 				Content:  composeFile,
 			},
 		},
-	}
-	loadOptions := func(options *loader.Options) {
+	}, func(options *loader.Options) {
 		options.SkipValidation = true
 		options.SkipExtends = true
 		options.SkipConsistencyCheck = true
 		options.ResolvePaths = true
 		options.SkipInterpolation = true
 		options.SkipResolveEnvironment = true
-	}
-
-	base, err := loader.LoadWithContext(ctx, configDetails, loadOptions)
-	if err == nil {
-		in, err := base.MarshalYAML()
-		if err != nil {
-			return nil, err
-		}
-		return bytes.NewBuffer(in), nil
-	}
-
-	model, err := loader.LoadModelWithContext(ctx, configDetails, loadOptions)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -36,6 +36,7 @@ import (
 	"github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/docker/compose/v5/internal/oci"
 	"github.com/docker/compose/v5/pkg/api"
@@ -476,7 +477,7 @@ func composeFileAsByteReader(ctx context.Context, filePath string, project *type
 	if err != nil {
 		return nil, fmt.Errorf("failed to open compose file %s: %w", filePath, err)
 	}
-	base, err := loader.LoadWithContext(ctx, types.ConfigDetails{
+	model, err := loader.LoadModelWithContext(ctx, types.ConfigDetails{
 		WorkingDir:  project.WorkingDir,
 		Environment: project.Environment,
 		ConfigFiles: []types.ConfigFile{
@@ -497,7 +498,7 @@ func composeFileAsByteReader(ctx context.Context, filePath string, project *type
 		return nil, err
 	}
 
-	in, err := base.MarshalYAML()
+	in, err := yaml.Marshal(model)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compose/publish_test.go
+++ b/pkg/compose/publish_test.go
@@ -17,6 +17,8 @@
 package compose
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -99,4 +101,32 @@ services:
 	assert.DeepEqual(t, expectedLayers, layers, cmp.FilterPath(func(path cmp.Path) bool {
 		return !slices.Contains([]string{".Data", ".Digest", ".Size"}, path.String())
 	}, cmp.Ignore()))
+}
+
+func TestComposeFileAsByteReaderWithShortFormPortsAndInterpolation(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	err := os.WriteFile(composePath, []byte(`name: publish-test
+services:
+  whoami:
+    image: docker.io/traefik/whoami:v1.11
+    ports:
+      - ${DASHBOARD_PORT:-3000}:3000
+`), 0o600)
+	assert.NilError(t, err)
+
+	project, err := loader.LoadWithContext(t.Context(), types.ConfigDetails{
+		WorkingDir: dir,
+		Environment: types.Mapping{
+			"DASHBOARD_PORT": "",
+		},
+		ConfigFiles: []types.ConfigFile{
+			{Filename: composePath},
+		},
+	})
+	assert.NilError(t, err)
+
+	reader, err := composeFileAsByteReader(t.Context(), composePath, project)
+	assert.NilError(t, err)
+	assert.Assert(t, reader != nil)
 }

--- a/pkg/e2e/publish_test.go
+++ b/pkg/e2e/publish_test.go
@@ -18,6 +18,8 @@ package e2e
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -55,6 +57,23 @@ or remove sensitive data from your Compose configuration
 
 	t.Run("publish success env_file", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/publish/compose-env-file.yml",
+			"-p", projectName, "publish", "test/test", "--with-env", "-y", "--dry-run")
+		assert.Assert(t, strings.Contains(res.Combined(), "test/test publishing"), res.Combined())
+		assert.Assert(t, strings.Contains(res.Combined(), "test/test published"), res.Combined())
+	})
+
+	t.Run("publish success short-form port mapping", func(t *testing.T) {
+		dir := t.TempDir()
+		composePath := filepath.Join(dir, "compose-short-port.yml")
+		err := os.WriteFile(composePath, []byte(`services:
+  whoami:
+    image: docker.io/traefik/whoami:v1.11
+    ports:
+      - ${DASHBOARD_PORT:-3000}:3000
+`), 0o600)
+		assert.NilError(t, err)
+
+		res := c.RunDockerComposeCmd(t, "-f", composePath,
 			"-p", projectName, "publish", "test/test", "--with-env", "-y", "--dry-run")
 		assert.Assert(t, strings.Contains(res.Combined(), "test/test publishing"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Combined(), "test/test published"), res.Combined())


### PR DESCRIPTION
**What I did**

Fixed `docker compose publish` so it works with short-form port mappings like `${DASHBOARD_PORT:-3000}:3000`.

The issue was in the publish scan path. It was loading a non-interpolated Compose file back into `types.Project`, and that caused short-form port entries to fail decoding. This change keeps that path as raw YAML model data instead.

I also added:
- a unit test for this case in `pkg/compose/publish_test.go`
- an e2e regression test in `pkg/e2e/publish_test.go`

**Related issue**

Fixes #13672

**(not mandatory) A picture of a cute animal, if possible in relation to what you did)**
