### PR TITLE
Fix grammar in Attestations field comment

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -218,7 +218,7 @@ type BuildOptions struct {
 	Print bool
 	// Check let builder validate build configuration
 	Check bool
-	// Attestations allows to enable attestations generation
+	// Attestations enables attestation generation
 	Attestations bool
 	// Provenance generate a provenance attestation
 	Provenance string


### PR DESCRIPTION
**What I did**

Fixed a grammatical issue in the `Attestations` field comment and simplified the wording for clarity.

This is a documentation-only change and does not affect behavior.

**Related issue**

N/A