### PR TITLE
pkg/compose: fix TestRunHook_ConsoleSize on macOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/containerd/containerd/v2 v2.2.2
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/platforms v1.0.0-rc.3
+	github.com/creack/pty v1.1.24
 	github.com/distribution/reference v0.6.0
 	github.com/docker/buildx v0.31.1
 	github.com/docker/cli v29.2.1+incompatible

--- a/pkg/compose/hook_test.go
+++ b/pkg/compose/hook_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/containerd/console"
+	"github.com/creack/pty"
 	"github.com/docker/cli/cli/streams"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -67,16 +67,14 @@ func TestRunHook_ConsoleSize(t *testing.T) {
 
 			// Create a PTY so GetTtySize() returns real non-zero dimensions,
 			// simulating an interactive terminal session.
-			pty, slavePath, err := console.NewPty()
+			ptmx, tty, err := pty.Open()
 			assert.NilError(t, err)
-			defer pty.Close() //nolint:errcheck
-			assert.NilError(t, pty.Resize(console.WinSize{Height: 24, Width: 80}))
-
-			slaveFile, err := os.OpenFile(slavePath, os.O_RDWR, 0)
-			assert.NilError(t, err)
-			defer slaveFile.Close() //nolint:errcheck
-
-			mockCli.EXPECT().Out().Return(streams.NewOut(slaveFile)).AnyTimes()
+			t.Cleanup(func() {
+				_ = ptmx.Close()
+				_ = tty.Close()
+			})
+			assert.NilError(t, pty.Setsize(ptmx, &pty.Winsize{Rows: 24, Cols: 80}))
+			mockCli.EXPECT().Out().Return(streams.NewOut(tty)).AnyTimes()
 
 			service := types.ServiceConfig{
 				Name: "test",


### PR DESCRIPTION
relates to:

- https://github.com/containerd/console/issues/79
- https://github.com/containerd/console/pull/80

containerd/console is broken on macOS, and panics; use creack/pty instead for this test.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
