### PR TITLE
fix(config): apply config flags to --services/--volumes/--networks/--models/--hash

### DIFF
--- a/cmd/compose/config.go
+++ b/cmd/compose/config.go
@@ -64,8 +64,9 @@ type configOptions struct {
 	lockImageDigests    bool
 }
 
-func (o *configOptions) ToProject(ctx context.Context, dockerCli command.Cli, backend api.Compose, services []string) (*types.Project, error) {
-	project, _, err := o.ProjectOptions.ToProject(ctx, dockerCli, backend, services, o.toProjectOptionsFns()...)
+func (o *configOptions) ToProject(ctx context.Context, dockerCli command.Cli, backend api.Compose, services []string, po ...cli.ProjectOptionsFn) (*types.Project, error) {
+	po = append(po, o.toProjectOptionsFns()...)
+	project, _, err := o.ProjectOptions.ToProject(ctx, dockerCli, backend, services, po...)
 	return project, err
 }
 
@@ -491,7 +492,7 @@ func runServices(ctx context.Context, dockerCli command.Cli, opts configOptions)
 		return err
 	}
 
-	project, _, err := opts.ProjectOptions.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
+	project, err := opts.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
 	if err != nil {
 		return err
 	}
@@ -509,7 +510,7 @@ func runVolumes(ctx context.Context, dockerCli command.Cli, opts configOptions) 
 		return err
 	}
 
-	project, _, err := opts.ProjectOptions.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
+	project, err := opts.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
 	if err != nil {
 		return err
 	}
@@ -525,7 +526,7 @@ func runNetworks(ctx context.Context, dockerCli command.Cli, opts configOptions)
 		return err
 	}
 
-	project, _, err := opts.ProjectOptions.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
+	project, err := opts.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
 	if err != nil {
 		return err
 	}
@@ -541,7 +542,7 @@ func runModels(ctx context.Context, dockerCli command.Cli, opts configOptions) e
 		return err
 	}
 
-	project, _, err := opts.ProjectOptions.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
+	project, err := opts.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
 	if err != nil {
 		return err
 	}
@@ -564,7 +565,7 @@ func runHash(ctx context.Context, dockerCli command.Cli, opts configOptions) err
 		return err
 	}
 
-	project, _, err := opts.ProjectOptions.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
+	project, err := opts.ToProject(ctx, dockerCli, backend, nil, cli.WithoutEnvironmentResolution)
 	if err != nil {
 		return err
 	}

--- a/pkg/e2e/config_test.go
+++ b/pkg/e2e/config_test.go
@@ -83,4 +83,34 @@ func TestLocalComposeConfig(t *testing.T) {
 			Out: `PORT`,
 		})
 	})
+
+	t.Run("--no-consistency --services", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/no-consistency.yaml", "--project-name", projectName, "config", "--no-consistency", "--services")
+		res.Assert(t, icmd.Expected{Out: `incomplete`})
+	})
+
+	t.Run("--no-consistency --volumes", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/no-consistency.yaml", "--project-name", projectName, "config", "--no-consistency", "--volumes")
+		res.Assert(t, icmd.Expected{Out: `data`})
+	})
+
+	t.Run("--no-consistency --networks", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/no-consistency.yaml", "--project-name", projectName, "config", "--no-consistency", "--networks")
+		res.Assert(t, icmd.Expected{Out: `internal`})
+	})
+
+	t.Run("--no-consistency --models", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/no-consistency.yaml", "--project-name", projectName, "config", "--no-consistency", "--models")
+		res.Assert(t, icmd.Expected{Out: `ai/example`})
+	})
+
+	t.Run("--no-consistency --hash", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/no-consistency.yaml", "--project-name", projectName, "config", "--no-consistency", "--hash", "*")
+		res.Assert(t, icmd.Expected{Out: `incomplete `})
+	})
+
+	t.Run("--profile --no-consistency --services", func(t *testing.T) {
+		res := c.RunDockerComposeCmd(t, "-f", "./fixtures/config/no-consistency.yaml", "--project-name", projectName, "--profile", "extra", "config", "--no-consistency", "--services")
+		res.Assert(t, icmd.Expected{Out: `gated`})
+	})
 }

--- a/pkg/e2e/fixtures/config/no-consistency.yaml
+++ b/pkg/e2e/fixtures/config/no-consistency.yaml
@@ -1,0 +1,17 @@
+services:
+  incomplete:
+    volumes:
+      - data:/data
+    networks:
+      - internal
+    models:
+      llm:
+  gated:
+    profiles: ["extra"]
+volumes:
+  data:
+networks:
+  internal:
+models:
+  llm:
+    model: ai/example


### PR DESCRIPTION
**What I did**
The runServices, runVolumes, runNetworks, runModels and runHash paths called ProjectOptions.ToProject directly, bypassing the configOptions wrapper that applies --no-consistency, --no-interpolate, --no-normalize, --no-path-resolution, --profile filtering and env_file discarding. Restore the variadic wrapper (mirroring configOptions.ToModel) and route the five call sites through it.

Regression introduced by b80bb0586 (LoadProject API migration).

**Related issue**

Fixes #13974

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="3000" height="2000" alt="image" src="https://github.com/user-attachments/assets/376cf848-c0cc-4d41-81f3-1977c8cc0a80" />
