### PR TITLE
api: option structs document what the implementation actually honors

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,7 +52,10 @@ type ProjectLoadOptions struct {
 	EnvFiles []string
 	// Profiles to activate
 	Profiles []string
-	// Services to select (empty = all)
+	// Services narrows the loaded project to the named services and their
+	// dependencies, and enables the profiles they require (empty = all).
+	// This is where an operation's scope is decided: the Services fields of
+	// downstream option structs do not filter.
 	Services []string
 	// Offline mode disables remote resource loading
 	Offline bool
@@ -80,6 +83,14 @@ type OCIOptions struct {
 
 // Compose is the API interface one can use to programmatically use docker/compose in a third-party software
 // Use [compose.NewComposeService] to get an actual instance
+//
+// Methods act on the whole *types.Project they receive: to scope an operation
+// to a subset of services, narrow the project itself before calling — at load
+// time through ProjectLoadOptions.Services, or with
+// types.Project.WithSelectedServices. The Services fields found on some
+// option structs are not filters: they mark the services the user explicitly
+// named, and only drive side concerns (recreation policy, log scoping) as
+// documented on each field.
 type Compose interface {
 	// Build executes the equivalent to a `compose build`
 	Build(ctx context.Context, project *types.Project, options BuildOptions) error
@@ -262,7 +273,11 @@ func (o BuildOptions) Apply(project *types.Project) error {
 // CreateOptions group options of the Create API
 type CreateOptions struct {
 	Build *BuildOptions
-	// Services defines the services user interacts with
+	// Services names the services the user explicitly targeted. It does NOT
+	// restrict what gets created — the whole project converges; narrow the
+	// project instead. Targeted services follow the Recreate policy, the
+	// others follow RecreateDependencies. Empty means every service is
+	// targeted.
 	Services []string
 	// Remove legacy containers for services that are not defined in the project
 	RemoveOrphans bool
@@ -297,7 +312,9 @@ type StartOptions struct {
 	// Wait won't return until containers reached the running|healthy state
 	Wait        bool
 	WaitTimeout time.Duration
-	// Services passed in the command line to be started
+	// Services names the services the user explicitly targeted; it only
+	// scopes the log monitor of Up's foreground session. Start ignores it:
+	// narrow the project instead.
 	Services       []string
 	Watch          bool
 	NavigationMenu bool

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -441,8 +441,15 @@ type RemoveOptions struct {
 	Services []string
 }
 
-// RunOptions group options of the Run API
+// RunOptions group options of the Run API — and, for historical reasons, of
+// the Exec API, which only honors the exec-relevant subset: Service, Index,
+// Command, Environment, WorkingDir, User, Privileged, Interactive, Tty and
+// Detach.
 type RunOptions struct {
+	// CreateOptions is embedded, but creating the one-off's dependencies
+	// only honors Build, IgnoreOrphans, RemoveOrphans and QuietPull; the
+	// other fields (Recreate, RecreateDependencies, Inherit, Timeout,
+	// Services, SkipProviders) are ignored.
 	CreateOptions
 	// Project is the compose project used to define this app. Might be nil if user ran command just with project name
 	Project           *types.Project
@@ -463,7 +470,7 @@ type RunOptions struct {
 	Privileged        bool
 	UseNetworkAliases bool
 	NoDeps            bool
-	// used by exec
+	// Index selects the replica to target; only used by Exec.
 	Index int
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -301,13 +301,21 @@ type CreateOptions struct {
 type StartOptions struct {
 	// Project is the compose project used to define this app. Might be nil if user ran command just with project name
 	Project *types.Project
-	// Attach to container and forward logs if not nil
+	// Attach receives the containers' logs during Up's foreground session.
+	// It doubles as the mode switch: when nil, Up returns once containers
+	// are started (detached mode); when set, Up keeps running the
+	// interactive session (log streaming, cascade, keyboard menu).
+	// Ignored by Start.
 	Attach LogConsumer
-	// AttachTo set the services to attach to
+	// AttachTo carries two unrelated meanings: for Start, the service names
+	// used to rebuild a project from container labels when Project is nil;
+	// for Up's foreground session, the services whose logs are streamed.
 	AttachTo []string
-	// OnExit defines behavior when a container stops
+	// OnExit defines behavior when a container stops. Honored by Up's
+	// foreground session only; ignored by Start.
 	OnExit Cascade
-	// ExitCodeFrom return exit code from specified service
+	// ExitCodeFrom reports the exit code of the specified service. Honored
+	// by Up's foreground session only; ignored by Start.
 	ExitCodeFrom string
 	// Wait won't return until containers reached the running|healthy state
 	Wait        bool
@@ -315,8 +323,12 @@ type StartOptions struct {
 	// Services names the services the user explicitly targeted; it only
 	// scopes the log monitor of Up's foreground session. Start ignores it:
 	// narrow the project instead.
-	Services       []string
-	Watch          bool
+	Services []string
+	// Watch enables watch mode during Up's foreground session; ignored by
+	// Start.
+	Watch bool
+	// NavigationMenu enables the keyboard menu of Up's foreground session;
+	// ignored by Start.
 	NavigationMenu bool
 }
 


### PR DESCRIPTION
Doc-only. Three commits, one per finding of #14074 section B:

1. **The scoping invariant** (`Services` × 3 semantics): the interface doc now states that methods act on the whole `*types.Project` they receive and that scoping is done by narrowing the project — the `Services` fields of downstream option structs are intent markers, not filters. Each of the three fields (`ProjectLoadOptions`, `CreateOptions`, `StartOptions`) documents its actual effect.
2. **`StartOptions`**: the five fields only Up's foreground session reads (`Attach`, `OnExit`, `ExitCodeFrom`, `Watch`, `NavigationMenu`) are marked as ignored by `Start`; two implicit behaviors become explicit — `Attach == nil` is the detached/interactive mode switch, and `AttachTo` has two unrelated meanings.
3. **`RunOptions`**: the embedded `CreateOptions` only propagates 4 fields to dependency creation, and the same struct doubles as Exec's options, which honors only the exec-relevant subset.

No code change — comments only. Structural reshaping of these structs is deliberately out of scope.

Part of #14074 (section B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)