### PR TITLE
chore: migrate to docker-agent-action v2.0.1

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,7 +1,7 @@
 name: PR Review - Trigger
 on:
   pull_request:
-    types: [ready_for_review, opened]
+    types: [ready_for_review, opened, review_requested]
   pull_request_review_comment:
     types: [created]
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@3c0fa9d282c3f84d08dfd70ab0a28b151d11db70 # v2.0.0
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
Bumps `docker/docker-agent-action` from v2.0.0 to v2.0.1 (`e96a4bb`).

Also checks `review_requested` trigger and `actions: read` permission.