### PR TITLE
pkg/e2e: drop unused run param from getEnv

### DIFF
--- a/pkg/e2e/providers_test.go
+++ b/pkg/e2e/providers_test.go
@@ -73,21 +73,18 @@ func TestDependsOnMultipleProviders(t *testing.T) {
 
 	res := c.RunDockerComposeCmd(t, "-f", "fixtures/providers/depends-on-multiple-providers.yaml", "--project-name", projectName, "up")
 	res.Assert(t, icmd.Success)
-	env := getEnv(res.Combined(), false)
+	env := getEnv(res.Combined())
 	assert.Check(t, slices.Contains(env, "PROVIDER1_URL=https://magic.cloud/provider1"), env)
 	assert.Check(t, slices.Contains(env, "PROVIDER2_URL=https://magic.cloud/provider2"), env)
 }
 
-func getEnv(out string, run bool) []string {
+func getEnv(out string) []string {
 	var env []string
 	scanner := bufio.NewScanner(strings.NewReader(out))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !run && strings.HasPrefix(line, "test-1  | ") {
+		if strings.HasPrefix(line, "test-1  | ") {
 			env = append(env, line[10:])
-		}
-		if run && strings.Contains(line, "=") && len(strings.Split(line, "=")) == 2 {
-			env = append(env, line)
 		}
 	}
 	slices.Sort(env)


### PR DESCRIPTION
**What I did**
The run parameter was always passed as false at the single call site and the run==true branch was dead code. Remove it so unparam stops flagging callers added by PR #13742.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
