### PR TITLE
fix(reconcile): preserve zero-replica services during hashing

### DIFF
--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -242,6 +242,31 @@ func TestWaitDependencies(t *testing.T) {
 		}
 		assert.NilError(t, tested.(*composeService).waitDependencies(t.Context(), &project, "", dependencies, nil, 0))
 	})
+	t.Run("should skip zero-replica dependencies after service hashing", func(t *testing.T) {
+		replicas := 0
+		project := types.Project{Name: strings.ToLower(testProject), Services: types.Services{
+			"app": {
+				Name: "app",
+				DependsOn: types.DependsOnConfig{
+					"disabled": {
+						Condition: ServiceConditionRunningOrHealthy,
+						Required:  true,
+					},
+				},
+			},
+			"disabled": {
+				Name:   "disabled",
+				Deploy: &types.DeployConfig{Replicas: &replicas},
+			},
+		}}
+
+		_, err := ServiceHash(project.Services["disabled"])
+		assert.NilError(t, err)
+
+		assert.NilError(t, tested.(*composeService).waitDependencies(
+			t.Context(), &project, "app", project.Services["app"].DependsOn, nil, 0,
+		))
+	})
 	t.Run("should skip dependencies with condition service_started", func(t *testing.T) {
 		dbService := types.ServiceConfig{Name: "db", Scale: intPtr(1)}
 		redisService := types.ServiceConfig{Name: "redis", Scale: intPtr(1)}

--- a/pkg/compose/hash.go
+++ b/pkg/compose/hash.go
@@ -30,7 +30,9 @@ func ServiceHash(o types.ServiceConfig) (string, error) {
 	o.PullPolicy = ""
 	o.Scale = nil
 	if o.Deploy != nil {
-		o.Deploy.Replicas = nil
+		deploy := *o.Deploy
+		deploy.Replicas = nil
+		o.Deploy = &deploy
 	}
 	o.DependsOn = nil
 	o.Profiles = nil


### PR DESCRIPTION
**What I did**

Prevent `ServiceHash` from mutating the caller's `DeployConfig` when excluding `deploy.replicas` from the service hash. This preserves `deploy.replicas: 0` through reconciliation so `docker compose up` continues to skip zero-replica dependencies instead of waiting for a missing container.

Added a focused regression test that hashes a zero-replica dependency before running dependency-wait logic and verifies the dependency is still skipped.

**Related issue**

Fixes #13899.

**Validation**

`gofmt -w pkg/compose/hash.go pkg/compose/convergence_test.go`

No stdout/stderr.

`go test ./pkg/compose -run 'TestServiceHash|TestWaitDependencies' -count=1`

```text
ok  	github.com/docker/compose/v5/pkg/compose	0.008s
```

`go test ./pkg/compose -count=1`

```text
ok  	github.com/docker/compose/v5/pkg/compose	0.146s
```

`go vet ./pkg/compose`

No stdout/stderr.

`go build -tags e2e -o /tmp/docker-compose-pr-build ./cmd`

No stdout/stderr.

`git diff --check`

No stdout/stderr.
