### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,7 @@ jobs:
           files: ./coverage.txt
 
   release:
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write # to create a release (ncipollo/release-action)
     runs-on: ubuntu-latest
@@ -329,7 +330,6 @@ jobs:
           find bin/release -type f -exec file -e ascii -- {} +
       -
         name: GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: ./bin/release/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,14 @@ jobs:
             fi
           done
       -
+        name: List artifacts
+        run: |
+          tree -nh ./bin/release
+      -
+        name: Check artifacts
+        run: |
+          find bin/release -type f -exec file -e ascii -- {} +
+      -
         name: Upload artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -306,7 +314,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
-      contents: write # to create a release (ncipollo/release-action)
+      contents: write # to create a release (softprops/action-gh-release)
     runs-on: ubuntu-latest
     needs:
       - binary-finalize
@@ -321,6 +329,8 @@ jobs:
           path: ./bin/release
           name: release
       -
+        # inspect what was actually downloaded from the artifact store —
+        # this is what gets attached to the release
         name: List artifacts
         run: |
           tree -nh ./bin/release
@@ -330,9 +340,12 @@ jobs:
           find bin/release -type f -exec file -e ascii -- {} +
       -
         name: GitHub Release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
-          artifacts: ./bin/release/*
-          generateReleaseNotes: true
+          files: ./bin/release/*
+          generate_release_notes: true
           draft: true
+          # never replace assets already uploaded to an existing release
+          # (softprops updates an existing release for the tag instead of failing)
+          overwrite_files: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,7 +39,7 @@ jobs:
       cache: true
       cache-scope: bin-image
       output: image
-      push: ${{ github.event_name != 'pull_request' }}
+      push: true # this workflow only triggers on push (main and tags)
       sbom: true
       set-meta-labels: true
       meta-images: |

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -61,6 +61,6 @@ jobs:
       
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+        uses: github/codeql-action/upload-sarif@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
**What I did**
The pinned codeql-action/upload-sarif v2 (v2.28.1) falls in the vulnerable range of CVE-2025-24362 and the v2 line has no patched release, so bump to v3.36.3. Enable Dependabot for github-actions to keep action pins from going stale. Scope the release job to tag refs so its contents:write token is only minted when a release is actually created. In merge.yml, drop a dead conditional (workflow only triggers on push) and pass DOCKERDESKTOP_REPO to github-script via env rather than inline interpolation, as recommended against script injection.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1200" height="899" alt="image" src="https://github.com/user-attachments/assets/65e42fec-356d-4927-899f-f1d23aa581ac" />
