### PR TITLE
gha: update docs-upstream to pin workflows by sha

### DIFF
--- a/.github/workflows/docs-upstream.yml
+++ b/.github/workflows/docs-upstream.yml
@@ -44,7 +44,7 @@ jobs:
           retention-days: 1
 
   validate:
-    uses: docker/docs/.github/workflows/validate-upstream.yml@464a44a6e72b37cf1755968477e242a5e5f6ef7d # main 2026-03-24
+    uses: docker/docs/.github/workflows/validate-upstream.yml@00aefd5eae73898c4d3bcd7a6fe95a039293706b # main 2026-03-24
     needs:
       - docs-yaml
     with:


### PR DESCRIPTION
- follow-up to https://github.com/docker/compose/pull/13662


This workflow was updated in 56e2dba366020ecc162c064b66aa322de12c8bf3 but it looks to have pinned to a version before the workflows were pinned; https://github.com/docker/docs/blob/464a44a6e72b37cf1755968477e242a5e5f6ef7d/.github/workflows/validate-upstream.yml

This patch updates the workflow to a version that uses pinned actions; https://github.com/docker/docs/blob/00aefd5eae73898c4d3bcd7a6fe95a039293706b/.github/workflows/validate-upstream.yml

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
