### PR TITLE
docs(security): fix typo "docs" -> "does" in SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -37,7 +37,7 @@ offer a paid security bounty program at this time.
 
 ## Supported Versions
 
-This project docs not provide long-term supported versions, and only the current
+This project does not provide long-term supported versions, and only the current
 release and `main` branch are actively maintained. Docker Compose v1, and the
 corresponding [v1 branch](https://github.com/docker/compose/tree/v1) reached
 EOL and are no longer supported. 


### PR DESCRIPTION
`.github/SECURITY.md` had "This project docs not provide long-term supported versions..." — `docs` should be `does`.

Closes #13729