### PR TITLE
feat: add confirmation label when volume spec changes

### DIFF
--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -33,6 +33,9 @@ const (
 	ContainerNumberLabel = "com.docker.compose.container-number"
 	// VolumeLabel allow to track resource related to a compose volume
 	VolumeLabel = "com.docker.compose.volume"
+	// VolumeRecreateWhenSpecUpdatedLabel, when set to true, causes the volume to be recreated when its specification is updated. Otherwise, the volume is not recreated.
+	// WARNING: Recreating a volume may result in data loss, depending on the volume driver.
+	VolumeRecreateWhenSpecUpdatedLabel = "com.docker.compose.volume.recreate-when-spec-updated"
 	// NetworkLabel allow to track resource related to a compose network
 	NetworkLabel = "com.docker.compose.network"
 	// WorkingDirLabel stores absolute path to compose project working directory

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -43,6 +43,7 @@ import (
 	cdi "tags.cncf.io/container-device-interface/pkg/parser"
 
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/utils"
 )
 
 type createOptions struct {
@@ -1623,8 +1624,8 @@ func (s *composeService) ensureVolume(ctx context.Context, name string, volume t
 	}
 	actual, ok := inspected.Volume.Labels[api.ConfigHashLabel]
 	if ok && actual != expected {
-		msg := fmt.Sprintf("Volume %q exists but doesn't match configuration in compose file. Recreate (data will be lost)?", volume.Name)
-		confirm, err := s.prompt(msg, false)
+		// use the volume label from the compose file.
+		confirm, err := confirmVolumeRecreate(volume.Labels, s.prompt, volume.Name)
 		if err != nil {
 			return "", err
 		}
@@ -1637,6 +1638,25 @@ func (s *composeService) ensureVolume(ctx context.Context, name string, volume t
 		}
 	}
 	return inspected.Volume.Name, nil
+}
+
+func confirmVolumeRecreate(labels map[string]string, prompt Prompt, name string) (bool, error) {
+	recreate, ok := labels[api.VolumeRecreateWhenSpecUpdatedLabel]
+	msg := fmt.Sprintf("Volume %q exists but doesn't match configuration in compose file.", name)
+	// if label not set or set to false, ask user to confirm volume recreate,
+	// if set to true, recreate without asking
+	if ok && utils.StringToBool(recreate) {
+		logrus.Warnf("%s The label %s is set to %s, so the volume is being recreated.",
+			msg, api.VolumeRecreateWhenSpecUpdatedLabel, recreate)
+		return true, nil
+	} else {
+		promptMsg := msg + " Recreate (data will be lost)?"
+		c, err := prompt(promptMsg, false)
+		if err != nil {
+			return false, err
+		}
+		return c, nil
+	}
 }
 
 func (s *composeService) removeDivergedVolume(ctx context.Context, name string, volume types.VolumeConfig, project *types.Project) error {

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -17,11 +17,13 @@
 package compose
 
 import (
+	"io"
 	"net"
 	"net/netip"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	composeloader "github.com/compose-spec/compose-go/v2/loader"
@@ -35,6 +37,8 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 
+	"github.com/docker/cli/cli/streams"
+	"github.com/docker/compose/v5/cmd/prompt"
 	"github.com/docker/compose/v5/pkg/api"
 )
 
@@ -481,6 +485,98 @@ volumes:
 			assert.NilError(t, err)
 			assert.DeepEqual(t, tt.binds, binds)
 			assert.DeepEqual(t, tt.mounts, mounts)
+		})
+	}
+}
+
+func Test_composeService_confirmVolumeRecreate(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "no labels no input",
+			labels:  nil,
+			input:   "",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "no labels and input is y",
+			labels:  nil,
+			input:   "y",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "no labels and input is true",
+			labels:  nil,
+			input:   "true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "no labels and input is no",
+			labels:  nil,
+			input:   "no",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "no input, has labels recreate true",
+			labels:  map[string]string{api.VolumeRecreateWhenSpecUpdatedLabel: "true"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "no input, has labels recreate TRUE",
+			labels:  map[string]string{api.VolumeRecreateWhenSpecUpdatedLabel: "TRUE"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "no input, has labels recreate false",
+			labels:  map[string]string{api.VolumeRecreateWhenSpecUpdatedLabel: "false"},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "input true, has labels recreate false",
+			labels:  map[string]string{api.VolumeRecreateWhenSpecUpdatedLabel: "false"},
+			input:   "true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "input false, has labels recreate false",
+			labels:  map[string]string{api.VolumeRecreateWhenSpecUpdatedLabel: "false"},
+			input:   "false",
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prompt := prompt.NewPrompt(
+				streams.NewIn(io.NopCloser(strings.NewReader(tt.input))),
+				streams.NewOut(t.Output())).Confirm
+
+			got, gotErr := confirmVolumeRecreate(tt.labels, prompt, "volumeName")
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("confirmVolumeRecreate() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("confirmVolumeRecreate() succeeded unexpectedly")
+			}
+			if tt.want != got {
+				t.Errorf("confirmVolumeRecreate() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/pkg/e2e/fixtures/recreate-volumes/label-new.yml
+++ b/pkg/e2e/fixtures/recreate-volumes/label-new.yml
@@ -1,0 +1,15 @@
+services:
+  app:
+    image: alpine
+    volumes:
+      - my_vol:/my_vol
+      - no_recreate_label:/no_recreate_label
+
+volumes:
+  my_vol:
+    labels:
+      com.docker.compose.volume.recreate-when-spec-updated: "true"
+      foo: zot
+  no_recreate_label:
+    labels:
+      foo: zot

--- a/pkg/e2e/fixtures/recreate-volumes/label-old.yml
+++ b/pkg/e2e/fixtures/recreate-volumes/label-old.yml
@@ -1,0 +1,14 @@
+services:
+  app:
+    image: alpine
+    volumes:
+      - my_vol:/my_vol
+      - no_recreate_label:/no_recreate_label
+
+volumes:
+  my_vol:
+    labels:
+      foo: bar
+  no_recreate_label:
+    labels:
+      foo: bar

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -172,6 +172,38 @@ func TestUpRecreateVolumes_IgnoreBinds(t *testing.T) {
 	assert.Check(t, !strings.Contains(res.Combined(), "Recreated"))
 }
 
+func TestUpRecreateVolumes_RecreateLabel(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "compose-e2e-recreate-volumes-recreate-label"
+	t.Cleanup(func() {
+		c.cleanupWithDown(t, projectName)
+	})
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/recreate-volumes/label-old.yml", "--project-name", projectName, "up", "-d")
+
+	checkVol := func(volumeName string, label string, expected string) {
+		res := c.RunDockerCmd(t, "volume", "inspect",
+			fmt.Sprintf("%s_%s", projectName, volumeName),
+			"-f", fmt.Sprintf("{{ index .Labels \"%s\" }}", label))
+		res.Assert(t, icmd.Expected{Out: expected})
+	}
+
+	checkVol("my_vol", "foo", "bar")
+	checkVol("no_recreate_label", "foo", "bar")
+
+	_ = c.RunDockerComposeCmd(t, "-f", "./fixtures/recreate-volumes/label-new.yml", "--project-name", projectName, "up", "-d")
+
+	checkVol("my_vol", "foo", "zot")
+	// The no_recreate_label volume should not be recreated, so its label should remain unchanged
+	checkVol("no_recreate_label", "foo", "bar")
+
+	// --yes should recreate the no_recreate_label volume
+	_ = c.RunDockerComposeCmd(t, "-f", "./fixtures/recreate-volumes/label-new.yml", "--project-name", projectName, "up", "--yes", "-d")
+
+	checkVol("my_vol", "foo", "zot")
+	checkVol("no_recreate_label", "foo", "zot")
+}
+
 func TestImageVolume(t *testing.T) {
 	c := NewCLI(t)
 	const projectName = "compose-e2e-image-volume"


### PR DESCRIPTION
**What I did**

Add support for label: `com.docker.compose.volume.recreate-when-spec-updated`

```yaml
volumes:
  my_data:
    labels:
      com.docker.compose.volume.recreate-when-spec-updated: "true"
````

This allows automatic handling of volume recreation when specs change, improving compatibility with CD workflows by avoiding interactive prompts.

**Related issue**

closes: https://github.com/docker/compose/issues/13807

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
