### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq and replace HasPrefix+TrimPrefix with CutPrefix

### DIFF
--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -416,10 +416,10 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 		output := inspect.Stdout()
 		isDockerDriver := false
 		platforms := ""
-		for _, line := range strings.Split(output, "\n") {
+		for line := range strings.SplitSeq(output, "\n") {
 			trimmed := strings.TrimSpace(line)
-			if strings.HasPrefix(trimmed, "Driver:") {
-				isDockerDriver = strings.TrimSpace(strings.TrimPrefix(trimmed, "Driver:")) == "docker"
+			if after, ok := strings.CutPrefix(trimmed, "Driver:"); ok {
+				isDockerDriver = strings.TrimSpace(after) == "docker"
 			}
 			if strings.HasPrefix(trimmed, "Platforms:") {
 				platforms = trimmed


### PR DESCRIPTION


**What I did**


Optimize code using a more modern writing style which can make the code more efficient and cleaner.

And also use strings.CutPrefix for clearer and more idiomatic prefix handling.

More info: https://github.com/golang/go/issues/61901


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**


<img width="1140" height="1144" alt="image" src="https://github.com/user-attachments/assets/66e5c718-edb5-4de0-bb33-569e60663aa1" />

