### PR TITLE
test(e2e): prepend provider bin dir to PATH in provider tests

### DIFF
--- a/pkg/e2e/providers_test.go
+++ b/pkg/e2e/providers_test.go
@@ -38,7 +38,7 @@ func TestProviderStopHook(t *testing.T) {
 
 	markerFile := filepath.Join(t.TempDir(), "example-provider-stop-marker")
 
-	path := fmt.Sprintf("%s%s%s", os.Getenv("PATH"), string(os.PathListSeparator), filepath.Dir(provider))
+	path := fmt.Sprintf("%s%s%s", filepath.Dir(provider), string(os.PathListSeparator), os.Getenv("PATH"))
 	c := NewParallelCLI(t, WithEnv(
 		"PATH="+path,
 		"PROVIDER_STOP_MARKER="+markerFile,
@@ -64,7 +64,7 @@ func TestDependsOnMultipleProviders(t *testing.T) {
 	provider, err := findExecutable("example-provider")
 	assert.NilError(t, err)
 
-	path := fmt.Sprintf("%s%s%s", os.Getenv("PATH"), string(os.PathListSeparator), filepath.Dir(provider))
+	path := fmt.Sprintf("%s%s%s", filepath.Dir(provider), string(os.PathListSeparator), os.Getenv("PATH"))
 	c := NewParallelCLI(t, WithEnv("PATH="+path))
 	const projectName = "depends-on-multiple-providers"
 	t.Cleanup(func() {
@@ -82,7 +82,7 @@ func TestProviderRawSetEnv(t *testing.T) {
 	provider, err := findExecutable("example-provider")
 	assert.NilError(t, err)
 
-	path := fmt.Sprintf("%s%s%s", os.Getenv("PATH"), string(os.PathListSeparator), filepath.Dir(provider))
+	path := fmt.Sprintf("%s%s%s", filepath.Dir(provider), string(os.PathListSeparator), os.Getenv("PATH"))
 	c := NewParallelCLI(t, WithEnv("PATH="+path))
 	const projectName = "rawsetenv"
 	t.Cleanup(func() {
@@ -102,7 +102,7 @@ func TestProviderRawSetEnvOverridesUserEnv(t *testing.T) {
 	provider, err := findExecutable("example-provider")
 	assert.NilError(t, err)
 
-	path := fmt.Sprintf("%s%s%s", os.Getenv("PATH"), string(os.PathListSeparator), filepath.Dir(provider))
+	path := fmt.Sprintf("%s%s%s", filepath.Dir(provider), string(os.PathListSeparator), os.Getenv("PATH"))
 	c := NewParallelCLI(t, WithEnv("PATH="+path))
 	const projectName = "rawsetenv-override"
 	t.Cleanup(func() {
@@ -123,7 +123,7 @@ func TestProviderRawSetEnvOverridesInheritedEnv(t *testing.T) {
 	provider, err := findExecutable("example-provider")
 	assert.NilError(t, err)
 
-	path := fmt.Sprintf("%s%s%s", os.Getenv("PATH"), string(os.PathListSeparator), filepath.Dir(provider))
+	path := fmt.Sprintf("%s%s%s", filepath.Dir(provider), string(os.PathListSeparator), os.Getenv("PATH"))
 	c := NewParallelCLI(t, WithEnv("PATH="+path))
 	const projectName = "rawsetenv-inherit"
 	t.Cleanup(func() {
@@ -141,7 +141,7 @@ func TestProviderRawSetEnvOverridesInheritedEnvMapForm(t *testing.T) {
 	provider, err := findExecutable("example-provider")
 	assert.NilError(t, err)
 
-	path := fmt.Sprintf("%s%s%s", os.Getenv("PATH"), string(os.PathListSeparator), filepath.Dir(provider))
+	path := fmt.Sprintf("%s%s%s", filepath.Dir(provider), string(os.PathListSeparator), os.Getenv("PATH"))
 	c := NewParallelCLI(t, WithEnv("PATH="+path))
 	const projectName = "rawsetenv-inherit-map"
 	t.Cleanup(func() {


### PR DESCRIPTION
**What I did**
When a locally-installed binary with the same name (e.g. example-provider) sits in an earlier PATH directory than `bin/build/`, `exec.LookPath` resolves the wrong binary.  The old tests appended the build directory to the end of PATH, so any pre-existing system binary shadowed the test one. 
Prepending instead ensures the freshly built binary always wins, regardless of what is installed on the developer's machine.  CI is unaffected since no such system binary exists there.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="630" height="422" alt="image" src="https://github.com/user-attachments/assets/1eb1d1ff-ac3c-43bc-89fd-3688b72d6ccf" />
