### PR TITLE
feat: support long syntax for image names and build tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,6 +147,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+replace github.com/compose-spec/compose-go/v2 => github.com/ssam18/compose-go/v2 v2.10.1-0.20260403150144-9520977b355e
+
 exclude (
 	// FIXME(thaJeztah): remove this once kubernetes updated their dependencies to no longer need this.
 	//

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.10.1 h1:mFbXobojGRFIVi1UknrvaDAZ+PkJfyjqkA1yseh+vAU=
-github.com/compose-spec/compose-go/v2 v2.10.1/go.mod h1:Ohac1SzhO/4fXXrzWIztIVB6ckmKBv1Nt5Z5mGVESUg=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
@@ -343,6 +341,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/ssam18/compose-go/v2 v2.10.1-0.20260403150144-9520977b355e h1:cEGBnX0T7lYq9QboJwmnxj6M5zk1H+KFqdBQsXQ2GNg=
+github.com/ssam18/compose-go/v2 v2.10.1-0.20260403150144-9520977b355e/go.mod h1:Ohac1SzhO/4fXXrzWIztIVB6ckmKBv1Nt5Z5mGVESUg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/compose/loader_test.go
+++ b/pkg/compose/loader_test.go
@@ -286,6 +286,70 @@ services:
 	api.Separator = "-"
 }
 
+func TestLoadProject_ImageLongSyntax(t *testing.T) {
+	tmpDir := t.TempDir()
+	composeFile := filepath.Join(tmpDir, "compose.yaml")
+	composeContent := `
+name: test-project
+services:
+  web:
+    image:
+      name: nginx
+      tag: "1.25"
+    build:
+      context: .
+      tags:
+        - name: nginx
+          tag: "1.25"
+        - name: nginx
+          tag: latest
+        - nginx:stable
+`
+	err := os.WriteFile(composeFile, []byte(composeContent), 0o644)
+	assert.NilError(t, err)
+
+	service, err := NewComposeService(nil)
+	assert.NilError(t, err)
+
+	project, err := service.LoadProject(t.Context(), api.ProjectLoadOptions{
+		ConfigPaths: []string{composeFile},
+	})
+	assert.NilError(t, err)
+
+	webService := project.Services["web"]
+	assert.Equal(t, "nginx:1.25", webService.Image)
+	assert.Check(t, is.Len(webService.Build.Tags, 3))
+	assert.Equal(t, "nginx:1.25", webService.Build.Tags[0])
+	assert.Equal(t, "nginx:latest", webService.Build.Tags[1])
+	assert.Equal(t, "nginx:stable", webService.Build.Tags[2])
+}
+
+func TestLoadProject_ImageLongSyntaxDigest(t *testing.T) {
+	tmpDir := t.TempDir()
+	composeFile := filepath.Join(tmpDir, "compose.yaml")
+	composeContent := `
+name: test-project
+services:
+  web:
+    image:
+      name: nginx
+      digest: sha256:abc123
+`
+	err := os.WriteFile(composeFile, []byte(composeContent), 0o644)
+	assert.NilError(t, err)
+
+	service, err := NewComposeService(nil)
+	assert.NilError(t, err)
+
+	project, err := service.LoadProject(t.Context(), api.ProjectLoadOptions{
+		ConfigPaths: []string{composeFile},
+	})
+	assert.NilError(t, err)
+
+	webService := project.Services["web"]
+	assert.Equal(t, "nginx@sha256:abc123", webService.Image)
+}
+
 func TestLoadProject_InvalidComposeFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	composeFile := filepath.Join(tmpDir, "compose.yaml")


### PR DESCRIPTION
Users can now write `image` as a map with `name`, `tag`, and `digest` fields instead of a plain string. The same long syntax works for entries in `build.tags`, so a single YAML anchor can drive both the service image and the build tags without string interpolation tricks.

The core parsing changes live in compose-spec/compose-go (see ssam18/compose-go feat/image-long-syntax); this PR wires in that dependency and adds loader-level tests. Once the upstream compose-go PR is merged and released, the replace directive here will be swapped for a normal version bump.

**Example usage:**
```yaml
x-version: &version 1.0.0

services:
  my:
    image:
      name: myimage
      tag: *version
    build:
      context: .
      args:
        VERSION: *version
      tags:
        - name: myimage
          tag: *version
        - name: myimage
          tag: latest
```