### PR TITLE
Dockerfile: update golang image to alpine 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM crazymax/osxcross:15.5-alpine AS osxcross
 FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
 FROM ghcr.io/google/addlicense:${ADDLICENSE_VERSION} AS addlicense
 
-FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine3.22 AS base
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine3.23 AS base
 COPY --from=xx / /
 RUN apk add --no-cache \
       clang \
@@ -78,6 +78,7 @@ FROM build-base AS build
 ARG BUILD_TAGS
 ARG BUILD_FLAGS
 ARG TARGETPLATFORM
+ARG MACOSX_VERSION_MIN=11.0
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \


### PR DESCRIPTION
The alpine 3.22 variant was removed.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
