### PR TITLE
fix(publish): accept short-form port mappings (fixes #13672)

### DIFF
--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -38,6 +38,7 @@ import (
 	"github.com/opencontainers/image-spec/specs-go"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/docker/compose/v5/internal/desktop"
 	"github.com/docker/compose/v5/internal/oci"
@@ -724,11 +725,24 @@ func (s *composeService) checkForSensitiveData(ctx context.Context, project *typ
 }
 
 func composeFileAsByteReader(ctx context.Context, filePath string, project *types.Project) (io.Reader, error) {
-	base, err := loadUnresolvedFile(ctx, project, filePath)
+	model, err := loader.LoadModelWithContext(ctx, types.ConfigDetails{
+		WorkingDir:  project.WorkingDir,
+		Environment: project.Environment,
+		ConfigFiles: []types.ConfigFile{{Filename: filePath}},
+	}, func(options *loader.Options) {
+		options.SkipValidation = true
+		options.SkipExtends = true
+		options.SkipConsistencyCheck = true
+		options.ResolvePaths = true
+		options.SkipInclude = true
+		options.SkipInterpolation = true
+		options.SkipResolveEnvironment = true
+		options.Profiles = project.Profiles
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load compose file %s: %w", filePath, err)
 	}
-	in, err := base.MarshalYAML()
+	in, err := yaml.Marshal(model)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -325,7 +325,7 @@ func (s *composeService) preChecks(ctx context.Context, project *types.Project, 
 			return false, err
 		}
 	}
-	detectedSecrets, err := s.checkForSensitiveData(ctx, project)
+	detectedSecrets, err := s.checkForSensitiveData(project)
 	if err != nil {
 		return false, err
 	}
@@ -602,7 +602,7 @@ func buildConfigContentPromptMessage(configs []string) string {
 
 // loadUnresolvedFile loads a single compose file with interpolation and
 // environment resolution skipped, so callers can inspect raw user-provided
-// values. Used by both checkEnvironmentVariables and composeFileAsByteReader.
+// values. Used by checkEnvironmentVariables.
 func loadUnresolvedFile(ctx context.Context, project *types.Project, filePath string) (*types.Project, error) {
 	return loader.LoadWithContext(ctx, types.ConfigDetails{
 		WorkingDir:  project.WorkingDir,
@@ -671,12 +671,12 @@ func (s *composeService) checkForBindMount(project *types.Project) map[string][]
 	return allFindings
 }
 
-func (s *composeService) checkForSensitiveData(ctx context.Context, project *types.Project) ([]secrets.DetectedSecret, error) {
+func (s *composeService) checkForSensitiveData(project *types.Project) ([]secrets.DetectedSecret, error) {
 	var allFindings []secrets.DetectedSecret
 	scan := scanner.NewDefaultScanner()
 	// Check all compose files
 	for _, file := range project.ComposeFiles {
-		in, err := composeFileAsByteReader(ctx, file, project)
+		in, err := composeFileAsByteReader(file)
 		if err != nil {
 			return nil, err
 		}
@@ -723,14 +723,10 @@ func (s *composeService) checkForSensitiveData(ctx context.Context, project *typ
 	return allFindings, nil
 }
 
-func composeFileAsByteReader(ctx context.Context, filePath string, project *types.Project) (io.Reader, error) {
-	base, err := loadUnresolvedFile(ctx, project, filePath)
+func composeFileAsByteReader(filePath string) (io.Reader, error) {
+	in, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load compose file %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to open compose file %s: %w", filePath, err)
 	}
-	in, err := base.MarshalYAML()
-	if err != nil {
-		return nil, err
-	}
-	return bytes.NewBuffer(in), nil
+	return bytes.NewReader(in), nil
 }

--- a/pkg/compose/publish_test.go
+++ b/pkg/compose/publish_test.go
@@ -593,3 +593,104 @@ func Test_publish_decline_returns_ErrCanceled(t *testing.T) {
 	assert.Assert(t, errors.Is(err, api.ErrCanceled),
 		"expected api.ErrCanceled when user declines, got: %v", err)
 }
+
+func Test_composeFileAsByteReader_shortFormPorts(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	err := os.WriteFile(composePath, []byte(`name: test
+services:
+  whoami:
+    image: docker.io/traefik/whoami:v1.11
+    ports:
+      - ${DASHBOARD_PORT:-3000}:3000
+`), 0o600)
+	assert.NilError(t, err)
+
+	project, err := loader.LoadWithContext(t.Context(), types.ConfigDetails{
+		WorkingDir:  dir,
+		Environment: types.Mapping{"DASHBOARD_PORT": ""},
+		ConfigFiles: []types.ConfigFile{{Filename: composePath}},
+	})
+	assert.NilError(t, err)
+	project.ComposeFiles = []string{composePath}
+
+	reader, err := composeFileAsByteReader(t.Context(), composePath, project)
+	assert.NilError(t, err)
+	assert.Assert(t, reader != nil)
+}
+
+func Test_composeFileAsByteReader_shortFormPortsBasic(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	err := os.WriteFile(composePath, []byte(`name: test
+services:
+  whoami:
+    image: docker.io/traefik/whoami:v1.11
+    ports:
+      - "8080:80"
+`), 0o600)
+	assert.NilError(t, err)
+
+	project, err := loader.LoadWithContext(t.Context(), types.ConfigDetails{
+		WorkingDir:  dir,
+		Environment: types.Mapping{},
+		ConfigFiles: []types.ConfigFile{{Filename: composePath}},
+	})
+	assert.NilError(t, err)
+	project.ComposeFiles = []string{composePath}
+
+	reader, err := composeFileAsByteReader(t.Context(), composePath, project)
+	assert.NilError(t, err)
+	assert.Assert(t, reader != nil)
+}
+
+func Test_composeFileAsByteReader_shortFormPortsIPBound(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	err := os.WriteFile(composePath, []byte(`name: test
+services:
+  whoami:
+    image: docker.io/traefik/whoami:v1.11
+    ports:
+      - "127.0.0.1:8080:80"
+`), 0o600)
+	assert.NilError(t, err)
+
+	project, err := loader.LoadWithContext(t.Context(), types.ConfigDetails{
+		WorkingDir:  dir,
+		Environment: types.Mapping{},
+		ConfigFiles: []types.ConfigFile{{Filename: composePath}},
+	})
+	assert.NilError(t, err)
+	project.ComposeFiles = []string{composePath}
+
+	reader, err := composeFileAsByteReader(t.Context(), composePath, project)
+	assert.NilError(t, err)
+	assert.Assert(t, reader != nil)
+}
+
+func Test_composeFileAsByteReader_longFormPorts(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yaml")
+	err := os.WriteFile(composePath, []byte(`name: test
+services:
+  whoami:
+    image: docker.io/traefik/whoami:v1.11
+    ports:
+      - target: 3000
+        published: "3000"
+`), 0o600)
+	assert.NilError(t, err)
+
+	project, err := loader.LoadWithContext(t.Context(), types.ConfigDetails{
+		WorkingDir:  dir,
+		Environment: types.Mapping{},
+		ConfigFiles: []types.ConfigFile{{Filename: composePath}},
+	})
+	assert.NilError(t, err)
+	project.ComposeFiles = []string{composePath}
+
+	reader, err := composeFileAsByteReader(t.Context(), composePath, project)
+	assert.NilError(t, err)
+	assert.Assert(t, reader != nil)
+}

--- a/pkg/compose/publish_test.go
+++ b/pkg/compose/publish_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -592,4 +593,27 @@ func Test_publish_decline_returns_ErrCanceled(t *testing.T) {
 	err := svc.publish(t.Context(), project, "docker.io/myorg/myapp:latest", api.PublishOptions{})
 	assert.Assert(t, errors.Is(err, api.ErrCanceled),
 		"expected api.ErrCanceled when user declines, got: %v", err)
+}
+
+func Test_composeFileAsByteReader(t *testing.T) {
+	composeFile := []byte(`name: test
+services:
+  whoami:
+    image: docker.io/traefik/whoami:v1.11
+    ports:
+      - ${DASHBOARD_PORT:-3000}:3000
+`)
+	composePath := filepath.Join(t.TempDir(), "compose.yaml")
+	assert.NilError(t, os.WriteFile(composePath, composeFile, 0o600))
+
+	reader, err := composeFileAsByteReader(composePath)
+	assert.NilError(t, err)
+	actual, err := io.ReadAll(reader)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, actual, composeFile)
+}
+
+func Test_composeFileAsByteReader_missingFile(t *testing.T) {
+	_, err := composeFileAsByteReader(filepath.Join(t.TempDir(), "missing.yaml"))
+	assert.Assert(t, errors.Is(err, os.ErrNotExist))
 }


### PR DESCRIPTION
**What I did**

`docker compose publish` failed with `'services[whoami].ports[0]' expected a map or struct, got "string"` when a service used short-form port syntax like `${DASHBOARD_PORT:-3000}:3000`.

`composeFileAsByteReader` used `LoadWithContext` which decodes ports into typed Go structs which rejects short-form string entries. Switching to `LoadModelWithContext` returns a raw map instead which in ths case avoids the struct decode

**Related issue**

Fixes #13672