### PR TITLE
fix(build): skip remote URL contexts from bake fs.read allowlist

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -197,7 +197,9 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			}
 		}
 
-		read = append(read, buildConfig.Context)
+		if _, _, err := gitutil.ParseGitRef(buildConfig.Context); !strings.Contains(buildConfig.Context, "://") && err != nil {
+			read = append(read, buildConfig.Context)
+		}
 		for _, path := range buildConfig.AdditionalContexts {
 			_, _, err := gitutil.ParseGitRef(path)
 			if !strings.Contains(path, "://") && err != nil {


### PR DESCRIPTION
## Summary
- Fix `docker compose build` failing on Windows when a service's `build:` context is a remote git/HTTP URL
- Apply the same `gitutil.ParseGitRef` + `://` filter to the main `Context` that was already applied to `additional_contexts`, so remote URLs are not passed to bake as `--allow fs.read=<url>`

## Why
On Windows, bake interprets `fs.read` entries as local filesystem paths. When the value is a URL like `https://github.com/.../repo.git#main`, evaluation fails with:

```
failed to evaluate path "https://...": CreateFile C:\...\https:: The filename, directory name, or volume label syntax is incorrect.
```

because `https:` is invalid Windows path syntax (colon is reserved for drive letters). The `fs.read` entitlement is only meaningful for local paths anyway.

Fixes #13815

## Test plan
- [x] Reproduced the failure on Windows with the compose file from #13815 (uses remote git URLs as build contexts)
- [x] After the fix, `docker compose build` completes successfully on the same project, building both services from their remote git sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)