### PR TITLE
fix(oci): honor --insecure-registry when `up` re-loads the model

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -348,9 +348,7 @@ func (o *ProjectOptions) ToProject(ctx context.Context, dockerCli command.Cli, b
 		Compatibility:     o.Compatibility,
 		ProjectOptionsFns: po,
 		LoadListeners:     []api.LoadListener{metricsListener},
-		OCI: api.OCIOptions{
-			InsecureRegistries: o.insecureRegistries,
-		},
+		OCI:               o.ociOptions(),
 	}
 
 	project, err := backend.LoadProject(ctx, loadOpts)
@@ -369,8 +367,19 @@ func (o *ProjectOptions) remoteLoaders(dockerCli command.Cli) []loader.ResourceL
 		return nil
 	}
 	git := remote.NewGitRemoteLoader(dockerCli, o.Offline)
-	oci := remote.NewOCIRemoteLoader(dockerCli, o.Offline, api.OCIOptions{})
+	oci := remote.NewOCIRemoteLoader(dockerCli, o.Offline, o.ociOptions())
 	return []loader.ResourceLoader{git, oci}
+}
+
+// ociOptions builds the OCI loader configuration from the project options.
+// Both the primary project load and the loaders returned by remoteLoaders
+// must use this so the --insecure-registry flag is honored on every path
+// that pulls an OCI compose artifact (e.g. the interpolation-variable
+// re-load that `up` runs via ToModel). See docker/compose#13824.
+func (o *ProjectOptions) ociOptions() api.OCIOptions {
+	return api.OCIOptions{
+		InsecureRegistries: o.insecureRegistries,
+	}
 }
 
 func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.ProjectOptions, error) {

--- a/pkg/e2e/fixtures/publish/oci/compose-interpolated.yaml
+++ b/pkg/e2e/fixtures/publish/oci/compose-interpolated.yaml
@@ -1,0 +1,5 @@
+services:
+  app:
+    image: alpine
+    environment:
+      GREETING: ${GREETING:-hello}

--- a/pkg/e2e/publish_test.go
+++ b/pkg/e2e/publish_test.go
@@ -205,4 +205,25 @@ networks:
   default:
     name: oci_default
 `)
+
+	// `up` loads the project twice: once through ToProject, then again through
+	// ToModel (checksForRemoteStack -> promptForInterpolatedVariables) to list
+	// the interpolation variables when --yes is not passed. That second load
+	// builds its own OCI loader, which used to drop --insecure-registry and so
+	// talked HTTPS to a plain-HTTP registry. See docker/compose#13824.
+	res = c.RunDockerComposeCmd(t, "-f", "./fixtures/publish/oci/compose-interpolated.yaml",
+		"-p", projectName, "publish", "--with-env", "--yes", "--insecure-registry", registry+"/test:interpolated")
+	res.Assert(t, icmd.Expected{ExitCode: 0})
+
+	// Declining the prompt keeps the test hermetic: nothing is created, but the
+	// re-load has already happened by then, which is what we want to cover.
+	cmd = c.NewDockerComposeCmd(t, "--project-name=oci-reload",
+		"--insecure-registry", registry,
+		"-f", fmt.Sprintf("oci://%s/test:interpolated", registry), "up")
+	cmd.Stdin = strings.NewReader("n\n")
+	res = icmd.RunCmd(cmd, func(cmd *icmd.Cmd) {
+		cmd.Env = append(cmd.Env, "XDG_CACHE_HOME="+t.TempDir())
+	})
+	assert.Assert(t, !strings.Contains(res.Combined(), "server gave HTTP response to HTTPS client"), res.Combined())
+	res.Assert(t, icmd.Expected{ExitCode: 1, Err: "operation cancelled by user"})
 }


### PR DESCRIPTION
## Problem

`docker compose -f oci://<insecure-registry>/... up` fails against a plain-HTTP /
loopback registry **unless `--yes` is passed**, even though the initial project
load succeeds.

## Root cause

`up` loads the project once via `ToProject` → `LoadProject`, which correctly
forwards `--insecure-registry`. `runUp` then calls `checksForRemoteStack`; without
`--yes` that path re-loads the model via `ToModel` to prompt for interpolation
variables. `ToModel` builds its OCI loader through `ProjectOptions.remoteLoaders`,
which constructed an **empty `api.OCIOptions{}`** — dropping the insecure-registry
list. The resolver then speaks HTTPS to a plain-HTTP registry and fails before the
prompt is even shown.

`oci.Get` always performs a network resolve (even with the artifact disk-cached),
so the second load genuinely re-contacts the registry with the wrong config.
`config` and `viz` share the `ToModel` path and hit the same failure.

Note this is distinct from the Docker Desktop proxy loopback bypass (#13824): the
shared transport already handles proxy bypass for consuming; this PR fixes the
separate plain-HTTP flag being dropped on the re-load path.

## Fix

The two OCI-options construction sites had drifted. Consolidate them into
`ProjectOptions.ociOptions()` so every path that pulls an OCI artifact uses the
same configuration.

## Testing

Covered by an e2e case appended to `TestPublish`, which already spins up an
insecure `registry:3` and does an `oci://` round-trip. The existing assertions
load back via `config` (the `ToProject` path, which always worked), so the new
case drives the re-load instead: publish a fixture carrying an interpolation
variable (`GREETING: ${GREETING:-hello}`) so the prompt fires, then run `up`
without `--yes` and decline, which keeps it hermetic — `checksForRemoteStack` is
the first statement in `runUp`, so nothing is created.

Verified in both directions locally with a real registry:

- with the fix, `TestPublish` passes;
- with `remoteLoaders` reverted to `api.OCIOptions{}`, it fails on exactly the
  regression:

```
publish_test.go:227: assertion failed:
  strings.Contains(res.Combined(), "server gave HTTP response to HTTPS client") is true:
  Your compose stack "oci://localhost:32769/test:interpolated" is stored in "..."
  failed to pull OCI resource "localhost:32769/test:interpolated": failed to do request:
  Head "https://localhost:32769/v2/test/manifests/interpolated":
  http: server gave HTTP response to HTTPS client
```

The "stack is stored in" line confirms the first load succeeded and only the
`ToModel` re-load went out over HTTPS.

Per review feedback, the earlier unit tests and the `ociRemoteLoader.InsecureRegistries()`
getter they needed are dropped — `pkg/remote/oci.go` is unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
