### PR TITLE
ci: grant actions:write to PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write # Create security incident issues if secrets detected
       checks: write # (Optional) Show review progress as a check run
       id-token: write # Required for OIDC authentication to AWS Secrets Manager
-      actions: read # Download artifacts from trigger workflow
+      actions: write # Download artifacts from trigger workflow; cache delete for review-lock release (required since docker-agent-action v2.0.3)
     with:
       trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}',
         github.event.workflow_run.id) || '' }}


### PR DESCRIPTION
**What I did**
docker-agent-action v2.0.3 raised the review job's required permission from actions:read to actions:write (cache delete for review-lock release, feedback artifact management). GitHub refuses to start a reusable workflow requesting more permissions than the caller grants, so every PR Review run since the v2.0.3 bump ended in startup_failure and docker-agent stopped launching automatically.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
<img width="1279" height="864" alt="Screenshot 2026-08-05 at 12 30 08" src="https://github.com/user-attachments/assets/c2a7a4b6-d6b4-4bb2-8126-3648d49a3f77" />

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="960" height="640" alt="image" src="https://github.com/user-attachments/assets/6fa4b5ee-b92d-4049-90b0-56fb1a28561f" />
