### PR TITLE
Fix broken MAINTAINERS link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ indicate acceptance.
 A change requires at least 2 LGTMs from the maintainers of each
 component affected.
 
-For more details, see the [MAINTAINERS](MAINTAINERS) page.
+For more details, see the [MAINTAINERS](https://github.com/docker/opensource/blob/main/MAINTAINERS) page.
 
 ### Sign your work
 


### PR DESCRIPTION
`CONTRIBUTING.md` links to the MAINTAINERS file as a repo-relative `[MAINTAINERS](MAINTAINERS)`, but that file no longer exists in this repository, so the link 404s.

Point it at the canonical MAINTAINERS file in `docker/opensource`, which this same document already links to a few lines later. Verified the target returns HTTP 200. Docs-only change; commit is DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)