### PR TITLE
fix(build): use image content digest, not attested index digest

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -404,6 +404,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	}
 
 	results := map[string]string{}
+	var builtImages []string
 	for name := range serviceToBeBuild {
 		image := expectedImages[name]
 		target := targets[name]
@@ -412,8 +413,28 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			return nil, fmt.Errorf("build result not found in Bake metadata for service %s", name)
 		}
 		results[image] = built.Digest
+		builtImages = append(builtImages, image)
 		s.events.On(builtEvent(image))
 	}
+
+	// Bake's "containerimage.digest" metadata is the top-level attested
+	// image/index digest. When BuildKit provenance attestations are enabled
+	// (the default), that digest also covers the attestation manifest and
+	// changes on every build even when the runnable image content is
+	// unchanged, causing compose to recreate containers unnecessarily (see
+	// https://github.com/docker/compose/issues/13636). Images that were
+	// loaded into the local engine (the common non-push case) are inspected
+	// to substitute a digest that only reflects the actual image content.
+	// Images that only exist in a registry (push/multi-platform builds)
+	// keep the Bake-reported digest.
+	summaries, err := s.getImageSummaries(ctx, builtImages)
+	if err != nil {
+		return nil, err
+	}
+	for image, summary := range summaries {
+		results[image] = summary.ID
+	}
+
 	return results, nil
 }
 

--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/versions"
 	"golang.org/x/sync/errgroup"
