### PR TITLE
docs: compose logs: add links for since/until flag descriptions

### DIFF
--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/docker/cli-docs-tool/annotation"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
@@ -63,7 +64,9 @@ func logsCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backe
 	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")
 	flags.IntVar(&opts.index, "index", 0, "index of the container if service has multiple replicas")
 	flags.StringVar(&opts.since, "since", "", "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
+	flags.SetAnnotation("since", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/"}) //nolint:errcheck
 	flags.StringVar(&opts.until, "until", "", "Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
+	flags.SetAnnotation("until", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#until"}) //nolint:errcheck
 	flags.BoolVar(&opts.noColor, "no-color", false, "Produce monochrome output")
 	flags.BoolVar(&opts.noPrefix, "no-log-prefix", false, "Don't print prefix in logs")
 	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps")

--- a/docs/reference/compose_logs.md
+++ b/docs/reference/compose_logs.md
@@ -5,17 +5,17 @@ Displays log output from services
 
 ### Options
 
-| Name                 | Type     | Default | Description                                                                                    |
-|:---------------------|:---------|:--------|:-----------------------------------------------------------------------------------------------|
-| `--dry-run`          | `bool`   |         | Execute command in dry run mode                                                                |
-| `-f`, `--follow`     | `bool`   |         | Follow log output                                                                              |
-| `--index`            | `int`    | `0`     | index of the container if service has multiple replicas                                        |
-| `--no-color`         | `bool`   |         | Produce monochrome output                                                                      |
-| `--no-log-prefix`    | `bool`   |         | Don't print prefix in logs                                                                     |
-| `--since`            | `string` |         | Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)    |
-| `-n`, `--tail`       | `string` | `all`   | Number of lines to show from the end of the logs for each container                            |
-| `-t`, `--timestamps` | `bool`   |         | Show timestamps                                                                                |
-| `--until`            | `string` |         | Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes) |
+| Name                                                                            | Type     | Default | Description                                                                                    |
+|:--------------------------------------------------------------------------------|:---------|:--------|:-----------------------------------------------------------------------------------------------|
+| `--dry-run`                                                                     | `bool`   |         | Execute command in dry run mode                                                                |
+| `-f`, `--follow`                                                                | `bool`   |         | Follow log output                                                                              |
+| `--index`                                                                       | `int`    | `0`     | index of the container if service has multiple replicas                                        |
+| `--no-color`                                                                    | `bool`   |         | Produce monochrome output                                                                      |
+| `--no-log-prefix`                                                               | `bool`   |         | Don't print prefix in logs                                                                     |
+| [`--since`](https://docs.docker.com/reference/cli/docker/container/logs/)       | `string` |         | Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)    |
+| `-n`, `--tail`                                                                  | `string` | `all`   | Number of lines to show from the end of the logs for each container                            |
+| `-t`, `--timestamps`                                                            | `bool`   |         | Show timestamps                                                                                |
+| [`--until`](https://docs.docker.com/reference/cli/docker/container/logs/#until) | `string` |         | Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_logs.yaml
+++ b/docs/reference/docker_compose_logs.yaml
@@ -50,6 +50,7 @@ options:
       value_type: string
       description: |
         Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+      details_url: /reference/cli/docker/container/logs/
       deprecated: false
       hidden: false
       experimental: false
@@ -83,6 +84,7 @@ options:
       value_type: string
       description: |
         Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+      details_url: /reference/cli/docker/container/logs/#until
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
- alternative to https://github.com/docker/compose/pull/13803

Link to the corresponding `docker container logs` equivalents, which contain more details on the accepted formats and use.

The container logs documentation still needs some updates to provide per-flag sections, so follow-ups can be made once those are done.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
