### PR TITLE
ci: upgrade cagent-action to v1.4.3 with OIDC-based credential fetching

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -8,7 +8,7 @@ on:
     types: [ready_for_review, opened]
 
 permissions:
-  contents: read # Required at top level so `GITHUB_TOKEN` for `issue_comment` events can read repository contents.
+  contents: read
 
 jobs:
   review:
@@ -16,15 +16,12 @@ jobs:
       github.event_name == 'issue_comment' ||
       github.event_name == 'pull_request_review_comment' ||
       github.event.pull_request.user.login != 'dependabot[bot]'
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@dba0ca51938c78afb363625363c50582243218d6 # v1.3.1
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@ec4865576952df6285652f2cf8ffb4ad45ff5f80 # v1.4.3
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read       # Read repository files and PR diffs
       pull-requests: write # Post review comments and approve/request changes
       issues: write        # Create security incident issues if secrets are detected in output
       checks: write        # (Optional) Show review progress as a check run on the PR
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      CAGENT_ORG_MEMBERSHIP_TOKEN: ${{ secrets.CAGENT_ORG_MEMBERSHIP_TOKEN }}         # PAT with read:org scope; gates auto-reviews to org members only
-      CAGENT_REVIEWER_APP_ID: ${{ secrets.CAGENT_REVIEWER_APP_ID }}                   # GitHub App ID; reviews appear as your app instead of github-actions[bot]
-      CAGENT_REVIEWER_APP_PRIVATE_KEY: ${{ secrets.CAGENT_REVIEWER_APP_PRIVATE_KEY }} # GitHub App private key; paired with App ID above
+      id-token: write      # Fetch app credentials and org membership token via OIDC
+      actions: read        # Download artifacts across workflow_run boundaries


### PR DESCRIPTION
## Summary

- Bumps `docker/cagent-action` from `v1.3.1` → `v1.4.3` (pinned to `ec4865576952df6285652f2cf8ffb4ad45ff5f80`)
- Removes all explicitly passed secrets — `ANTHROPIC_API_KEY`, `CAGENT_ORG_MEMBERSHIP_TOKEN`, `CAGENT_REVIEWER_APP_ID`, and `CAGENT_REVIEWER_APP_PRIVATE_KEY` are all now fetched automatically inside the called workflow via OIDC from AWS Secrets Manager
- Adds `id-token: write` (required for the OIDC token exchange in `setup-credentials`) and `actions: read` (required for cross-`workflow_run` artifact download in the feedback loop), both scoped to the `review` job only
- Drops the now-empty `secrets:` block entirely

## Test plan

- [ ] Merge this PR and verify the next auto-review run on a new PR completes successfully (all credentials fetched via OIDC)
- [ ] Verify none of the removed secrets need to remain provisioned in this repo's secret store

> *PR description drafted by Claude Code.*