### PR TITLE
watch: do not rebuild depends_on services on file change

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -206,9 +206,14 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		}
 
 		image := api.GetImageNameOrDefault(service, project.Name)
-		s.events.On(buildingEvent(image))
-
-		expectedImages[serviceName] = image
+		// project.Services lists every service (we still need their bake
+		// targets defined so additional_contexts: service:xxx references can
+		// resolve), but only emit "Building" progress and track expected
+		// images for services we actually plan to build.
+		if _, ok := serviceToBeBuild[serviceName]; ok {
+			s.events.On(buildingEvent(image))
+			expectedImages[serviceName] = image
+		}
 
 		pull := service.Build.Pull || options.Pull
 		noCache := service.Build.NoCache || options.NoCache

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -634,10 +634,17 @@ func (s *composeService) exec(ctx context.Context, project *types.Project, servi
 
 func (s *composeService) rebuild(ctx context.Context, project *types.Project, services []string, options api.WatchOptions) error {
 	options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Rebuilding service(s) %q after changes were detected...", services))
-	// restrict the build to ONLY this service, not any of its dependencies
-	options.Build.Services = services
-	options.Build.Progress = string(progressui.PlainMode)
-	options.Build.Out = cutils.GetWriter(func(line string) {
+	// Work on a copy so concurrent watch events don't race on the shared
+	// BuildOptions pointer carried by WatchOptions.
+	buildOpts := *options.Build
+	// Restrict the build to ONLY the watched services, not any of their
+	// dependencies. `up --build` sets Deps=true so initial startup builds
+	// images for depends_on services; here we must reset it, otherwise a
+	// rebuild for service A cascades to its upstream dependency B.
+	buildOpts.Services = services
+	buildOpts.Deps = false
+	buildOpts.Progress = string(progressui.PlainMode)
+	buildOpts.Out = cutils.GetWriter(func(line string) {
 		options.LogTo.Log(api.WatchLogger, line)
 	})
 
@@ -647,7 +654,7 @@ func (s *composeService) rebuild(ctx context.Context, project *types.Project, se
 	)
 	err = tracing.SpanWrapFunc("project/build", tracing.ProjectOptions(ctx, project),
 		func(ctx context.Context) error {
-			imageNameToIdMap, err = s.build(ctx, project, *options.Build, nil)
+			imageNameToIdMap, err = s.build(ctx, project, buildOpts, nil)
 			return err
 		})(ctx)
 	if err != nil {

--- a/pkg/e2e/fixtures/watch/rebuild-deps.yaml
+++ b/pkg/e2e/fixtures/watch/rebuild-deps.yaml
@@ -1,0 +1,22 @@
+services:
+  backend:
+    build:
+      dockerfile_inline: |
+        FROM nginx:alpine
+        RUN echo "backend_build_marker" > /built
+    command: sleep infinity
+    init: true
+  frontend:
+    build:
+      dockerfile_inline: |
+        FROM nginx:alpine
+        COPY test /tmp/test
+        RUN echo "frontend_build_marker" > /built
+    command: sleep infinity
+    init: true
+    depends_on:
+      - backend
+    develop:
+      watch:
+        - path: test
+          action: rebuild

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -368,6 +368,85 @@ func TestWatchMultiServices(t *testing.T) {
 	c.RunDockerComposeCmdNoCheck(t, "-p", projectName, "kill", "-s", "9")
 }
 
+// TestWatchRebuildIgnoresDependencies verifies that when `compose up --watch`
+// rebuilds a service after a file change, the rebuild does NOT cascade to its
+// `depends_on` dependencies.
+//
+// Reproduces docker/compose#13853: `up --build` sets BuildOptions.Deps=true to
+// build images for dependencies on initial startup; the watch rebuild path
+// reused those BuildOptions without resetting Deps, so a single watched
+// service triggered builds for the whole dependency chain.
+//
+// The test scans build progress output between the "Rebuilding service(s)" and
+// "successfully built" markers and asserts only the watched service appears.
+func TestWatchRebuildIgnoresDependencies(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "test_watch_rebuild_deps"
+
+	defer c.cleanupWithDown(t, projectName)
+
+	tmpdir := t.TempDir()
+	composeFilePath := filepath.Join(tmpdir, "compose.yaml")
+	CopyFile(t, filepath.Join("fixtures", "watch", "rebuild-deps.yaml"), composeFilePath)
+
+	testFile := filepath.Join(tmpdir, "test")
+	assert.NilError(t, os.WriteFile(testFile, []byte("initial"), 0o600))
+
+	cmd := c.NewDockerComposeCmd(t, "-p", projectName, "-f", composeFilePath, "up", "--build", "--watch")
+	buffer := bytes.NewBuffer(nil)
+	cmd.Stdout = buffer
+	cmd.Stderr = buffer
+	watch := icmd.StartCmd(cmd)
+	assert.NilError(t, watch.Error)
+	t.Cleanup(func() {
+		if watch.Cmd.Process != nil {
+			_ = watch.Cmd.Process.Kill()
+		}
+	})
+
+	// Wait until the watcher is actually running. "Watch enabled" is logged
+	// AFTER the initial up (and its build output) is done, so anchoring the
+	// cutoff here keeps initial-build noise out of the rebuild assertions.
+	poll.WaitOn(t, func(l poll.LogT) poll.Result {
+		if strings.Contains(buffer.String(), "Watch enabled") {
+			return poll.Success()
+		}
+		return poll.Continue("waiting for watch to start: %v", buffer.String())
+	}, poll.WithTimeout(120*time.Second))
+
+	// Record the cutoff point in the log buffer so we only inspect output
+	// produced AFTER the file change triggers the rebuild.
+	logCutoff := buffer.Len()
+
+	// Trigger a rebuild of the frontend (only) by modifying the watched file.
+	assert.NilError(t, os.WriteFile(testFile, []byte("updated"), 0o600))
+
+	// Wait until the rebuild is reported as completed.
+	poll.WaitOn(t, func(l poll.LogT) poll.Result {
+		out := buffer.String()
+		if len(out) <= logCutoff {
+			return poll.Continue("no new output yet")
+		}
+		if strings.Contains(out[logCutoff:], `service(s) ["frontend"] successfully built`) {
+			return poll.Success()
+		}
+		return poll.Continue("waiting for rebuild to finish: %v", out[logCutoff:])
+	}, poll.WithTimeout(120*time.Second), poll.WithDelay(time.Second))
+
+	rebuildLog := buffer.String()[logCutoff:]
+
+	// The watch rebuild must only touch the frontend service. The backend is
+	// an upstream dependency and must not be rebuilt.
+	assert.Assert(t, strings.Contains(rebuildLog, `Rebuilding service(s) ["frontend"]`),
+		"expected rebuild of frontend; got:\n%s", rebuildLog)
+	assert.Assert(t, !strings.Contains(rebuildLog, "backend Building"),
+		"backend was unexpectedly rebuilt; got:\n%s", rebuildLog)
+	assert.Assert(t, !strings.Contains(rebuildLog, "backend Built"),
+		"backend was unexpectedly rebuilt; got:\n%s", rebuildLog)
+
+	c.RunDockerComposeCmdNoCheck(t, "-p", projectName, "kill", "-s", "9")
+}
+
 func TestWatchIncludes(t *testing.T) {
 	c := NewCLI(t)
 	const projectName = "test_watch_includes"


### PR DESCRIPTION
## Summary

- Fixes #13853: `compose up --build --watch` rebuilt every `depends_on` dependency whenever a watched service changed.
- Root cause: `up --build` sets `BuildOptions.Deps=true` to build dep images at startup. The watch `rebuild()` path mutated the shared `*BuildOptions` to restrict `Services` to the watched service but never reset `Deps`, so `s.build()` switched back to `IncludeDependencies` and walked up the graph.
- Fix: `rebuild()` now works on a local copy of `BuildOptions` and explicitly sets `Deps=false`. The local copy also removes the data race on the shared pointer when concurrent file events fire.
- Bonus: `doBuildBake` was emitting `Image X Building` and tracking `expectedImages` for every service in the project, not just the ones in `serviceToBeBuild`. Filter those side-effects to the actual build set — `cfg.Targets` is still populated for every service so `additional_contexts: service:xxx` references keep resolving.

### Why not the approach in #13854

That PR also forced `IgnoreDependencies` in `selectWatchServices`, which strips dependency configs from the selected project. `create()` and `start()` need those configs (network membership, env interpolation) so the side-effects bleed into the restart path. Resetting `Build.Deps` and filtering the bake event leak is enough.

## Test plan

- [x] New e2e `TestWatchRebuildIgnoresDependencies` (fixture `pkg/e2e/fixtures/watch/rebuild-deps.yaml`) launches `up --build --watch` on a `frontend` → `backend` stack, modifies a frontend-watched file, and asserts the rebuild log between `Rebuilding service(s) ["frontend"]` and `successfully built` never mentions `backend Building` / `backend Built`.
- [x] `TestWatchMultiServices` and `TestWatchExec` still pass.
- [x] `go test ./pkg/compose/...` passes.
- [x] `golangci-lint run --build-tags "e2e" ./pkg/compose/... ./pkg/e2e/...` clean.