### PR TITLE
Change verb tense in Docker Compose reference documentation

### DIFF
--- a/docs/reference/compose_exec.md
+++ b/docs/reference/compose_exec.md
@@ -7,7 +7,7 @@ With this subcommand, you can run arbitrary commands in your services. Commands 
 you can use a command such as `docker compose exec web sh` to get an interactive prompt.
 
 By default, Compose will enter container in interactive mode and allocate a TTY, while the equivalent `docker exec`
-command requires passing `--interactive --tty` flags to get the same behavior. Compose also support those two flags
+command requires passing `--interactive --tty` flags to get the same behavior. Compose also supports those two flags
 to offer a smooth migration between commands, whenever they are no-op by default. Still, `interactive` can be used to
 force disabling interactive mode (`--interactive=false`), typically when `docker compose exec` command is used inside
 a script.
@@ -35,8 +35,8 @@ This is the equivalent of `docker exec` targeting a Compose service.
 With this subcommand, you can run arbitrary commands in your services. Commands allocate a TTY by default, so
 you can use a command such as `docker compose exec web sh` to get an interactive prompt.
 
-By default, Compose will enter container in interactive mode and allocate a TTY, while the equivalent `docker exec` 
-command requires passing `--interactive --tty` flags to get the same behavior. Compose also support those two flags
-to offer a smooth migration between commands, whenever they are no-op by default. Still, `interactive` can be used to 
-force disabling interactive mode (`--interactive=false`), typically when `docker compose exec` command is used inside 
+By default, Compose will enter container in interactive mode and allocate a TTY, while the equivalent `docker exec`
+command requires passing `--interactive --tty` flags to get the same behavior. Compose also supports those two flags
+to offer a smooth migration between commands, whenever they are no-op by default. Still, `interactive` can be used to
+force disabling interactive mode (`--interactive=false`), typically when `docker compose exec` command is used inside
 a script.

--- a/docs/reference/docker_compose_exec.yaml
+++ b/docs/reference/docker_compose_exec.yaml
@@ -7,7 +7,7 @@ long: |-
     you can use a command such as `docker compose exec web sh` to get an interactive prompt.
 
     By default, Compose will enter container in interactive mode and allocate a TTY, while the equivalent `docker exec`
-    command requires passing `--interactive --tty` flags to get the same behavior. Compose also support those two flags
+    command requires passing `--interactive --tty` flags to get the same behavior. Compose also supports those two flags
     to offer a smooth migration between commands, whenever they are no-op by default. Still, `interactive` can be used to
     force disabling interactive mode (`--interactive=false`), typically when `docker compose exec` command is used inside
     a script.


### PR DESCRIPTION
**What I did**

This pull requests changes the verb tense in the documentation of the Docker docker compose exec and Compose compose exec commands.