### PR TITLE
test: image volume from an already-local image

### DIFF
--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -191,6 +191,37 @@ func TestImageVolume(t *testing.T) {
 	assert.Check(t, strings.Contains(out, "index.html"))
 }
 
+func TestImageVolumeImageAlreadyLocal(t *testing.T) {
+	// Regression test for https://github.com/docker/compose/issues/14005
+	// (pulled-image scenario): when the source image of a `type: image` volume
+	// is already present locally, compose used to rewrite the mount source to a
+	// digest the daemon can't resolve as a mount source under the containerd
+	// image store ("No such image"). TestImageVolume only covers this path by
+	// accident, when a previous test left the image in the local store.
+	c := NewCLI(t)
+	const projectName = "compose-e2e-image-volume-local"
+	t.Cleanup(func() {
+		c.cleanupWithDown(t, projectName)
+	})
+
+	version := c.RunDockerCmd(t, "version", "-f", "{{.Server.Version}}")
+	major, _, found := strings.Cut(version.Combined(), ".")
+	assert.Assert(t, found)
+	if major == "26" || major == "27" {
+		t.Skip("Skipping test due to docker version < 28")
+	}
+
+	// make sure the source image is already in the local store
+	c.RunDockerCmd(t, "pull", "-q", "nginx:alpine")
+
+	res := c.RunDockerComposeCmd(t, "-f", "./fixtures/volumes/compose.yaml", "--project-name", projectName, "up", "with_image")
+	assert.Check(t, strings.Contains(res.Combined(), "index.html"), res.Combined())
+
+	// the unchanged service must not be recreated by a second up
+	res = c.RunDockerComposeCmd(t, "-f", "./fixtures/volumes/compose.yaml", "--project-name", projectName, "up", "with_image")
+	assert.Check(t, !strings.Contains(res.Combined(), "Recreate"), res.Combined())
+}
+
 func TestImageVolumeRecreateOnRebuild(t *testing.T) {
 	c := NewCLI(t)
 	const projectName = "compose-e2e-image-volume-recreate"


### PR DESCRIPTION
**What I did**
E2E regression test for #14005, pulled-image scenario: with the source image of a `type: image` volume already present in the local store, compose used to rewrite the mount source to a digest the daemon can't resolve as a mount source under the containerd image store (`No such image`). `TestImageVolume` only exercises this path when a previous test happens to have left the image in the local store — which is how openQA caught it while CI stayed green. Pre-pulling the image makes it deterministic, and a second unchanged `up` is asserted not to recreate the service.

Verified locally against a containerd image store daemon: fails on `main`, passes with #14011 — **#14011 is the fix for #14005** (the built-image scenario is already covered by `TestImageVolumeRecreateOnRebuild`, which its containerd CI job will exercise). Unlike the built-image tests, this one only bites under the containerd image store, so it stays green on the current graphdriver CI jobs and can merge independently.

**Related issue**
Reproduces #14005, fixed by #14011.
