### PR TITLE
fix(events): validate service names before subscribing to events

### DIFF
--- a/cmd/compose/events.go
+++ b/cmd/compose/events.go
@@ -57,7 +57,7 @@ func eventsCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Bac
 }
 
 func runEvents(ctx context.Context, dockerCli command.Cli, backendOptions *BackendOptions, opts eventsOpts, services []string) error {
-	name, err := opts.toProjectName(ctx, dockerCli)
+	_, name, err := opts.projectOrName(ctx, dockerCli, services...)
 	if err != nil {
 		return err
 	}

--- a/pkg/e2e/events_test.go
+++ b/pkg/e2e/events_test.go
@@ -1,0 +1,33 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/icmd"
+)
+
+func TestEventsUnknownService(t *testing.T) {
+	c := NewParallelCLI(t)
+
+	cmd := c.NewDockerComposeCmd(t, "-f", "./fixtures/simple-composefile/compose.yaml", "events", "not-a-service")
+	cmd.Timeout = 10 * time.Second
+	res := icmd.RunCmd(cmd)
+	res.Assert(t, icmd.Expected{ExitCode: 1, Err: "no such service: not-a-service"})
+}


### PR DESCRIPTION
**What I did**
`docker compose events <name>` was passing service arguments straight to the event filter without checking they exist in the project, so a typo would produce an event stream matching nothing and block forever with no output and no error.

Switch to `projectOrName` (which validates args via ToProject) before calling `backend.Events`, consistent with logs, kill, and restart.

**Related issue**
JIRA DDB-637

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="560" height="377" alt="image" src="https://github.com/user-attachments/assets/173390d4-be58-4f3a-b5a1-5f5c2e027b03" />
