### PR TITLE
fix: resolve include env_file override via compose-go fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,3 +152,5 @@ exclude (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 )
+
+replace github.com/compose-spec/compose-go/v2 v2.13.0 => github.com/AmariahAK/compose-go/v2 v2.13.0-patched

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
+github.com/AmariahAK/compose-go/v2 v2.13.0-patched h1:/tmZLQDHJ6MSmz/r5fMMTClwH+MKtKc8C6WDud9GQOo=
+github.com/AmariahAK/compose-go/v2 v2.13.0-patched/go.mod h1:ZU6zlcweCZKyiB7BVfCizQT9XmkEIMFE+PRZydVcsZg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DefangLabs/secret-detector v0.0.0-20250403165618-22662109213e h1:rd4bOvKmDIx0WeTv9Qz+hghsgyjikFiPrseXHlKepO0=
@@ -38,8 +40,6 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/compose-spec/compose-go/v2 v2.13.0 h1:2+2oS3v4SrtAOBdZRAZYBsBy47D571p5EXMSCppmTtE=
-github.com/compose-spec/compose-go/v2 v2.13.0/go.mod h1:ZU6zlcweCZKyiB7BVfCizQT9XmkEIMFE+PRZydVcsZg=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=


### PR DESCRIPTION
## What I did
Use a replace directive pointing to the compose-go fork
(AmariahAK/compose-go@v2.13.0-patched) which fixes
`Mapping.Merge` being first-wins in include processing.
## What was the issue
When an include specifies an `env_file` list containing `.env`, values
from `.env` always took precedence over files listed after it —
breaking the expected "last file wins" semantics. This happened because
`.env` is loaded globally by `WithDotEnv` before include processing
begins, and compose-go's `Mapping.Merge` (first-wins) refused to
overwrite keys already present in the parent environment.
## Where was the issue
`compose-go` library — `loader/include.go:147`:
`environment.Clone().Merge(envFromFile)` used the first-wins
`Mapping.Merge` method, silently dropping include-scoped env_file
overrides when the same keys already existed in the global environment.
## How this PR fixes it
This PR adds a `replace` directive in `go.mod` pointing to the
compose-go fork containing the fix (compose-spec/compose-go#898).
The fork replaces `Merge` with an explicit last-wins override loop
so the include's `env_file` entries correctly override the parent
environment.
Once the compose-go fix is merged upstream, the `replace` directive
can be replaced with a version bump.
## Related issue
Fixes #13945
See also: compose-go PR (https://github.com/compose-spec/compose-go/pull/898)