### PR TITLE
fix(images): tolerate containers whose image record is gone

### DIFF
--- a/pkg/compose/images.go
+++ b/pkg/compose/images.go
@@ -32,6 +32,7 @@ import (
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/versions"
+	godigest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -73,60 +74,84 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, c := range containers {
 		eg.Go(func() error {
-			img, err := s.apiClient().ImageInspect(ctx, c.Image)
+			img, err := s.containerImageSummary(ctx, c, withPlatform)
 			if err != nil {
 				return err
 			}
-			id := img.ID // platform-specific image ID can't be combined with image tag, see https://github.com/moby/moby/issues/49995
-
-			if withPlatform && c.ImageManifestDescriptor != nil && c.ImageManifestDescriptor.Platform != nil {
-				img, err = s.apiClient().ImageInspect(ctx, c.Image, client.ImageInspectWithPlatform(c.ImageManifestDescriptor.Platform))
-				if err != nil {
-					return err
-				}
-			}
-
-			var repository, tag string
-			ref, err := reference.ParseDockerRef(c.Image)
-			if err == nil {
-				// ParseDockerRef will reject a local image ID
-				repository = reference.FamiliarName(ref)
-				if tagged, ok := ref.(reference.Tagged); ok {
-					tag = tagged.Tag()
-				}
-			}
-
-			var created *time.Time
-			if img.Created != "" {
-				t, err := time.Parse(time.RFC3339Nano, img.Created)
-				if err != nil {
-					return err
-				}
-				created = &t
-			}
-
 			mux.Lock()
 			defer mux.Unlock()
-			summary[getCanonicalContainerName(c)] = api.ImageSummary{
-				ID:         id,
-				Repository: repository,
-				Tag:        tag,
-				Platform: platforms.Platform{
-					Architecture: img.Architecture,
-					OS:           img.Os,
-					OSVersion:    img.OsVersion,
-					Variant:      img.Variant,
-				},
-				Size:        img.Size,
-				Created:     created,
-				LastTagTime: img.Metadata.LastTagTime,
-			}
+			summary[getCanonicalContainerName(c)] = img
 			return nil
 		})
 	}
 
 	err = eg.Wait()
 	return summary, err
+}
+
+// containerImageSummary describes the image a container was created from. The
+// image record may not exist anymore: under the containerd image store the
+// daemon drops the dangling old index when a rebuild with identical content
+// moves the tag — without compose recreating the container (see #13636) — and
+// `docker rmi -f` may remove the image of a running container. In that case
+// report what the container itself knows rather than failing the whole
+// listing (#14014).
+func (s *composeService) containerImageSummary(ctx context.Context, c container.Summary, withPlatform bool) (api.ImageSummary, error) {
+	var repository, tag string
+	if _, err := godigest.Parse(c.Image); err != nil {
+		// c.Image is a reference, not the raw image ID the engine reports
+		// when the image record is gone or its tag was moved
+		if ref, err := reference.ParseDockerRef(c.Image); err == nil {
+			repository = reference.FamiliarName(ref)
+			if tagged, ok := ref.(reference.Tagged); ok {
+				tag = tagged.Tag()
+			}
+		}
+	}
+
+	img, err := s.apiClient().ImageInspect(ctx, c.Image)
+	if errdefs.IsNotFound(err) {
+		return api.ImageSummary{
+			ID:         c.ImageID,
+			Repository: repository,
+			Tag:        tag,
+		}, nil
+	}
+	if err != nil {
+		return api.ImageSummary{}, err
+	}
+	id := img.ID // platform-specific image ID can't be combined with image tag, see https://github.com/moby/moby/issues/49995
+
+	if withPlatform && c.ImageManifestDescriptor != nil && c.ImageManifestDescriptor.Platform != nil {
+		img, err = s.apiClient().ImageInspect(ctx, c.Image, client.ImageInspectWithPlatform(c.ImageManifestDescriptor.Platform))
+		if err != nil {
+			return api.ImageSummary{}, err
+		}
+	}
+
+	var created *time.Time
+	if img.Created != "" {
+		t, err := time.Parse(time.RFC3339Nano, img.Created)
+		if err != nil {
+			return api.ImageSummary{}, err
+		}
+		created = &t
+	}
+
+	return api.ImageSummary{
+		ID:         id,
+		Repository: repository,
+		Tag:        tag,
+		Platform: platforms.Platform{
+			Architecture: img.Architecture,
+			OS:           img.Os,
+			OSVersion:    img.OsVersion,
+			Variant:      img.Variant,
+		},
+		Size:        img.Size,
+		Created:     created,
+		LastTagTime: img.Metadata.LastTagTime,
+	}, nil
 }
 
 // inspectLocalImages inspects the given references in parallel, requesting

--- a/pkg/compose/images_test.go
+++ b/pkg/compose/images_test.go
@@ -94,6 +94,42 @@ func TestImages(t *testing.T) {
 	assert.DeepEqual(t, images, expected)
 }
 
