### PR TITLE
Fix/progress tty line overflow 13595

### DIFF
--- a/cmd/display/tty.go
+++ b/cmd/display/tty.go
@@ -449,7 +449,7 @@ func maxBeforeStatusWidth(lines []lineData) int {
 	var maxWidth int
 	for i := range lines {
 		l := &lines[i]
-		width := 3 + lenAnsi(l.prefix) + len(l.taskID) + lenAnsi(l.progress)
+		width := 3 + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
 		if width > maxWidth {
 			maxWidth = width
 		}
@@ -478,18 +478,29 @@ func computeOverflow(lines []lineData, maxBeforeStatus, maxStatusLen, timerLen, 
 }
 
 // truncateProgressSize drops the trailing "X.XMB / Y.YMB" size info from the
-// first line whose progress still carries it. Returns true if any line was
-// modified. Used to recover from overflow without abbreviating the taskID.
+// line currently driving maxBeforeStatusWidth — only that line's shrink can
+// reduce overflow. Returns true if any line was modified.
 func truncateProgressSize(lines []lineData) bool {
+	maxIdx := -1
+	var maxWidth int
 	for i := range lines {
 		l := &lines[i]
-		if l.progressSizeBytes > 0 {
-			l.progress = l.progress[:len(l.progress)-l.progressSizeBytes]
-			l.progressSizeBytes = 0
-			return true
+		if l.progressSizeBytes == 0 {
+			continue
+		}
+		w := lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
+		if maxIdx < 0 || w > maxWidth {
+			maxWidth = w
+			maxIdx = i
 		}
 	}
-	return false
+	if maxIdx < 0 {
+		return false
+	}
+	l := &lines[maxIdx]
+	l.progress = l.progress[:len(l.progress)-l.progressSizeBytes]
+	l.progressSizeBytes = 0
+	return true
 }
 
 // truncateDetails tries to truncate the first line's details to reduce overflow.
@@ -510,13 +521,14 @@ func truncateDetails(lines []lineData, overflow int) bool {
 }
 
 // truncateLongestTaskID truncates the longest taskID to reduce overflow.
-// Returns true if truncation was performed.
+// Returns true if truncation was performed. Lengths and slicing are in runes
+// to avoid emitting invalid UTF-8 when taskID contains multi-byte chars.
 func truncateLongestTaskID(lines []lineData, overflow, minIDLen int) bool {
 	longestIdx := -1
 	longestLen := minIDLen
 	for i := range lines {
-		if len(lines[i].taskID) > longestLen {
-			longestLen = len(lines[i].taskID)
+		if utf8.RuneCountInString(lines[i].taskID) > longestLen {
+			longestLen = utf8.RuneCountInString(lines[i].taskID)
 			longestIdx = i
 		}
 	}
@@ -527,10 +539,9 @@ func truncateLongestTaskID(lines []lineData, overflow, minIDLen int) bool {
 
 	l := &lines[longestIdx]
 	reduction := overflow + 3 // account for "..."
-	newLen := max(len(l.taskID)-reduction, minIDLen-3)
-	if newLen > 0 {
-		l.taskID = l.taskID[:newLen] + "..."
-	}
+	newLen := max(longestLen-reduction, minIDLen-3)
+	runes := []rune(l.taskID)
+	l.taskID = string(runes[:newLen]) + "..."
 	return true
 }
 

--- a/cmd/display/tty.go
+++ b/cmd/display/tty.go
@@ -268,16 +268,17 @@ func (w *ttyWriter) childrenTasks(parent string) iter.Seq[*task] {
 
 // lineData holds pre-computed formatting for a task line
 type lineData struct {
-	spinner     string // rendered spinner with color
-	prefix      string // dry-run prefix if any
-	taskID      string // possibly abbreviated
-	progress    string // progress bar and size info
-	status      string // rendered status with color
-	details     string // possibly abbreviated
-	timer       string // rendered timer with color
-	statusPad   int    // padding before status to align
-	timerPad    int    // padding before timer to align
-	statusColor colorFunc
+	spinner           string // rendered spinner with color
+	prefix            string // dry-run prefix if any
+	taskID            string // possibly abbreviated
+	progress          string // progress bar and (optionally) size info appended
+	progressSizeBytes int    // byte length of the trailing size suffix in progress, 0 if none
+	status            string // rendered status with color
+	details           string // possibly abbreviated
+	timer             string // rendered timer with color
+	statusPad         int    // padding before status to align
+	timerPad          int    // padding before timer to align
+	statusColor       colorFunc
 }
 
 func (w *ttyWriter) print() {
@@ -424,8 +425,8 @@ func (w *ttyWriter) adjustLineWidth(lines []lineData, timerLen int, terminalWidt
 			break
 		}
 
-		// First try to truncate details, then taskID
-		if !truncateDetails(lines, overflow) && !truncateLongestTaskID(lines, overflow, minIDLen) {
+		// Drop ancillary content (details, progress size info) before touching the taskID.
+		if !truncateDetails(lines, overflow) && !truncateProgressSize(lines) && !truncateLongestTaskID(lines, overflow, minIDLen) {
 			break // Can't truncate further
 		}
 	}
@@ -474,6 +475,21 @@ func computeOverflow(lines []lineData, maxBeforeStatus, maxStatusLen, timerLen, 
 		}
 	}
 	return maxOverflow
+}
+
+// truncateProgressSize drops the trailing "X.XMB / Y.YMB" size info from the
+// first line whose progress still carries it. Returns true if any line was
+// modified. Used to recover from overflow without abbreviating the taskID.
+func truncateProgressSize(lines []lineData) bool {
+	for i := range lines {
+		l := &lines[i]
+		if l.progressSizeBytes > 0 {
+			l.progress = l.progress[:len(l.progress)-l.progressSizeBytes]
+			l.progressSizeBytes = 0
+			return true
+		}
+	}
+	return false
 }
 
 // truncateDetails tries to truncate the first line's details to reduce overflow.
@@ -560,22 +576,26 @@ func (w *ttyWriter) prepareLineData(t *task) lineData {
 	}
 
 	var progress string
+	var progressSizeBytes int
 	if len(completion) > 0 {
 		progress = " [" + SuccessColor(strings.Join(completion, "")) + "]"
 		if !hideDetails {
-			progress += fmt.Sprintf(" %7s / %-7s", units.HumanSize(float64(current)), units.HumanSize(float64(total)))
+			sizeInfo := fmt.Sprintf(" %7s / %-7s", units.HumanSize(float64(current)), units.HumanSize(float64(total)))
+			progress += sizeInfo
+			progressSizeBytes = len(sizeInfo)
 		}
 	}
 
 	return lineData{
-		spinner:     spinner(t),
-		prefix:      prefix,
-		taskID:      t.ID,
-		progress:    progress,
-		status:      t.text,
-		statusColor: colorFn(t.status),
-		details:     t.details,
-		timer:       fmt.Sprintf("%.1fs", elapsed),
+		spinner:           spinner(t),
+		prefix:            prefix,
+		taskID:            t.ID,
+		progress:          progress,
+		progressSizeBytes: progressSizeBytes,
+		status:            t.text,
+		statusColor:       colorFn(t.status),
+		details:           t.details,
+		timer:             fmt.Sprintf("%.1fs", elapsed),
 	}
 }
 

--- a/cmd/display/tty_test.go
+++ b/cmd/display/tty_test.go
@@ -270,6 +270,69 @@ func TestAdjustLineWidth_TaskIDCorrectlyTruncated(t *testing.T) {
 	assert.Assert(t, strings.HasSuffix(lines[0].taskID, "..."), "truncated taskID should end with ...")
 }
 
+// TestAdjustLineWidth_MultiByteTaskIDFits guards against drift between
+// applyPadding (rune-based) and maxBeforeStatusWidth (formerly byte-based):
+// a byte-based measurement falsely flags overflow for multi-byte taskIDs.
+func TestAdjustLineWidth_MultiByteTaskIDFits(t *testing.T) {
+	w := &ttyWriter{}
+	taskID := "Image 测试测试" // 10 runes, 18 bytes
+	lines := []lineData{{
+		taskID: taskID,
+		status: "Pulling",
+	}}
+
+	// terminalWidth=30 fits in runes (3+10+1+7+1+4 = 26) but not in bytes
+	// (3+18+1+7+1+4 = 34), so a byte-based measurement would truncate.
+	w.adjustLineWidth(lines, 4, 30)
+
+	assert.Equal(t, taskID, lines[0].taskID,
+		"taskID should not be modified when it fits terminal width in runes")
+}
+
+// TestTruncateLongestTaskID_PreservesValidUTF8 verifies that when truncation
+// of a multi-byte UTF-8 taskID is genuinely required, the resulting string
+// remains valid UTF-8. Byte-indexed slicing can land mid-rune and emit
+// replacement characters (�) into the rendered output.
+func TestTruncateLongestTaskID_PreservesValidUTF8(t *testing.T) {
+	taskID := "Image 测试测试测试测试" // 14 runes, 30 bytes
+	lines := []lineData{{taskID: taskID}}
+
+	truncateLongestTaskID(lines, 8, 10)
+
+	assert.Assert(t, utf8.ValidString(lines[0].taskID),
+		"truncated taskID must remain valid UTF-8, got %q", lines[0].taskID)
+	assert.Assert(t, strings.HasSuffix(lines[0].taskID, "..."),
+		"truncated taskID should end with ..., got %q", lines[0].taskID)
+}
+
+// TestTruncateProgressSize_PicksWidestLine verifies that dropping the size
+// suffix targets the line currently driving maxBeforeStatusWidth (the only
+// line whose shrink can reduce overflow), preserving size info on narrower
+// lines that are not the bottleneck.
+func TestTruncateProgressSize_PicksWidestLine(t *testing.T) {
+	narrowSuffix := " 5MB / 10MB"
+	wideSuffix := " 50MB / 100MB"
+	lines := []lineData{
+		{
+			taskID:            "Image short",
+			progress:          " [⣿⣿]" + narrowSuffix,
+			progressSizeBytes: len(narrowSuffix),
+		},
+		{
+			taskID:            "Image very-long-named-task",
+			progress:          " [⣿⣿⣿⣿⣿⣿⣿⣿]" + wideSuffix,
+			progressSizeBytes: len(wideSuffix),
+		},
+	}
+
+	truncateProgressSize(lines)
+
+	assert.Equal(t, 0, lines[1].progressSizeBytes,
+		"widest line should lose its size suffix first")
+	assert.Equal(t, len(narrowSuffix), lines[0].progressSizeBytes,
+		"narrower line should retain its size suffix")
+}
+
 func TestAdjustLineWidth_NoTruncationNeeded(t *testing.T) {
 	w := &ttyWriter{}
 	originalDetails := "short"

--- a/cmd/display/tty_test.go
+++ b/cmd/display/tty_test.go
@@ -19,6 +19,7 @@ package display
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -502,5 +503,105 @@ func TestDoneDeadlockFix(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("Deadlock detected: Done() did not complete within 5 seconds")
+	}
+}
+
+// TestAdjustLineWidth_WideProgressForcesSizeInfoDrop is the unit-level
+// regression test for docker/compose#13595. When progress contains the
+// " X.XMB / Y.YMB" size suffix and the bar makes beforeStatus large enough
+// to overflow terminalWidth, taskID truncation alone cannot make the line
+// fit: applyPadding's max(timerPad, 1) floor adds one char back, and the
+// "..."-padding minimum (10 chars) on taskID puts a lower bound on
+// beforeStatus. The size info portion of progress must therefore be
+// droppable when overflow can't be eliminated otherwise.
+func TestAdjustLineWidth_WideProgressForcesSizeInfoDrop(t *testing.T) {
+	w := &ttyWriter{}
+	// Mirror prepareLineData's layout: " [bar]" + " %7s / %-7s".
+	sizeSuffix := "    50MB / 100MB  "
+	progress := " [" + strings.Repeat("⣿", 30) + "]" + sizeSuffix
+	lines := []lineData{{
+		taskID:            "Image mariadb:11",
+		progress:          progress,
+		progressSizeBytes: len(sizeSuffix),
+		status:            "Pulling",
+		statusColor:       nocolor,
+		spinner:           " ",
+		timer:             "5.4s",
+	}}
+
+	terminalWidth := 60
+	timerLen := 4
+	w.adjustLineWidth(lines, timerLen, terminalWidth)
+	w.applyPadding(lines, terminalWidth, timerLen)
+
+	rendered := strings.TrimRight(lineText(lines[0]), "\n")
+	assert.Assert(t, lenAnsi(rendered) <= terminalWidth,
+		"line length %d should not exceed terminal width %d: %q",
+		lenAnsi(rendered), terminalWidth, rendered)
+}
+
+// addParentWithDownloadingChildren wires a parent task with N children whose
+// non-zero totals trigger the " X.XMB / Y.YMB" suffix in prepareLineData's
+// progress field. Used by the multi-render regression test below.
+func addParentWithDownloadingChildren(w *ttyWriter, parentID string, children int, totalBytes int64) {
+	parent := &task{
+		ID:        parentID,
+		parents:   make(map[string]struct{}),
+		startTime: time.Now(),
+		text:      "Pulling",
+		status:    api.Working,
+		spinner:   NewSpinner(),
+	}
+	w.tasks[parent.ID] = parent
+	w.ids = append(w.ids, parent.ID)
+	for i := range children {
+		c := &task{
+			ID:        fmt.Sprintf("%s/layer%d", parentID, i),
+			parents:   map[string]struct{}{parent.ID: {}},
+			startTime: time.Now(),
+			text:      "Downloading",
+			status:    api.Working,
+			total:     totalBytes / int64(children),
+			current:   totalBytes / int64(children) / 2,
+			percent:   50,
+			spinner:   NewSpinner(),
+		}
+		w.tasks[c.ID] = c
+		w.ids = append(w.ids, c.ID)
+	}
+}
+
+// TestPrintWithDimensions_MultipleRendersFit verifies the cross-render aspect
+// of docker/compose#13595: even a single overflowing line desyncs the cursor
+// on the following tick because aec.Up(numLines) counts logical lines while
+// the terminal wraps visual lines. Use many concurrent parent tasks with
+// wide progress bars in a narrow terminal so adjustLineWidth's truncation
+// loop can't bring every line under terminalWidth without dropping size
+// info from progress.
+func TestPrintWithDimensions_MultipleRendersFit(t *testing.T) {
+	w, buf := newTestWriter()
+	// Two parents so the truncation loop must walk multiple lines; 30 children
+	// per parent makes each progress bar wide enough that taskID truncation
+	// alone can't bring the line under terminalWidth.
+	for i := range 2 {
+		addParentWithDownloadingChildren(w,
+			"Image very-long-name-image-"+string(rune('a'+i))+":v1.2.3",
+			30, 100_000_000)
+	}
+
+	terminalWidth := 60
+	for tick := range 10 {
+		for _, t := range w.tasks {
+			if t.status == api.Working && t.total > 0 {
+				t.current = min(t.current+t.total/10, t.total)
+			}
+		}
+		buf.Reset()
+		w.printWithDimensions(terminalWidth, 24)
+		for i, line := range extractLines(buf) {
+			assert.Assert(t, lenAnsi(line) <= terminalWidth,
+				"tick %d line %d has length %d > terminalWidth %d: %q",
+				tick, i, lenAnsi(line), terminalWidth, line)
+		}
 	}
 }


### PR DESCRIPTION
**What I did**
Fixes the TTY progress UI mangled output in narrow terminals (most visibly tmux panes) reported in #13595.                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                              
  `adjustLineWidth` could shrink `details` and `taskID` but never the `progress` field. When `progress` carried the ` X.XMB / Y.YMB` size suffix, the truncation loop exited with `overflow > 0` and `applyPadding`'s `max(timerPad, 1)` floor pushed the line one char over `terminalWidth`. tmux then       
  wrapped it visually while `print()` kept counting logical lines, desyncing `aec.Up()` on the next render and producing the `[+] pull X/Y` header overwriting prior task lines.                                                                                                                              
                                                                                                                                                                                                                                                                                                              
  ## Commits                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                              
  1. **drop size info from progress bar when line overflows** — track the size suffix byte length on `lineData` and let `adjustLineWidth` drop it as an intermediate truncation step before abbreviating the `taskID`. Adds two regression tests (unit + multi-render).                                       
  2. **measure taskID width in runes, not bytes** — `maxBeforeStatusWidth` used `len(l.taskID)` while `applyPadding` used `utf8.RuneCountInString`. For multi-byte UTF-8 task IDs (CJK, emoji, accented Latin) this overestimated width, triggering spurious truncation that sliced mid-multibyte and
  corrupted the rendered string. Aligns the two measurements.                                                                                                                                                                                                                                                 
                                                            
**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
  Fixes #13595
  
**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="800" height="589" alt="image" src="https://github.com/user-attachments/assets/58e3c5e8-080b-466a-887a-5514f0860711" />
