### PR TITLE
ci: raise e2e go-test timeout to 20m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ install: binary
 
 .PHONY: e2e-compose
 e2e-compose: example-provider ## Run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
-	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- -v $(TEST_FLAGS) -count=1 ./pkg/e2e
+	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- -v $(TEST_FLAGS) -count=1 -timeout 20m ./pkg/e2e
 
 .PHONY: e2e-compose-standalone
 e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test
-	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- $(TEST_FLAGS) -v -count=1 -parallel=1 --tags=standalone ./pkg/e2e
+	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- $(TEST_FLAGS) -v -count=1 -parallel=1 -timeout 20m --tags=standalone ./pkg/e2e
 
 .PHONY: build-and-e2e-compose
 build-and-e2e-compose: build e2e-compose ## Compile the compose cli-plugin and run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test


### PR DESCRIPTION
**What I did**

The e2e suite runs with the Go default 10-minute test timeout (no `-timeout` flag in the Makefile e2e targets). Its cumulative duration on the slowest matrix leg (`standalone, oldstable, graphdriver`) now reaches ~11 minutes of in-binary time on slower runners, so the whole suite gets killed at 600s and the tests in flight are reported as failed — observed with the same signature on unrelated PRs (#14049 twice, #14067, #14068). This gives the suite explicit headroom (`-timeout 20m`); no single test hangs (max observed gap 37s), and the CI job timeout still bounds the total.

**Related issue**

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)