### PR TITLE
ci: remove unused desktop-edge-test workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -80,32 +80,4 @@ jobs:
           username: ${{ secrets.DOCKERPUBLICBOT_USERNAME }}
           password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
 
-  desktop-edge-test:
-    runs-on: ubuntu-latest
-    needs: bin-image
-    steps:
-      -
-        name: Generate Token
-        id: generate_token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
-        with:
-          app-id: ${{ vars.DOCKERDESKTOP_APP_ID }}
-          private-key: ${{ secrets.DOCKERDESKTOP_APP_PRIVATEKEY }}
-          owner: docker
-          repositories: |
-            ${{ secrets.DOCKERDESKTOP_REPO }}
-      -
-        name: Trigger Docker Desktop e2e with edge version
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'docker',
-              repo: '${{ secrets.DOCKERDESKTOP_REPO }}',
-              workflow_id: 'compose-edge-integration.yml',
-              ref: 'main',
-              inputs: {
-                "image-tag": "${{ env.REPO_SLUG }}:edge"
-              }
-            })
+ 


### PR DESCRIPTION
It's not currently used, and we can probably trigger this from the desktop repository itself.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
