### PR TITLE
docs: compose logs: add more links for flag descriptions

### DIFF
--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -62,15 +62,18 @@ func logsCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backe
 	}
 	flags := logsCmd.Flags()
 	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")
+	flags.SetAnnotation("follow", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#follow"}) //nolint:errcheck
 	flags.IntVar(&opts.index, "index", 0, "index of the container if service has multiple replicas")
 	flags.StringVar(&opts.since, "since", "", "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
-	flags.SetAnnotation("since", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/"}) //nolint:errcheck
+	flags.SetAnnotation("since", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#since"}) //nolint:errcheck
 	flags.StringVar(&opts.until, "until", "", "Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
 	flags.SetAnnotation("until", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#until"}) //nolint:errcheck
 	flags.BoolVar(&opts.noColor, "no-color", false, "Produce monochrome output")
 	flags.BoolVar(&opts.noPrefix, "no-log-prefix", false, "Don't print prefix in logs")
 	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps")
+	flags.SetAnnotation("timestamps", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#timestamps"}) //nolint:errcheck
 	flags.StringVarP(&opts.tail, "tail", "n", "all", "Number of lines to show from the end of the logs for each container")
+	flags.SetAnnotation("tail", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#tail"}) //nolint:errcheck
 	return logsCmd
 }
 

--- a/docs/reference/compose_logs.md
+++ b/docs/reference/compose_logs.md
@@ -5,17 +5,17 @@ Displays log output from services
 
 ### Options
 
-| Name                                                                            | Type     | Default | Description                                                                                    |
-|:--------------------------------------------------------------------------------|:---------|:--------|:-----------------------------------------------------------------------------------------------|
-| `--dry-run`                                                                     | `bool`   |         | Execute command in dry run mode                                                                |
-| `-f`, `--follow`                                                                | `bool`   |         | Follow log output                                                                              |
-| `--index`                                                                       | `int`    | `0`     | index of the container if service has multiple replicas                                        |
-| `--no-color`                                                                    | `bool`   |         | Produce monochrome output                                                                      |
-| `--no-log-prefix`                                                               | `bool`   |         | Don't print prefix in logs                                                                     |
-| [`--since`](https://docs.docker.com/reference/cli/docker/container/logs/)       | `string` |         | Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)    |
-| `-n`, `--tail`                                                                  | `string` | `all`   | Number of lines to show from the end of the logs for each container                            |
-| `-t`, `--timestamps`                                                            | `bool`   |         | Show timestamps                                                                                |
-| [`--until`](https://docs.docker.com/reference/cli/docker/container/logs/#until) | `string` |         | Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes) |
+| Name                                                                                                                                                                       | Type     | Default | Description                                                                                    |
+|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:--------|:-----------------------------------------------------------------------------------------------|
+| `--dry-run`                                                                                                                                                                | `bool`   |         | Execute command in dry run mode                                                                |
+| [`-f`](https://docs.docker.com/reference/cli/docker/container/logs/#follow), [`--follow`](https://docs.docker.com/reference/cli/docker/container/logs/#follow)             | `bool`   |         | Follow log output                                                                              |
+| `--index`                                                                                                                                                                  | `int`    | `0`     | index of the container if service has multiple replicas                                        |
+| `--no-color`                                                                                                                                                               | `bool`   |         | Produce monochrome output                                                                      |
+| `--no-log-prefix`                                                                                                                                                          | `bool`   |         | Don't print prefix in logs                                                                     |
+| [`--since`](https://docs.docker.com/reference/cli/docker/container/logs/#since)                                                                                            | `string` |         | Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)    |
+| [`-n`](https://docs.docker.com/reference/cli/docker/container/logs/#tail), [`--tail`](https://docs.docker.com/reference/cli/docker/container/logs/#tail)                   | `string` | `all`   | Number of lines to show from the end of the logs for each container                            |
+| [`-t`](https://docs.docker.com/reference/cli/docker/container/logs/#timestamps), [`--timestamps`](https://docs.docker.com/reference/cli/docker/container/logs/#timestamps) | `bool`   |         | Show timestamps                                                                                |
+| [`--until`](https://docs.docker.com/reference/cli/docker/container/logs/#until)                                                                                            | `string` |         | Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes) |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_logs.yaml
+++ b/docs/reference/docker_compose_logs.yaml
@@ -10,6 +10,7 @@ options:
       value_type: bool
       default_value: "false"
       description: Follow log output
+      details_url: /reference/cli/docker/container/logs/#follow
       deprecated: false
       hidden: false
       experimental: false
@@ -50,7 +51,7 @@ options:
       value_type: string
       description: |
         Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
-      details_url: /reference/cli/docker/container/logs/
+      details_url: /reference/cli/docker/container/logs/#since
       deprecated: false
       hidden: false
       experimental: false
@@ -63,6 +64,7 @@ options:
       default_value: all
       description: |
         Number of lines to show from the end of the logs for each container
+      details_url: /reference/cli/docker/container/logs/#tail
       deprecated: false
       hidden: false
       experimental: false
@@ -74,6 +76,7 @@ options:
       value_type: bool
       default_value: "false"
       description: Show timestamps
+      details_url: /reference/cli/docker/container/logs/#timestamps
       deprecated: false
       hidden: false
       experimental: false


### PR DESCRIPTION
- follow-up to https://github.com/docker/compose/pull/13806
- relates to https://github.com/docker/cli/pull/7003

follow-up to 7eeb7de7a20b8d1e3e319e1499ae4b62d6fc2af9, adding more links now that the CLI reference for docker logs has anchors for them.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
