### PR TITLE
fix: bake target names collision for services differing by '.' vs '_'

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -305,18 +306,20 @@ func (s *composeService) prepareBakeBuild(project *types.Project, serviceToBeBui
 	return bake
 }
 
-// bakeTargetNames produces a unique ID for each service, used as bake target
+// bakeTargetNames produces a unique ID for each service, used as bake target.
+// Replacing dots can make distinct service names collide (`a.b` vs `a_b`), so
+// names are allocated in sorted service order — deterministic — and a
+// colliding name gets `_` appended until unique.
 func bakeTargetNames(project *types.Project) map[string]string {
 	targets := make(map[string]string, len(project.Services))
-	for serviceName := range project.Services {
+	used := make(map[string]bool, len(project.Services))
+	for _, serviceName := range slices.Sorted(maps.Keys(project.Services)) {
 		t := strings.ReplaceAll(serviceName, ".", "_")
-		for {
-			if _, ok := targets[serviceName]; !ok {
-				targets[serviceName] = t
-				break
-			}
+		for used[t] {
 			t += "_"
 		}
+		targets[serviceName] = t
+		used[t] = true
 	}
 	return targets
 }

--- a/pkg/compose/build_bake_test.go
+++ b/pkg/compose/build_bake_test.go
@@ -1,0 +1,48 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestBakeTargetNames(t *testing.T) {
+	project := &types.Project{
+		Services: types.Services{
+			"web":   {},
+			"a.b":   {},
+			"a_b":   {},
+			"a.b.c": {},
+			"a_b.c": {},
+		},
+	}
+
+	names := bakeTargetNames(project)
+
+	// dots are replaced, and services whose names only differ by `.` vs `_`
+	// still get distinct bake targets, allocated in sorted service order
+	assert.DeepEqual(t, names, map[string]string{
+		"web":   "web",
+		"a.b":   "a_b",
+		"a_b":   "a_b_",
+		"a.b.c": "a_b_c",
+		"a_b.c": "a_b_c_",
+	})
+}


### PR DESCRIPTION
**What I did**

Stacked on #14057.

The dedup loop in `bakeTargetNames` checked whether the service already had a name — never true on first pass — instead of whether the name was already taken, so services like `a.b` and `a_b` silently mapped to the same bake target and one overwrote the other in the bake file. Names are now allocated in sorted service order (deterministic) and a colliding name gets `_` appended until unique. Covered by a new unit test.

**Related issue**

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)