### PR TITLE
build and push Docker Desktop module image on release

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -110,6 +110,33 @@ jobs:
           username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
           password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
+  module-image:
+    uses: docker/github-builder/.github/workflows/bake.yml@70313223e2665c3211b454b3fea6534624e78d64 # v1.4.0
+    permissions:
+      contents: read # same as global permission
+      id-token: write # for signing attestation(s) with GitHub OIDC Token
+    with:
+      runner: amd64
+      target: image-module-cross
+      cache: true
+      cache-scope: module-image
+      output: image
+      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      sbom: true
+      provenance: true
+      set-meta-labels: true
+      meta-images: |
+        docker/compose-desktop-module
+      meta-tags: |
+        type=ref,event=branch
+        type=ref,event=tag
+      meta-bake-target: meta-helper
+    secrets:
+      registry-auths: |
+        - registry: docker.io
+          username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+
   desktop-edge-test:
     runs-on: ubuntu-latest
     needs: bin-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,3 +195,16 @@ RUN --mount=from=binary \
 
 FROM scratch AS release
 COPY --from=releaser /out/ /
+
+FROM --platform=$BUILDPLATFORM alpine AS module-releaser
+WORKDIR /work
+ARG TARGETOS
+RUN --mount=from=binary \
+    mkdir -p /cli-plugins/compose/$TARGETOS && \
+    cp docker-compose* "/cli-plugins/compose/$TARGETOS/docker-compose$(ls docker-compose* | sed -e 's/^docker-compose//')"
+
+FROM scratch AS module
+ARG TARGETOS
+COPY --from=module-releaser /cli-plugins/compose/$TARGETOS /cli-plugins/compose/$TARGETOS
+COPY ./desktop-module/module-metadata.json /
+COPY LICENSE /

--- a/desktop-module/module-metadata.json
+++ b/desktop-module/module-metadata.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "content": [
+    {
+      "type": "cli-plugin",
+      "name": "compose"
+    }
+  ]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -146,3 +146,17 @@ target "image-cross" {
   inherits = ["meta-helper", "binary-cross"]
   output = ["type=image"]
 }
+
+target "image-module-cross" {
+  inherits = ["meta-helper", "binary-cross"]
+  target = "module"
+  output = ["type=image"]
+  platforms = [
+    "darwin/amd64",
+    "darwin/arm64",
+    "linux/amd64",
+    "linux/arm64",
+    "windows/amd64",
+    "windows/arm64",
+  ]
+}


### PR DESCRIPTION
**What I did**
Add workflow to build and push docker/compose-desktop-module image to Docker Hub on version tag push, used by Docker Desktop's update system to deliver the Compose CLI plugin.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6aade29a-f05e-4154-b5cc-b933f4dae4a4" />
