### PR TITLE
plan/start groundwork: defined wait-timeout semantics, soft-failing operations

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -187,6 +187,14 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 				select {
 				case <-ticker.C:
 				case <-ctx.Done():
+					// A deadline IS the failure this function must detect:
+					// surface it so --wait/--wait-timeout callers report it
+					// instead of silently succeeding. A plain cancellation
+					// (user interruption) is not a wait failure: return nil
+					// and let the caller's own context handling decide.
+					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+						return ctx.Err()
+					}
 					return nil
 				}
 				switch config.Condition {

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -22,6 +22,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/config/configfile"
@@ -266,6 +267,49 @@ func TestWaitDependencies(t *testing.T) {
 		assert.NilError(t, tested.(*composeService).waitDependencies(
 			t.Context(), &project, "app", project.Services["app"].DependsOn, nil, 0,
 		))
+	})
+	t.Run("timeout expiry surfaces as an error", func(t *testing.T) {
+		project := types.Project{Name: strings.ToLower(testProject), Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+		}}
+		dependencies := types.DependsOnConfig{
+			"db": {Condition: types.ServiceConditionHealthy, Required: true},
+		}
+		containers := Containers{{
+			ID:     "db-container",
+			Labels: map[string]string{api.ServiceLabel: "db"},
+		}}
+		// the dependency never turns healthy: health stays "starting"
+		apiClient.EXPECT().ContainerInspect(gomock.Any(), "db-container", gomock.Any()).Return(client.ContainerInspectResult{
+			Container: container.InspectResponse{
+				ID:   "db-container",
+				Name: "/db-container",
+				State: &container.State{
+					Status: container.StateRunning,
+					Health: &container.Health{Status: container.Starting},
+				},
+				Config: &container.Config{Healthcheck: &container.HealthConfig{Test: []string{"CMD", "true"}}},
+			},
+		}, nil).AnyTimes()
+
+		err := tested.(*composeService).waitDependencies(t.Context(), &project, "app", dependencies, containers, 600*time.Millisecond)
+		assert.ErrorContains(t, err, "timeout waiting for dependencies")
+	})
+	t.Run("user cancellation is not a wait failure", func(t *testing.T) {
+		project := types.Project{Name: strings.ToLower(testProject), Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+		}}
+		dependencies := types.DependsOnConfig{
+			"db": {Condition: types.ServiceConditionHealthy, Required: true},
+		}
+		containers := Containers{{
+			ID:     "db-container",
+			Labels: map[string]string{api.ServiceLabel: "db"},
+		}}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		err := tested.(*composeService).waitDependencies(ctx, &project, "app", dependencies, containers, 0)
+		assert.NilError(t, err)
 	})
 	t.Run("should skip dependencies with condition service_started", func(t *testing.T) {
 		dbService := types.ServiceConfig{Name: "db", Scale: intPtr(1)}

--- a/pkg/compose/executor.go
+++ b/pkg/compose/executor.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -118,6 +119,14 @@ func (exec *planExecutor) run(ctx context.Context, plan *Plan) error {
 			groups.onNodeStart(node, events)
 
 			err := exec.executeNode(ctx, node)
+
+			if err != nil && node.Operation.Optional && ctx.Err() == nil {
+				// A best-effort operation reports its failure as a skip and
+				// does not fail the plan: dependent nodes still run.
+				logrus.Warnf("%s (%s): %v", node.Operation.Cause, node.Operation.ResourceID, err)
+				events.On(skippedEvent(nodeEventName(node), err.Error()))
+				err = nil
+			}
 
 			if err == nil {
 				// Emit group done event if this is the last node of a group

--- a/pkg/compose/executor_events.go
+++ b/pkg/compose/executor_events.go
@@ -154,17 +154,19 @@ func emitDoneEvent(node *PlanNode, events api.EventProcessor) {
 
 // emitErrorEvent emits an error event for an ungrouped node.
 func emitErrorEvent(node *PlanNode, events api.EventProcessor, err error) {
-	op := node.Operation
-	var id string
-	switch {
-	case op.Container != nil:
-		id = getContainerProgressName(*op.Container)
-	default:
-		id = op.ResourceID
-	}
 	events.On(api.Resource{
-		ID:     id,
+		ID:     nodeEventName(node),
 		Status: api.Error,
 		Text:   err.Error(),
 	})
+}
+
+// nodeEventName resolves the progress-event identifier of a node: the
+// container's display name when the operation targets one, the resource ID
+// otherwise.
+func nodeEventName(node *PlanNode) string {
+	if node.Operation.Container != nil {
+		return getContainerProgressName(*node.Operation.Container)
+	}
+	return node.Operation.ResourceID
 }

--- a/pkg/compose/executor_test.go
+++ b/pkg/compose/executor_test.go
@@ -57,6 +57,43 @@ func TestExecutePlanEmpty(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestExecutePlanOptionalFailure(t *testing.T) {
+	svc, apiClient := newTestService(t)
+
+	bad := types.NetworkConfig{Name: "test_bad"}
+	good := types.NetworkConfig{Name: "test_good"}
+	project := &types.Project{
+		Name:     "test",
+		Networks: types.Networks{"bad": bad, "good": good},
+	}
+
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), "test_bad", gomock.Any()).
+		Return(client.NetworkCreateResult{}, errors.New("boom"))
+	// the dependent node must still run after the optional node failed
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), "test_good", gomock.Any()).
+		Return(client.NetworkCreateResult{ID: "net-good"}, nil)
+
+	plan := &Plan{}
+	optional := plan.addNode(Operation{
+		Type:       OpCreateNetwork,
+		ResourceID: "network:bad",
+		Cause:      "not found",
+		Name:       bad.Name,
+		Network:    &bad,
+		Optional:   true,
+	}, "")
+	plan.addNode(Operation{
+		Type:       OpCreateNetwork,
+		ResourceID: "network:good",
+		Cause:      "not found",
+		Name:       good.Name,
+		Network:    &good,
+	}, "", optional)
+
+	err := svc.executePlan(t.Context(), project, emptyObservedState("test"), plan)
+	assert.NilError(t, err, "an Optional node failure must not fail the plan")
+}
+
 func TestExecutePlanCreateNetwork(t *testing.T) {
 	svc, apiClient := newTestService(t)
 

--- a/pkg/compose/plan.go
+++ b/pkg/compose/plan.go
@@ -103,12 +103,20 @@ type Operation struct {
 	Volume       *types.VolumeConfig  // for volume operations
 	Timeout      *time.Duration       // for stop operations
 	CreateNodeID int                  // for OpRenameContainer: ID of the CreateContainer node whose result to rename
-	// BestEffort marks an operation whose failure must not abort the plan. It is
-	// used for the optional removal of the old network on a rename: if the
-	// network is still in use (by non-Compose containers) the removal is skipped
-	// with a warning instead of failing — the new network already carries a
-	// different name, so the migration does not depend on the old one going away.
+	// BestEffort marks an operation that tolerates one specific, expected
+	// error inside its own execution (today: removing the old network on a
+	// rename skips a conflict when the network is still in use — the new
+	// network already carries a different name, so the migration does not
+	// depend on the old one going away). For an operation whose whole outcome
+	// is optional, see Optional.
 	BestEffort bool
+
+	// Optional marks an operation whose outcome is best-effort at the plan
+	// level: any failure is reported as a Skipped event and a warning instead
+	// of aborting the plan, and dependent nodes still run. Used for waits on
+	// dependencies declared with required: false. For tolerating one specific
+	// error inside an operation, see BestEffort.
+	Optional bool
 }
 
 // PlanNode is a single node in the reconciliation DAG. It represents one


### PR DESCRIPTION
Phase 0 of #14081 (converge the start phase into the plan engine) — the two prerequisites, each useful on its own:

1. **`waitDependencies` no longer swallows its timeout** (🐛 from #14074 C): every polling goroutine returned `nil` on `ctx.Done()`, making the 'timeout waiting for dependencies' path unreachable except by race — `up --wait --wait-timeout` could succeed silently with nothing healthy. A deadline now surfaces as the failure it is; a plain user cancellation still returns nil so Ctrl-C doesn't masquerade as a dependency failure. Both paths gain their first unit tests.
2. **Walker-level `Operation.Optional`**: a failing Optional node emits a Skipped event + warning and lets dependents run, instead of aborting the plan — the capability `required: false` dependency waits will need once they become plan nodes. Documented against the narrower pre-existing `BestEffort` flag so the two can't be confused. Unit-tested.

Part of #14081; also closes one 🐛 item of #14074 (section C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)