### PR TITLE
fix(bridge): skip pulling default image references for build-only ser…

### DIFF
--- a/pkg/bridge/convert.go
+++ b/pkg/bridge/convert.go
@@ -169,8 +169,11 @@ func LoadAdditionalResources(ctx context.Context, dockerCLI command.Cli, project
 		var inspect image.InspectResponse
 		if service.Build != nil && service.Image == "" {
 			result, err := dockerCLI.Client().ImageInspect(ctx, imageName)
-			if err != nil && !errdefs.IsNotFound(err) {
-				return nil, err
+			if err != nil {
+				if !errdefs.IsNotFound(err) {
+					return nil, err
+				}
+				logrus.Warnf("image %s for service %s not found locally; Dockerfile-exposed ports will not be included — run `docker compose build` first to include them", imageName, name)
 			}
 			inspect = result.InspectResponse
 		} else {

--- a/pkg/bridge/convert.go
+++ b/pkg/bridge/convert.go
@@ -166,19 +166,31 @@ func LoadAdditionalResources(ctx context.Context, dockerCLI command.Cli, project
 	for name, service := range project.Services {
 		imageName := api.GetImageNameOrDefault(service, project.Name)
 
-		inspect, err := inspectWithPull(ctx, dockerCLI, imageName)
-		if err != nil {
-			return nil, err
+		var inspect image.InspectResponse
+		if service.Build != nil && service.Image == "" {
+			result, err := dockerCLI.Client().ImageInspect(ctx, imageName)
+			if err != nil && !errdefs.IsNotFound(err) {
+				return nil, err
+			}
+			inspect = result.InspectResponse
+		} else {
+			var err error
+			inspect, err = inspectWithPull(ctx, dockerCLI, imageName)
+			if err != nil {
+				return nil, err
+			}
 		}
 		service.Image = imageName
 		exposed := utils.Set[string]{}
 		exposed.AddAll(service.Expose...)
-		for port := range inspect.Config.ExposedPorts {
-			p, err := network.ParsePort(port)
-			if err != nil {
-				return nil, err
+		if inspect.Config != nil {
+			for port := range inspect.Config.ExposedPorts {
+				p, err := network.ParsePort(port)
+				if err != nil {
+					return nil, err
+				}
+				exposed.Add(strconv.Itoa(int(p.Num())))
 			}
-			exposed.Add(strconv.Itoa(int(p.Num())))
 		}
 		for _, port := range service.Ports {
 			exposed.Add(strconv.Itoa(int(port.Target)))

--- a/pkg/bridge/convert_test.go
+++ b/pkg/bridge/convert_test.go
@@ -1,0 +1,54 @@
+/*
+   Copyright 2026 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package bridge
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/client"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/mocks"
+)
+
+func TestLoadAdditionalResources_BuildOnlySkipsPull(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	dockerCLI := mocks.NewMockCli(mockCtrl)
+	apiClient := mocks.NewMockAPIClient(mockCtrl)
+	dockerCLI.EXPECT().Client().Return(apiClient).AnyTimes()
+	apiClient.EXPECT().ImageInspect(gomock.Any(), "test-api").
+		Return(client.ImageInspectResult{}, errdefs.ErrNotFound)
+
+	project := &types.Project{
+		Name: "test",
+		Services: types.Services{
+			"api": {
+				Name:   "api",
+				Build:  &types.BuildConfig{Context: "."},
+				Expose: []string{"8080"},
+			},
+		},
+	}
+
+	actual, err := LoadAdditionalResources(t.Context(), dockerCLI, project)
+	assert.NilError(t, err)
+	assert.Equal(t, actual.Services["api"].Image, "test-api")
+	assert.DeepEqual(t, actual.Services["api"].Expose, types.StringOrNumberList{"8080"})
+}

--- a/pkg/e2e/bridge_test.go
+++ b/pkg/e2e/bridge_test.go
@@ -26,11 +26,12 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+const bridgeImageVersion = "v0.0.3"
+
 func TestConvertAndTransformList(t *testing.T) {
 	c := NewParallelCLI(t)
 
 	const projectName = "bridge"
-	const bridgeImageVersion = "v0.0.3"
 	tmpDir := t.TempDir()
 
 	t.Run("kubernetes manifests", func(t *testing.T) {
@@ -66,7 +67,7 @@ func TestConvertBuildOnlyService(t *testing.T) {
 	outDir := t.TempDir()
 
 	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/bridge-build-only/compose.yaml", "--project-name", "bridge-build-only", "bridge", "convert",
-		"--output", outDir, "--transformation", "docker/compose-bridge-kubernetes:v0.0.3")
+		"--output", outDir, "--transformation", fmt.Sprintf("docker/compose-bridge-kubernetes:%s", bridgeImageVersion))
 	assert.NilError(t, res.Error)
 	assert.Equal(t, res.ExitCode, 0)
 

--- a/pkg/e2e/bridge_test.go
+++ b/pkg/e2e/bridge_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -58,4 +59,18 @@ func TestConvertAndTransformList(t *testing.T) {
 		assert.Assert(t, strings.Contains(res.Stdout(), "docker/compose-bridge-helm"), res.Combined())
 		assert.Assert(t, strings.Contains(res.Stdout(), "docker/compose-bridge-kubernetes"), res.Combined())
 	})
+}
+
+func TestConvertBuildOnlyService(t *testing.T) {
+	c := NewParallelCLI(t)
+	outDir := t.TempDir()
+
+	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/bridge-build-only/compose.yaml", "--project-name", "bridge-build-only", "bridge", "convert",
+		"--output", outDir, "--transformation", "docker/compose-bridge-kubernetes:v0.0.3")
+	assert.NilError(t, res.Error)
+	assert.Equal(t, res.ExitCode, 0)
+
+	entries, err := os.ReadDir(outDir)
+	assert.NilError(t, err)
+	assert.Assert(t, len(entries) > 0, "expected bridge conversion to produce output")
 }

--- a/pkg/e2e/fixtures/bridge-build-only/Dockerfile
+++ b/pkg/e2e/fixtures/bridge-build-only/Dockerfile
@@ -1,0 +1,17 @@
+#   Copyright 2026 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM alpine
+EXPOSE 8080
+CMD ["echo", "Hello from Dockerfile"]

--- a/pkg/e2e/fixtures/bridge-build-only/compose.yaml
+++ b/pkg/e2e/fixtures/bridge-build-only/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  app:
+    build: .
+    expose:
+      - "8080"


### PR DESCRIPTION
This fixes LoadAdditionalResources so "build-only services" (those with a `build:` definition but no explicit `image:` reference) are not pulled from a registry or local Docker daemon.

I encountered this while developing a Compose Bridge transformation that converts Compose files into [Zarf](https://zarf.dev/) packages using [imageArchives](https://docs.zarf.dev/ref/components/#container-image-archives). The transformation uses Buildx to build images directly into OCI archive files, which Zarf then consumes; no image needs to be available in a registry or local Docker image store.

Previously, Compose derived a default image name for the build-only service and attempted to pull it before the transformation ran. This caused conversion to fail even though the image was going to be produced directly as an archive and there was nothing to pull.

<img width="1025" height="608" alt="image" src="https://github.com/user-attachments/assets/9a62dea6-9294-4728-b5cd-d2c503d6a89d" />
Build-only services now cross the bridge without trying to pull a nonexistent image.