### PR TITLE
Use content digest for pulled service images

### DIFF
--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -185,6 +185,27 @@ func (s *composeService) manifestsSupported(ctx context.Context) (bool, error) {
 	return versions.GreaterThanOrEqualTo(version, apiVersion148), nil
 }
 
+// inspectContentDigest inspects ref, requesting per-manifest data on engines
+// that support it, and returns the digest identifying the image's runnable
+// content for the default platform. Callers that record an image identity
+// compose later compares for staleness must go through this, so every such
+// identity is computed the same way — see contentDigest.
+func (s *composeService) inspectContentDigest(ctx context.Context, ref string) (string, error) {
+	withManifests, err := s.manifestsSupported(ctx)
+	if err != nil {
+		return "", err
+	}
+	var opts []client.ImageInspectOption
+	if withManifests {
+		opts = append(opts, client.ImageInspectWithManifests(true))
+	}
+	inspected, err := s.apiClient().ImageInspect(ctx, ref, opts...)
+	if err != nil {
+		return "", err
+	}
+	return contentDigest(inspected.InspectResponse, platforms.Default()), nil
+}
+
 // contentDigest returns the digest identifying an image's runnable content
 // (config + layers) for the given platform. With BuildKit provenance
 // attestations enabled (the default since recent Buildx/BuildKit), the image is

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -293,19 +293,7 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 	// index digest, under the containerd store with a tag@digest ref) while
 	// later ups resolve the platform manifest digest via contentDigest made
 	// the first up after a pull recreate every container despite no change.
-	withManifests, err := s.manifestsSupported(ctx)
-	if err != nil {
-		return "", err
-	}
-	var opts []client.ImageInspectOption
-	if withManifests {
-		opts = append(opts, client.ImageInspectWithManifests(true))
-	}
-	inspected, err := s.apiClient().ImageInspect(ctx, service.Image, opts...)
-	if err != nil {
-		return "", err
-	}
-	return contentDigest(inspected.InspectResponse, platforms.Default()), nil
+	return s.inspectContentDigest(ctx, service.Image)
 }
 
 // ImageDigestResolver creates a func able to resolve image digest from a docker ref,

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -286,11 +286,26 @@ func (s *composeService) pullServiceImage(ctx context.Context, service types.Ser
 	}
 	s.events.On(newEvent(resource, api.Done, api.StatusPulled))
 
-	inspected, err := s.apiClient().ImageInspect(ctx, service.Image)
+	// Resolve the pulled image's identity exactly the way getImageSummaries
+	// does for already-local images: both values feed the
+	// com.docker.compose.image label used to detect stale containers, so they
+	// must be computed identically. Returning the raw inspect ID here (the
+	// index digest, under the containerd store with a tag@digest ref) while
+	// later ups resolve the platform manifest digest via contentDigest made
+	// the first up after a pull recreate every container despite no change.
+	withManifests, err := s.manifestsSupported(ctx)
 	if err != nil {
 		return "", err
 	}
-	return inspected.ID, nil
+	var opts []client.ImageInspectOption
+	if withManifests {
+		opts = append(opts, client.ImageInspectWithManifests(true))
+	}
+	inspected, err := s.apiClient().ImageInspect(ctx, service.Image, opts...)
+	if err != nil {
+		return "", err
+	}
+	return contentDigest(inspected.InspectResponse, platforms.Default()), nil
 }
 
 // ImageDigestResolver creates a func able to resolve image digest from a docker ref,

