### PR TITLE
fix: ignore one-off container events in up monitor

### DIFF
--- a/pkg/compose/monitor.go
+++ b/pkg/compose/monitor.go
@@ -77,7 +77,7 @@ func (c *monitor) Start(ctx context.Context) error {
 	restarting := utils.Set[string]{}
 
 	res := c.apiClient.Events(ctx, client.EventsListOptions{
-		Filters: projectFilter(c.project).Add("type", "container"),
+		Filters: projectFilter(c.project).Add("type", "container").Add("label", oneOffFilter(false)),
 	})
 	for {
 		if len(containers) == 0 {

--- a/pkg/e2e/cascade_test.go
+++ b/pkg/e2e/cascade_test.go
@@ -21,8 +21,11 @@ package e2e
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/poll"
 )
 
 func TestCascadeStop(t *testing.T) {
@@ -37,6 +40,32 @@ func TestCascadeStop(t *testing.T) {
 	assert.Assert(t, strings.Contains(res.Combined(), "exit-1 exited with code 0"), res.Combined())
 	// no --exit-code-from, so this is not an error
 	assert.Equal(t, res.ExitCode, 0)
+}
+
+func TestCascadeIgnoresOneOffContainer(t *testing.T) {
+	const projectName = "compose-e2e-cascade-oneoff"
+	c := NewCLI(t, WithEnv("COMPOSE_PROJECT_NAME="+projectName))
+	t.Cleanup(func() {
+		c.RunDockerComposeCmd(t, "down")
+	})
+
+	cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/cascade/compose.yaml",
+		"up", "--abort-on-container-exit", "--menu=false", "running")
+	res := icmd.StartCmd(cmd)
+	t.Cleanup(func() {
+		_ = res.Cmd.Process.Kill()
+	})
+
+	poll.WaitOn(t, expectOutput(res, "Attaching to running-1"),
+		poll.WithDelay(100*time.Millisecond), poll.WithTimeout(30*time.Second))
+
+	c.RunDockerComposeCmd(t, "-f", "./fixtures/cascade/compose.yaml",
+		"run", "--rm", "--no-deps", "running", "/bin/true")
+
+	time.Sleep(3 * time.Second)
+
+	assert.Assert(t, !strings.Contains(res.Combined(), "Aborting on container exit"), res.Combined())
+	RequireServiceState(t, c, "running", "running")
 }
 
 func TestCascadeFail(t *testing.T) {


### PR DESCRIPTION
**What I did**
`up --abort-on-container-exit` tears down the whole project when a one-off container created by `docker compose run` exits. `monitor.Start` already excludes one-off containers from the container list it builds via `oneOffFilter(false)`, but the `api.Events` subscription did not. The only guard on an incoming event is the service label, which a one-off container inherits from the service it was run from. This applies the same filter to the event subscription.

Regression since v2.39.0 (v2.38.2 is the last unaffected release). Same bug as docker/compose-cli#1955, fixed there by docker/compose-cli#1987 with this same filter. #13152 / #13178 are the same class in the exec path.

The monitor's initial container list already applies `oneOffFilter(false)`. This just makes the event stream agree with it. Same for the other caller, `Logs` with `--follow`, whose container set is built with `oneOffExclude`.

Adds `TestCascadeIgnoresOneOffContainer` to `pkg/e2e/cascade_test.go`: it fails on unpatched main with `Aborting on container exit...` and passes with the fix. `TestCascadeStop` and `TestCascadeFail` still pass.

This supersedes #14021, which carries the same one-liner. That PR is approved but its DCO check needs an amended commit from its author. This branch is signed off and adds the regression test. Happy to close this one if #14021 gets updated instead.


**Related issue**
fixes #14020

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="4256" height="3333" alt="dalina" src="https://github.com/user-attachments/assets/0ea91653-8338-4b57-a24c-88cdd42e7c75" />
