### PR TITLE
docs: require dated AI_AGENT_DISCLOSURE.md, drop committed copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,10 @@
 
 - Never create an issue or pull request without the user's explicit instruction.
 - If a user asks you to create a pull request on their behalf, add a file named
-  `AI_AGENT_DISCLOSURE.md` to the change containing the text:
+  `AI_AGENT_DISCLOSURE.md` to the change containing the text below followed by
+  the current date (`YYYY-MM-DD`). If the file is already present in the
+  repository, update its date to the current date so the disclosure is always
+  part of the change:
 
   > *"This contribution was prepared by an AI agent acting on a human's behalf.
   > The human submitter may not have independently reviewed or tested the change."*

--- a/AI_AGENT_DISCLOSURE.md
+++ b/AI_AGENT_DISCLOSURE.md
@@ -1,2 +1,0 @@
-This contribution was prepared by an AI agent acting on a human's behalf.
-The human submitter may not have independently reviewed or tested the change.


### PR DESCRIPTION
### What I did

- Removed `AI_AGENT_DISCLOSURE.md`, which was merged by accident as part of 44ac2c94e.
- Updated the `AGENTS.md` PR guideline: AI agents must add `AI_AGENT_DISCLOSURE.md` with the current date (`YYYY-MM-DD`), or refresh the date if the file is already present, so the disclosure is always part of the change being reviewed.

### Why

With an undated copy of the file permanently committed, the "add the file" instruction became a no-op: AI-prepared pull requests no longer carried any visible disclosure in their diff. Date-stamping the file makes the disclosure show up in every AI-prepared change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)