### PR TITLE
fix(bridge): validate arguments of bridge subcommands

### DIFF
--- a/cmd/compose/bridge.go
+++ b/cmd/compose/bridge.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/distribution/reference"
+	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/image"
@@ -51,6 +52,7 @@ func convertCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert",
 		Short: "Convert compose files to Kubernetes manifests, Helm charts, or another model",
+		Args:  cobra.NoArgs,
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runConvert(ctx, dockerCli, p, convertOpts)
 		}),
@@ -93,6 +95,7 @@ func listTransformersCommand(dockerCli command.Cli) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List available transformations",
+		Args:    cobra.NoArgs,
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			transformers, err := bridge.ListTransformers(ctx, dockerCli)
 			if err != nil {
@@ -145,6 +148,7 @@ func createTransformerCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [OPTION] PATH",
 		Short: "Create a new transformation",
+		Args:  cli.ExactArgs(1),
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			opts.Dest = args[0]
 			return bridge.CreateTransformer(ctx, dockerCli, opts)

--- a/cmd/compose/bridge_test.go
+++ b/cmd/compose/bridge_test.go
@@ -1,0 +1,69 @@
+/*
+   Copyright 2025 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"io"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+)
+
+func TestBridgeCommandsArgsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     *cobra.Command
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "create requires a PATH argument",
+			cmd:     createTransformerCommand(nil),
+			args:    []string{},
+			wantErr: "requires 1 argument",
+		},
+		{
+			name:    "create rejects extra arguments",
+			cmd:     createTransformerCommand(nil),
+			args:    []string{"dest", "extra"},
+			wantErr: "requires 1 argument",
+		},
+		{
+			name:    "convert rejects arguments",
+			cmd:     convertCommand(&ProjectOptions{}, nil),
+			args:    []string{"extra"},
+			wantErr: "unknown command",
+		},
+		{
+			name:    "list rejects arguments",
+			cmd:     listTransformersCommand(nil),
+			args:    []string{"extra"},
+			wantErr: "unknown command",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.cmd.SetArgs(test.args)
+			test.cmd.SetOut(io.Discard)
+			test.cmd.SetErr(io.Discard)
+			err := test.cmd.Execute()
+			assert.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
**What I did**
`docker compose bridge transformations create` panicked with an index out of range when invoked without its PATH argument, as RunE indexed args[0] without any validator. Add cli.ExactArgs(1) so the CLI reports a proper usage error instead.

Also add cobra.NoArgs to `bridge convert` and `bridge transformations list`, which silently ignored stray arguments.

**Related issue**
https://docker.atlassian.net/browse/DDB-612

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="768" height="512" alt="image" src="https://github.com/user-attachments/assets/bf1c1481-791c-46c1-9f8f-c354526a1e2d" />
