### PR TITLE
ci: remove unused e2e job from merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,62 +18,6 @@ env:
   REPO_SLUG: "docker/compose-bin"
 
 jobs:
-  e2e:
-    name: Build and test
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [desktop-windows, desktop-macos, desktop-m1]
-        # mode: [plugin, standalone]
-        mode: [plugin]
-    env:
-      GO111MODULE: "on"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
-        with:
-          go-version-file: '.go-version'
-          cache: true
-          check-latest: true
-
-      - name: List Docker resources on machine
-        run: |
-          docker ps --all
-          docker volume ls
-          docker network ls
-          docker image ls
-      - name: Remove Docker resources on machine
-        continue-on-error: true
-        run: |
-          docker kill $(docker ps -q)
-          docker rm -f $(docker ps -aq)
-          docker volume rm -f $(docker volume ls -q)
-          docker ps --all
-
-      - name: Unit tests
-        run: make test
-
-      - name: Build binaries
-        run: |
-          make
-      - name: Check arch of go compose binary
-        run: |
-          file ./bin/build/docker-compose
-        if: ${{ !contains(matrix.os, 'desktop-windows') }}
-      -
-        name: Test plugin mode
-        if: ${{ matrix.mode == 'plugin' }}
-        run: |
-          make e2e-compose
-      -
-        name: Test standalone mode
-        if: ${{ matrix.mode == 'standalone' }}
-        run: |
-          make e2e-compose-standalone
-
   bin-image-prepare:
     runs-on: ubuntu-24.04
     outputs:


### PR DESCRIPTION
**What I did**
The e2e job targets desktop runners (desktop-windows, desktop-macos, desktop-m1) that are not configured anymore for this project.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1260" height="833" alt="image" src="https://github.com/user-attachments/assets/367b133a-6026-420d-9fb6-6cf36e19956d" />