+func TestImagesMissingImageRecord(t *testing.T) {
+	// A container may reference an image record that no longer exists: under
+	// the containerd image store, a rebuild with identical content moves the
+	// tag and the daemon drops the old index the running container was created
+	// from (https://github.com/docker/compose/issues/14014), and `docker rmi
+	// -f` may remove the image of a running container. The listing must
+	// degrade to what the container itself knows instead of failing.
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	api, cli := prepareMocks(mockCtrl)
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+
+	args := projectFilter(strings.ToLower(testProject))
+	listOpts := client.ContainerListOptions{All: true, Filters: args}
+	api.EXPECT().Ping(gomock.Any(), client.PingOptions{NegotiateAPIVersion: true}).Return(client.PingResult{APIVersion: "1.96"}, nil).AnyTimes()
+	api.EXPECT().ClientVersion().Return("1.96").AnyTimes()
+
+	// the raw image ID the engine reports once the image record is gone
+	const goneID = "sha256:52c159e21b703f2c750d0bfd8d0af93324b46c0df0859331fb9489b7ec033d0c"
+	gone := containerDetail("service1", "123", container.StateRunning, goneID)
+	gone.ImageID = goneID
+	api.EXPECT().ImageInspect(anyCancellableContext(), goneID).
+		Return(client.ImageInspectResult{}, errdefs.ErrNotFound)
+	api.EXPECT().ContainerList(t.Context(), listOpts).Return(client.ContainerListResult{
+		Items: []container.Summary{gone},
+	}, nil)
+
+	images, err := tested.Images(t.Context(), strings.ToLower(testProject), compose.ImagesOptions{})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, images, map[string]compose.ImageSummary{
+		"123": {ID: goneID},
+	})
+}
+
 func imageInspect(id string, imageReference string, size int64, created string) image.InspectResponse {
 	return image.InspectResponse{
 		ID: id,

--- a/pkg/e2e/fixtures/images-removed/compose.yaml
+++ b/pkg/e2e/fixtures/images-removed/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: compose-e2e-images-removed:v1
+    pull_policy: never
+    init: true
+    command: ["sleep", "infinity"]

--- a/pkg/e2e/images_test.go
+++ b/pkg/e2e/images_test.go
@@ -1,0 +1,60 @@
+/*
+   Copyright 2026 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+)
+
+func TestImagesAfterImageRemoved(t *testing.T) {
+	// Regression test for https://github.com/docker/compose/issues/14014
+	// A running container may reference an image record that no longer exists:
+	// under the containerd image store, `up --build` with identical content
+	// moves the tag to a new index digest and the daemon drops the old one the
+	// container was created from — without compose recreating the container
+	// (see #13636). `docker rmi -f` of a running container's image produces
+	// the same state deterministically. `compose images` must not fail on it.
+	c := NewParallelCLI(t)
+	const projectName = "compose-e2e-images-removed"
+	const image = "compose-e2e-images-removed:v1"
+
+	cleanup := func() {
+		c.RunDockerComposeCmdNoCheck(t, "--project-name", projectName, "down", "--timeout=0")
+		c.RunDockerOrExitError(t, "image", "rm", "-f", image)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	c.RunDockerCmd(t, "pull", "-q", "alpine:3.22")
+	c.RunDockerCmd(t, "tag", "alpine:3.22", image)
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/images-removed/compose.yaml",
+		"--project-name", projectName, "up", "-d")
+
+	// remove the image record while the container keeps running; under the
+	// containerd image store this leaves the container referencing an image
+	// the daemon can't inspect anymore
+	c.RunDockerOrExitError(t, "image", "rm", "-f", image)
+
+	res := c.RunDockerComposeCmdNoCheck(t, "--project-name", projectName, "images")
+	res.Assert(t, icmd.Success)
+	assert.Assert(t, strings.Contains(res.Combined(), projectName+"-app-1"), res.Combined())
+}


### PR DESCRIPTION
**What I did**
Make `compose images` tolerate containers whose image record no longer exists, instead of failing the whole listing with `No such image`.

A running container can legitimately reference a gone image record: under the containerd image store, `up --build` with identical content produces a new index digest (provenance attestation churn), the tag moves, and the daemon drops the old dangling index the container was created from; `docker rmi -f` of a running container's image produces the same state. `Images()` now degrades such entries to what the container itself knows (image ID, plus repository/tag when the recorded reference is not a raw ID) rather than propagating the NotFound.

**Interaction with #14011 — and why this fix shape**
Same root family (image-identity digests under the containerd store), but a surface #14011 doesn't touch: the failure reproduces identically with #14011's build. Not recreating the container when only the index digest changes is *by design* (#13636), an invariant #14011 locks in (`TestUpIdempotentContainerdStore`) — so a container running a vanished image record is a legitimate, durable state, and "recreate when the record is gone" would reintroduce the rebuild churn #13636/#14011 eliminate. Making the listing resilient is the only fix shape consistent with #14011. Overlap is textual only (both touch `images.go`); whichever merges second has a trivial rebase.

Covered by a unit test and an e2e test (`up` then `rmi -f` of the running container's image — the deterministic way to reach the state). The e2e test only bites under the containerd image store: it needs the CI matrix from #14027 (or #14011's containerd job) to be exercised in CI.

**Related issue**
Fixes #14014

