### PR TITLE
chore: fix-comment-grammar in pkg/compose/container.go

### DIFF
--- a/pkg/compose/container.go
+++ b/pkg/compose/container.go
@@ -24,17 +24,17 @@ import (
 
 var _ io.ReadCloser = ContainerStdout{}
 
-// ContainerStdout implement ReadCloser for moby.HijackedResponse
+// ContainerStdout implements io.ReadCloser for moby.HijackedResponse
 type ContainerStdout struct {
 	client.HijackedResponse
 }
 
-// Read implement io.ReadCloser
+// Read implements io.Reader
 func (l ContainerStdout) Read(p []byte) (n int, err error) {
 	return l.Reader.Read(p)
 }
 
-// Close implement io.ReadCloser
+// Close implements io.Closer
 func (l ContainerStdout) Close() error {
 	l.HijackedResponse.Close()
 	return nil
@@ -42,17 +42,17 @@ func (l ContainerStdout) Close() error {
 
 var _ io.WriteCloser = ContainerStdin{}
 
-// ContainerStdin implement WriteCloser for moby.HijackedResponse
+// ContainerStdin implements io.WriteCloser for moby.HijackedResponse
 type ContainerStdin struct {
 	client.HijackedResponse
 }
 
-// Write implement io.WriteCloser
+// Write implements io.Writer
 func (c ContainerStdin) Write(p []byte) (n int, err error) {
 	return c.Conn.Write(p)
 }
 
-// Close implement io.WriteCloser
+// Close implements io.Closer
 func (c ContainerStdin) Close() error {
 	return c.CloseWrite()
 }


### PR DESCRIPTION
**What I did**

 fix-comment-grammar in pkg/compose/container.go


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1440" height="1920" alt="d00e0f458099458c3cf85181922941e8" src="https://github.com/user-attachments/assets/e8b8e104-d9f5-4dd4-81e2-1338a22b27bc" />

