### PR TITLE
lint: replace gocyclo with gocognit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,13 @@ run:
   concurrency: 2
 linters:
   default: none
+  disable:
+    # gocognit deliberately replaced gocyclo — do not re-enable. Cyclomatic
+    # complexity charges a flat guard clause the same as a nested branch, so
+    # our fail-fast style accumulated //nolint suppressions on functions that
+    # are long but flat. Cognitive complexity penalizes nesting and barely
+    # charges early returns, keeping the signal on genuinely tangled code.
+    - gocyclo
   enable:
     - copyloopvar
     - depguard

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,8 @@ linters:
     - errcheck
     - errorlint
     - forbidigo
+    - gocognit
     - gocritic
-    - gocyclo
     - gomodguard
     - govet
     - ineffassign
@@ -63,8 +63,8 @@ linters:
         - diagnostic
         - opinionated
         - style
-    gocyclo:
-      min-complexity: 16
+    gocognit:
+      min-complexity: 30
     gomodguard:
       blocked:
         modules:

--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -434,7 +434,10 @@ func (o *BackendOptions) Add(option compose.Option) {
 }
 
 // RootCommand returns the compose command with its child commands
-func RootCommand(dockerCli command.Cli, backendOptions *BackendOptions) *cobra.Command { //nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
+func RootCommand(dockerCli command.Cli, backendOptions *BackendOptions) *cobra.Command {
 	opts := ProjectOptions{}
 	var (
 		ansi     string

--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -92,7 +92,7 @@ func psCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backend
 	return psCmd
 }
 
-func runPs(ctx context.Context, dockerCli command.Cli, backendOptions *BackendOptions, services []string, opts psOptions) error { //nolint:gocyclo
+func runPs(ctx context.Context, dockerCli command.Cli, backendOptions *BackendOptions, services []string, opts psOptions) error {
 	project, name, err := opts.projectOrName(ctx, dockerCli, services...)
 	if err != nil {
 		return err

--- a/cmd/compose/up.go
+++ b/cmd/compose/up.go
@@ -186,7 +186,6 @@ func upCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backend
 	return upCmd
 }
 
-//nolint:gocyclo
 func validateFlags(up *upOptions, create *createOptions) error {
 	if up.waitTimeout < 0 {
 		return fmt.Errorf("--wait-timeout must be a non-negative integer")
@@ -228,7 +227,6 @@ func validateFlags(up *upOptions, create *createOptions) error {
 	return nil
 }
 
-//nolint:gocyclo
 func runUp(
 	ctx context.Context,
 	dockerCli command.Cli,

--- a/pkg/bridge/convert.go
+++ b/pkg/bridge/convert.go
@@ -162,6 +162,9 @@ func convert(ctx context.Context, dockerCli command.Cli, model map[string]any, o
 }
 
 // LoadAdditionalResources loads additional resources from the project, such as image references, secrets, configs and exposed ports
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func LoadAdditionalResources(ctx context.Context, dockerCLI command.Cli, project *types.Project) (*types.Project, error) {
 	for name, service := range project.Services {
 		imageName := api.GetImageNameOrDefault(service, project.Name)

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -115,9 +115,18 @@ type buildStatus struct {
 	Image  string `json:"image.name"`
 }
 
-// FIXME(ndeloof) complete migration to gocognit
-//
-//nolint:gocognit
+// bakeBuild is everything derived from the project that doBuildBake needs to
+// drive `buildx bake`: the bake file definition, plus the settings that travel
+// as command arguments or environment variables rather than in the file.
+type bakeBuild struct {
+	cfg            bakeConfig
+	targetNames    map[string]string // service name -> bake target name
+	expectedImages map[string]string // service name -> expected image
+	localPaths     []string          // local build contexts bake needs `--allow fs.read` for
+	privileged     bool
+	secretsEnv     []string
+}
+
 func (s *composeService) doBuildBake(ctx context.Context, project *types.Project, serviceToBeBuild types.Services, options api.BuildOptions) (map[string]string, error) {
 	eg := errgroup.Group{}
 	ch := make(chan *client.SolveStatus)
@@ -138,103 +147,128 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 		return err
 	})
 
-	cfg := bakeConfig{
-		Groups:  map[string]bakeGroup{},
-		Targets: map[string]bakeTarget{},
-	}
-	var (
-		group          bakeGroup
-		privileged     bool
-		read           []string
-		expectedImages = make(map[string]string, len(serviceToBeBuild)) // service name -> expected image
-		targets        = make(map[string]string, len(serviceToBeBuild)) // service name -> build target
-	)
+	bake := s.prepareBakeBuild(project, serviceToBeBuild, options)
 
-	// produce a unique ID for service used as bake target
-	for serviceName := range project.Services {
-		t := strings.ReplaceAll(serviceName, ".", "_")
-		for {
-			if _, ok := targets[serviceName]; !ok {
-				targets[serviceName] = t
-				break
-			}
-			t += "_"
+	cfgJSON, err := json.MarshalIndent(bake.cfg, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if options.Print {
+		_, err = fmt.Fprintln(s.stdout(), string(cfgJSON))
+		return nil, err
+	}
+	logrus.Debugf("bake build config:\n%s", string(cfgJSON))
+
+	metadataFile, err := bakeMetadataPath()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = os.Remove(metadataFile)
+	}()
+
+	buildx, err := s.getBuildxPlugin()
+	if err != nil {
+		return nil, err
+	}
+	args := bakeArgs(bake, metadataFile, options)
+	logrus.Debugf("Executing bake with args: %v", args)
+
+	if s.dryRun {
+		return s.dryRunBake(bake.cfg), nil
+	}
+	cmd := exec.CommandContext(ctx, buildx.Path, args...)
+
+	err = s.prepareShellOut(ctx, types.NewMapping(os.Environ()), cmd)
+	if err != nil {
+		return nil, err
+	}
+	endpoint, cleanup, err := s.propagateDockerEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	cmd.Env = append(cmd.Env, endpoint...)
+	cmd.Env = append(cmd.Env, bake.secretsEnv...)
+
+	cmd.Stdout = s.stdout()
+	cmd.Stdin = bytes.NewBuffer(cfgJSON)
+	pipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+	eg.Go(cmd.Wait)
+
+	errMessage, err := forwardBakeStatus(pipe, ch)
+	if err != nil {
+		return nil, err
+	}
+	close(ch) // stop build progress UI
+
+	err = eg.Wait()
+	if err != nil {
+		if len(errMessage) > 0 {
+			return nil, errors.New(strings.Join(errMessage, "\n"))
 		}
+		return nil, fmt.Errorf("failed to execute bake: %w", err)
 	}
 
-	var secretsEnv []string
+	return s.collectBakeResults(ctx, metadataFile, serviceToBeBuild, bake)
+}
+
+// prepareBakeBuild translates the project's build configuration into a bake
+// file definition and the side-band settings bake takes on its command line.
+func (s *composeService) prepareBakeBuild(project *types.Project, serviceToBeBuild types.Services, options api.BuildOptions) *bakeBuild {
+	bake := &bakeBuild{
+		cfg: bakeConfig{
+			Groups:  map[string]bakeGroup{},
+			Targets: map[string]bakeTarget{},
+		},
+		targetNames:    bakeTargetNames(project),
+		expectedImages: make(map[string]string, len(serviceToBeBuild)),
+	}
+
+	// project.Services lists every service (we still need their bake targets
+	// defined so additional_contexts: service:xxx references can resolve),
+	// but only emit "Building" progress and track expected images for
+	// services we actually plan to build.
 	for serviceName, service := range project.Services {
 		if service.Build == nil {
 			continue
 		}
 		buildConfig := *service.Build
-		labels := getImageBuildLabels(project, service)
 
 		args := resolveAndMergeBuildArgs(s.getProxyConfig(), project, service, options).ToMapping()
 		for k, v := range args {
 			args[k] = strings.ReplaceAll(v, "${", "$${")
 		}
 
-		entitlements := buildConfig.Entitlements
-		if slices.Contains(buildConfig.Entitlements, "security.insecure") {
-			privileged = true
-		}
-		if buildConfig.Privileged {
-			entitlements = append(entitlements, "security.insecure")
-			privileged = true
-		}
-
-		var outputs []string
-		var call string
-		push := options.Push && service.Image != ""
-		switch {
-		case options.Check:
-			call = "lint"
-		case len(service.Build.Platforms) > 1:
-			outputs = []string{fmt.Sprintf("type=image,push=%t", push)}
-		default:
-			if push {
-				outputs = []string{"type=registry"}
-			} else {
-				outputs = []string{"type=docker"}
-			}
-		}
-
-		if _, _, err := gitutil.ParseGitRef(buildConfig.Context); !strings.Contains(buildConfig.Context, "://") && err != nil {
-			read = append(read, buildConfig.Context)
-		}
-		for _, path := range buildConfig.AdditionalContexts {
-			_, _, err := gitutil.ParseGitRef(path)
-			if !strings.Contains(path, "://") && err != nil {
-				read = append(read, path)
-			}
-		}
+		entitlements, privileged := bakeEntitlements(buildConfig)
+		bake.privileged = bake.privileged || privileged
+		bake.localPaths = append(bake.localPaths, localBuildPaths(buildConfig)...)
 
 		image := api.GetImageNameOrDefault(service, project.Name)
-		// project.Services lists every service (we still need their bake
-		// targets defined so additional_contexts: service:xxx references can
-		// resolve), but only emit "Building" progress and track expected
-		// images for services we actually plan to build.
 		if _, ok := serviceToBeBuild[serviceName]; ok {
 			s.events.On(buildingEvent(image))
-			expectedImages[serviceName] = image
+			bake.expectedImages[serviceName] = image
 		}
 
-		pull := service.Build.Pull || options.Pull
-		noCache := service.Build.NoCache || options.NoCache
-
-		target := targets[serviceName]
-
 		secrets, env := toBakeSecrets(project, buildConfig.Secrets)
-		secretsEnv = append(secretsEnv, env...)
+		bake.secretsEnv = append(bake.secretsEnv, env...)
 
-		cfg.Targets[target] = bakeTarget{
+		outputs, call := bakeOutputs(service, options)
+		bake.cfg.Targets[bake.targetNames[serviceName]] = bakeTarget{
 			Context:          buildConfig.Context,
-			Contexts:         additionalContexts(buildConfig.AdditionalContexts, targets),
+			Contexts:         additionalContexts(buildConfig.AdditionalContexts, bake.targetNames),
 			Dockerfile:       dockerFilePath(buildConfig.Context, buildConfig.Dockerfile),
 			DockerfileInline: strings.ReplaceAll(buildConfig.DockerfileInline, "${", "$${"),
 			Args:             args,
-			Labels:           labels,
+			Labels:           getImageBuildLabels(project, service),
 			Tags:             append(buildConfig.Tags, image),
 
 			CacheFrom:     buildConfig.CacheFrom,
@@ -245,8 +279,8 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 			Target:        buildConfig.Target,
 			Secrets:       secrets,
 			SSH:           toBakeSSH(append(buildConfig.SSH, options.SSHs...)),
-			Pull:          pull,
-			NoCache:       noCache,
+			Pull:          buildConfig.Pull || options.Pull,
+			NoCache:       buildConfig.NoCache || options.NoCache,
 			ShmSize:       buildConfig.ShmSize,
 			Ulimits:       toBakeUlimits(buildConfig.Ulimits),
 			Entitlements:  entitlements,
@@ -259,57 +293,105 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	}
 
 	// create a bake group with targets for services to build
+	var group bakeGroup
 	for serviceName, service := range serviceToBeBuild {
 		if service.Build == nil {
 			continue
 		}
-		group.Targets = append(group.Targets, targets[serviceName])
+		group.Targets = append(group.Targets, bake.targetNames[serviceName])
 	}
+	bake.cfg.Groups["default"] = group
 
-	cfg.Groups["default"] = group
+	return bake
+}
 
-	b, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	if options.Print {
-		_, err = fmt.Fprintln(s.stdout(), string(b))
-		return nil, err
-	}
-	logrus.Debugf("bake build config:\n%s", string(b))
-
-	tmpdir := os.TempDir()
-	var metadataFile string
-	for {
-		// we don't use os.CreateTemp here as we need a temporary file name, but don't want it actually created
-		// as bake relies on atomicwriter and this creates conflict during rename
-		metadataFile = filepath.Join(tmpdir, fmt.Sprintf("compose-build-metadataFile-%s.json", uuid.New().String()))
-		if _, err = os.Stat(metadataFile); err != nil {
-			if os.IsNotExist(err) {
+// bakeTargetNames produces a unique ID for each service, used as bake target
+func bakeTargetNames(project *types.Project) map[string]string {
+	targets := make(map[string]string, len(project.Services))
+	for serviceName := range project.Services {
+		t := strings.ReplaceAll(serviceName, ".", "_")
+		for {
+			if _, ok := targets[serviceName]; !ok {
+				targets[serviceName] = t
 				break
 			}
-			var pathError *fs.PathError
-			if errors.As(err, &pathError) {
-				return nil, fmt.Errorf("can't access os.tempDir %s: %w", tmpdir, pathError.Err)
-			}
+			t += "_"
 		}
 	}
-	defer func() {
-		_ = os.Remove(metadataFile)
-	}()
+	return targets
+}
 
-	buildx, err := s.getBuildxPlugin()
-	if err != nil {
-		return nil, err
+// bakeEntitlements returns the entitlements for a build target, and whether
+// bake must be granted `security.insecure`.
+func bakeEntitlements(buildConfig types.BuildConfig) ([]string, bool) {
+	entitlements := buildConfig.Entitlements
+	privileged := slices.Contains(buildConfig.Entitlements, "security.insecure")
+	if buildConfig.Privileged {
+		entitlements = append(entitlements, "security.insecure")
+		privileged = true
 	}
+	return entitlements, privileged
+}
 
+// bakeOutputs selects the bake output type — or the lint call for `--check` —
+// for a service build.
+func bakeOutputs(service types.ServiceConfig, options api.BuildOptions) (outputs []string, call string) {
+	push := options.Push && service.Image != ""
+	switch {
+	case options.Check:
+		return nil, "lint"
+	case len(service.Build.Platforms) > 1:
+		return []string{fmt.Sprintf("type=image,push=%t", push)}, ""
+	case push:
+		return []string{"type=registry"}, ""
+	default:
+		return []string{"type=docker"}, ""
+	}
+}
+
+// localBuildPaths returns the build context paths that live on the local
+// filesystem — remote (git or URL) contexts need no fs.read entitlement.
+func localBuildPaths(buildConfig types.BuildConfig) []string {
+	paths := []string{buildConfig.Context}
+	for _, path := range buildConfig.AdditionalContexts {
+		paths = append(paths, path)
+	}
+	var local []string
+	for _, path := range paths {
+		if _, _, err := gitutil.ParseGitRef(path); !strings.Contains(path, "://") && err != nil {
+			local = append(local, path)
+		}
+	}
+	return local
+}
+
+// bakeMetadataPath picks a fresh temporary path for bake's --metadata-file.
+// We don't use os.CreateTemp here as we need a temporary file name, but don't
+// want it actually created, as bake relies on atomicwriter and this creates
+// conflict during rename.
+func bakeMetadataPath() (string, error) {
+	tmpdir := os.TempDir()
+	for {
+		metadataFile := filepath.Join(tmpdir, fmt.Sprintf("compose-build-metadataFile-%s.json", uuid.New().String()))
+		_, err := os.Stat(metadataFile)
+		if os.IsNotExist(err) {
+			return metadataFile, nil
+		}
+		var pathError *fs.PathError
+		if errors.As(err, &pathError) {
+			return "", fmt.Errorf("can't access os.tempDir %s: %w", tmpdir, pathError.Err)
+		}
+	}
+}
+
+// bakeArgs assembles the buildx bake command line.
+func bakeArgs(bake *bakeBuild, metadataFile string, options api.BuildOptions) []string {
 	args := []string{"bake", "--file", "-", "--progress", "rawjson", "--metadata-file", metadataFile}
 	// FIXME we should prompt user about this, but this is a breaking change in UX
-	for _, path := range read {
+	for _, path := range bake.localPaths {
 		args = append(args, "--allow", "fs.read="+path)
 	}
-	if privileged {
+	if bake.privileged {
 		args = append(args, "--allow", "security.insecure")
 	}
 	if options.SBOM != "" {
@@ -318,90 +400,52 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	if options.Provenance != "" {
 		args = append(args, "--provenance="+options.Provenance)
 	}
-
 	if options.Builder != "" {
 		args = append(args, "--builder", options.Builder)
 	}
 	if options.Quiet {
 		args = append(args, "--progress=quiet")
 	}
+	return args
+}
 
-	logrus.Debugf("Executing bake with args: %v", args)
-
-	if s.dryRun {
-		return s.dryRunBake(cfg), nil
-	}
-	cmd := exec.CommandContext(ctx, buildx.Path, args...)
-
-	err = s.prepareShellOut(ctx, types.NewMapping(os.Environ()), cmd)
-	if err != nil {
-		return nil, err
-	}
-	endpoint, cleanup, err := s.propagateDockerEndpoint()
-	if err != nil {
-		return nil, err
-	}
-	cmd.Env = append(cmd.Env, endpoint...)
-	cmd.Env = append(cmd.Env, secretsEnv...)
-	defer cleanup()
-
-	cmd.Stdout = s.stdout()
-	cmd.Stdin = bytes.NewBuffer(b)
-	pipe, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, err
-	}
-
+// forwardBakeStatus reads bake's rawjson stderr stream, forwarding solve
+// statuses to the progress UI channel. Lines that are not solve statuses are
+// collected as error messages, to be reported if bake exits non-zero.
+func forwardBakeStatus(pipe io.Reader, ch chan<- *client.SolveStatus) ([]string, error) {
 	var errMessage []string
 	reader := bufio.NewReader(pipe)
-
-	err = cmd.Start()
-	if err != nil {
-		return nil, err
-	}
-	eg.Go(cmd.Wait)
 	for {
 		line, readErr := reader.ReadString('\n')
+		if readErr == io.EOF {
+			return errMessage, nil
+		}
+		if errors.Is(readErr, os.ErrClosed) {
+			logrus.Debugf("bake stopped")
+			return errMessage, nil
+		}
 		if readErr != nil {
-			if readErr == io.EOF {
-				break
-			}
-			if errors.Is(readErr, os.ErrClosed) {
-				logrus.Debugf("bake stopped")
-				break
-			}
 			return nil, fmt.Errorf("failed to execute bake: %w", readErr)
 		}
 		decoder := json.NewDecoder(strings.NewReader(line))
 		var status client.SolveStatus
-		err := decoder.Decode(&status)
-		if err != nil {
-			if strings.HasPrefix(line, "ERROR: ") {
-				errMessage = append(errMessage, line[7:])
-			} else {
-				errMessage = append(errMessage, line)
-			}
+		if err := decoder.Decode(&status); err != nil {
+			errMessage = append(errMessage, strings.TrimPrefix(line, "ERROR: "))
 			continue
 		}
 		ch <- &status
 	}
-	close(ch) // stop build progress UI
+}
 
-	err = eg.Wait()
-	if err != nil {
-		if len(errMessage) > 0 {
-			return nil, errors.New(strings.Join(errMessage, "\n"))
-		}
-		return nil, fmt.Errorf("failed to execute bake: %w", err)
-	}
-
-	b, err = os.ReadFile(metadataFile)
+// collectBakeResults reads bake's metadata file and maps each built image to
+// its canonical digest.
+func (s *composeService) collectBakeResults(ctx context.Context, metadataFile string, serviceToBeBuild types.Services, bake *bakeBuild) (map[string]string, error) {
+	raw, err := os.ReadFile(metadataFile)
 	if err != nil {
 		return nil, err
 	}
-
 	var md bakeMetadata
-	err = json.Unmarshal(b, &md)
+	err = json.Unmarshal(raw, &md)
 	if err != nil {
 		return nil, err
 	}
@@ -414,9 +458,8 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	// set — so unchanged rebuilds don't recreate containers.
 	results := map[string]string{}
 	for name, service := range serviceToBeBuild {
-		image := expectedImages[name]
-		target := targets[name]
-		built, ok := md[target]
+		image := bake.expectedImages[name]
+		built, ok := md[bake.targetNames[name]]
 		if !ok {
 			return nil, fmt.Errorf("build result not found in Bake metadata for service %s", name)
 		}

--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -115,7 +115,10 @@ type buildStatus struct {
 	Image  string `json:"image.name"`
 }
 
-func (s *composeService) doBuildBake(ctx context.Context, project *types.Project, serviceToBeBuild types.Services, options api.BuildOptions) (map[string]string, error) { //nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
+func (s *composeService) doBuildBake(ctx context.Context, project *types.Project, serviceToBeBuild types.Services, options api.BuildOptions) (map[string]string, error) {
 	eg := errgroup.Group{}
 	ch := make(chan *client.SolveStatus)
 	displayMode := progressui.DisplayMode(options.Progress)

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -121,7 +121,9 @@ func (s *composeService) doBuildClassic(ctx context.Context, project *types.Proj
 	return imageIDs, err
 }
 
-//nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) doBuildImage(ctx context.Context, project *types.Project, service types.ServiceConfig, options api.BuildOptions) (string, error) {
 	var (
 		buildCtx      io.ReadCloser

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -153,7 +153,9 @@ func containerReasonEvents(containers Containers, eventFunc func(string, string)
 // ServiceConditionRunningOrHealthy is a service condition on status running or healthy
 const ServiceConditionRunningOrHealthy = "running_or_healthy"
 
-//nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) waitDependencies(ctx context.Context, project *types.Project, dependant string, dependencies types.DependsOnConfig, containers Containers, timeout time.Duration) error {
 	if timeout > 0 {
 		withTimeout, cancelFunc := context.WithTimeout(ctx, timeout)

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -249,7 +249,6 @@ func warnUnmanagedVolumes(project *types.Project, observed *ObservedState) {
 	}
 }
 
-//nolint:gocyclo
 func (s *composeService) getCreateConfigs(ctx context.Context,
 	p *types.Project,
 	service types.ServiceConfig,
@@ -474,6 +473,9 @@ func getAliases(project *types.Project, service types.ServiceConfig, serviceInde
 	return aliases
 }
 
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func createEndpointSettings(p *types.Project, service types.ServiceConfig, serviceIndex int, networkKey string, links []string, useNetworkAliases bool) (*network.EndpointSettings, error) {
 	const ifname = "com.docker.network.endpoint.ifname"
 
@@ -931,6 +933,9 @@ func getDependentServiceFromMode(mode string) string {
 	return ""
 }
 
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) buildContainerVolumes(
 	ctx context.Context,
 	p types.Project,

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -41,7 +41,7 @@ func (s *composeService) Down(ctx context.Context, projectName string, options a
 	}, "down", s.events)
 }
 
-func (s *composeService) down(ctx context.Context, projectName string, options api.DownOptions) error { //nolint:gocyclo
+func (s *composeService) down(ctx context.Context, projectName string, options api.DownOptions) error {
 	resourceToRemove := false
 
 	include := oneOffExclude

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -31,6 +31,9 @@ import (
 	"github.com/docker/compose/v5/pkg/utils"
 )
 
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) Logs(
 	ctx context.Context,
 	projectName string,

--- a/pkg/compose/monitor.go
+++ b/pkg/compose/monitor.go
@@ -53,7 +53,9 @@ func (c *monitor) withServices(services []string) {
 
 // Start runs monitor to detect application events and return after termination
 //
-//nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (c *monitor) Start(ctx context.Context) error {
 	// collect initial application container
 	initialState, err := c.apiClient.ContainerList(ctx, client.ContainerListOptions{

--- a/pkg/compose/plugins.go
+++ b/pkg/compose/plugins.go
@@ -105,7 +105,7 @@ func (s *composeService) runPlugin(ctx context.Context, project *types.Project, 
 	return nil
 }
 
-func (s *composeService) executePlugin(cmd *exec.Cmd, command string, service types.ServiceConfig) (pluginVariables, error) { //nolint:gocyclo
+func (s *composeService) executePlugin(cmd *exec.Cmd, command string, service types.ServiceConfig) (pluginVariables, error) {
 	var action string
 	switch command {
 	case "up":

--- a/pkg/compose/ps.go
+++ b/pkg/compose/ps.go
@@ -28,7 +28,9 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 )
 
-//nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) Ps(ctx context.Context, projectName string, options api.PsOptions) ([]api.ContainerSummary, error) {
 	projectName = strings.ToLower(projectName)
 	oneOff := oneOffExclude

--- a/pkg/compose/publish.go
+++ b/pkg/compose/publish.go
@@ -51,7 +51,9 @@ func (s *composeService) Publish(ctx context.Context, project *types.Project, re
 	}, "publish", s.events)
 }
 
-//nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) publish(ctx context.Context, project *types.Project, repository string, options api.PublishOptions) error {
 	project, err := project.WithProfiles([]string{"*"})
 	if err != nil {
@@ -684,6 +686,9 @@ func (s *composeService) checkForBindMount(project *types.Project) map[string][]
 	return allFindings
 }
 
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) checkForSensitiveData(ctx context.Context, project *types.Project) ([]secrets.DetectedSecret, error) {
 	var allFindings []secrets.DetectedSecret
 	scan := scanner.NewDefaultScanner()

--- a/pkg/compose/pull.go
+++ b/pkg/compose/pull.go
@@ -50,7 +50,10 @@ func (s *composeService) Pull(ctx context.Context, project *types.Project, optio
 	}, "pull", s.events)
 }
 
-func (s *composeService) pull(ctx context.Context, project *types.Project, opts api.PullOptions) error { //nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
+func (s *composeService) pull(ctx context.Context, project *types.Project, opts api.PullOptions) error {
 	images, _, err := s.getLocalImagesDigests(ctx, project)
 	if err != nil {
 		return err

--- a/pkg/compose/remove.go
+++ b/pkg/compose/remove.go
@@ -27,7 +27,7 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 )
 
-func (s *composeService) Remove(ctx context.Context, projectName string, options api.RemoveOptions) error { //nolint:gocyclo
+func (s *composeService) Remove(ctx context.Context, projectName string, options api.RemoveOptions) error {
 	projectName = strings.ToLower(projectName)
 
 	if options.Stop {

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -34,7 +34,10 @@ func (s *composeService) Restart(ctx context.Context, projectName string, option
 	}, "restart", s.events)
 }
 
-func (s *composeService) restart(ctx context.Context, projectName string, options api.RestartOptions) error { //nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
+func (s *composeService) restart(ctx context.Context, projectName string, options api.RestartOptions) error {
 	containers, err := s.getContainers(ctx, projectName, oneOffExclude, true)
 	if err != nil {
 		return err

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -41,7 +41,10 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 )
 
-func (s *composeService) Up(ctx context.Context, project *types.Project, options api.UpOptions) error { //nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
+func (s *composeService) Up(ctx context.Context, project *types.Project, options api.UpOptions) error {
 	err := Run(ctx, tracing.SpanWrapFunc("project/up", tracing.ProjectOptions(ctx, project), func(ctx context.Context) error {
 		err := s.create(ctx, project, options.Create)
 		if err != nil {

--- a/pkg/compose/viz_test.go
+++ b/pkg/compose/viz_test.go
@@ -29,6 +29,9 @@ import (
 	"github.com/docker/compose/v5/pkg/mocks"
 )
 
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func TestViz(t *testing.T) {
 	project := types.Project{
 		Name:       "viz-test",

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -186,7 +186,10 @@ func (r watchRule) Matches(event watch.FileEvent) *sync.PathMapping {
 	}
 }
 
-func (s *composeService) watch(ctx context.Context, project *types.Project, options api.WatchOptions) (func() error, error) { //nolint: gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
+func (s *composeService) watch(ctx context.Context, project *types.Project, options api.WatchOptions) (func() error, error) {
 	var err error
 	if project, err = project.WithSelectedServices(options.Services); err != nil {
 		return nil, err
@@ -529,7 +532,6 @@ func (t tarDockerClient) Untar(ctx context.Context, id string, archive io.ReadCl
 	return err
 }
 
-//nolint:gocyclo
 func (s *composeService) handleWatchBatch(ctx context.Context, project *types.Project, options api.WatchOptions, batch []watch.FileEvent, rules []watchRule, syncer sync.Syncer) error {
 	var (
 		restart   = map[string]bool{}
@@ -776,7 +778,9 @@ func (s *composeService) initialSync(ctx context.Context, project *types.Project
 
 // Syncs files from develop.watch.path if they have been modified after the image has been created
 //
-//nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (s *composeService) initialSyncFiles(ctx context.Context, project *types.Project, service types.ServiceConfig, trigger types.Trigger, ignore watch.PathMatcher) ([]*sync.PathMapping, error) {
 	fi, err := os.Stat(trigger.Path)
 	if err != nil {

--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -113,7 +113,9 @@ func (g *ociRemoteLoader) Accept(path string) bool {
 	return strings.HasPrefix(path, OciPrefix)
 }
 
-//nolint:gocyclo
+// FIXME(ndeloof) complete migration to gocognit
+//
+//nolint:gocognit
 func (g *ociRemoteLoader) Load(ctx context.Context, path string) (string, error) {
 	enabled, err := ociRemoteLoaderEnabled()
 	if err != nil {


### PR DESCRIPTION
**What I did**

Replaced the `gocyclo` linter with `gocognit` (cognitive complexity, threshold 30 — the linter default). Cognitive complexity barely charges guard clauses and early returns, and penalizes nesting instead, which matches how this codebase is written: 8 of the 21 `//nolint:gocyclo` suppressions become unnecessary, while deeply nested functions gocyclo never flagged are now caught. Remaining functions above the threshold keep a suppression, each marked `FIXME` so they can be restructured over time; `doBuildBake` (the worst offender, cognitive complexity 88) is restructured in this PR as a demonstrator, and `gocyclo` is explicitly disabled so it doesn't sneak back in.

includes refactoring of doBuildBake (hot spot after migration to gocognit, never identified by gocyclo)

Supersedes #14055 (recreated from an in-repo branch to allow a stacked follow-up PR).

**Related issue**

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)