--- a/pkg/compose/pull_test.go
+++ b/pkg/compose/pull_test.go
@@ -54,10 +54,10 @@ func scheduledHookImages(t *testing.T, project *types.Project, present map[strin
 	return images
 }
 
-func serviceWithHook(name, image, policy string) types.ServiceConfig {
+func serviceWithHook(name, img, policy string) types.ServiceConfig {
 	return types.ServiceConfig{
 		Name:       name,
-		Image:      image,
+		Image:      img,
 		PullPolicy: policy,
 		PreStart:   []types.ServiceHook{{Image: "init:latest"}},
 	}

--- a/pkg/compose/pull_test.go
+++ b/pkg/compose/pull_test.go
@@ -17,10 +17,18 @@
 package compose
 
 import (
+	"context"
+	"io"
+	"iter"
 	"sort"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/jsonstream"
+	"github.com/moby/moby/client"
+	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 
 	"github.com/docker/compose/v5/pkg/api"
@@ -100,6 +108,59 @@ func TestAddPreStartHookPulls_NeverSkips(t *testing.T) {
 	}
 
 	assert.Equal(t, len(scheduledHookImages(t, project, map[string]api.ImageSummary{})), 0)
+}
+
+// fakePullResponse is an empty, already-complete pull stream.
+type fakePullResponse struct{}
+
+func (fakePullResponse) Read([]byte) (int, error) { return 0, io.EOF }
+func (fakePullResponse) Close() error             { return nil }
+func (fakePullResponse) Wait(context.Context) error {
+	return nil
+}
+
+func (fakePullResponse) JSONMessages(context.Context) iter.Seq2[jsonstream.Message, error] {
+	return func(func(jsonstream.Message, error) bool) {}
+}
+
+// TestPullServiceImageUsesContentDigest verifies the pull path resolves the
+// pulled image's identity with the same contentDigest scheme
+// getImageSummaries uses for already-local images. Both values feed the
+// com.docker.compose.image label that detects stale containers, so when the
+// pull path returned the raw inspect ID instead (the index digest, under the
+// containerd store with a tag@digest ref), the first up after the pulling up
+// saw a phantom image change and recreated every container once.
+func TestPullServiceImageUsesContentDigest(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockAPI, cli := prepareMocks(mockCtrl)
+	cli.EXPECT().ConfigFile().Return(configfile.New("")).AnyTimes()
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+	mockAPI.EXPECT().Ping(gomock.Any(), client.PingOptions{NegotiateAPIVersion: true}).
+		Return(client.PingResult{APIVersion: "1.48"}, nil).AnyTimes()
+	mockAPI.EXPECT().ClientVersion().Return("1.48").AnyTimes()
+
+	ref := "foo:1@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	mockAPI.EXPECT().
+		ImagePull(anyCancellableContext(), ref, gomock.Any()).
+		Return(fakePullResponse{}, nil)
+	inspect := image.InspectResponse{
+		ID: "sha256:index",
+		Manifests: []image.ManifestSummary{
+			imageManifest("sha256:image", "amd64", true),
+			attestationManifest(),
+		},
+	}
+	mockAPI.EXPECT().
+		ImageInspect(anyCancellableContext(), ref, gomock.Any()).
+		Return(client.ImageInspectResult{InspectResponse: inspect}, nil)
+
+	id, err := tested.(*composeService).
+		pullServiceImage(t.Context(), types.ServiceConfig{Name: "web", Image: ref}, true, "")
+	assert.NilError(t, err)
+	assert.Equal(t, id, "sha256:image")
 }
 
 // TestAddPreStartHookPulls_DedupsSharedHookImage verifies a hook image shared by


### PR DESCRIPTION
**What I did**

`pullServiceImage` returned the pulled image's raw inspect ID, while `getImageSummaries` resolves already-local images through `contentDigest` (the platform image-manifest digest, introduced for #13636). Both values feed the `com.docker.compose.image` label that `mustRecreate` compares to detect image changes - so the two paths disagreeing made the first `up` after the pulling `up` see a phantom image change and recreate every container once, with no change to the project, the image, or the compose file.

Under the containerd image store a `tag@digest` image reference triggers this reliably: the pull path records the **index digest** (the raw inspect ID) on the container, and the next `up` resolves the same image to its **platform manifest digest** via `contentDigest`. The strings differ, `mustRecreate` fires, and the replacement container gets the platform digest - so it happens exactly once per container, which makes it easy to miss but breaks any workflow that relies on `up` being idempotent (we hit it because our orchestrator asserts unchanged services are never recreated across reconciles).

The fix makes `pullServiceImage` resolve the pulled image through the same manifests-aware inspect + `contentDigest` call `getImageSummaries` uses, so both sides of the staleness comparison speak the same scheme. Engines without manifest support (API < 1.48) keep the previous behavior via `contentDigest`'s plain-ID fallback.

**Repro**

```console
$ docker run -d --privileged --name repro -e DOCKER_TLS_CERTDIR= docker:dind   # 29.7.0, containerd store
$ cat repro.yml
services:
  app:
    image: alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1
    command: ["sleep", "infinity"]
# (compose v5.4.0 as the CLI plugin inside the dind)
$ docker compose -f repro.yml -p repro up -d   # pulls, creates container A
$ docker compose -f repro.yml -p repro up -d   # => "Recreated" - container replaced, nothing changed
$ docker compose -f repro.yml -p repro up -d   # stable from here on
```

The two containers' `com.docker.compose.image` labels show the mismatch: container A carries `sha256:6baf...` (the pinned index digest), its replacement carries the platform manifest digest. v5.3.1 does not exhibit this; it appeared when the local-inspect side moved to `contentDigest`.

**Verification**

- New unit test `TestPullServiceImageUsesContentDigest` fails against the old return value and passes with the fix.
- `go build ./...`, `go vet ./pkg/compose/`, `gofmt -s -l` clean; `go test ./pkg/compose/` passes.
- End-to-end against a fresh `docker:dind` (29.7.0): with this fix the container from the pulling `up` survives repeated `up` runs (same container ID); unpatched v5.4.0 recreates it on the second `up`.

Related: #13636 (the fix that introduced `contentDigest` for the local-inspect path; this aligns the pull path with it).

---
Disclosure: this PR was prepared by Claude Code (Anthropic) - the diagnosis, fix, tests, and the verification runs above - in an agentic session I directed. I'm the submitter and point of contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
