### PR TITLE
chore(deps): bump github.com/containerd/containerd/v2 to v2.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/buger/goterm v1.0.4
 	github.com/compose-spec/compose-go/v2 v2.11.0
 	github.com/containerd/console v1.0.5
-	github.com/containerd/containerd/v2 v2.2.4
+	github.com/containerd/containerd/v2 v2.2.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
 github.com/containerd/containerd/api v1.10.0/go.mod h1:NBm1OAk8ZL+LG8R0ceObGxT5hbUYj7CzTmR3xh0DlMM=
-github.com/containerd/containerd/v2 v2.2.4 h1:8x2UdXqww7NYqGNabQ7i1nAgB5LegzjC9KQzO/900iA=
-github.com/containerd/containerd/v2 v2.2.4/go.mod h1:YBcTO8D9149QY9zNmUjy04Mhuc4DlrZQ8FIOwKZEM7o=
+github.com/containerd/containerd/v2 v2.2.5 h1:KTFzB02LviYmmfRmz8r9UFd+n6YlddVFK+5lbgQXUTU=
+github.com/containerd/containerd/v2 v2.2.5/go.mod h1:5t2+xFv2dGd/iDYp9Z8DXB4cmWrWQi1XqxGJPS2gBzU=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=


### PR DESCRIPTION
- full diff: https://github.com/containerd/containerd/compare/v2.2.4...v2.2.5
- release notes: https://github.com/containerd/containerd/releases/tag/v2.2.5

The fifth patch release for containerd 2.2 contains various fixes and updates including security patches.

-  CVE-2026-50195 / [GHSA-cvxm-645q-p574] CRI: checkpoint import allows local image tag poisoning
-  CVE-2026-53488 / [GHSA-xhf5-7wjv-pqxp] CRI: image-config LABEL flows to host-root command execution from an image pull
-  CVE-2026-53492 / [GHSA-33vj-92qq-66hc] CRI: CDI annotation smuggling during CRI checkpoint restore
-  CVE-2026-53489 / [GHSA-rgh6-rfwx-v388] CRI: Arbitrary host file read via symlink following in CRI checkpoint restore
-  CVE-2026-47262 / [GHSA-jpcc-p29g-p8mq] containerd image-triggered runtime DoS via unbounded group parsing

[GHSA-cvxm-645q-p574]: https://github.com/containerd/containerd/security/advisories/GHSA-cvxm-645q-p574
[GHSA-xhf5-7wjv-pqxp]: https://github.com/containerd/containerd/security/advisories/GHSA-xhf5-7wjv-pqxp
[GHSA-33vj-92qq-66hc]: https://github.com/containerd/containerd/security/advisories/GHSA-33vj-92qq-66hc
[GHSA-rgh6-rfwx-v388]: https://github.com/containerd/containerd/security/advisories/GHSA-rgh6-rfwx-v388
[GHSA-jpcc-p29g-p8mq]: https://github.com/containerd/containerd/security/advisories/GHSA-jpcc-p29g-p8mq

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
