### PR TITLE
refactor: flatten Ps, restart and Logs orchestration

### DIFF
--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -31,50 +31,21 @@ import (
 	"github.com/docker/compose/v5/pkg/utils"
 )
 
-// FIXME(ndeloof) complete migration to gocognit
-//
-//nolint:gocognit
 func (s *composeService) Logs(
 	ctx context.Context,
 	projectName string,
 	consumer api.LogConsumer,
 	options api.LogOptions,
 ) error {
-	var containers Containers
-	var err error
-
-	if options.Index > 0 {
-		ctr, err := s.getSpecifiedContainer(ctx, projectName, oneOffExclude, true, options.Services[0], options.Index)
-		if err != nil {
-			return err
-		}
-		containers = append(containers, ctr)
-	} else {
-		containers, err = s.getContainers(ctx, projectName, oneOffExclude, true, options.Services...)
-		if err != nil {
-			return err
-		}
-	}
-
-	if options.Project != nil && len(options.Services) == 0 {
-		// we run with an explicit compose.yaml, so only consider services defined in this file
-		options.Services = options.Project.ServiceNames()
-		containers = containers.filter(isService(options.Services...))
+	containers, err := s.selectLogsContainers(ctx, projectName, &options)
+	if err != nil {
+		return err
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, ctr := range containers {
 		eg.Go(func() error {
-			res, err := s.apiClient().ContainerInspect(ctx, ctr.ID, client.ContainerInspectOptions{})
-			if err != nil {
-				return err
-			}
-			err = s.doLogContainer(ctx, consumer, getContainerNameWithoutProject(ctr), res.Container, options)
-			if errdefs.IsNotImplemented(err) {
-				logrus.Warnf("Can't retrieve logs for %q: %s", getCanonicalContainerName(ctr), err.Error())
-				return nil
-			}
-			return err
+			return s.logContainer(ctx, consumer, ctr, options)
 		})
 	}
 
@@ -88,29 +59,7 @@ func (s *composeService) Logs(
 			monitor.withServices(options.Project.ServiceNames())
 		}
 		monitor.withListener(printer.HandleEvent)
-		monitor.withListener(func(event api.ContainerEvent) {
-			if event.Type == api.ContainerEventStarted {
-				eg.Go(func() error {
-					res, err := s.apiClient().ContainerInspect(ctx, event.ID, client.ContainerInspectOptions{})
-					if err != nil {
-						return err
-					}
-
-					err = s.doLogContainer(ctx, consumer, event.Source, res.Container, api.LogOptions{
-						Follow:     options.Follow,
-						Since:      res.Container.State.StartedAt,
-						Until:      options.Until,
-						Tail:       options.Tail,
-						Timestamps: options.Timestamps,
-					})
-					if errdefs.IsNotImplemented(err) {
-						// ignore
-						return nil
-					}
-					return err
-				})
-			}
-		})
+		monitor.withListener(s.followStartedContainersLogs(ctx, eg, consumer, options))
 		eg.Go(func() error {
 			// pass ctx so monitor will immediately stop on SIGINT
 			return monitor.Start(ctx)
@@ -118,6 +67,73 @@ func (s *composeService) Logs(
 	}
 
 	return eg.Wait()
+}
+
+// selectLogsContainers returns the containers to stream logs from, per the
+// requested services, container index, and project
+func (s *composeService) selectLogsContainers(ctx context.Context, projectName string, options *api.LogOptions) (Containers, error) {
+	if options.Index > 0 {
+		ctr, err := s.getSpecifiedContainer(ctx, projectName, oneOffExclude, true, options.Services[0], options.Index)
+		if err != nil {
+			return nil, err
+		}
+		return Containers{ctr}, nil
+	}
+	containers, err := s.getContainers(ctx, projectName, oneOffExclude, true, options.Services...)
+	if err != nil {
+		return nil, err
+	}
+	if options.Project != nil && len(options.Services) == 0 {
+		// we run with an explicit compose.yaml, so only consider services defined in this file
+		options.Services = options.Project.ServiceNames()
+		containers = containers.filter(isService(options.Services...))
+	}
+	return containers, nil
+}
+
+// logContainer streams a container's logs, warning when its logging driver
+// doesn't support reading logs
+func (s *composeService) logContainer(ctx context.Context, consumer api.LogConsumer, ctr container.Summary, options api.LogOptions) error {
+	res, err := s.apiClient().ContainerInspect(ctx, ctr.ID, client.ContainerInspectOptions{})
+	if err != nil {
+		return err
+	}
+	err = s.doLogContainer(ctx, consumer, getContainerNameWithoutProject(ctr), res.Container, options)
+	if errdefs.IsNotImplemented(err) {
+		logrus.Warnf("Can't retrieve logs for %q: %s", getCanonicalContainerName(ctr), err.Error())
+		return nil
+	}
+	return err
+}
+
+// followStartedContainersLogs streams the logs of containers (re)started
+// while following, ignoring those whose logging driver doesn't support
+// reading logs
+func (s *composeService) followStartedContainersLogs(ctx context.Context, eg *errgroup.Group, consumer api.LogConsumer, options api.LogOptions) api.ContainerEventListener {
+	return func(event api.ContainerEvent) {
+		if event.Type != api.ContainerEventStarted {
+			return
+		}
+		eg.Go(func() error {
+			res, err := s.apiClient().ContainerInspect(ctx, event.ID, client.ContainerInspectOptions{})
+			if err != nil {
+				return err
+			}
+
+			err = s.doLogContainer(ctx, consumer, event.Source, res.Container, api.LogOptions{
+				Follow:     options.Follow,
+				Since:      res.Container.State.StartedAt,
+				Until:      options.Until,
+				Tail:       options.Tail,
+				Timestamps: options.Timestamps,
+			})
+			if errdefs.IsNotImplemented(err) {
+				// ignore
+				return nil
+			}
+			return err
+		})
+	}
 }
 
 func (s *composeService) doLogContainer(ctx context.Context, consumer api.LogConsumer, name string, ctr container.InspectResponse, options api.LogOptions) error {

--- a/pkg/compose/ps.go
+++ b/pkg/compose/ps.go
@@ -28,9 +28,6 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 )
 
-// FIXME(ndeloof) complete migration to gocognit
-//
-//nolint:gocognit
 func (s *composeService) Ps(ctx context.Context, projectName string, options api.PsOptions) ([]api.ContainerSummary, error) {
 	projectName = strings.ToLower(projectName)
 	oneOff := oneOffExclude
@@ -49,88 +46,110 @@ func (s *composeService) Ps(ctx context.Context, projectName string, options api
 	eg, ctx := errgroup.WithContext(ctx)
 	for i, ctr := range containers {
 		eg.Go(func() error {
-			publishers := make([]api.PortPublisher, len(ctr.Ports))
-			sort.Slice(ctr.Ports, func(i, j int) bool {
-				return ctr.Ports[i].PrivatePort < ctr.Ports[j].PrivatePort
-			})
-			for i, p := range ctr.Ports {
-				var url string
-				if p.IP.IsValid() {
-					url = p.IP.String()
-				}
-				publishers[i] = api.PortPublisher{
-					URL:           url, // TODO(thaJeztah); change this to a netip.Addr ??
-					TargetPort:    int(p.PrivatePort),
-					PublishedPort: int(p.PublicPort),
-					Protocol:      p.Type,
-				}
-			}
-
-			inspect, err := s.apiClient().ContainerInspect(ctx, ctr.ID, client.ContainerInspectOptions{})
-			if err != nil {
-				return err
-			}
-
-			var (
-				health   container.HealthStatus
-				exitCode int
-			)
-			if inspect.Container.State != nil {
-				switch inspect.Container.State.Status {
-				case container.StateRunning:
-					if inspect.Container.State.Health != nil {
-						health = inspect.Container.State.Health.Status
-					}
-				case container.StateExited, container.StateDead:
-					exitCode = inspect.Container.State.ExitCode
-				}
-			}
-
-			var (
-				local  int
-				mounts []string
-			)
-			for _, m := range ctr.Mounts {
-				name := m.Name
-				if name == "" {
-					name = m.Source
-				}
-				if m.Driver == "local" {
-					local++
-				}
-				mounts = append(mounts, name)
-			}
-
-			var networks []string
-			if ctr.NetworkSettings != nil {
-				for k := range ctr.NetworkSettings.Networks {
-					networks = append(networks, k)
-				}
-			}
-
-			summary[i] = api.ContainerSummary{
-				ID:           ctr.ID,
-				Name:         getCanonicalContainerName(ctr),
-				Names:        ctr.Names,
-				Image:        ctr.Image,
-				Project:      ctr.Labels[api.ProjectLabel],
-				Service:      ctr.Labels[api.ServiceLabel],
-				Command:      ctr.Command,
-				State:        ctr.State,
-				Status:       ctr.Status,
-				Created:      ctr.Created,
-				Labels:       ctr.Labels,
-				SizeRw:       ctr.SizeRw,
-				SizeRootFs:   ctr.SizeRootFs,
-				Mounts:       mounts,
-				LocalVolumes: local,
-				Networks:     networks,
-				Health:       health,
-				ExitCode:     exitCode,
-				Publishers:   publishers,
-			}
-			return nil
+			var err error
+			summary[i], err = s.containerSummary(ctx, ctr)
+			return err
 		})
 	}
 	return summary, eg.Wait()
+}
+
+// containerSummary builds the api summary for a container, inspecting it to
+// retrieve its health and exit code
+func (s *composeService) containerSummary(ctx context.Context, ctr container.Summary) (api.ContainerSummary, error) {
+	inspect, err := s.apiClient().ContainerInspect(ctx, ctr.ID, client.ContainerInspectOptions{})
+	if err != nil {
+		return api.ContainerSummary{}, err
+	}
+	health, exitCode := containerHealthAndExitCode(inspect)
+	mounts, localVolumes := containerMounts(ctr)
+	return api.ContainerSummary{
+		ID:           ctr.ID,
+		Name:         getCanonicalContainerName(ctr),
+		Names:        ctr.Names,
+		Image:        ctr.Image,
+		Project:      ctr.Labels[api.ProjectLabel],
+		Service:      ctr.Labels[api.ServiceLabel],
+		Command:      ctr.Command,
+		State:        ctr.State,
+		Status:       ctr.Status,
+		Created:      ctr.Created,
+		Labels:       ctr.Labels,
+		SizeRw:       ctr.SizeRw,
+		SizeRootFs:   ctr.SizeRootFs,
+		Mounts:       mounts,
+		LocalVolumes: localVolumes,
+		Networks:     containerNetworks(ctr),
+		Health:       health,
+		ExitCode:     exitCode,
+		Publishers:   containerPublishers(ctr),
+	}, nil
+}
+
+func containerPublishers(ctr container.Summary) []api.PortPublisher {
+	sort.Slice(ctr.Ports, func(i, j int) bool {
+		return ctr.Ports[i].PrivatePort < ctr.Ports[j].PrivatePort
+	})
+	publishers := make([]api.PortPublisher, len(ctr.Ports))
+	for i, p := range ctr.Ports {
+		var url string
+		if p.IP.IsValid() {
+			url = p.IP.String()
+		}
+		publishers[i] = api.PortPublisher{
+			URL:           url, // TODO(thaJeztah); change this to a netip.Addr ??
+			TargetPort:    int(p.PrivatePort),
+			PublishedPort: int(p.PublicPort),
+			Protocol:      p.Type,
+		}
+	}
+	return publishers
+}
+
+func containerHealthAndExitCode(inspect client.ContainerInspectResult) (container.HealthStatus, int) {
+	var (
+		health   container.HealthStatus
+		exitCode int
+	)
+	state := inspect.Container.State
+	if state == nil {
+		return health, exitCode
+	}
+	switch state.Status {
+	case container.StateRunning:
+		if state.Health != nil {
+			health = state.Health.Status
+		}
+	case container.StateExited, container.StateDead:
+		exitCode = state.ExitCode
+	}
+	return health, exitCode
+}
+
+func containerMounts(ctr container.Summary) ([]string, int) {
+	var (
+		local  int
+		mounts []string
+	)
+	for _, m := range ctr.Mounts {
+		name := m.Name
+		if name == "" {
+			name = m.Source
+		}
+		if m.Driver == "local" {
+			local++
+		}
+		mounts = append(mounts, name)
+	}
+	return mounts, local
+}
+
+func containerNetworks(ctr container.Summary) []string {
+	var networks []string
+	if ctr.NetworkSettings != nil {
+		for k := range ctr.NetworkSettings.Networks {
+			networks = append(networks, k)
+		}
+	}
+	return networks
 }

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"golang.org/x/sync/errgroup"
 
@@ -34,27 +35,50 @@ func (s *composeService) Restart(ctx context.Context, projectName string, option
 	}, "restart", s.events)
 }
 
-// FIXME(ndeloof) complete migration to gocognit
-//
-//nolint:gocognit
 func (s *composeService) restart(ctx context.Context, projectName string, options api.RestartOptions) error {
 	containers, err := s.getContainers(ctx, projectName, oneOffExclude, true)
 	if err != nil {
 		return err
 	}
 
+	project, err := s.prepareRestartProject(ctx, containers, projectName, options)
+	if err != nil {
+		return err
+	}
+
+	return InDependencyOrder(ctx, project, func(c context.Context, service string) error {
+		config := project.Services[service]
+		err := s.waitDependencies(ctx, project, service, config.DependsOn, containers, 0)
+		if err != nil {
+			return err
+		}
+
+		eg, ctx := errgroup.WithContext(ctx)
+		for _, ctr := range containers.filter(isService(service)) {
+			eg.Go(func() error {
+				return s.restartContainer(ctx, project.Services[service], ctr, options)
+			})
+		}
+		return eg.Wait()
+	})
+}
+
+// prepareRestartProject resolves the project restart applies to, restricted
+// to the requested services and the depends_on relations with restart: true
+func (s *composeService) prepareRestartProject(ctx context.Context, containers Containers, projectName string, options api.RestartOptions) (*types.Project, error) {
 	project := options.Project
+	var err error
 	if project == nil {
 		project, err = s.getProjectWithResources(ctx, containers, projectName)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if options.NoDeps {
 		project, err = project.WithSelectedServices(options.Services, types.IgnoreDependencies)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -68,51 +92,41 @@ func (s *composeService) restart(ctx context.Context, projectName string, option
 		return s, nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(options.Services) != 0 {
 		project, err = project.WithSelectedServices(options.Services, types.IncludeDependents)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
+	return project, nil
+}
 
-	return InDependencyOrder(ctx, project, func(c context.Context, service string) error {
-		config := project.Services[service]
-		err = s.waitDependencies(ctx, project, service, config.DependsOn, containers, 0)
+// restartContainer restarts a container, running its pre_stop and post_start
+// hooks around the restart
+func (s *composeService) restartContainer(ctx context.Context, def types.ServiceConfig, ctr container.Summary, options api.RestartOptions) error {
+	for _, hook := range def.PreStop {
+		err := s.runHook(ctx, ctr, def, hook, nil)
 		if err != nil {
 			return err
 		}
-
-		eg, ctx := errgroup.WithContext(ctx)
-		for _, ctr := range containers.filter(isService(service)) {
-			eg.Go(func() error {
-				def := project.Services[service]
-				for _, hook := range def.PreStop {
-					err = s.runHook(ctx, ctr, def, hook, nil)
-					if err != nil {
-						return err
-					}
-				}
-				eventName := getContainerProgressName(ctr)
-				s.events.On(newEvent(eventName, api.Working, api.StatusRestarting))
-				_, err = s.apiClient().ContainerRestart(ctx, ctr.ID, client.ContainerRestartOptions{
-					Timeout: utils.DurationSecondToInt(options.Timeout),
-				})
-				if err != nil {
-					return err
-				}
-				s.events.On(newEvent(eventName, api.Done, api.StatusStarted))
-				for _, hook := range def.PostStart {
-					err = s.runHook(ctx, ctr, def, hook, nil)
-					if err != nil {
-						return err
-					}
-				}
-				return nil
-			})
-		}
-		return eg.Wait()
+	}
+	eventName := getContainerProgressName(ctr)
+	s.events.On(newEvent(eventName, api.Working, api.StatusRestarting))
+	_, err := s.apiClient().ContainerRestart(ctx, ctr.ID, client.ContainerRestartOptions{
+		Timeout: utils.DurationSecondToInt(options.Timeout),
 	})
+	if err != nil {
+		return err
+	}
+	s.events.On(newEvent(eventName, api.Done, api.StatusStarted))
+	for _, hook := range def.PostStart {
+		err := s.runHook(ctx, ctr, def, hook, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**What I did**

Three command paths with the same shape (setup + per-container goroutines with inlined bodies), flattened the same way: `Ps` (cognitive complexity 44 → 6), `restart` (42 → 8, also fixing a latent data race on the outer `err` assigned from concurrent goroutines) and `Logs` (31 → 6). No behavior change. Three more `FIXME`/`nolint:gocognit` suppressions removed.

**Related issue**

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)