### PR TITLE
fix: ignore one-off container exit events in monitor

### DIFF
--- a/pkg/compose/monitor.go
+++ b/pkg/compose/monitor.go
@@ -77,7 +77,7 @@ func (c *monitor) Start(ctx context.Context) error {
 	restarting := utils.Set[string]{}
 
 	res := c.apiClient.Events(ctx, client.EventsListOptions{
-		Filters: projectFilter(c.project).Add("type", "container"),
+		Filters: projectFilter(c.project).Add("type", "container").Add("label", oneOffFilter(false)),
 	})
 	for {
 		if len(containers) == 0 {


### PR DESCRIPTION
## Description

Fixes #14020

Since 2.39.0, the new `monitor.go` refactoring introduced a regression where `docker compose up --abort-on-container-exit` tears down the project when an unrelated one-off container created by `docker compose run` exits.

**Root cause:** The `ContainerList` call in `monitor.Start()` correctly excludes one-off containers via `oneOffFilter(false)`, but the event subscription (`Events()`) does not. One-off containers carry `com.docker.compose.oneoff=True` and pass through the service guard, causing the monitor to see their exit and abort the project.

**Fix:** Add `oneOffFilter(false)` to the `Events()` filter args, matching the `ContainerList` filter. This is consistent with `docker/compose-cli#1987` which established this exclusion deliberately.

## Verification
- `docker compose up --abort-on-container-exit main` + `docker compose run --rm main true` no longer triggers premature abort
- Existing regression: `docker compose up --abort-on-container-exit` still aborts when a declared service exits (verified independent of this fix)

## Related
- docker/compose-cli#1955, docker/compose-cli#1987 (same fix for the old codebase)