### PR TITLE
test: Set stop_signal to SIGTERM in nginx-based services

### DIFF
--- a/pkg/e2e/fixtures/watch/rebuild-deps.yaml
+++ b/pkg/e2e/fixtures/watch/rebuild-deps.yaml
@@ -6,6 +6,7 @@ services:
         RUN echo "backend_build_marker" > /built
     command: sleep infinity
     init: true
+    stop_signal: SIGTERM
   frontend:
     build:
       dockerfile_inline: |
@@ -14,6 +15,7 @@ services:
         RUN echo "frontend_build_marker" > /built
     command: sleep infinity
     init: true
+    stop_signal: SIGTERM
     depends_on:
       - backend
     develop:


### PR DESCRIPTION
The official nginx images set STOPSIGNAL to SIGQUIT which dumps core. Set it to SIGTERM to avoid dumping core on e2e tests when containers running `sleep infinity` are stopped.

Mirrors similar fix done in https://github.com/docker/compose/pull/13214

**What I did**

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
