### PR TITLE
refactor: split ociRemoteLoader.Load pull and index resolution

### DIFF
--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -113,9 +113,6 @@ func (g *ociRemoteLoader) Accept(path string) bool {
 	return strings.HasPrefix(path, OciPrefix)
 }
 
-// FIXME(ndeloof) complete migration to gocognit
-//
-//nolint:gocognit
 func (g *ociRemoteLoader) Load(ctx context.Context, path string) (string, error) {
 	enabled, err := ociRemoteLoaderEnabled()
 	if err != nil {
@@ -131,69 +128,90 @@ func (g *ociRemoteLoader) Load(ctx context.Context, path string) (string, error)
 
 	local, ok := g.known[path]
 	if !ok {
-		ref, err := reference.ParseDockerRef(path[len(OciPrefix):])
+		local, err = g.pullComposeArtifact(ctx, path)
 		if err != nil {
 			return "", err
-		}
-
-		resolver := oci.NewResolver(g.dockerCli.ConfigFile(), g.httpTransport(ctx), g.insecureRegistries...)
-
-		descriptor, content, err := oci.Get(ctx, resolver, ref)
-		if err != nil {
-			return "", fmt.Errorf("failed to pull OCI resource %q: %w", ref, err)
-		}
-
-		cache, err := cacheDir()
-		if err != nil {
-			return "", fmt.Errorf("initializing remote resource cache: %w", err)
-		}
-
-		local = filepath.Join(cache, descriptor.Digest.Hex())
-		if _, err = os.Stat(local); os.IsNotExist(err) {
-
-			// a Compose application bundle is published as an image index
-			if images.IsIndexType(descriptor.MediaType) {
-				var index spec.Index
-				err = json.Unmarshal(content, &index)
-				if err != nil {
-					return "", err
-				}
-				found := false
-				for _, manifest := range index.Manifests {
-					if manifest.ArtifactType != oci.ComposeProjectArtifactType {
-						continue
-					}
-					found = true
-					digested, err := reference.WithDigest(ref, manifest.Digest)
-					if err != nil {
-						return "", err
-					}
-					descriptor, content, err = oci.Get(ctx, resolver, digested)
-					if err != nil {
-						return "", fmt.Errorf("failed to pull OCI resource %q: %w", ref, err)
-					}
-				}
-				if !found {
-					return "", fmt.Errorf("OCI index %s doesn't refer to compose artifacts", ref)
-				}
-			}
-
-			var manifest spec.Manifest
-			err = json.Unmarshal(content, &manifest)
-			if err != nil {
-				return "", err
-			}
-
-			err = g.pullComposeFiles(ctx, local, manifest, ref, resolver)
-			if err != nil {
-				// we need to clean up the directory to be sure we won't leave empty files behind
-				_ = os.RemoveAll(local)
-				return "", err
-			}
 		}
 		g.known[path] = local
 	}
 	return filepath.Join(local, "compose.yaml"), nil
+}
+
+// pullComposeArtifact resolves an oci:// path and pulls the compose artifact
+// files into the local cache, unless already cached
+func (g *ociRemoteLoader) pullComposeArtifact(ctx context.Context, path string) (string, error) {
+	ref, err := reference.ParseDockerRef(path[len(OciPrefix):])
+	if err != nil {
+		return "", err
+	}
+
+	resolver := oci.NewResolver(g.dockerCli.ConfigFile(), g.httpTransport(ctx), g.insecureRegistries...)
+
+	descriptor, content, err := oci.Get(ctx, resolver, ref)
+	if err != nil {
+		return "", fmt.Errorf("failed to pull OCI resource %q: %w", ref, err)
+	}
+
+	cache, err := cacheDir()
+	if err != nil {
+		return "", fmt.Errorf("initializing remote resource cache: %w", err)
+	}
+
+	local := filepath.Join(cache, descriptor.Digest.Hex())
+	if _, err = os.Stat(local); !os.IsNotExist(err) {
+		return local, nil
+	}
+
+	// a Compose application bundle is published as an image index
+	if images.IsIndexType(descriptor.MediaType) {
+		content, err = g.resolveComposeManifest(ctx, resolver, ref, content)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	var manifest spec.Manifest
+	err = json.Unmarshal(content, &manifest)
+	if err != nil {
+		return "", err
+	}
+
+	err = g.pullComposeFiles(ctx, local, manifest, ref, resolver)
+	if err != nil {
+		// we need to clean up the directory to be sure we won't leave empty files behind
+		_ = os.RemoveAll(local)
+		return "", err
+	}
+	return local, nil
+}
+
+// resolveComposeManifest returns the content of the compose artifact manifest
+// referenced by an image index
+func (g *ociRemoteLoader) resolveComposeManifest(ctx context.Context, resolver remotes.Resolver, ref reference.Named, content []byte) ([]byte, error) {
+	var index spec.Index
+	err := json.Unmarshal(content, &index)
+	if err != nil {
+		return nil, err
+	}
+	found := false
+	for _, manifest := range index.Manifests {
+		if manifest.ArtifactType != oci.ComposeProjectArtifactType {
+			continue
+		}
+		found = true
+		digested, err := reference.WithDigest(ref, manifest.Digest)
+		if err != nil {
+			return nil, err
+		}
+		_, content, err = oci.Get(ctx, resolver, digested)
+		if err != nil {
+			return nil, fmt.Errorf("failed to pull OCI resource %q: %w", ref, err)
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("OCI index %s doesn't refer to compose artifacts", ref)
+	}
+	return content, nil
 }
 
 func (g *ociRemoteLoader) Dir(path string) string {


### PR DESCRIPTION
**What I did**

Restructured `ociRemoteLoader.Load` (cognitive complexity 48 → 5): the artifact pull moves to `pullComposeArtifact` and the image-index indirection to `resolveComposeManifest`, so `Load` reads as guards → cache lookup → pull on miss. No behavior change. One more `FIXME`/`nolint:gocognit` suppression removed.

**Related issue**

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)