### PR TITLE
Support extra_hosts on pre_start

### DIFF
--- a/pkg/compose/pre_start.go
+++ b/pkg/compose/pre_start.go
@@ -150,6 +150,7 @@ func (s *composeService) createPreStartContainer(
 		AutoRemove:  true,
 		Privileged:  hook.Privileged,
 		VolumesFrom: []string{ctr.ID},
+		ExtraHosts:  service.ExtraHosts.AsList(":"),
 	}
 
 	apiVersion, err := s.RuntimeAPIVersion(ctx)

--- a/pkg/compose/pre_start_test.go
+++ b/pkg/compose/pre_start_test.go
@@ -247,6 +247,40 @@ func TestPreStart_VolumesFromServiceContainer(t *testing.T) {
 	assert.Assert(t, gotAutoRemove)
 }
 
+func TestPreStart_ExtraHostsPassedToContainer(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "demo"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		ExtraHosts: types.HostsList{
+			"somehost": {"162.242.195.82"},
+		},
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "service-ctr-id"}
+
+	var gotExtraHosts []string
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
+			gotExtraHosts = opts.HostConfig.ExtraHosts
+			return client.ContainerCreateResult{ID: "hook-1"}, nil
+		})
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, gotExtraHosts, []string{"somehost:162.242.195.82"})
+}
+
 func TestPreStart_ContainerCreateFailurePropagates(t *testing.T) {
 	tested, apiClient := newPreStartTestService(t)
 


### PR DESCRIPTION
**What I did**

Fixes #13939.

pre_start hooks run as ephemeral containers with their own `HostConfig`, but the configuration was built with only four fields (`AutoRemove`, `Privileged`, `VolumesFrom`, `NetworkMode`), omitting `ExtraHosts` entirely. This meant custom host mappings defined on the service were invisible inside pre_start containers, even though they were correctly applied to the main service containers.

This PR propagates `service.ExtraHosts` into the pre_start container's `HostConfig`, matching the behavior of regular containers created via `getCreateConfigs()`.

| Location | Change |
| --- | --- |
| `pkg/compose/pre_start.go` — `createPreStartContainer` | Set `ExtraHosts: service.ExtraHosts.AsList(":")` on the hook container's `HostConfig` |
| `pkg/compose/pre_start_test.go` | New `TestPreStart_ExtraHostsPassedToContainer` verifying the host mapping is forwarded |

**Scope**

Only `ExtraHosts` is in scope. Other `HostConfig` fields (e.g. `DNS`, `CapAdd`, `SecurityOpt`) are not propagated to pre_start containers and can be addressed separately if needed.

**How to test manually**

```yaml
services:
  test:
    image: busybox
    extra_hosts:
      - "somehost:162.242.195.82"
    pre_start:
      - command: cat /etc/hosts
    command: cat /etc/hosts
```
```bash
$ docker compose up
test pre_start[0] -> | 127.0.0.1	localhost
test pre_start[0] -> | 162.242.195.82	somehost   ← now visible
test-1               | 162.242.195.82	somehost
```