### PR TITLE
docs(CLAUDE.md): note that commits must be signed off (DCO)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,7 @@
 - Use `github.com/containerd/errdefs` instead of `github.com/docker/docker/errdefs`
 - In tests: use `t.Context()` instead of `context.Background()` or `context.TODO()`
 - Prefer `fmt.Fprintf` over `WriteString(fmt.Sprintf(...))`
+
+## Git
+
+- **All commits MUST be signed off (DCO)**. Always pass `--signoff` (`-s`) to `git commit` and `git commit --amend`.


### PR DESCRIPTION
## Summary
- Add a `Git` section to `CLAUDE.md` reminding contributors (and Claude Code) that all commits to this project require a DCO sign-off (`git commit --signoff`)

## Test plan
- [x] N/A — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)