### PR TITLE
fix(compose/port): show private port in portNotFoundError message

### DIFF
--- a/pkg/compose/port.go
+++ b/pkg/compose/port.go
@@ -47,7 +47,7 @@ func portNotFoundError(protocol string, port uint16, ctr container.Summary) erro
 
 	var containerPorts []string
 	for _, p := range ctr.Ports {
-		containerPorts = append(containerPorts, formatPort(p.Type, p.PublicPort))
+		containerPorts = append(containerPorts, formatPort(p.Type, p.PrivatePort))
 	}
 
 	name := strings.TrimPrefix(ctr.Names[0], "/")


### PR DESCRIPTION
**What I did**

While running `docker compose port web 9090` on a service with a `32768:8080` mapping, the error message was showing the host port (32768) instead of the container port (8080). The user queries by container port, so the error should list container ports to be meaningful. Traced it to `portNotFoundError` using `p.PublicPort`.

<img width="976" height="403" alt="image" src="https://github.com/user-attachments/assets/7df1a575-a25d-4ead-b9a4-779d7c03a6f7" />


**Related issue**
None

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
