### PR TITLE
fix: do not add service name as alias on external networks

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -368,10 +368,13 @@ func (s *composeService) prepareContainerMACAddress(service types.ServiceConfig,
 	return nil
 }
 
-func getAliases(project *types.Project, service types.ServiceConfig, serviceIndex int, cfg *types.ServiceNetworkConfig, useNetworkAliases bool) []string {
+func getAliases(project *types.Project, service types.ServiceConfig, serviceIndex int, networkKey string, cfg *types.ServiceNetworkConfig, useNetworkAliases bool) []string {
 	aliases := []string{getContainerName(project.Name, service, serviceIndex)}
 	if useNetworkAliases {
-		aliases = append(aliases, service.Name)
+		// service name is not registered as an alias on external networks; see warnExternalNetworkAliases
+		if n := project.Networks[networkKey]; !n.External {
+			aliases = append(aliases, service.Name)
+		}
 		if cfg != nil {
 			aliases = append(aliases, cfg.Aliases...)
 		}
@@ -445,7 +448,7 @@ func createEndpointSettings(p *types.Project, service types.ServiceConfig, servi
 	}
 
 	return &network.EndpointSettings{
-		Aliases:     getAliases(p, service, serviceIndex, config, useNetworkAliases),
+		Aliases:     getAliases(p, service, serviceIndex, networkKey, config, useNetworkAliases),
 		Links:       links,
 		IPAddress:   ipv4Address,
 		IPv6Gateway: ipv6Address,

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -365,6 +365,26 @@ func TestCreateEndpointSettings(t *testing.T) {
 	}, cmpopts.EquateComparable(netip.Addr{})))
 }
 
+func TestCreateEndpointSettings_ExternalNetwork(t *testing.T) {
+	eps, err := createEndpointSettings(&composetypes.Project{
+		Name: "projName",
+		Networks: composetypes.Networks{
+			"netName": {External: true},
+		},
+	}, composetypes.ServiceConfig{
+		Name:          "serviceName",
+		ContainerName: "containerName",
+		Networks: map[string]*composetypes.ServiceNetworkConfig{
+			"netName": {
+				Aliases: []string{"alias1"},
+			},
+		},
+	}, 0, "netName", nil, true)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.DeepEqual(eps.Aliases, []string{"containerName", "alias1"}),
+		"service name must not be added as alias on external networks")
+}
+
 func Test_buildContainerVolumes(t *testing.T) {
 	pwd, err := os.Getwd()
 	assert.NilError(t, err)

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -42,6 +43,7 @@ import (
 )
 
 func (s *composeService) Up(ctx context.Context, project *types.Project, options api.UpOptions) error { //nolint:gocyclo
+	warnExternalNetworkAliases(project)
 	err := Run(ctx, tracing.SpanWrapFunc("project/up", tracing.ProjectOptions(ctx, project), func(ctx context.Context) error {
 		err := s.create(ctx, project, options.Create)
 		if err != nil {
@@ -313,4 +315,36 @@ func shouldFollowStartEvent(event api.ContainerEvent, attached []string, attachT
 		return false
 	}
 	return true
+}
+
+// warnExternalNetworkAliases emits one warning per external network the project is connected to, listing the services
+// whose service-name alias is intentionally not registered (see getAliases). Services that already include their own
+// name under the network's explicit aliases are excluded, so the warning disappears once the user adopts the
+// workaround. Must be called before Run() to avoid interleaving with the TUI progress display.
+func warnExternalNetworkAliases(project *types.Project) {
+	byNetwork := map[string][]string{}
+	for _, service := range project.Services {
+		for networkKey, cfg := range service.Networks {
+			n := project.Networks[networkKey]
+			if !n.External {
+				continue
+			}
+			if cfg != nil && slices.Contains(cfg.Aliases, service.Name) {
+				continue
+			}
+			byNetwork[networkKey] = append(byNetwork[networkKey], service.Name)
+		}
+	}
+	networks := make([]string, 0, len(byNetwork))
+	for k := range byNetwork {
+		networks = append(networks, k)
+	}
+	slices.Sort(networks)
+	for _, networkKey := range networks {
+		services := byNetwork[networkKey]
+		slices.Sort(services)
+		logrus.Warnf("service names [%s] not registered as aliases on external "+
+			"network %q; add them under each service's networks.%s.aliases if needed",
+			strings.Join(services, ", "), networkKey, networkKey)
+	}
 }

--- a/pkg/compose/up_test.go
+++ b/pkg/compose/up_test.go
@@ -17,8 +17,12 @@
 package compose
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 
 	"github.com/docker/compose/v5/pkg/api"
@@ -99,6 +103,135 @@ func TestShouldFollowStartEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := shouldFollowStartEvent(tt.event, tt.attached, tt.attachTo)
 			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestWarnExternalNetworkAliases(t *testing.T) {
+	tests := []struct {
+		name        string
+		project     *composetypes.Project
+		expected    []string
+		notExpected []string
+	}{
+		{
+			name: "internal-only network emits no warning",
+			project: &composetypes.Project{
+				Networks: composetypes.Networks{"internal": {}},
+				Services: composetypes.Services{
+					"web": {
+						Name:     "web",
+						Networks: map[string]*composetypes.ServiceNetworkConfig{"internal": nil},
+					},
+				},
+			},
+			notExpected: []string{"not registered as aliases"},
+		},
+		{
+			name: "external network emits one warning listing services in sorted order",
+			project: &composetypes.Project{
+				Networks: composetypes.Networks{"shared": {External: true}},
+				Services: composetypes.Services{
+					"web": {
+						Name:     "web",
+						Networks: map[string]*composetypes.ServiceNetworkConfig{"shared": nil},
+					},
+					"db": {
+						Name:     "db",
+						Networks: map[string]*composetypes.ServiceNetworkConfig{"shared": nil},
+					},
+				},
+			},
+			expected: []string{
+				`service names [db, web] not registered as aliases on external network`,
+				`networks.shared.aliases`,
+			},
+		},
+		{
+			name: "service with explicit self-alias is excluded from the warning",
+			project: &composetypes.Project{
+				Networks: composetypes.Networks{"shared": {External: true}},
+				Services: composetypes.Services{
+					"web": {
+						Name: "web",
+						Networks: map[string]*composetypes.ServiceNetworkConfig{
+							"shared": {Aliases: []string{"web"}},
+						},
+					},
+					"db": {
+						Name:     "db",
+						Networks: map[string]*composetypes.ServiceNetworkConfig{"shared": nil},
+					},
+				},
+			},
+			expected: []string{
+				`service names [db] not registered as aliases on external network`,
+				`networks.shared.aliases`,
+			},
+			notExpected: []string{"web"},
+		},
+		{
+			name: "all services explicitly self-aliased emits no warning",
+			project: &composetypes.Project{
+				Networks: composetypes.Networks{"shared": {External: true}},
+				Services: composetypes.Services{
+					"web": {
+						Name: "web",
+						Networks: map[string]*composetypes.ServiceNetworkConfig{
+							"shared": {Aliases: []string{"web"}},
+						},
+					},
+				},
+			},
+			notExpected: []string{"not registered as aliases"},
+		},
+		{
+			name: "multiple external networks each emit their own warning",
+			project: &composetypes.Project{
+				Networks: composetypes.Networks{
+					"sharedA": {External: true},
+					"sharedB": {External: true},
+				},
+				Services: composetypes.Services{
+					"web": {
+						Name: "web",
+						Networks: map[string]*composetypes.ServiceNetworkConfig{
+							"sharedA": nil,
+							"sharedB": nil,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`networks.sharedA.aliases`,
+				`networks.sharedB.aliases`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			origOut := logrus.StandardLogger().Out
+			origLevel := logrus.GetLevel()
+			origFormatter := logrus.StandardLogger().Formatter
+			logrus.SetOutput(&buf)
+			logrus.SetLevel(logrus.WarnLevel)
+			logrus.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableTimestamp: true})
+			t.Cleanup(func() {
+				logrus.SetOutput(origOut)
+				logrus.SetLevel(origLevel)
+				logrus.SetFormatter(origFormatter)
+			})
+
+			warnExternalNetworkAliases(tt.project)
+
+			out := buf.String()
+			for _, s := range tt.expected {
+				assert.Assert(t, strings.Contains(out, s), "expected %q in output:\n%s", s, out)
+			}
+			for _, s := range tt.notExpected {
+				assert.Assert(t, !strings.Contains(out, s), "did not expect %q in output:\n%s", s, out)
+			}
 		})
 	}
 }

--- a/pkg/e2e/fixtures/network-external-alias/compose.yaml
+++ b/pkg/e2e/fixtures/network-external-alias/compose.yaml
@@ -1,0 +1,21 @@
+networks:
+  default: {}
+  external-net:
+    external: true
+    name: ${EXTERNAL_NETWORK}
+
+services:
+  web:
+    image: busybox
+    command: sleep infinity
+    networks:
+      - default
+      - external-net
+  db:
+    image: busybox
+    command: sleep infinity
+    networks:
+      default: {}
+      external-net:
+        aliases:
+          - db

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -219,3 +219,63 @@ func TestNetworkRecreate(t *testing.T) {
 		t.Fatalf("unexpected output, missing expected events, stderr: %s", err)
 	}
 }
+
+func TestExternalNetworkAliases(t *testing.T) {
+	const projectName = "network_external_alias_e2e"
+	const externalNet = projectName + "_external"
+
+	c := NewParallelCLI(t, WithEnv("EXTERNAL_NETWORK="+externalNet))
+
+	c.RunDockerOrExitError(t, "network", "rm", externalNet)
+	c.RunDockerCmd(t, "network", "create", externalNet)
+	t.Cleanup(func() {
+		c.cleanupWithDown(t, projectName)
+		c.RunDockerOrExitError(t, "network", "rm", externalNet)
+	})
+
+	upRes := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-external-alias/compose.yaml",
+		"--project-name", projectName,
+		"up", "-d")
+
+	internalNet := projectName + "_default"
+
+	t.Run("warning lists services without explicit external-net alias and excludes self-aliased ones", func(t *testing.T) {
+		var warningLine string
+		for line := range strings.SplitSeq(upRes.Combined(), "\n") {
+			if strings.Contains(line, `not registered as aliases on external network`) {
+				warningLine = line
+				break
+			}
+		}
+		assert.Assert(t, warningLine != "", "expected warning line in output:\n%s", upRes.Combined())
+		assert.Assert(t, strings.Contains(warningLine, "web"), warningLine)
+		assert.Assert(t, strings.Contains(warningLine, "external-net"), warningLine)
+		assert.Assert(t, !strings.Contains(warningLine, "db"),
+			"db declares its own external-net alias and must be excluded from the warning: %s", warningLine)
+	})
+
+	t.Run("service name is an alias on internal network", func(t *testing.T) {
+		res := c.RunDockerCmd(t, "inspect", projectName+"-web-1", "-f",
+			fmt.Sprintf(`{{ range (index .NetworkSettings.Networks %q).Aliases }}[{{ . }}]{{ end }}`, internalNet))
+		assert.Assert(t, strings.Contains(res.Stdout(), "[web]"), res.Stdout())
+	})
+
+	t.Run("service name is not an alias on external network", func(t *testing.T) {
+		res := c.RunDockerCmd(t, "inspect", projectName+"-web-1", "-f",
+			fmt.Sprintf(`{{ range (index .NetworkSettings.Networks %q).Aliases }}[{{ . }}]{{ end }}`, externalNet))
+		assert.Assert(t, !strings.Contains(res.Stdout(), "[web]"), res.Stdout())
+	})
+
+	t.Run("explicit alias under networks.<external>.aliases is registered on external network", func(t *testing.T) {
+		res := c.RunDockerCmd(t, "inspect", projectName+"-db-1", "-f",
+			fmt.Sprintf(`{{ range (index .NetworkSettings.Networks %q).Aliases }}[{{ . }}]{{ end }}`, externalNet))
+		assert.Assert(t, strings.Contains(res.Stdout(), "[db]"), res.Stdout())
+	})
+
+	t.Run("service name resolves on internal network", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/network-external-alias/compose.yaml",
+			"--project-name", projectName,
+			"exec", "-T", "web", "ping", "-c1", "db")
+		assert.Assert(t, strings.Contains(res.Combined(), "1 packets transmitted"), res.Combined())
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes #8223
- Stop adding the service name as an alias on external networks (`pkg/compose/create.go`)
- On `up`, log a `WARN` when this alias is skipped, so users notice the change and learn about the workaround
- Add unit tests and an e2e test

### What changed

Before this fix, `getAliases()` always added the service name as an alias when `useNetworkAliases` was true. This put internal service names onto external networks (networks Compose does not manage). On a shared external network, two projects with a service named `db` would resolve to each other - which is the bug.

The fix skips the service name on external networks. Aliases that the user sets under `services.<name>.networks.<net>.aliases` still go through.

### Discoverability

Users who relied on cross-project resolution over a shared external network would lose it silently. To make the change visible, `up` prints one warning per external network used by the project:

```
WARN[0000] service names [db, web] not registered as aliases on external network "shared-net"; add them under each service's networks.shared-net.aliases if needed
```

One warning per network keeps the output short, even on stacks with many services on the same external network. A service that already lists its own name under `networks.<net>.aliases` is left out of the warning, so the warning disappears once the user adopts the workaround.

Only `up` prints the warning. `create` and `run --use-aliases` do not:

- `create` is rarely used alone - it almost always runs as part of `up`
- `run --use-aliases` creates one-off containers, where the warning would just be noise

### Workaround

Add the alias per service, under that service's network entry. The alias namespace lives on the service, not on the network itself:

```yaml
networks:
  shared-net:
    external: true

services:
  web:
    networks:
      shared-net:
        aliases: [web]
  db:
    networks:
      shared-net:
        aliases: [db]
```

### Related

https://github.com/ddev/ddev/issues/8390 - DDEV projects share one external network (`ddev_default`). A `db` in one project resolved to another project's `db` over that shared network, because the service name was registered as an alias on it.

## Before / After

<details>
<summary>Setup</summary>

Two independent Compose projects and a standalone router share one external network. Project1 has `web` and `db`. Project2 has only `web` - no `db` of its own, so any `db` resolution from it would cross into project1. The router is a separate project on `shared-net` only, simulating a reverse proxy like ddev-router.

```sh
docker network create shared-net

cat <<'EOF' > project1.yaml
networks:
  default: {}
  shared-net:
    external: true

services:
  web:
    image: busybox
    command: sleep infinity
    networks:
      - default
      - shared-net
  db:
    image: busybox
    command: sleep infinity
    networks:
      - default
      - shared-net
EOF

cat <<'EOF' > project2.yaml
networks:
  default: {}
  shared-net:
    external: true

services:
  web:
    image: busybox
    command: sleep infinity
    networks:
      - default
      - shared-net
EOF

cat <<'EOF' > router.yaml
networks:
  shared-net:
    external: true

services:
  router:
    image: busybox
    command: sleep infinity
    networks:
      - shared-net
EOF

docker-compose -p project1 -f project1.yaml up -d
docker-compose -p project2 -f project2.yaml up -d
docker-compose -p router -f router.yaml up -d
```

Cleanup:

```bash
docker-compose -p project1 -f project1.yaml down
docker-compose -p project2 -f project2.yaml down
docker-compose -p router -f router.yaml down
docker network rm shared-net
```

</details>

<details>
<summary>Before (buggy behavior)</summary>

Service names appear as aliases on the external network:

```
$ docker inspect $(docker-compose -p project1 -f project1.yaml ps -q web) \
    --format '{{json .NetworkSettings.Networks}}' | jq 'to_entries[] | {network: .key, aliases: .value.Aliases}'
{"network": "project1_default", "aliases": ["project1-web-1", "web"]}
{"network": "shared-net",       "aliases": ["project1-web-1", "web"]}
#                                                               ^^^
#                                          service name leaks onto external network
```

Within project1, `web` can ping its own `db` by service name (expected):

```
$ docker-compose -p project1 -f project1.yaml exec web ping -c1 db
PING db (172.18.0.3): 56 data bytes
64 bytes from 172.18.0.3: seq=0 ttl=64 time=0.121 ms
```

Project2's `web` has no `db` of its own, but can reach project1's `db` via `shared-net` (bug):

```
$ docker-compose -p project2 -f project2.yaml exec web ping -c1 db
PING db (172.20.0.3): 56 data bytes
64 bytes from 172.20.0.3: seq=0 ttl=64 time=0.112 ms
```

`router` in project2 can also resolve project1's services via `shared-net` (bug):

```
$ docker-compose -p router -f router.yaml exec router ping -c1 web
PING web (172.20.0.2): 56 data bytes
64 bytes from 172.20.0.2: seq=0 ttl=64 time=0.098 ms

$ docker-compose -p router -f router.yaml exec router ping -c1 db
PING db (172.20.0.3): 56 data bytes
64 bytes from 172.20.0.3: seq=0 ttl=64 time=0.104 ms
```

</details>

<details>
<summary>After (fixed behavior)</summary>

Service names are no longer registered as aliases on the external network:

```
$ docker inspect $(docker-compose -p project1 -f project1.yaml ps -q web) \
    --format '{{json .NetworkSettings.Networks}}' | jq 'to_entries[] | {network: .key, aliases: .value.Aliases}'
{"network": "project1_default", "aliases": ["project1-web-1", "web"]}
{"network": "shared-net",       "aliases": ["project1-web-1"]}
#                                                        no service name
```

Within project1, `web` can still ping its own `db` by service name via the internal `default` network (unchanged):

```
$ docker-compose -p project1 -f project1.yaml exec web ping -c1 db
PING db (172.18.0.3): 56 data bytes
64 bytes from 172.18.0.3: seq=0 ttl=64 time=0.121 ms
```

Project2's `web` can no longer resolve project1's `db` (fixed):

```
$ docker-compose -p project2 -f project2.yaml exec web ping -c1 db
ping: bad address 'db'
```

`router` can no longer resolve services from project1 either (fixed):

```
$ docker-compose -p router -f router.yaml exec router ping -c1 web
ping: bad address 'web'

$ docker-compose -p router -f router.yaml exec router ping -c1 db
ping: bad address 'db'
```

Containers are still reachable on `shared-net` by their fully qualified container name, which remains as an alias on the external network:

```
$ docker-compose -p router -f router.yaml exec router ping -c1 project1-web-1
PING project1-web-1 (172.20.0.2): 56 data bytes
64 bytes from 172.20.0.2: seq=0 ttl=64 time=0.094 ms

$ docker-compose -p router -f router.yaml exec router ping -c1 project2-web-1
PING project2-web-1 (172.20.0.4): 56 data bytes
64 bytes from 172.20.0.4: seq=0 ttl=64 time=0.091 ms
```

</details>

## Test plan

- [x] `TestCreateEndpointSettings` - non-external network case still produces `containerName`, `serviceName`, and configured aliases
- [x] `TestCreateEndpointSettings_ExternalNetwork` - external network case produces only `containerName` and configured aliases (no service name)
- [x] `TestWarnExternalNetworkAliases` - covers the warning helper:
  - internal-only networks emit no warning
  - external network emits one warning per network, with services listed in sorted order
  - services that already list their own name under `networks.<net>.aliases` are excluded
  - if all services are explicitly self-aliased, no warning is emitted
  - multiple external networks each get their own warning
- [x] `TestExternalNetworkAliases` (e2e) - mixed internal + external network fixture, where `web` has no explicit alias on the external network and `db` declares `networks.external-net.aliases: [db]`:
  - the warning is logged on `up`
  - the warning lists `web` and excludes `db` (since `db` is self-aliased)
  - `web`'s service name is in `Aliases` on the internal network
  - `web`'s service name is not in `Aliases` on the external network
  - `db`'s explicit alias `[db]` is registered on the external network (workaround works end-to-end)
  - service-name DNS resolution still works between services over the internal network (`web` -> `db`)
- [x] `golangci-lint run --build-tags "e2e" ./pkg/compose/... ./pkg/e2e/...` - 0 issues
