### PR TITLE
fix(cp): return non-nil Content from dry-run CopyFromContainer

### DIFF
--- a/pkg/dryrun/dryrunclient.go
+++ b/pkg/dryrun/dryrunclient.go
@@ -191,7 +191,9 @@ func (d *DryRunClient) CopyFromContainer(ctx context.Context, container string, 
 	if _, err := d.ContainerStatPath(ctx, container, client.ContainerStatPathOptions{Path: options.SourcePath}); err != nil {
 		return client.CopyFromContainerResult{}, fmt.Errorf("could not find the file %s in container %s", options.SourcePath, container)
 	}
-	return client.CopyFromContainerResult{}, nil
+	return client.CopyFromContainerResult{
+		Content: io.NopCloser(bytes.NewReader(nil)),
+	}, nil
 }
 
 func (d *DryRunClient) CopyToContainer(ctx context.Context, container string, options client.CopyToContainerOptions) (client.CopyToContainerResult, error) {


### PR DESCRIPTION
**What I did**
The caller in `pkg/compose/cp.go` unconditionally defers `res.Content.Close()` once the call succeeds. The dry-run client returned a zero-value result with a nil `Content` reader, so `docker compose cp --dry-run <ctr>:<path> <dst>` panicked with a nil pointer dereference. Return an empty `NopCloser` instead, matching the pattern already used for the other stream results in this file.

**Related issue**
https://docker.atlassian.net/browse/DDB-589

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1600" height="1065" alt="image" src="https://github.com/user-attachments/assets/879c184e-6d7b-422b-8cd7-7b8dcd5c75e6" />
