### PR TITLE
fix(compose): return nil error on non-zero container exit codes

### DIFF
--- a/pkg/compose/exec.go
+++ b/pkg/compose/exec.go
@@ -53,7 +53,7 @@ func (s *composeService) Exec(ctx context.Context, projectName string, options a
 	err = container.RunExec(ctx, s.dockerCli, target.ID, exec)
 	var sterr cli.StatusError
 	if errors.As(err, &sterr) {
-		return sterr.StatusCode, err
+		return sterr.StatusCode, nil
 	}
 	return 0, err
 }


### PR DESCRIPTION
## What I did

From my understanding, `cli.StatusError` means the container's command ran and exited non-zero. Hence, that's not a compose failure, but the command's own exit code. Returning a non-nil err alongside it made callers treat a normal exit as a tool error. Now it just passes the exit code through.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

