### PR TITLE
ci: block merge while a PR contains AI_AGENT_DISCLOSURE.md

### DIFF
--- a/.github/workflows/ai-disclosure-gate.yml
+++ b/.github/workflows/ai-disclosure-gate.yml
@@ -1,0 +1,25 @@
+name: ai-disclosure-gate
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: AI disclosure gate
+    steps:
+      - name: Block merge while AI_AGENT_DISCLOSURE.md is present
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[] | select(.status != "removed") | .filename')
+          if echo "$files" | grep -qE '(^|/)AI_AGENT_DISCLOSURE\.md$'; then
+            echo "::error::This pull request contains AI_AGENT_DISCLOSURE.md, which states the change may not have been independently reviewed or tested by its human submitter. Please review the code your AI agent produced yourself, then remove the file from the commits (amend/rebase) to confirm that manual review took place. The merge stays blocked while the file is present."
+            exit 1
+          fi
+          echo "No AI_AGENT_DISCLOSURE.md in this pull request."


### PR DESCRIPTION
**What I did**
Add a PR check that fails while the pull request adds or modifies an `AI_AGENT_DISCLOSURE.md` file (any path), with an explicit error telling the contributor to review the code their AI agent produced and remove the file from the commits to confirm that manual review took place.

The disclosure file states the change *may not have been independently reviewed or tested* by its human submitter — it is a checkpoint, not something to merge. Recent agent-authored PRs (#14031, #14037) carried it; this makes the expectation enforceable instead of relying on reviewers to notice. Deleting the file in the PR is what lifts the block, so the check passes on ordinary PRs and on the removal commit itself.