### PR TITLE
fix: restore stoppingEvent/stoppedEvent helpers for plugin stop hook

### DIFF
--- a/pkg/compose/progress.go
+++ b/pkg/compose/progress.go
@@ -57,6 +57,16 @@ func createdEvent(id string) api.Resource {
 	return newEvent(id, api.Done, api.StatusCreated)
 }
 
+// stoppingEvent creates a new Stopping in progress Resource
+func stoppingEvent(id string) api.Resource {
+	return newEvent(id, api.Working, api.StatusStopping)
+}
+
+// stoppedEvent creates a new Stopped (done) Resource
+func stoppedEvent(id string) api.Resource {
+	return newEvent(id, api.Done, api.StatusStopped)
+}
+
 // removingEvent creates a new Removing in progress Resource
 func removingEvent(id string) api.Resource {
 	return newEvent(id, api.Working, api.StatusRemoving)


### PR DESCRIPTION
**What I did**
The stop lifecycle hook added in 672dc14d2 calls stoppingEvent and stoppedEvent from pkg/compose/plugins.go, but the helpers had been removed by the earlier wrapper-cleanup in da530c723. The result was a broken go build for pkg/compose on upstream/main.

Restore the two helpers alongside the symmetric creating/created and removing/removed pairs so call sites in plugins.go match the existing pattern used in the same switch.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
