### PR TITLE
Use short image ID for image volume mount source

### DIFF
--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/containerd/platforms"
+	"github.com/moby/moby/client/pkg/stringid"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 
@@ -179,11 +180,13 @@ func resolveImageVolumes(service *types.ServiceConfig, images map[string]api.Ima
 				}
 			}
 			if img, ok := images[imgName]; ok {
-				// Use Image ID directly as source.
+				// Use the short image ID as source.
 				// Using name@digest format (via reference.WithDigest) fails for local-only images
 				// that don't have RepoDigests (e.g. built locally in CI).
-				// Image ID (sha256:...) is always valid and ensures ServiceHash changes on rebuild.
-				service.Volumes[i].Source = img.ID
+				// The full "sha256:<digest>" reference form is rejected by the engine as an image
+				// mount source (see issue #14005), so the ID is truncated to the short form the
+				// daemon resolves; it still changes on rebuild, keeping ServiceHash accurate.
+				service.Volumes[i].Source = stringid.TruncateID(img.ID)
 			}
 		}
 	}

--- a/pkg/compose/build_test.go
+++ b/pkg/compose/build_test.go
@@ -18,13 +18,17 @@ package compose
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/stringid"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/api"
 )
 
 func Test_dockerFilePath(t *testing.T) {
@@ -138,4 +142,29 @@ func TestGetLocalImagesDigests_PreStartHook(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, images["alpine:3.20"].ID, "sha256:service")
 	assert.Equal(t, images["alpine:3.19"].ID, "sha256:hook")
+}
+
+func TestResolveImageVolumes(t *testing.T) {
+	// Full config-digest form of a locally-built image ID.
+	const imageID = "sha256:26a04b05e50737f5d07b282e87da9c7b6eb061fc7b955243916e6792d007d353"
+
+	service := &types.ServiceConfig{
+		Name: "consumer",
+		Volumes: []types.ServiceVolumeConfig{
+			{Type: types.VolumeTypeImage, Source: "imgvol-source", Target: "/data"},
+		},
+	}
+	images := map[string]api.ImageSummary{
+		"imgvol-source": {ID: imageID},
+	}
+
+	resolveImageVolumes(service, images, "proj")
+
+	source := service.Volumes[0].Source
+	// The engine rejects the full "sha256:<digest>" reference form as an image
+	// mount source (see #14005), so we must resolve it to a plain short image ID
+	// that the daemon accepts while still changing whenever the image is rebuilt.
+	assert.Assert(t, !strings.HasPrefix(source, "sha256:"),
+		"image volume source %q must not use the sha256: reference form rejected by the engine", source)
+	assert.Equal(t, source, stringid.TruncateID(imageID))
 }


### PR DESCRIPTION
### What I did

Fixes #14005.

`docker compose up` fails to create a container that mounts a `type: image`
volume with `Error response from daemon: No such image: sha256:<digest>` when the
referenced image is already present locally (either built by the project or
pulled on a previous run). openQA caught this via `TestImageVolume` and
`TestImageVolumeRecreateOnRebuild`.

**Root cause.** `resolveImageVolumes` (`pkg/compose/build.go`) set the volume
mount source to the *full* image ID (`sha256:<digest>`). The engine does not
accept that reference form as a `type=image` mount source, so the create call is
rejected. The full ID had been chosen over `name@digest` (which fails for
local-only images without RepoDigests) and to make `ServiceHash` change on
rebuild — but the full-ID form itself is what the daemon rejects.

**Fix.** Resolve the source to the short image ID via `stringid.TruncateID`
(already used elsewhere in the repo). The short form is accepted by the daemon,
still has no RepoDigest dependency, and still changes whenever the image is
rebuilt, so recreate-on-rebuild behaviour is preserved.

### Related issue

| Issues | Fixes #14005

### Test verification (RED → GREEN)

New unit test `TestResolveImageVolumes` (`pkg/compose/build_test.go`) asserts the
resolved source is not the `sha256:` reference form.

RED — on the unmodified `main` branch (before the fix):

```
=== RUN   TestResolveImageVolumes
    build_test.go:167: assertion failed: strings.HasPrefix(source, "sha256:") is true:
    image volume source "sha256:26a04b05e50737f5d07b282e87da9c7b6eb061fc7b955243916e6792d007d353"
    must not use the sha256: reference form rejected by the engine
--- FAIL: TestResolveImageVolumes (0.00s)
FAIL	github.com/docker/compose/v5/pkg/compose
```

GREEN — with the fix:

```
=== RUN   TestResolveImageVolumes
--- PASS: TestResolveImageVolumes (0.00s)
ok  	github.com/docker/compose/v5/pkg/compose	0.027s
```

### Real-world validation against the engine

Building an image and requesting a `type=image` mount through the Engine API
(daemon 29.1.3), using the source form Compose produced before vs. after this
change:

```
OLD form (source = full sha256 image ID, pre-fix):
  [create REJECTED]  failed to mount ... (engine refuses the sha256:<digest> source)

NEW form (source = short image ID "26a04b05e507", post-fix):
  mount OK (container start HTTP 204)
```

### Validation

- `golangci-lint run --build-tags e2e ./...` → `0 issues.`
- Unit tests (`go test $(go list ./... | grep -vE '/e2e')`) pass; `pkg/compose`
  green. No new failures versus the `main` baseline.
