### PR TITLE
ci: run e2e matrix with and without the containerd image store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,32 +165,46 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    name: e2e (${{ matrix.mode }}, ${{ matrix.channel }})
+    name: e2e (${{ matrix.mode }}, ${{ matrix.channel }}, ${{ matrix.store }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          # current stable
+          # current stable, both image store backends: several digest-identity
+          # bugs only manifest on one of them (graphdriver vs containerd)
           - mode: plugin
             engine: 29
             channel: stable
+            store: graphdriver
+          - mode: plugin
+            engine: 29
+            channel: stable
+            store: containerd
           - mode: standalone
             engine: 29
             channel: stable
+            store: graphdriver
+          - mode: standalone
+            engine: 29
+            channel: stable
+            store: containerd
 
           # old stable (latest major - 1)
           - mode: plugin
             engine: 28
             channel: oldstable
+            store: graphdriver
           - mode: standalone
             engine: 28
             channel: oldstable
+            store: graphdriver
     steps:
       - name: Prepare
         run: |
           mode=${{ matrix.mode }}
           engine=${{ matrix.engine }}
-          echo "MODE_ENGINE_PAIR=${mode}-${engine}" >> $GITHUB_ENV
+          store=${{ matrix.store }}
+          echo "MODE_ENGINE_PAIR=${mode}-${engine}-${store}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -205,6 +219,20 @@ jobs:
 
       - name: Check Docker Version
         run: docker --version
+
+      - name: Enable containerd image store
+        if: ${{ matrix.store == 'containerd' }}
+        run: |
+          sudo mkdir -p /etc/docker
+          if [ -s /etc/docker/daemon.json ]; then
+            jq -s '.[0] * .[1]' /etc/docker/daemon.json <(echo '{"features": {"containerd-snapshotter": true}}') \
+              | sudo tee /etc/docker/daemon.json.new > /dev/null
+            sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
+          else
+            echo '{"features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json > /dev/null
+          fi
+          sudo systemctl restart docker.service
+          docker info -f '{{json .DriverStatus}}' | grep -q io.containerd.snapshotter.v1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0


### PR DESCRIPTION
**What I did**
Cross the stable e2e CI jobs with an image-store axis (`graphdriver` / `containerd`), in both plugin and standalone modes; oldstable jobs stay on the default graphdriver. 6 jobs total instead of 4.

Several image-identity bugs only manifest on one store backend — #14005, #14007 and #14014 all reproduce only under the containerd image store, which no CI job covered (this is how `TestImageVolume`/`TestImageVolumeRecreateOnRebuild` stayed green in CI while failing on openQA). With this matrix, the e2e regression tests from #14025 and #14026 actually exercise the configuration they were written for.

Overlaps with the single containerd job added by #14011's ci.yml change (same store-enablement step): whichever merges second just rebases its ci.yml part.

**Note**: the containerd-store jobs will be red until #14011 merges — they expose #14005 through the existing image-volume tests, which is exactly the point.

**Related issue**
Context for #14005 / #14007 / #14014 / #14011.
