### PR TITLE
fix(config): warn when service selection is silently ignored

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v4"
 
@@ -266,6 +267,9 @@ func imagesOnly(project *types.Project) *types.Project {
 }
 
 func runConfigNoInterpolate(ctx context.Context, dockerCli command.Cli, opts configOptions, services []string) ([]byte, error) {
+	if len(services) > 0 {
+		logrus.Warn("service filtering is not applied when --no-interpolate is set, the full model will be rendered")
+	}
 	// we can't use ToProject, so the model we render here is only partially resolved
 	model, err := opts.ToModel(ctx, dockerCli, services)
 	if err != nil {
@@ -519,6 +523,9 @@ func runConfigImages(ctx context.Context, dockerCli command.Cli, opts configOpti
 }
 
 func runVariables(ctx context.Context, dockerCli command.Cli, opts configOptions, services []string) error {
+	if len(services) > 0 {
+		logrus.Warn("service filtering is not applied when --variables is set, variables from the full model will be rendered")
+	}
 	opts.noInterpolate = true
 	model, err := opts.ToModel(ctx, dockerCli, services, cli.WithoutEnvironmentResolution, cli.WithLoadOptions(loader.WithSkipValidation))
 	if err != nil {

--- a/pkg/e2e/config_test.go
+++ b/pkg/e2e/config_test.go
@@ -47,6 +47,14 @@ func TestLocalComposeConfig(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `- ${PORT:-8080}:80`})
 	})
 
+	t.Run("--no-interpolate with service selection", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/compose.yaml", "--project-name", projectName, "config", "--no-interpolate", "test")
+		res.Assert(t, icmd.Expected{
+			Err: "service filtering is not applied when --no-interpolate is set",
+			Out: `- ${PORT:-8080}:80`,
+		})
+	})
+
 	t.Run("--variables --format json", func(t *testing.T) {
 		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/compose.yaml", "--project-name", projectName, "config", "--variables", "--format", "json")
 		res.Assert(t, icmd.Expected{Out: `{
@@ -66,5 +74,13 @@ func TestLocalComposeConfig(t *testing.T) {
     defaultvalue: "8080"
     presencevalue: ""
     required: false`})
+	})
+
+	t.Run("--variables with service selection", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/compose.yaml", "--project-name", projectName, "config", "--variables", "test")
+		res.Assert(t, icmd.Expected{
+			Err: "service filtering is not applied when --variables is set",
+			Out: `PORT`,
+		})
 	})
 }


### PR DESCRIPTION
**What I did**
`docker compose config --no-interpolate <service>` and `docker compose config --variables <service>` load the raw model without applying service filtering, so the full model is rendered regardless of the services passed as arguments. Filtering will not be supported on these paths, so emit a warning to make sure users are no longer misled by silently ignored arguments.

**Related issue**
Fixes #13614

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
