### PR TITLE
fix(run): normalize --no-TTY flag to --no-tty

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -178,12 +178,12 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backen
 				options.entrypointCmd = command
 			}
 			if cmd.Flags().Changed("tty") {
-				if cmd.Flags().Changed("no-TTY") {
-					return fmt.Errorf("--tty and --no-TTY can't be used together")
+				if cmd.Flags().Changed("no-tty") {
+					return fmt.Errorf("--tty and --no-tty can't be used together")
 				} else {
 					options.noTty = !ttyFlag
 				}
-			} else if !cmd.Flags().Changed("no-TTY") && !cmd.Flags().Changed("interactive") && !dockerCli.In().IsTerminal() {
+			} else if !cmd.Flags().Changed("no-tty") && !cmd.Flags().Changed("interactive") && !dockerCli.In().IsTerminal() {
 				// while `docker run` requires explicit `-it` flags, Compose enables interactive mode and TTY by default
 				// but when compose is used from a script that has stdin piped from another command, we just can't
 				// Here, we detect we run "by default" (user didn't passed explicit flags) and disable TTY allocation if
@@ -229,7 +229,7 @@ func runCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backen
 	flags.StringArrayVar(&options.envFiles, "env-from-file", []string{}, "Set environment variables from file")
 	flags.StringArrayVarP(&options.labels, "label", "l", []string{}, "Add or override a label")
 	flags.BoolVar(&options.Remove, "rm", false, "Automatically remove the container when it exits")
-	flags.BoolVarP(&options.noTty, "no-TTY", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-TTY allocation (default: auto-detected)")
+	flags.BoolVarP(&options.noTty, "no-tty", "T", !dockerCli.Out().IsTerminal(), "Disable pseudo-TTY allocation (default: auto-detected)")
 	flags.StringVar(&options.name, "name", "", "Assign a name to the container")
 	flags.StringVarP(&options.user, "user", "u", "", "Run as specified username or uid")
 	flags.StringVarP(&options.workdir, "workdir", "w", "", "Working directory inside the container")
@@ -263,6 +263,8 @@ func normalizeRunFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "volume"
 	case "labels":
 		name = "label"
+	case "no-TTY":
+		name = "no-tty"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -70,7 +70,7 @@ specified in the service configuration.
 | `-i`, `--interactive`   | `bool`        | `true`   | Keep STDIN open even if not attached                                             |
 | `-l`, `--label`         | `stringArray` |          | Add or override a label                                                          |
 | `--name`                | `string`      |          | Assign a name to the container                                                   |
-| `-T`, `--no-TTY`        | `bool`        | `true`   | Disable pseudo-TTY allocation (default: auto-detected)                           |
+| `-T`, `--no-tty`        | `bool`        | `true`   | Disable pseudo-TTY allocation (default: auto-detected)                           |
 | `--no-deps`             | `bool`        |          | Don't start linked services                                                      |
 | `-p`, `--publish`       | `stringArray` |          | Publish a container's port(s) to the host                                        |
 | `--pull`                | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                         |

--- a/docs/reference/compose_run.md
+++ b/docs/reference/compose_run.md
@@ -70,8 +70,8 @@ specified in the service configuration.
 | `-i`, `--interactive`   | `bool`        | `true`   | Keep STDIN open even if not attached                                             |
 | `-l`, `--label`         | `stringArray` |          | Add or override a label                                                          |
 | `--name`                | `string`      |          | Assign a name to the container                                                   |
-| `-T`, `--no-tty`        | `bool`        | `true`   | Disable pseudo-TTY allocation (default: auto-detected)                           |
 | `--no-deps`             | `bool`        |          | Don't start linked services                                                      |
+| `-T`, `--no-tty`        | `bool`        | `true`   | Disable pseudo-TTY allocation (default: auto-detected)                           |
 | `-p`, `--publish`       | `stringArray` |          | Publish a container's port(s) to the host                                        |
 | `--pull`                | `string`      | `policy` | Pull image before running ("always"\|"missing"\|"never")                         |
 | `-q`, `--quiet`         | `bool`        |          | Don't print anything to STDOUT                                                   |

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -158,7 +158,7 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-    - option: no-TTY
+    - option: no-tty
       shorthand: T
       value_type: bool
       default_value: "true"

--- a/docs/reference/docker_compose_run.yaml
+++ b/docs/reference/docker_compose_run.yaml
@@ -158,21 +158,21 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-    - option: no-tty
-      shorthand: T
+    - option: no-deps
       value_type: bool
-      default_value: "true"
-      description: 'Disable pseudo-TTY allocation (default: auto-detected)'
+      default_value: "false"
+      description: Don't start linked services
       deprecated: false
       hidden: false
       experimental: false
       experimentalcli: false
       kubernetes: false
       swarm: false
-    - option: no-deps
+    - option: no-tty
+      shorthand: T
       value_type: bool
-      default_value: "false"
-      description: Don't start linked services
+      default_value: "true"
+      description: 'Disable pseudo-TTY allocation (default: auto-detected)'
       deprecated: false
       hidden: false
       experimental: false

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -272,13 +272,13 @@ func TestLocalComposeRun(t *testing.T) {
 		})
 	})
 
-	t.Run("compose run piped input with --no-TTY=false should fail", func(t *testing.T) {
+	t.Run("compose run piped input with --no-tty=false should fail", func(t *testing.T) {
 		if composeStandaloneMode {
 			t.Skip("Skipping test compose with piped input detection in standalone mode")
 		}
-		// Test that explicitly disabling --no-TTY (i.e., requesting TTY) with piped input fails
+		// Test that explicitly disabling --no-tty (i.e., requesting TTY) with piped input fails
 		// This should also trigger the "input device is not a TTY" error
-		cmd := c.NewCmd("sh", "-c", "echo 'test' | docker compose -f ./fixtures/run-test/piped-test.yaml run --rm --no-TTY=false piped-test")
+		cmd := c.NewCmd("sh", "-c", "echo 'test' | docker compose -f ./fixtures/run-test/piped-test.yaml run --rm --no-tty=false piped-test")
 		res := icmd.RunCmd(cmd)
 
 		res.Assert(t, icmd.Expected{


### PR DESCRIPTION
**What I did**

Normalized the run command's `--no-TTY` flag to `--no-tty`.

Couple of things to note:

- Never worked on this code base (I'm depending on this repo's CI test suite to test the changes)
- Looked at https://github.com/docker/compose/commit/0cdc5c9bff1232262ceb2aad5e03c56c2367e7eb for inspiration
- Matched what `exec` did by supporting `--no-TTY` silently
- Searched the code base for `--no-TTY` and changed them to `--no-tty` for the run command

**Related issue**

https://github.com/docker/compose/issues/13884

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1280" height="1920" alt="image" src="https://github.com/user-attachments/assets/1d03a20c-f573-444d-ae5f-feaf5b617c83" />

A Cheetah "runs" fast and here is a small one which is lowercase!