@@ -69,14 +70,14 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, c := range containers {
 		eg.Go(func() error {
-			image, err := s.apiClient().ImageInspect(ctx, c.Image)
+			img, err := s.apiClient().ImageInspect(ctx, c.Image)
 			if err != nil {
 				return err
 			}
-			id := image.ID // platform-specific image ID can't be combined with image tag, see https://github.com/moby/moby/issues/49995
+			id := img.ID // platform-specific image ID can't be combined with image tag, see https://github.com/moby/moby/issues/49995
 
 			if withPlatform && c.ImageManifestDescriptor != nil && c.ImageManifestDescriptor.Platform != nil {
-				image, err = s.apiClient().ImageInspect(ctx, c.Image, client.ImageInspectWithPlatform(c.ImageManifestDescriptor.Platform))
+				img, err = s.apiClient().ImageInspect(ctx, c.Image, client.ImageInspectWithPlatform(c.ImageManifestDescriptor.Platform))
 				if err != nil {
 					return err
 				}
@@ -93,8 +94,8 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 			}
 
 			var created *time.Time
-			if image.Created != "" {
-				t, err := time.Parse(time.RFC3339Nano, image.Created)
+			if img.Created != "" {
+				t, err := time.Parse(time.RFC3339Nano, img.Created)
 				if err != nil {
 					return err
 				}
@@ -108,14 +109,14 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 				Repository: repository,
 				Tag:        tag,
 				Platform: platforms.Platform{
-					Architecture: image.Architecture,
-					OS:           image.Os,
-					OSVersion:    image.OsVersion,
-					Variant:      image.Variant,
+					Architecture: img.Architecture,
+					OS:           img.Os,
+					OSVersion:    img.OsVersion,
+					Variant:      img.Variant,
 				},
-				Size:        image.Size,
+				Size:        img.Size,
 				Created:     created,
-				LastTagTime: image.Metadata.LastTagTime,
+				LastTagTime: img.Metadata.LastTagTime,
 			}
 			return nil
 		})
@@ -128,10 +129,21 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 func (s *composeService) getImageSummaries(ctx context.Context, repoTags []string) (map[string]api.ImageSummary, error) {
 	summary := map[string]api.ImageSummary{}
 	l := sync.Mutex{}
+
+	version, err := s.RuntimeAPIVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	withManifests := versions.GreaterThanOrEqualTo(version, apiVersion148)
+
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, repoTag := range repoTags {
 		eg.Go(func() error {
-			inspect, err := s.apiClient().ImageInspect(ctx, repoTag)
+			var opts []client.ImageInspectOption
+			if withManifests {
+				opts = append(opts, client.ImageInspectWithManifests(true))
+			}
+			inspect, err := s.apiClient().ImageInspect(ctx, repoTag, opts...)
 			if err != nil {
 				if errdefs.IsNotFound(err) {
 					return nil
@@ -150,7 +162,7 @@ func (s *composeService) getImageSummaries(ctx context.Context, repoTags []strin
 			}
 			l.Lock()
 			summary[repoTag] = api.ImageSummary{
-				ID:          inspect.ID,
+				ID:          contentDigest(inspect.InspectResponse),
 				Repository:  repository,
 				Tag:         tag,
 				Size:        inspect.Size,
@@ -161,4 +173,20 @@ func (s *composeService) getImageSummaries(ctx context.Context, repoTags []strin
 		})
 	}
 	return summary, eg.Wait()
+}
+
+// contentDigest returns the digest identifying an image's actual content
+// (config + layers). When BuildKit provenance attestations are enabled, the
+// image is stored as a multi-manifest index whose top-level digest
+// (inspect.ID) also covers the attestation manifest and therefore changes on
+// every build even when the runnable image itself is unchanged. Reading the
+// "image" kind manifest instead gives a digest that only reflects the image
+// content, matching what compose actually needs to detect staleness.
+func contentDigest(inspect image.InspectResponse) string {
+	for _, m := range inspect.Manifests {
+		if m.Kind == image.ManifestKindImage {
+			return m.ID
+		}
+	}
+	return inspect.ID
 }

--- a/pkg/compose/images_test.go
+++ b/pkg/compose/images_test.go
@@ -100,6 +100,61 @@ func imageInspect(id string, imageReference string, size int64, created string) 
 	}
 }
 
+func TestContentDigest(t *testing.T) {
+	t.Run("no manifests falls back to the plain ID", func(t *testing.T) {
+		inspect := image.InspectResponse{ID: "sha256:top"}
+		assert.Equal(t, contentDigest(inspect), "sha256:top")
+	})
+
+	t.Run("attested image picks the image kind manifest, not the index digest", func(t *testing.T) {
+		inspect := image.InspectResponse{
+			ID: "sha256:index", // top-level digest, changes on every build due to attestation churn
+			Manifests: []image.ManifestSummary{
+				{ID: "sha256:image", Kind: image.ManifestKindImage},
+				{ID: "sha256:attestation", Kind: image.ManifestKindAttestation},
+			},
+		}
+		assert.Equal(t, contentDigest(inspect), "sha256:image")
+	})
+
+	t.Run("only attestation manifests present falls back to the plain ID", func(t *testing.T) {
+		inspect := image.InspectResponse{
+			ID: "sha256:top",
+			Manifests: []image.ManifestSummary{
+				{ID: "sha256:attestation", Kind: image.ManifestKindAttestation},
+			},
+		}
+		assert.Equal(t, contentDigest(inspect), "sha256:top")
+	})
+}
+
+func TestGetImageSummariesUsesContentDigestNotAttestedIndexDigest(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	api, cli := prepareMocks(mockCtrl)
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+
+	api.EXPECT().Ping(gomock.Any(), client.PingOptions{NegotiateAPIVersion: true}).Return(client.PingResult{APIVersion: "1.48"}, nil).AnyTimes()
+	api.EXPECT().ClientVersion().Return("1.48").AnyTimes()
+
+	inspect := image.InspectResponse{
+		ID: "sha256:index",
+		Manifests: []image.ManifestSummary{
+			{ID: "sha256:image", Kind: image.ManifestKindImage},
+			{ID: "sha256:attestation", Kind: image.ManifestKindAttestation},
+		},
+	}
+	api.EXPECT().
+		ImageInspect(anyCancellableContext(), "foo:1", gomock.Any()).
+		Return(client.ImageInspectResult{InspectResponse: inspect}, nil)
+
+	summaries, err := tested.(*composeService).getImageSummaries(t.Context(), []string{"foo:1"})
+	assert.NilError(t, err)
+	assert.Equal(t, summaries["foo:1"].ID, "sha256:image")
+}
+
 func containerDetail(service string, id string, status container.ContainerState, imageName string) container.Summary {
 	return container.Summary{
 		ID:     id,


### PR DESCRIPTION
**What I did**

`docker compose build` (via Bake) recorded BuildKit's top-level `containerimage.digest` metadata field as the built image's identity, used to decide whether a container needs to be recreated. With provenance attestations enabled (the default since recent Buildx/BuildKit) and the containerd image store, this digest is for the whole attested index (image manifest + attestation manifest), and it changes on every build — even a fully cached one — because the attestation manifest embeds per-build metadata (timestamps, build refs). The image content itself never changes.

This made `docker compose up --build` recreate containers unnecessarily on every run, even when nothing actually changed.

The fix inspects the built (or already-local) image via the Engine API with `manifests=true` (API 1.48+ / Engine 28.0+) and picks the digest of the manifest with `Kind == "image"`, ignoring the `"attestation"` manifest. That digest only reflects the actual image content (config + layers), so it's stable across rebuilds with unchanged content, and still changes correctly when the content does change. I applied the same fix to `getImageSummaries` (used for already-local images) so both sides of the staleness comparison use the same, consistent digest. Images that only exist in a registry (push / multi-platform builds) aren't locally inspectable, so they keep the Bake-reported digest as before — this only affects the common local build case where the bug was reported.

**Verification**

I reproduced the bug against a real Docker Desktop engine (containerd snapshotter, default provenance attestations on arm64), confirmed the root cause by inspecting BuildKit's raw Bake metadata and the daemon's `manifests=true` image inspect response directly, then verified the fix end-to-end:
- Before the fix: `docker buildx bake` on an unchanged Dockerfile produces a different `containerimage.digest`/image ID on every run despite `CACHED` build steps.
- With the fix: two consecutive `docker compose up -d --build` runs with no changes keep the exact same container (same ID, same creation timestamp) — no unnecessary recreate.
- Sanity check: changing the Dockerfile content still correctly triggers `Recreate`/`Recreated`.
- `go build ./...`, `go vet ./...`, and `golangci-lint run` are all clean.
- Full `go test ./...` passes; the only pre-existing failures (in `pkg/watch` and `pkg/e2e`) are environmental/flaky and reproduce identically on unmodified `main`, unrelated to this change.
- Added unit tests (`TestContentDigest`, `TestGetImageSummariesUsesContentDigestNotAttestedIndexDigest`) covering the digest-selection logic directly.

**Related issue**

Fixes #13636

---
Disclosure: this PR was prepared with the assistance of Claude Code (Anthropic). All investigation, the root-cause diagnosis, the fix, and the verification steps above were done and checked by me; I'm disclosing the tool's involvement for transparency.