### PR TITLE
Pass IPAM options when creating networks

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1380,7 +1380,7 @@ func buildBindOption(bind *types.ServiceVolumeBind) *mount.BindOptions {
 // name-matched networks is decided by the reconciler from the observed state.
 func (s *composeService) createNetwork(ctx context.Context, n *types.NetworkConfig) error {
 	var ipam *network.IPAM
-	if n.Ipam.Config != nil {
+	if n.Ipam.Driver != "" || len(n.Ipam.Config) > 0 || len(n.Ipam.Options) > 0 {
 		var config []network.IPAMConfig
 		for _, pool := range n.Ipam.Config {
 			c, err := parseIPAMPool(pool)
@@ -1390,8 +1390,9 @@ func (s *composeService) createNetwork(ctx context.Context, n *types.NetworkConf
 			config = append(config, c)
 		}
 		ipam = &network.IPAM{
-			Driver: n.Ipam.Driver,
-			Config: config,
+			Driver:  n.Ipam.Driver,
+			Config:  config,
+			Options: n.Ipam.Options,
 		}
 	}
 	hash, err := NetworkHash(n)
@@ -1408,26 +1409,6 @@ func (s *composeService) createNetwork(ctx context.Context, n *types.NetworkConf
 		IPAM:       ipam,
 		EnableIPv6: n.EnableIPv6,
 		EnableIPv4: n.EnableIPv4,
-	}
-
-	if n.Ipam.Driver != "" || len(n.Ipam.Config) > 0 || len(n.Ipam.Options) > 0 {
-		createOpts.IPAM = &network.IPAM{}
-	}
-
-	if n.Ipam.Driver != "" {
-		createOpts.IPAM.Driver = n.Ipam.Driver
-	}
-
-	if len(n.Ipam.Options) > 0 {
-		createOpts.IPAM.Options = n.Ipam.Options
-	}
-
-	for _, ipamConfig := range n.Ipam.Config {
-		c, err := parseIPAMPool(ipamConfig)
-		if err != nil {
-			return err
-		}
-		createOpts.IPAM.Config = append(createOpts.IPAM.Config, c)
 	}
 
 	networkEventName := fmt.Sprintf("Network %s", n.Name)

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1410,12 +1410,16 @@ func (s *composeService) createNetwork(ctx context.Context, n *types.NetworkConf
 		EnableIPv4: n.EnableIPv4,
 	}
 
-	if n.Ipam.Driver != "" || len(n.Ipam.Config) > 0 {
+	if n.Ipam.Driver != "" || len(n.Ipam.Config) > 0 || len(n.Ipam.Options) > 0 {
 		createOpts.IPAM = &network.IPAM{}
 	}
 
 	if n.Ipam.Driver != "" {
 		createOpts.IPAM.Driver = n.Ipam.Driver
+	}
+
+	if len(n.Ipam.Options) > 0 {
+		createOpts.IPAM.Options = n.Ipam.Options
 	}
 
 	for _, ipamConfig := range n.Ipam.Config {

--- a/pkg/compose/executor_test.go
+++ b/pkg/compose/executor_test.go
@@ -41,12 +41,14 @@ func (noopEventProcessor) On(_ ...api.Resource)              {}
 func (noopEventProcessor) Done(_ string, _ bool)             {}
 
 const (
-	ipamOptionsProjectName  = "test"
-	ipamOptionsNetworkKey   = "default"
-	ipamOptionsNetworkName  = "test_default"
-	ipamOptionsKey          = "test"
-	ipamOptionsValue        = "1"
-	ipamOptionsCreatedNetID = "net1"
+	executorTestProjectName      = "test"
+	executorTestNetworkKey       = "default"
+	executorTestNetworkName      = "test_default"
+	executorTestNetworkResource  = "network:" + executorTestNetworkKey
+	executorTestNotFoundCause    = "not found"
+	executorTestCreatedNetworkID = "net1"
+	ipamOptionsKey               = "ipam-option"
+	ipamOptionsValue             = "enabled"
 )
 
 func newTestService(t *testing.T) (*composeService, *mocks.MockAPIClient) {
@@ -63,34 +65,34 @@ func newTestService(t *testing.T) (*composeService, *mocks.MockAPIClient) {
 
 func TestExecutePlanEmpty(t *testing.T) {
 	svc, _ := newTestService(t)
-	err := svc.executePlan(t.Context(), &types.Project{Name: "test"}, emptyObservedState("test"), &Plan{})
+	err := svc.executePlan(t.Context(), &types.Project{Name: executorTestProjectName}, emptyObservedState(executorTestProjectName), &Plan{})
 	assert.NilError(t, err)
 }
 
 func TestExecutePlanCreateNetwork(t *testing.T) {
 	svc, apiClient := newTestService(t)
 
-	nw := types.NetworkConfig{Name: "test_default"}
+	nw := types.NetworkConfig{Name: executorTestNetworkName}
 	project := &types.Project{
-		Name:     "test",
-		Networks: types.Networks{"default": nw},
+		Name:     executorTestProjectName,
+		Networks: types.Networks{executorTestNetworkKey: nw},
 	}
 
 	// createNetwork issues a plain NetworkCreate (divergence/reuse decisions are
 	// made by the reconciler from the observed state, not here).
-	apiClient.EXPECT().NetworkCreate(gomock.Any(), "test_default", gomock.Any()).
-		Return(client.NetworkCreateResult{ID: "net1"}, nil)
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), executorTestNetworkName, gomock.Any()).
+		Return(client.NetworkCreateResult{ID: executorTestCreatedNetworkID}, nil)
 
 	plan := &Plan{}
 	plan.addNode(Operation{
 		Type:       OpCreateNetwork,
-		ResourceID: "network:default",
-		Cause:      "not found",
+		ResourceID: executorTestNetworkResource,
+		Cause:      executorTestNotFoundCause,
 		Name:       nw.Name,
 		Network:    &nw,
 	}, "")
 
-	err := svc.executePlan(t.Context(), project, emptyObservedState("test"), plan)
+	err := svc.executePlan(t.Context(), project, emptyObservedState(executorTestProjectName), plan)
 	assert.NilError(t, err)
 }
 
@@ -98,7 +100,7 @@ func TestExecutePlanCreateNetworkWithIPAMOptions(t *testing.T) {
 	svc, apiClient := newTestService(t)
 
 	nw := types.NetworkConfig{
-		Name: ipamOptionsNetworkName,
+		Name: executorTestNetworkName,
 		Ipam: types.IPAMConfig{
 			Options: types.Options{
 				ipamOptionsKey: ipamOptionsValue,
@@ -106,34 +108,30 @@ func TestExecutePlanCreateNetworkWithIPAMOptions(t *testing.T) {
 		},
 	}
 	project := &types.Project{
-		Name:     ipamOptionsProjectName,
-		Networks: types.Networks{ipamOptionsNetworkKey: nw},
+		Name:     executorTestProjectName,
+		Networks: types.Networks{executorTestNetworkKey: nw},
 	}
 
-	apiClient.EXPECT().NetworkInspect(gomock.Any(), ipamOptionsNetworkName, gomock.Any()).
-		Return(client.NetworkInspectResult{}, notFoundError{})
-	apiClient.EXPECT().NetworkList(gomock.Any(), gomock.Any()).
-		Return(client.NetworkListResult{}, nil)
-	apiClient.EXPECT().NetworkCreate(gomock.Any(), ipamOptionsNetworkName, gomock.Any()).
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), executorTestNetworkName, gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ string, opts client.NetworkCreateOptions) (client.NetworkCreateResult, error) {
 			assert.DeepEqual(t, opts.IPAM, &network.IPAM{
 				Options: map[string]string{
 					ipamOptionsKey: ipamOptionsValue,
 				},
 			})
-			return client.NetworkCreateResult{ID: ipamOptionsCreatedNetID}, nil
+			return client.NetworkCreateResult{ID: executorTestCreatedNetworkID}, nil
 		})
 
 	plan := &Plan{}
 	plan.addNode(Operation{
 		Type:       OpCreateNetwork,
-		ResourceID: "network:" + ipamOptionsNetworkKey,
-		Cause:      "not found",
+		ResourceID: executorTestNetworkResource,
+		Cause:      executorTestNotFoundCause,
 		Name:       nw.Name,
 		Network:    &nw,
 	}, "")
 
-	err := svc.executePlan(t.Context(), project, emptyObservedState(ipamOptionsProjectName), plan)
+	err := svc.executePlan(t.Context(), project, emptyObservedState(executorTestProjectName), plan)
 	assert.NilError(t, err)
 }
 

--- a/pkg/compose/executor_test.go
+++ b/pkg/compose/executor_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
@@ -38,6 +39,15 @@ type noopEventProcessor struct{}
 func (noopEventProcessor) Start(_ context.Context, _ string) {}
 func (noopEventProcessor) On(_ ...api.Resource)              {}
 func (noopEventProcessor) Done(_ string, _ bool)             {}
+
+const (
+	ipamOptionsProjectName  = "test"
+	ipamOptionsNetworkKey   = "default"
+	ipamOptionsNetworkName  = "test_default"
+	ipamOptionsKey          = "test"
+	ipamOptionsValue        = "1"
+	ipamOptionsCreatedNetID = "net1"
+)
 
 func newTestService(t *testing.T) (*composeService, *mocks.MockAPIClient) {
 	t.Helper()
@@ -81,6 +91,49 @@ func TestExecutePlanCreateNetwork(t *testing.T) {
 	}, "")
 
 	err := svc.executePlan(t.Context(), project, emptyObservedState("test"), plan)
+	assert.NilError(t, err)
+}
+
+func TestExecutePlanCreateNetworkWithIPAMOptions(t *testing.T) {
+	svc, apiClient := newTestService(t)
+
+	nw := types.NetworkConfig{
+		Name: ipamOptionsNetworkName,
+		Ipam: types.IPAMConfig{
+			Options: types.Options{
+				ipamOptionsKey: ipamOptionsValue,
+			},
+		},
+	}
+	project := &types.Project{
+		Name:     ipamOptionsProjectName,
+		Networks: types.Networks{ipamOptionsNetworkKey: nw},
+	}
+
+	apiClient.EXPECT().NetworkInspect(gomock.Any(), ipamOptionsNetworkName, gomock.Any()).
+		Return(client.NetworkInspectResult{}, notFoundError{})
+	apiClient.EXPECT().NetworkList(gomock.Any(), gomock.Any()).
+		Return(client.NetworkListResult{}, nil)
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), ipamOptionsNetworkName, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, opts client.NetworkCreateOptions) (client.NetworkCreateResult, error) {
+			assert.DeepEqual(t, opts.IPAM, &network.IPAM{
+				Options: map[string]string{
+					ipamOptionsKey: ipamOptionsValue,
+				},
+			})
+			return client.NetworkCreateResult{ID: ipamOptionsCreatedNetID}, nil
+		})
+
+	plan := &Plan{}
+	plan.addNode(Operation{
+		Type:       OpCreateNetwork,
+		ResourceID: "network:" + ipamOptionsNetworkKey,
+		Cause:      "not found",
+		Name:       nw.Name,
+		Network:    &nw,
+	}, "")
+
+	err := svc.executePlan(t.Context(), project, emptyObservedState(ipamOptionsProjectName), plan)
 	assert.NilError(t, err)
 }
 


### PR DESCRIPTION
## Summary
- Pass Compose `networks.*.ipam.options` through to Docker network creation.
- Add regression coverage for IPAM options without an IPAM driver or pool config.

Fixes #13785

## Test verification (RED -> GREEN)
- Baseline: `make test` initially reported `DONE 497 tests, 2 skipped, 1 failure`; the pre-existing failure was `pkg/watch TestGitBranchSwitch`.
- RED: with only `pkg/compose/create.go` reverted, `TestExecutePlanCreateNetworkWithIPAMOptions` failed because `opts.IPAM` was `nil` instead of containing `Options: {"ipam-option": "enabled"}`.
- GREEN: `go test ./pkg/compose -run TestExecutePlanCreateNetworkWithIPAMOptions -count=1 -v` passed.

## Full local suite
- Command: `make test`
- Result: passed with `DONE 499 tests, 2 skipped` after rebasing on latest main.
