### PR TITLE
fix: allow detach during compose up startup wait

### DIFF
--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -111,8 +111,13 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	globalCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	var detachRequested atomic.Bool
+
 	if navigationMenu != nil {
-		navigationMenu.EnableDetach(cancel)
+		navigationMenu.EnableDetach(func() {
+			detachRequested.Store(true)
+			cancel()
+		})
 	}
 
 	var (
@@ -123,6 +128,9 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 
 	appendErr := func(err error) {
 		if err != nil {
+			if detachRequested.Load() && errors.Is(err, context.Canceled) {
+				return
+			}
 			mu.Lock()
 			errs = append(errs, err)
 			mu.Unlock()


### PR DESCRIPTION
Fixes #13716

This updates the attached `compose up` flow so the interactive detach shortcut can interrupt the startup/wait phase.

Previously, the detach shortcut cancelled `globalCtx`, but service startup was executed with `context.WithoutCancel(ctx)`. As a result, pressing `d` could cancel the interactive/log side while the startup/wait path continued until services reached running/healthy state.

This change introduces a detach-aware startup context. It keeps startup isolated from parent cancellation for the existing signal-handling behavior, while allowing the explicit detach action to cancel startup/wait and return control cleanly.

Validation:
- gofmt -w pkg/compose/up.go
- go test ./pkg/compose
- go test ./pkg/compose -run Test
- git diff --check
- manual reproduction with a health-gated Compose project:
  - created a project where `dependent` waits on `slow: condition: service_healthy`
  - kept `slow` in healthcheck waiting state
  - ran `/tmp/docker-compose -f /tmp/compose-13716-repro/compose.yaml up --menu`
  - pressed `d` while `slow` was Waiting
  - confirmed the shell prompt returned immediately
  - confirmed `slow` remained running with `docker ps`
  - cleaned up with `down -v --remove-orphans`