### PR TITLE
phase 1: scale, up -d, watch and start converge through the plan engine (#14081)

### DIFF
--- a/pkg/api/event.go
+++ b/pkg/api/event.go
@@ -97,6 +97,27 @@ func (e *Resource) StatusText() string {
 }
 
 // EventProcessor is notified about Compose operations and tasks
+//
+// # Event contract
+//
+// The event stream is ordered per resource, not globally: operations run
+// concurrently and events of distinct resources interleave freely, but a
+// given resource's events follow a fixed progression. Consumers must key on
+// Resource.ID and must not rely on global ordering.
+//
+// Typical per-resource progressions (statuses from the Status* constants):
+//
+//	container being created:  Creating → Created
+//	container being started:  Starting → Started
+//	container being replaced: Recreate → Recreated
+//	container stop/removal:   Stopping → Stopped, Removing → Removed
+//	dependency being waited:  Waiting → Healthy | Exited
+//	networks and volumes:     Creating → Created, Removing → Removed
+//
+// Any progression can end early with an Error status, or — for optional
+// outcomes such as a dependency declared with required: false — with a
+// Skipped status carrying the reason. Status texts are stable identifiers:
+// tools may match on them.
 type EventProcessor interface {
 	// Start is triggered as a Compose operation is starting with context
 	Start(ctx context.Context, operation string)

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -185,6 +185,14 @@ func (s *composeService) waitDependencies(ctx context.Context, project *types.Pr
 				select {
 				case <-ticker.C:
 				case <-ctx.Done():
+					// A deadline IS the failure this function must detect:
+					// surface it so --wait/--wait-timeout callers report it
+					// instead of silently succeeding. A plain cancellation
+					// (user interruption) is not a wait failure: return nil
+					// and let the caller's own context handling decide.
+					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+						return ctx.Err()
+					}
 					return nil
 				}
 				switch config.Condition {

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -22,6 +22,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/config/configfile"
@@ -266,6 +267,49 @@ func TestWaitDependencies(t *testing.T) {
 		assert.NilError(t, tested.(*composeService).waitDependencies(
 			t.Context(), &project, "app", project.Services["app"].DependsOn, nil, 0,
 		))
+	})
+	t.Run("timeout expiry surfaces as an error", func(t *testing.T) {
+		project := types.Project{Name: strings.ToLower(testProject), Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+		}}
+		dependencies := types.DependsOnConfig{
+			"db": {Condition: types.ServiceConditionHealthy, Required: true},
+		}
+		containers := Containers{{
+			ID:     "db-container",
+			Labels: map[string]string{api.ServiceLabel: "db"},
+		}}
+		// the dependency never turns healthy: health stays "starting"
+		apiClient.EXPECT().ContainerInspect(gomock.Any(), "db-container", gomock.Any()).Return(client.ContainerInspectResult{
+			Container: container.InspectResponse{
+				ID:   "db-container",
+				Name: "/db-container",
+				State: &container.State{
+					Status: container.StateRunning,
+					Health: &container.Health{Status: container.Starting},
+				},
+				Config: &container.Config{Healthcheck: &container.HealthConfig{Test: []string{"CMD", "true"}}},
+			},
+		}, nil).AnyTimes()
+
+		err := tested.(*composeService).waitDependencies(t.Context(), &project, "app", dependencies, containers, 600*time.Millisecond)
+		assert.ErrorContains(t, err, "timeout waiting for dependencies")
+	})
+	t.Run("user cancellation is not a wait failure", func(t *testing.T) {
+		project := types.Project{Name: strings.ToLower(testProject), Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+		}}
+		dependencies := types.DependsOnConfig{
+			"db": {Condition: types.ServiceConditionHealthy, Required: true},
+		}
+		containers := Containers{{
+			ID:     "db-container",
+			Labels: map[string]string{api.ServiceLabel: "db"},
+		}}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		err := tested.(*composeService).waitDependencies(ctx, &project, "app", dependencies, containers, 0)
+		assert.NilError(t, err)
 	})
 	t.Run("should skip dependencies with condition service_started", func(t *testing.T) {
 		dbService := types.ServiceConfig{Name: "db", Scale: intPtr(1)}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -66,14 +66,14 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, cre
 }
 
 func (s *composeService) create(ctx context.Context, project *types.Project, options api.CreateOptions) error {
-	return s.converge(ctx, project, options, false)
+	return s.converge(ctx, project, options, nil)
 }
 
 // converge reconciles the project against the observed state and executes the
-// resulting plan. With planStart the plan also carries the start phase
+// resulting plan. With start set the plan also carries the start phase
 // (dependency-condition waits, pre_start hooks, container starts); without it
 // the plan stops at container creation and starting is the caller's business.
-func (s *composeService) converge(ctx context.Context, project *types.Project, options api.CreateOptions, planStart bool) error {
+func (s *composeService) converge(ctx context.Context, project *types.Project, options api.CreateOptions, start *startPhaseOptions) error {
 	if len(options.Services) == 0 {
 		options.Services = project.ServiceNames()
 	}
@@ -128,7 +128,7 @@ func (s *composeService) converge(ctx context.Context, project *types.Project, o
 	}
 
 	reconcileOptions := toReconcileOptions(options)
-	reconcileOptions.PlanStart = planStart
+	reconcileOptions.Start = start
 	plan, err := reconcile(ctx, project, observed, reconcileOptions, s.prompt)
 	if err != nil {
 		return err

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -66,6 +66,14 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, cre
 }
 
 func (s *composeService) create(ctx context.Context, project *types.Project, options api.CreateOptions) error {
+	return s.converge(ctx, project, options, false)
+}
+
+// converge reconciles the project against the observed state and executes the
+// resulting plan. With planStart the plan also carries the start phase
+// (dependency-condition waits, pre_start hooks, container starts); without it
+// the plan stops at container creation and starting is the caller's business.
+func (s *composeService) converge(ctx context.Context, project *types.Project, options api.CreateOptions, planStart bool) error {
 	if len(options.Services) == 0 {
 		options.Services = project.ServiceNames()
 	}
@@ -119,7 +127,9 @@ func (s *composeService) create(ctx context.Context, project *types.Project, opt
 			"--remove-orphans flag to clean it up.", observed.orphanNames())
 	}
 
-	plan, err := reconcile(ctx, project, observed, toReconcileOptions(options), s.prompt)
+	reconcileOptions := toReconcileOptions(options)
+	reconcileOptions.PlanStart = planStart
+	plan, err := reconcile(ctx, project, observed, reconcileOptions, s.prompt)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/executor.go
+++ b/pkg/compose/executor.go
@@ -122,9 +122,13 @@ func (exec *planExecutor) run(ctx context.Context, plan *Plan) error {
 
 			if err != nil && node.Operation.Optional && ctx.Err() == nil {
 				// A best-effort operation reports its failure as a skip and
-				// does not fail the plan: dependent nodes still run.
+				// does not fail the plan: dependent nodes still run. Wait
+				// nodes emit their own per-container Skipped events (see
+				// reportWaitFailure), so the generic one is theirs to skip.
 				logrus.Warnf("%s (%s): %v", node.Operation.Cause, node.Operation.ResourceID, err)
-				events.On(skippedEvent(nodeEventName(node), err.Error()))
+				if node.Operation.Type != OpWaitCondition {
+					events.On(skippedEvent(nodeEventName(node), err.Error()))
+				}
 				err = nil
 			}
 

--- a/pkg/compose/executor.go
+++ b/pkg/compose/executor.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -118,6 +119,14 @@ func (exec *planExecutor) run(ctx context.Context, plan *Plan) error {
 			groups.onNodeStart(node, events)
 
 			err := exec.executeNode(ctx, node)
+
+			if err != nil && node.Operation.Optional && ctx.Err() == nil {
+				// A best-effort operation reports its failure as a skip and
+				// does not fail the plan: dependent nodes still run.
+				logrus.Warnf("%s (%s): %v", node.Operation.Cause, node.Operation.ResourceID, err)
+				events.On(skippedEvent(nodeEventName(node), err.Error()))
+				err = nil
+			}
 
 			if err == nil {
 				// Emit group done event if this is the last node of a group

--- a/pkg/compose/executor.go
+++ b/pkg/compose/executor.go
@@ -163,6 +163,10 @@ func (exec *planExecutor) executeNode(ctx context.Context, node *PlanNode) error
 		return exec.execCreateContainer(ctx, node)
 	case OpStartContainer:
 		return exec.execStartContainer(ctx, op)
+	case OpWaitCondition:
+		return exec.execWaitCondition(ctx, op)
+	case OpRunPreStart:
+		return exec.execRunPreStart(ctx, op)
 	case OpStopContainer:
 		return exec.execStopContainer(ctx, op)
 	case OpRemoveContainer:

--- a/pkg/compose/executor_events.go
+++ b/pkg/compose/executor_events.go
@@ -111,8 +111,7 @@ func emitStartEvent(node *PlanNode, events api.EventProcessor) {
 	case OpCreateContainer:
 		events.On(creatingEvent("Container " + op.Name))
 	case OpStartContainer:
-		name := getContainerProgressName(*op.Container)
-		events.On(newEvent(name, api.Working, api.StatusStarting))
+		events.On(newEvent(startEventName(op), api.Working, api.StatusStarting))
 	case OpStopContainer:
 		events.On(stoppingEvent(getContainerProgressName(*op.Container)))
 	case OpRemoveContainer:
@@ -135,8 +134,7 @@ func emitDoneEvent(node *PlanNode, events api.EventProcessor) {
 	case OpCreateContainer:
 		events.On(createdEvent("Container " + op.Name))
 	case OpStartContainer:
-		name := getContainerProgressName(*op.Container)
-		events.On(newEvent(name, api.Done, api.StatusStarted))
+		events.On(newEvent(startEventName(op), api.Done, api.StatusStarted))
 	case OpStopContainer:
 		events.On(stoppedEvent(getContainerProgressName(*op.Container)))
 	case OpRemoveContainer:
@@ -169,4 +167,13 @@ func nodeEventName(node *PlanNode) string {
 		return getContainerProgressName(*node.Operation.Container)
 	}
 	return node.Operation.ResourceID
+}
+
+// startEventName names a start operation's progress event: start-phase nodes
+// for plan-created containers carry no Summary yet, only the target name.
+func startEventName(op Operation) string {
+	if op.Container != nil {
+		return getContainerProgressName(*op.Container)
+	}
+	return "Container " + op.Name
 }

--- a/pkg/compose/executor_events.go
+++ b/pkg/compose/executor_events.go
@@ -154,17 +154,19 @@ func emitDoneEvent(node *PlanNode, events api.EventProcessor) {
 
 // emitErrorEvent emits an error event for an ungrouped node.
 func emitErrorEvent(node *PlanNode, events api.EventProcessor, err error) {
-	op := node.Operation
-	var id string
-	switch {
-	case op.Container != nil:
-		id = getContainerProgressName(*op.Container)
-	default:
-		id = op.ResourceID
-	}
 	events.On(api.Resource{
-		ID:     id,
+		ID:     nodeEventName(node),
 		Status: api.Error,
 		Text:   err.Error(),
 	})
+}
+
+// nodeEventName resolves the progress-event identifier of a node: the
+// container's display name when the operation targets one, the resource ID
+// otherwise.
+func nodeEventName(node *PlanNode) string {
+	if node.Operation.Container != nil {
+		return getContainerProgressName(*node.Operation.Container)
+	}
+	return node.Operation.ResourceID
 }

--- a/pkg/compose/executor_ops.go
+++ b/pkg/compose/executor_ops.go
@@ -279,6 +279,19 @@ func (exec *planExecutor) checkWaitCondition(ctx context.Context, op Operation, 
 // execRunPreStart runs the service's pre_start hooks on the replica the plan
 // selected (once per service, before any of its containers start).
 func (exec *planExecutor) execRunPreStart(ctx context.Context, op Operation) error {
+	// The plan scheduled this node because no replica was running at
+	// observation time. Re-check against the daemon at execution time: if a
+	// replica started in the meantime (observe-to-execute drift), the
+	// once-per-service rule says the hooks must not run again.
+	running, err := exec.compose.getContainers(ctx, exec.project.Name, oneOffExclude, false, op.Service.Name)
+	if err != nil {
+		return err
+	}
+	if len(running) > 0 {
+		logrus.Debugf("skipping pre_start hooks of service %s: a replica is already running", op.Service.Name)
+		return nil
+	}
+
 	id, name := exec.resolveContainer(op)
 	if id == "" {
 		return fmt.Errorf("no container to run pre_start hooks for %s", op.ResourceID)

--- a/pkg/compose/executor_ops.go
+++ b/pkg/compose/executor_ops.go
@@ -228,18 +228,36 @@ func (exec *planExecutor) execWaitCondition(ctx context.Context, op Operation) e
 		case <-ticker.C:
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return fmt.Errorf("timeout waiting for dependencies")
+				return exec.reportWaitFailure(op, waitingFor, fmt.Errorf("timeout waiting for dependencies"))
 			}
 			return ctx.Err()
 		}
 		satisfied, err := exec.checkWaitCondition(ctx, op, waitingFor)
 		if err != nil {
-			return err
+			return exec.reportWaitFailure(op, waitingFor, err)
 		}
 		if satisfied {
 			return nil
 		}
 	}
+}
+
+// reportWaitFailure emits the per-container events a failed dependency wait
+// owes the progress display — Skipped with a reason when the dependency is
+// optional, Error otherwise — and returns the error for the walker (which
+// skips the generic event for wait nodes, see run()).
+func (exec *planExecutor) reportWaitFailure(op Operation, waitingFor Containers, err error) error {
+	s := exec.compose
+	if op.Optional {
+		reason := fmt.Sprintf("optional dependency %q: %v", op.Name, err)
+		s.events.On(containerReasonEvents(waitingFor, skippedEvent, reason)...)
+		logrus.Warnf("%s", reason)
+	} else {
+		s.events.On(containerEvents(waitingFor, func(id string) api.Resource {
+			return errorEventf(id, "dependency %s failed to start", op.Name)
+		})...)
+	}
+	return err
 }
 
 // checkWaitCondition performs one probe of a WaitCondition operation,

--- a/pkg/compose/executor_ops.go
+++ b/pkg/compose/executor_ops.go
@@ -18,9 +18,12 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
+	"time"
 
+	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -127,11 +130,161 @@ func (exec *planExecutor) execCreateContainer(ctx context.Context, node *PlanNod
 	return nil
 }
 
+// execStartContainer starts a container. When the operation carries a Service
+// (start-phase nodes), it performs the full service start: secret/config
+// injection before ContainerStart, post_start hooks after — mirroring
+// startServiceContainer. Bare operations (paused/dead restarts) keep the
+// plain ContainerStart.
 func (exec *planExecutor) execStartContainer(ctx context.Context, op Operation) error {
+	id, name := exec.resolveContainer(op)
+	if id == "" {
+		return fmt.Errorf("no container to start for %s", op.ResourceID)
+	}
+
+	if op.Service != nil {
+		if err := exec.compose.injectSecrets(ctx, exec.project, *op.Service, id); err != nil {
+			return err
+		}
+		if err := exec.compose.injectConfigs(ctx, exec.project, *op.Service, id); err != nil {
+			return err
+		}
+	}
+
 	startMx.Lock()
-	defer startMx.Unlock()
-	_, err := exec.compose.apiClient().ContainerStart(ctx, op.Container.ID, client.ContainerStartOptions{})
-	return err
+	_, err := exec.compose.apiClient().ContainerStart(ctx, id, client.ContainerStartOptions{})
+	startMx.Unlock()
+	if err != nil {
+		return err
+	}
+
+	if op.Service != nil {
+		ctr := exec.containerSummary(op, id, name)
+		for _, hook := range op.Service.PostStart {
+			if err := exec.compose.runHook(ctx, ctr, *op.Service, hook, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// resolveContainer returns the ID and display name of the container an
+// operation targets: the observed container when set, otherwise the result of
+// the create node the operation references.
+func (exec *planExecutor) resolveContainer(op Operation) (string, string) {
+	if op.Container != nil {
+		return op.Container.ID, getCanonicalContainerName(*op.Container)
+	}
+	res := exec.pctx.get(op.CreateNodeID)
+	name := op.Name
+	if name == "" {
+		name = res.ContainerName
+	}
+	return res.ContainerID, name
+}
+
+// containerSummary rebuilds a minimal container.Summary for helpers (hooks)
+// that need one, preferring the live view populated by earlier create nodes.
+func (exec *planExecutor) containerSummary(op Operation, id, name string) container.Summary {
+	if op.Container != nil {
+		return *op.Container
+	}
+	exec.containersMu.Lock()
+	defer exec.containersMu.Unlock()
+	if op.Service != nil {
+		for _, c := range exec.containersByService[op.Service.Name] {
+			if c.ID == id {
+				return c
+			}
+		}
+	}
+	return container.Summary{ID: id, Names: []string{"/" + name}}
+}
+
+// execWaitCondition polls the dependency service named by the operation until
+// it satisfies the declared depends_on condition, the deadline expires, or
+// the context ends. It is the plan-side equivalent of waitDependencies for a
+// single (dependent, dependency) edge; required: false edges are planned as
+// Optional nodes, so their failure is reported as a skip by the walker.
+func (exec *planExecutor) execWaitCondition(ctx context.Context, op Operation) error {
+	if op.Timeout != nil {
+		withTimeout, cancel := context.WithTimeout(ctx, *op.Timeout)
+		defer cancel()
+		ctx = withTimeout
+	}
+
+	exec.containersMu.Lock()
+	waitingFor := exec.containersByService[op.Name].filter(isNotOneOff)
+	exec.containersMu.Unlock()
+	if len(waitingFor) == 0 {
+		return fmt.Errorf("missing dependency %s", op.Name)
+	}
+	exec.compose.events.On(containerEvents(waitingFor, waiting)...)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("timeout waiting for dependencies")
+			}
+			return ctx.Err()
+		}
+		satisfied, err := exec.checkWaitCondition(ctx, op, waitingFor)
+		if err != nil {
+			return err
+		}
+		if satisfied {
+			return nil
+		}
+	}
+}
+
+// checkWaitCondition performs one probe of a WaitCondition operation,
+// reporting whether the dependency satisfies the declared condition.
+func (exec *planExecutor) checkWaitCondition(ctx context.Context, op Operation, waitingFor Containers) (bool, error) {
+	s := exec.compose
+	switch op.Condition {
+	case ServiceConditionRunningOrHealthy, types.ServiceConditionHealthy:
+		fallbackRunning := op.Condition == ServiceConditionRunningOrHealthy
+		ok, err := s.isServiceHealthy(ctx, waitingFor, fallbackRunning)
+		if err != nil {
+			return false, fmt.Errorf("dependency failed to start: %w", err)
+		}
+		if ok {
+			s.events.On(containerEvents(waitingFor, healthy)...)
+		}
+		return ok, nil
+	case types.ServiceConditionCompletedSuccessfully:
+		done, code, err := s.isServiceCompleted(ctx, waitingFor)
+		if err != nil {
+			return false, err
+		}
+		if !done {
+			return false, nil
+		}
+		if code != 0 {
+			return false, fmt.Errorf("service %q didn't complete successfully: exit %d", op.Name, code)
+		}
+		s.events.On(containerEvents(waitingFor, exited)...)
+		return true, nil
+	default:
+		logrus.Warnf("unsupported depends_on condition: %s", op.Condition)
+		return true, nil
+	}
+}
+
+// execRunPreStart runs the service's pre_start hooks on the replica the plan
+// selected (once per service, before any of its containers start).
+func (exec *planExecutor) execRunPreStart(ctx context.Context, op Operation) error {
+	id, name := exec.resolveContainer(op)
+	if id == "" {
+		return fmt.Errorf("no container to run pre_start hooks for %s", op.ResourceID)
+	}
+	ctr := exec.containerSummary(op, id, name)
+	return exec.compose.runPreStart(ctx, exec.project, *op.Service, ctr, nil)
 }
 
 func (exec *planExecutor) execStopContainer(ctx context.Context, op Operation) error {

--- a/pkg/compose/executor_test.go
+++ b/pkg/compose/executor_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -487,3 +488,103 @@ type conflictError struct{}
 
 func (conflictError) Error() string { return "conflict" }
 func (conflictError) Conflict()     {}
+
+// recordingEvents captures, per resource ID, the sequence of status texts —
+// the per-resource progression the event contract promises (see
+// api.EventProcessor).
+type recordingEvents struct {
+	mu   sync.Mutex
+	byID map[string][]string
+}
+
+func (r *recordingEvents) Start(_ context.Context, _ string) {}
+func (r *recordingEvents) Done(_ string, _ bool)             {}
+func (r *recordingEvents) On(events ...api.Resource) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range events {
+		r.byID[e.ID] = append(r.byID[e.ID], e.Text)
+	}
+}
+
+func TestExecutePlanStartPhaseEventContract(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	cli := mocks.NewMockCli(mockCtrl)
+	apiClient := mocks.NewMockAPIClient(mockCtrl)
+	cli.EXPECT().Client().Return(apiClient).AnyTimes()
+
+	recorder := &recordingEvents{byID: map[string][]string{}}
+	svcAny, err := NewComposeService(cli, WithEventProcessor(recorder))
+	assert.NilError(t, err)
+	svc := svcAny.(*composeService)
+
+	project := &types.Project{
+		Name: "test",
+		Services: types.Services{
+			"db":  {Name: "db"},
+			"app": {Name: "app"},
+		},
+	}
+	dbSummary := container.Summary{
+		ID:     "db-id",
+		Names:  []string{"/test-db-1"},
+		State:  container.StateRunning,
+		Labels: map[string]string{api.ServiceLabel: "db", api.OneoffLabel: "False"},
+	}
+	appSummary := container.Summary{
+		ID:     "app-id",
+		Names:  []string{"/test-app-1"},
+		State:  container.StateCreated,
+		Labels: map[string]string{api.ServiceLabel: "app", api.OneoffLabel: "False"},
+	}
+	observed := &ObservedState{
+		ProjectName: "test",
+		Containers: map[string][]ObservedContainer{
+			"db":  {{ID: "db-id", Name: "test-db-1", Number: 1, State: container.StateRunning, Summary: dbSummary}},
+			"app": {{ID: "app-id", Name: "test-app-1", Number: 1, State: container.StateCreated, Summary: appSummary}},
+		},
+		Networks: map[string][]ObservedNetwork{},
+		Volumes:  map[string][]ObservedVolume{},
+	}
+
+	// db reports healthy on the first probe
+	apiClient.EXPECT().ContainerInspect(gomock.Any(), "db-id", gomock.Any()).Return(client.ContainerInspectResult{
+		Container: container.InspectResponse{
+			ID:   "db-id",
+			Name: "/test-db-1",
+			State: &container.State{
+				Status: container.StateRunning,
+				Health: &container.Health{Status: container.Healthy},
+			},
+			Config: &container.Config{Healthcheck: &container.HealthConfig{Test: []string{"CMD", "true"}}},
+		},
+	}, nil).AnyTimes()
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "app-id", gomock.Any()).Return(client.ContainerStartResult{}, nil)
+
+	appSvc := project.Services["app"]
+	dbSvc := project.Services["db"]
+	plan := &Plan{}
+	wait := plan.addNode(Operation{
+		Type:       OpWaitCondition,
+		ResourceID: "wait:app:db",
+		Cause:      "app depends on db (service_healthy)",
+		Service:    &dbSvc,
+		Name:       "db",
+		Condition:  types.ServiceConditionHealthy,
+	}, "")
+	plan.addNode(Operation{
+		Type:       OpStartContainer,
+		ResourceID: "service:app:1",
+		Cause:      "service start",
+		Service:    &appSvc,
+		Container:  &appSummary,
+		Name:       "test-app-1",
+		Number:     1,
+	}, "", wait)
+
+	assert.NilError(t, svc.executePlan(t.Context(), project, observed, plan))
+
+	// per-resource progressions promised by the event contract
+	assert.DeepEqual(t, recorder.byID["Container test-db-1"], []string{api.StatusWaiting, api.StatusHealthy})
+	assert.DeepEqual(t, recorder.byID["Container test-app-1"], []string{api.StatusStarting, api.StatusStarted})
+}

--- a/pkg/compose/executor_test.go
+++ b/pkg/compose/executor_test.go
@@ -57,6 +57,43 @@ func TestExecutePlanEmpty(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestExecutePlanOptionalFailure(t *testing.T) {
+	svc, apiClient := newTestService(t)
+
+	bad := types.NetworkConfig{Name: "test_bad"}
+	good := types.NetworkConfig{Name: "test_good"}
+	project := &types.Project{
+		Name:     "test",
+		Networks: types.Networks{"bad": bad, "good": good},
+	}
+
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), "test_bad", gomock.Any()).
+		Return(client.NetworkCreateResult{}, errors.New("boom"))
+	// the dependent node must still run after the optional node failed
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), "test_good", gomock.Any()).
+		Return(client.NetworkCreateResult{ID: "net-good"}, nil)
+
+	plan := &Plan{}
+	optional := plan.addNode(Operation{
+		Type:       OpCreateNetwork,
+		ResourceID: "network:bad",
+		Cause:      "not found",
+		Name:       bad.Name,
+		Network:    &bad,
+		Optional:   true,
+	}, "")
+	plan.addNode(Operation{
+		Type:       OpCreateNetwork,
+		ResourceID: "network:good",
+		Cause:      "not found",
+		Name:       good.Name,
+		Network:    &good,
+	}, "", optional)
+
+	err := svc.executePlan(t.Context(), project, emptyObservedState("test"), plan)
+	assert.NilError(t, err, "an Optional node failure must not fail the plan")
+}
+
 func TestExecutePlanCreateNetwork(t *testing.T) {
 	svc, apiClient := newTestService(t)
 

--- a/pkg/compose/plan.go
+++ b/pkg/compose/plan.go
@@ -51,6 +51,14 @@ const (
 	OpRemoveContainer OperationType = 23
 	OpRenameContainer OperationType = 24
 
+	// OpWaitCondition blocks until a dependency service reaches the condition
+	// its dependent declared (healthy, completed_successfully, ...). The
+	// service_started condition needs no such node: plain DAG edges express it.
+	OpWaitCondition OperationType = 25
+	// OpRunPreStart runs a service's pre_start hooks, once per service,
+	// before its first container start.
+	OpRunPreStart OperationType = 26
+
 	// Provider operations
 	OpRunProvider OperationType = 30
 )
@@ -80,6 +88,10 @@ func (o OperationType) String() string {
 		return "RemoveContainer"
 	case OpRenameContainer:
 		return "RenameContainer"
+	case OpWaitCondition:
+		return "WaitCondition"
+	case OpRunPreStart:
+		return "RunPreStart"
 	case OpRunProvider:
 		return "RunProvider"
 	default:
@@ -101,8 +113,9 @@ type Operation struct {
 	Name         string               // target container/resource name
 	Network      *types.NetworkConfig // for network operations
 	Volume       *types.VolumeConfig  // for volume operations
-	Timeout      *time.Duration       // for stop operations
-	CreateNodeID int                  // for OpRenameContainer: ID of the CreateContainer node whose result to rename
+	Timeout      *time.Duration       // for stop operations, and deadline of OpWaitCondition
+	Condition    string               // for OpWaitCondition: the depends_on condition to wait for
+	CreateNodeID int                  // for OpRenameContainer and OpStartContainer: ID of the CreateContainer node whose result to target (when Container is nil)
 	// BestEffort marks an operation that tolerates one specific, expected
 	// error inside its own execution (today: removing the old network on a
 	// rename skips a conflict when the network is still in use — the new

--- a/pkg/compose/plan.go
+++ b/pkg/compose/plan.go
@@ -103,12 +103,20 @@ type Operation struct {
 	Volume       *types.VolumeConfig  // for volume operations
 	Timeout      *time.Duration       // for stop operations
 	CreateNodeID int                  // for OpRenameContainer: ID of the CreateContainer node whose result to rename
-	// BestEffort marks an operation whose failure must not abort the plan. It is
-	// used for the optional removal of the old network on a rename: if the
-	// network is still in use (by non-Compose containers) the removal is skipped
-	// with a warning instead of failing — the new network already carries a
-	// different name, so the migration does not depend on the old one going away.
+	// BestEffort marks an operation that tolerates one specific, expected
+	// error inside its own execution (today: removing the old network on a
+	// rename skips a conflict when the network is still in use — the new
+	// network already carries a different name, so the migration does not
+	// depend on the old one going away). For an operation whose whole outcome
+	// is optional, see Optional.
 	BestEffort bool
+
+	// Optional marks an operation whose outcome is best-effort at the plan
+	// level: any failure is reported as a Skipped event and a warning instead
+	// of aborting the plan, and dependent nodes still run. Used for waits on
+	// dependencies declared with required: false. For tolerating one specific
+	// error inside an operation, see BestEffort.
+	Optional bool
 }
 
 // PlanNode is a single node in the reconciliation DAG. It represents one

--- a/pkg/compose/reconcile.go
+++ b/pkg/compose/reconcile.go
@@ -54,13 +54,25 @@ type ReconcileOptions struct {
 	Timeout              *time.Duration // for stop operations
 	RemoveOrphans        bool
 	SkipProviders        bool
-	// PlanStart extends the plan with the start phase: dependency-condition
-	// waits, pre_start hooks and container starts. When false the plan stops
-	// at container creation and starting is left to the caller (the
-	// historical two-engine split).
-	PlanStart bool
+	// Start, when set, extends the plan with the start phase:
+	// dependency-condition waits, pre_start hooks and container starts. When
+	// nil the plan stops at container creation and starting is left to the
+	// caller (the historical two-engine split).
+	Start *startPhaseOptions
+}
+
+// startPhaseOptions configures the start phase of a plan.
+type startPhaseOptions struct {
+	// Services restricts which services get start-phase nodes (nil = all).
+	// Used by watch, which only restarts the rebuilt services and their
+	// dependents.
+	Services []string
 	// WaitTimeout bounds each dependency-condition wait (0 = no deadline).
 	WaitTimeout time.Duration
+	// Only plans the start phase alone — the `compose start` profile: no
+	// network/volume reconciliation, no container creation, recreation or
+	// removal; existing containers are started as they are.
+	Only bool
 }
 
 // reconciler compares a types.Project (desired state) with an ObservedState
@@ -110,9 +122,16 @@ type reconciler struct {
 	observedContainersByService map[string]Containers
 
 	// startNodes tracks, per service, the start-phase nodes emitted when
-	// options.PlanStart is set. Dependents chain their own start phase after
+	// options.Start is set. Dependents chain their own start phase after
 	// these (a service is "started" once all its replicas are).
 	startNodes map[string][]*PlanNode
+
+	// waitConditionNodes dedupes WaitCondition nodes: several dependents
+	// waiting on the same dependency with the same condition and the same
+	// required-ness share one polling node. required stays in the key because
+	// Optional is a node property: a required and an optional edge to the
+	// same dependency do not fail the same way.
+	waitConditionNodes map[string]*PlanNode
 
 	// resolvedNetworks/resolvedVolumes hold the single live resource selected per
 	// compose key from the (possibly multi-valued) observed state — see
@@ -140,6 +159,16 @@ func reconcile(_ context.Context, project *types.Project, observed *ObservedStat
 		recreatedServices:           map[string]bool{},
 		observedContainersByService: observed.containersByService(),
 		startNodes:                  map[string][]*PlanNode{},
+		waitConditionNodes:          map[string]*PlanNode{},
+	}
+
+	if options.Start != nil && options.Start.Only {
+		// `compose start` profile: only the start phase is planned, resources
+		// and containers are taken as they are.
+		if err := r.reconcileContainers(); err != nil {
+			return nil, err
+		}
+		return r.plan, nil
 	}
 
 	r.resolveObserved()
@@ -651,6 +680,9 @@ func (r *reconciler) visitInDependencyOrder(g *Graph) error {
 // reconcileService handles a single service: scale down, recreate diverged,
 // start stopped, scale up.
 func (r *reconciler) reconcileService(service types.ServiceConfig) error {
+	if r.options.Start != nil && r.options.Start.Only {
+		return r.reconcileServiceStartOnly(service)
+	}
 	if service.Provider != nil && r.options.SkipProviders {
 		return nil
 	}
@@ -719,7 +751,7 @@ func (r *reconciler) reconcileService(service types.ServiceConfig) error {
 		})
 	}
 
-	if r.options.PlanStart {
+	if r.options.Start != nil {
 		node, err := r.planServiceStart(service, candidates)
 		if err != nil {
 			return err
@@ -731,6 +763,34 @@ func (r *reconciler) reconcileService(service types.ServiceConfig) error {
 
 	if lastNode != nil {
 		r.serviceNodes[service.Name] = lastNode
+	}
+	return nil
+}
+
+// reconcileServiceStartOnly is the `compose start` profile of reconcileService:
+// existing containers are taken as they are — no creation, recreation or
+// removal — and only the start phase (waits, pre_start, starts) is planned.
+func (r *reconciler) reconcileServiceStartOnly(service types.ServiceConfig) error {
+	if service.Provider != nil {
+		return nil
+	}
+	var candidates []startCandidate
+	for i, oc := range r.observed.Containers[service.Name] {
+		if oc.State == container.StateRunning {
+			candidates = append(candidates, startCandidate{number: oc.Number, running: true})
+			continue
+		}
+		candidates = append(candidates, startCandidate{
+			number:    oc.Number,
+			container: &r.observed.Containers[service.Name][i].Summary,
+		})
+	}
+	node, err := r.planServiceStart(service, candidates)
+	if err != nil {
+		return err
+	}
+	if node != nil {
+		r.serviceNodes[service.Name] = node
 	}
 	return nil
 }
@@ -831,6 +891,9 @@ type startCandidate struct {
 // dependency-condition waits, pre_start hooks and one start per non-running
 // replica. Returns the last node emitted, or nil if nothing needed starting.
 func (r *reconciler) planServiceStart(service types.ServiceConfig, candidates []startCandidate) (*PlanNode, error) {
+	if r.options.Start.Services != nil && !slices.Contains(r.options.Start.Services, service.Name) {
+		return nil, nil
+	}
 	svc := service // copy for pointer stability
 
 	var toStart []startCandidate
@@ -846,40 +909,10 @@ func (r *reconciler) planServiceStart(service types.ServiceConfig, candidates []
 		return nil, nil
 	}
 
-	// Dependency conditions. service_started needs no wait node: the edges on
-	// the dependency's own start nodes express it.
-	var waitNodes []*PlanNode
-	var startDeps []*PlanNode
-	for _, dep := range sortedKeys(service.DependsOn) {
-		config := service.DependsOn[dep]
-		depNodes := r.startNodes[dep]
-		if len(depNodes) == 0 {
-			if node := r.serviceNodes[dep]; node != nil {
-				depNodes = []*PlanNode{node}
-			}
-		}
-		startDeps = append(startDeps, depNodes...)
-
-		shouldWait, err := shouldWaitForDependency(dep, config, r.project)
-		if err != nil {
-			return nil, err
-		}
-		if !shouldWait {
-			continue
-		}
-		depSvc := r.project.Services[dep]
-		waitNodes = append(waitNodes, r.plan.addNode(Operation{
-			Type:       OpWaitCondition,
-			ResourceID: fmt.Sprintf("wait:%s:%s", service.Name, dep),
-			Cause:      fmt.Sprintf("%s depends on %s (%s)", service.Name, dep, config.Condition),
-			Service:    &depSvc,
-			Name:       dep,
-			Condition:  config.Condition,
-			Timeout:    waitTimeout(r.options.WaitTimeout),
-			Optional:   !config.Required,
-		}, "", depNodes...))
+	startDeps, err := r.planDependencyWaits(service)
+	if err != nil {
+		return nil, err
 	}
-	startDeps = append(startDeps, waitNodes...)
 
 	// pre_start hooks run once per service, only when no replica is already
 	// running, on the lowest-numbered replica — decided here at plan time
@@ -924,6 +957,52 @@ func (r *reconciler) planServiceStart(service types.ServiceConfig, candidates []
 		r.startNodes[service.Name] = append(r.startNodes[service.Name], last)
 	}
 	return last, nil
+}
+
+// planDependencyWaits returns the nodes a service's start must depend on for
+// its depends_on edges: the dependencies' own start nodes (which alone express
+// the service_started condition) plus one WaitCondition node per conditional
+// edge. Dependents waiting on the same dependency with the same condition and
+// required-ness share one polling node.
+func (r *reconciler) planDependencyWaits(service types.ServiceConfig) ([]*PlanNode, error) {
+	var startDeps []*PlanNode
+	for _, dep := range sortedKeys(service.DependsOn) {
+		config := service.DependsOn[dep]
+		depNodes := r.startNodes[dep]
+		if len(depNodes) == 0 {
+			if node := r.serviceNodes[dep]; node != nil {
+				depNodes = []*PlanNode{node}
+			}
+		}
+		startDeps = append(startDeps, depNodes...)
+
+		shouldWait, err := shouldWaitForDependency(dep, config, r.project)
+		if err != nil {
+			return nil, err
+		}
+		if !shouldWait {
+			continue
+		}
+		key := fmt.Sprintf("%s:%s:%t", dep, config.Condition, config.Required)
+		if node, ok := r.waitConditionNodes[key]; ok {
+			startDeps = append(startDeps, node)
+			continue
+		}
+		depSvc := r.project.Services[dep]
+		node := r.plan.addNode(Operation{
+			Type:       OpWaitCondition,
+			ResourceID: fmt.Sprintf("wait:%s:%s", dep, config.Condition),
+			Cause:      fmt.Sprintf("dependency %s must be %s", dep, config.Condition),
+			Service:    &depSvc,
+			Name:       dep,
+			Condition:  config.Condition,
+			Timeout:    waitTimeout(r.options.Start.WaitTimeout),
+			Optional:   !config.Required,
+		}, "", depNodes...)
+		r.waitConditionNodes[key] = node
+		startDeps = append(startDeps, node)
+	}
+	return startDeps, nil
 }
 
 func waitTimeout(d time.Duration) *time.Duration {

--- a/pkg/compose/reconcile.go
+++ b/pkg/compose/reconcile.go
@@ -54,6 +54,13 @@ type ReconcileOptions struct {
 	Timeout              *time.Duration // for stop operations
 	RemoveOrphans        bool
 	SkipProviders        bool
+	// PlanStart extends the plan with the start phase: dependency-condition
+	// waits, pre_start hooks and container starts. When false the plan stops
+	// at container creation and starting is left to the caller (the
+	// historical two-engine split).
+	PlanStart bool
+	// WaitTimeout bounds each dependency-condition wait (0 = no deadline).
+	WaitTimeout time.Duration
 }
 
 // reconciler compares a types.Project (desired state) with an ObservedState
@@ -102,6 +109,11 @@ type reconciler struct {
 	// called once per service.
 	observedContainersByService map[string]Containers
 
+	// startNodes tracks, per service, the start-phase nodes emitted when
+	// options.PlanStart is set. Dependents chain their own start phase after
+	// these (a service is "started" once all its replicas are).
+	startNodes map[string][]*PlanNode
+
 	// resolvedNetworks/resolvedVolumes hold the single live resource selected per
 	// compose key from the (possibly multi-valued) observed state — see
 	// resolveObserved. All reconcile logic reads these, never observed.Networks/
@@ -127,6 +139,7 @@ func reconcile(_ context.Context, project *types.Project, observed *ObservedStat
 		connectNodes:                map[string][]*PlanNode{},
 		recreatedServices:           map[string]bool{},
 		observedContainersByService: observed.containersByService(),
+		startNodes:                  map[string][]*PlanNode{},
 	}
 
 	r.resolveObserved()
@@ -683,9 +696,55 @@ func (r *reconciler) reconcileService(service types.ServiceConfig) error {
 	// Collect dependency nodes that container creation should depend on
 	infraDeps := r.infrastructureDeps(service)
 
-	var lastNode *PlanNode
+	lastNode, candidates := r.planExistingContainers(service, containers, expected, strategy, expectedHash, parentRecreated, infraDeps)
 
-	// Process existing containers
+	// Scale up: create new containers
+	nextNum := nextContainerNumber(r.observedSummaries(service.Name))
+	for i := 0; i < expected-actual; i++ {
+		number := nextNum + i
+		name := getContainerName(r.project.Name, service, number)
+		svc := service // copy for pointer stability
+		lastNode = r.plan.addNode(Operation{
+			Type:       OpCreateContainer,
+			ResourceID: fmt.Sprintf("service:%s:%d", service.Name, number),
+			Cause:      "no existing container",
+			Service:    &svc,
+			Number:     number,
+			Name:       name,
+		}, "", infraDeps...)
+		candidates = append(candidates, startCandidate{
+			number:       number,
+			after:        []*PlanNode{lastNode},
+			createNodeID: lastNode.ID,
+		})
+	}
+
+	if r.options.PlanStart {
+		node, err := r.planServiceStart(service, candidates)
+		if err != nil {
+			return err
+		}
+		if node != nil {
+			lastNode = node
+		}
+	}
+
+	if lastNode != nil {
+		r.serviceNodes[service.Name] = lastNode
+	}
+	return nil
+}
+
+// planExistingContainers walks the service's observed containers (pre-sorted
+// by sortContainers) and plans scale-downs, recreations and paused/dead
+// restarts. It returns the last node emitted and the start candidates the
+// start phase will act on when options.PlanStart is set.
+func (r *reconciler) planExistingContainers(
+	service types.ServiceConfig, containers []ObservedContainer, expected int,
+	strategy, expectedHash string, parentRecreated bool, infraDeps []*PlanNode,
+) (*PlanNode, []startCandidate) {
+	var lastNode *PlanNode
+	var candidates []startCandidate
 	for i, oc := range containers {
 		if i >= expected {
 			// Scale down: stop + remove excess containers. Track the remove
@@ -708,15 +767,42 @@ func (r *reconciler) reconcileService(service types.ServiceConfig) error {
 		}
 
 		if r.mustRecreate(service, expectedHash, parentRecreated, oc, strategy) {
-			lastNode = r.planRecreateContainer(service, &containers[i], infraDeps)
+			var createNode *PlanNode
+			lastNode, createNode = r.planRecreateContainer(service, &containers[i], infraDeps)
 			r.recreatedServices[service.Name] = true
+			candidates = append(candidates, startCandidate{
+				number:       oc.Number,
+				after:        []*PlanNode{lastNode},
+				createNodeID: createNode.ID,
+			})
 			continue
 		}
 
 		// Container is up-to-date
 		switch oc.State {
-		case container.StateRunning, container.StateCreated, container.StateRestarting, container.StateExited:
-			// Nothing to do (exited containers are left as-is, matching convergence.go behavior)
+		case container.StateRunning, container.StateRestarting:
+			if stopNode, stopped := r.stoppedByPlan[oc.ID]; stopped {
+				// The plan stops this container (e.g. to recreate a diverged
+				// network): it must be started again once reconnected.
+				after := append([]*PlanNode{stopNode}, r.connectNodes[oc.ID]...)
+				candidates = append(candidates, startCandidate{
+					number:    oc.Number,
+					after:     after,
+					container: &containers[i].Summary,
+				})
+			} else {
+				candidates = append(candidates, startCandidate{number: oc.Number, running: true})
+			}
+		case container.StateCreated, container.StateExited:
+			// Nothing to plan on the create side: starting created/exited
+			// containers is the start phase's job — planned by
+			// planServiceStart when PlanStart is set, left to the caller's
+			// start engine otherwise.
+			candidates = append(candidates, startCandidate{
+				number:    oc.Number,
+				after:     r.connectNodes[oc.ID],
+				container: &containers[i].Summary,
+			})
 		default:
 			// Any other state (paused, dead, ...): attempt to (re)start
 			lastNode = r.plan.addNode(Operation{
@@ -727,27 +813,124 @@ func (r *reconciler) reconcileService(service types.ServiceConfig) error {
 			}, "", infraDeps...)
 		}
 	}
+	return lastNode, candidates
+}
 
-	// Scale up: create new containers
-	nextNum := nextContainerNumber(r.observedSummaries(service.Name))
-	for i := 0; i < expected-actual; i++ {
-		number := nextNum + i
-		name := getContainerName(r.project.Name, service, number)
-		svc := service // copy for pointer stability
-		lastNode = r.plan.addNode(Operation{
-			Type:       OpCreateContainer,
-			ResourceID: fmt.Sprintf("service:%s:%d", service.Name, number),
-			Cause:      "no existing container",
-			Service:    &svc,
-			Number:     number,
-			Name:       name,
-		}, "", infraDeps...)
+// startCandidate describes one replica the start phase may have to start:
+// either an existing container (container set) or one the plan creates
+// (createNodeID set, resolved by the executor once the create ran).
+type startCandidate struct {
+	number       int
+	after        []*PlanNode        // nodes the start must wait for (create, reconnects, ...)
+	container    *container.Summary // existing container, nil for plan-created ones
+	createNodeID int                // create node whose result carries the container ID
+	running      bool               // already running and left untouched: nothing to start
+}
+
+// planServiceStart extends the plan with the service's start phase:
+// dependency-condition waits, pre_start hooks and one start per non-running
+// replica. Returns the last node emitted, or nil if nothing needed starting.
+func (r *reconciler) planServiceStart(service types.ServiceConfig, candidates []startCandidate) (*PlanNode, error) {
+	svc := service // copy for pointer stability
+
+	var toStart []startCandidate
+	anyRunning := false
+	for _, c := range candidates {
+		if c.running {
+			anyRunning = true
+			continue
+		}
+		toStart = append(toStart, c)
+	}
+	if len(toStart) == 0 {
+		return nil, nil
 	}
 
-	if lastNode != nil {
-		r.serviceNodes[service.Name] = lastNode
+	// Dependency conditions. service_started needs no wait node: the edges on
+	// the dependency's own start nodes express it.
+	var waitNodes []*PlanNode
+	var startDeps []*PlanNode
+	for _, dep := range sortedKeys(service.DependsOn) {
+		config := service.DependsOn[dep]
+		depNodes := r.startNodes[dep]
+		if len(depNodes) == 0 {
+			if node := r.serviceNodes[dep]; node != nil {
+				depNodes = []*PlanNode{node}
+			}
+		}
+		startDeps = append(startDeps, depNodes...)
+
+		shouldWait, err := shouldWaitForDependency(dep, config, r.project)
+		if err != nil {
+			return nil, err
+		}
+		if !shouldWait {
+			continue
+		}
+		depSvc := r.project.Services[dep]
+		waitNodes = append(waitNodes, r.plan.addNode(Operation{
+			Type:       OpWaitCondition,
+			ResourceID: fmt.Sprintf("wait:%s:%s", service.Name, dep),
+			Cause:      fmt.Sprintf("%s depends on %s (%s)", service.Name, dep, config.Condition),
+			Service:    &depSvc,
+			Name:       dep,
+			Condition:  config.Condition,
+			Timeout:    waitTimeout(r.options.WaitTimeout),
+			Optional:   !config.Required,
+		}, "", depNodes...))
 	}
-	return nil
+	startDeps = append(startDeps, waitNodes...)
+
+	// pre_start hooks run once per service, only when no replica is already
+	// running, on the lowest-numbered replica — decided here at plan time
+	// from the observed state, accepting the same observe-to-execute drift
+	// window as the rest of the plan.
+	var preStart *PlanNode
+	if len(service.PreStart) > 0 && !anyRunning {
+		lowest := toStart[0]
+		for _, c := range toStart[1:] {
+			if c.number < lowest.number {
+				lowest = c
+			}
+		}
+		deps := append(slices.Clone(startDeps), lowest.after...)
+		preStart = r.plan.addNode(Operation{
+			Type:         OpRunPreStart,
+			ResourceID:   fmt.Sprintf("prestart:%s", service.Name),
+			Cause:        "pre_start hooks",
+			Service:      &svc,
+			Number:       lowest.number,
+			Container:    lowest.container,
+			CreateNodeID: lowest.createNodeID,
+		}, "", deps...)
+	}
+
+	var last *PlanNode
+	for _, c := range toStart {
+		deps := append(slices.Clone(startDeps), c.after...)
+		if preStart != nil {
+			deps = append(deps, preStart)
+		}
+		last = r.plan.addNode(Operation{
+			Type:         OpStartContainer,
+			ResourceID:   fmt.Sprintf("service:%s:%d", service.Name, c.number),
+			Cause:        "service start",
+			Service:      &svc,
+			Name:         getContainerName(r.project.Name, service, c.number),
+			Number:       c.number,
+			Container:    c.container,
+			CreateNodeID: c.createNodeID,
+		}, "", deps...)
+		r.startNodes[service.Name] = append(r.startNodes[service.Name], last)
+	}
+	return last, nil
+}
+
+func waitTimeout(d time.Duration) *time.Duration {
+	if d <= 0 {
+		return nil
+	}
+	return &d
 }
 
 // mustRecreate decides whether oc must be recreated to match expected. The
@@ -871,7 +1054,10 @@ func (r *reconciler) hasVolumeMismatch(expected types.ServiceConfig, oc Observed
 
 // planRecreateContainer decomposes container recreation into 4 atomic operations:
 // CreateContainer(tmpName) → StopContainer → RemoveContainer → RenameContainer
-func (r *reconciler) planRecreateContainer(service types.ServiceConfig, oc *ObservedContainer, infraDeps []*PlanNode) *PlanNode {
+// planRecreateContainer returns the final node of the recreate sequence and
+// the create node (whose result carries the new container's ID, needed by the
+// start phase).
+func (r *reconciler) planRecreateContainer(service types.ServiceConfig, oc *ObservedContainer, infraDeps []*PlanNode) (*PlanNode, *PlanNode) {
 	resID := fmt.Sprintf("service:%s:%d", service.Name, oc.Number)
 	group := fmt.Sprintf("recreate:%s:%d", service.Name, oc.Number)
 	tmpName := fmt.Sprintf("%s_%s", oc.ID[:min(12, len(oc.ID))], getContainerName(r.project.Name, service, oc.Number))
@@ -952,7 +1138,7 @@ func (r *reconciler) planRecreateContainer(service types.ServiceConfig, oc *Obse
 		CreateNodeID: createNode.ID,
 	}, group, removeNode)
 
-	return renameNode
+	return renameNode, createNode
 }
 
 // planStopDependents plans stop operations for containers of services that

--- a/pkg/compose/reconcile_test.go
+++ b/pkg/compose/reconcile_test.go
@@ -1623,14 +1623,14 @@ func TestReconcilePlanStart(t *testing.T) {
 	}
 
 	options := defaultReconcileOptions()
-	options.PlanStart = true
+	options.Start = &startPhaseOptions{}
 	plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
 	assert.NilError(t, err)
 	assert.Equal(t, plan.String(), strings.TrimSpace(`
 [] -> #1 service:db:1, CreateContainer, no existing container
 [1] -> #2 service:db:1, StartContainer, service start
 [2] -> #3 service:app:1, CreateContainer, no existing container
-[2] -> #4 wait:app:db, WaitCondition, app depends on db (service_healthy)
+[2] -> #4 wait:db:service_healthy, WaitCondition, dependency db must be service_healthy
 [2,3,4] -> #5 service:app:1, StartContainer, service start
 `)+"\n")
 }
@@ -1653,7 +1653,7 @@ func TestReconcilePlanStartOptionalDependency(t *testing.T) {
 	}
 
 	options := defaultReconcileOptions()
-	options.PlanStart = true
+	options.Start = &startPhaseOptions{}
 	plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
 	assert.NilError(t, err)
 	for _, node := range plan.Nodes {
@@ -1683,7 +1683,7 @@ func TestReconcilePlanStartPreStart(t *testing.T) {
 			Volumes:     map[string][]ObservedVolume{},
 		}
 		options := defaultReconcileOptions()
-		options.PlanStart = true
+		options.Start = &startPhaseOptions{}
 		plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
 		assert.NilError(t, err)
 		count := 0
@@ -1717,7 +1717,7 @@ func TestReconcilePlanStartPreStart(t *testing.T) {
 			Volumes:  map[string][]ObservedVolume{},
 		}
 		options := defaultReconcileOptions()
-		options.PlanStart = true
+		options.Start = &startPhaseOptions{}
 		plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
 		assert.NilError(t, err)
 		for _, node := range plan.Nodes {
@@ -1725,4 +1725,145 @@ func TestReconcilePlanStartPreStart(t *testing.T) {
 				"scale-up beside a running replica must not re-run pre_start")
 		}
 	})
+}
+
+func TestReconcilePlanStartWaitDedup(t *testing.T) {
+	project := &types.Project{
+		Name: "myproject",
+		Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+			"app1": {Name: "app1", Scale: intPtr(1), DependsOn: types.DependsOnConfig{
+				"db": {Condition: types.ServiceConditionHealthy, Required: true},
+			}},
+			"app2": {Name: "app2", Scale: intPtr(1), DependsOn: types.DependsOnConfig{
+				"db": {Condition: types.ServiceConditionHealthy, Required: true},
+			}},
+			"app3": {Name: "app3", Scale: intPtr(1), DependsOn: types.DependsOnConfig{
+				"db": {Condition: types.ServiceConditionHealthy, Required: false},
+			}},
+		},
+	}
+	observed := &ObservedState{
+		ProjectName: "myproject",
+		Containers:  map[string][]ObservedContainer{},
+		Networks:    map[string][]ObservedNetwork{},
+		Volumes:     map[string][]ObservedVolume{},
+	}
+	options := defaultReconcileOptions()
+	options.Start = &startPhaseOptions{}
+	plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+	assert.NilError(t, err)
+
+	required, optional := 0, 0
+	for _, node := range plan.Nodes {
+		if node.Operation.Type != OpWaitCondition {
+			continue
+		}
+		if node.Operation.Optional {
+			optional++
+		} else {
+			required++
+		}
+	}
+	assert.Equal(t, required, 1, "same-required waits on the same dependency must share one node")
+	assert.Equal(t, optional, 1, "an optional edge must not share the required edge's node")
+}
+
+func TestReconcileStartOnly(t *testing.T) {
+	project := &types.Project{
+		Name: "myproject",
+		Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+			"app": {Name: "app", Scale: intPtr(1), DependsOn: types.DependsOnConfig{
+				"db": {Condition: types.ServiceConditionHealthy, Required: true},
+			}},
+		},
+	}
+
+	t.Run("existing stopped containers are started, nothing is created", func(t *testing.T) {
+		observed := &ObservedState{
+			ProjectName: "myproject",
+			Containers: map[string][]ObservedContainer{
+				"db":  {{ID: "db1", Name: "myproject-db-1", Number: 1, State: container.StateExited}},
+				"app": {{ID: "app1", Name: "myproject-app-1", Number: 1, State: container.StateCreated}},
+			},
+			Networks: map[string][]ObservedNetwork{},
+			Volumes:  map[string][]ObservedVolume{},
+		}
+		options := ReconcileOptions{Start: &startPhaseOptions{Only: true}}
+		plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+		assert.NilError(t, err)
+		assert.Equal(t, plan.String(), strings.TrimSpace(`
+[] -> #1 service:db:1, StartContainer, service start
+[1] -> #2 wait:db:service_healthy, WaitCondition, dependency db must be service_healthy
+[1,2] -> #3 service:app:1, StartContainer, service start
+`)+"\n")
+	})
+
+	t.Run("running containers produce an empty plan", func(t *testing.T) {
+		observed := &ObservedState{
+			ProjectName: "myproject",
+			Containers: map[string][]ObservedContainer{
+				"db":  {{ID: "db1", Number: 1, State: container.StateRunning}},
+				"app": {{ID: "app1", Number: 1, State: container.StateRunning}},
+			},
+			Networks: map[string][]ObservedNetwork{},
+			Volumes:  map[string][]ObservedVolume{},
+		}
+		options := ReconcileOptions{Start: &startPhaseOptions{Only: true}}
+		plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+		assert.NilError(t, err)
+		assert.Assert(t, plan.IsEmpty())
+	})
+
+	t.Run("diverged containers are not recreated", func(t *testing.T) {
+		observed := &ObservedState{
+			ProjectName: "myproject",
+			Containers: map[string][]ObservedContainer{
+				"db":  {{ID: "db1", Number: 1, State: container.StateExited, ConfigHash: "stale"}},
+				"app": {{ID: "app1", Number: 1, State: container.StateRunning, ConfigHash: "stale"}},
+			},
+			Networks: map[string][]ObservedNetwork{},
+			Volumes:  map[string][]ObservedVolume{},
+		}
+		options := ReconcileOptions{Start: &startPhaseOptions{Only: true}}
+		plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+		assert.NilError(t, err)
+		for _, node := range plan.Nodes {
+			assert.Assert(t, node.Operation.Type == OpStartContainer || node.Operation.Type == OpWaitCondition,
+				"start-only plan must not carry %s operations", node.Operation.Type)
+		}
+	})
+}
+
+func TestReconcilePlanStartScope(t *testing.T) {
+	project := &types.Project{
+		Name: "myproject",
+		Services: types.Services{
+			"web":   {Name: "web", Scale: intPtr(1)},
+			"other": {Name: "other", Scale: intPtr(1)},
+		},
+	}
+	observed := &ObservedState{
+		ProjectName: "myproject",
+		Containers: map[string][]ObservedContainer{
+			// both exist and are stopped; only web is in the start scope
+			"web":   {{ID: "w1", Number: 1, State: container.StateExited}},
+			"other": {{ID: "o1", Number: 1, State: container.StateExited}},
+		},
+		Networks: map[string][]ObservedNetwork{},
+		Volumes:  map[string][]ObservedVolume{},
+	}
+	options := defaultReconcileOptions()
+	options.Recreate = api.RecreateNever
+	options.RecreateDependencies = api.RecreateNever
+	options.Start = &startPhaseOptions{Services: []string{"web"}}
+	plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+	assert.NilError(t, err)
+	for _, node := range plan.Nodes {
+		if node.Operation.Type == OpStartContainer {
+			assert.Equal(t, node.Operation.ResourceID, "service:web:1",
+				"only scoped services may get start nodes")
+		}
+	}
 }

--- a/pkg/compose/reconcile_test.go
+++ b/pkg/compose/reconcile_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1600,4 +1601,128 @@ func mustResolvedServiceHash(t *testing.T, svc types.ServiceConfig, containers m
 	h, err := serviceHashWithResolvedRefs(svc, containers)
 	assert.NilError(t, err)
 	return h
+}
+
+// --- Start-phase planning tests ---
+
+func TestReconcilePlanStart(t *testing.T) {
+	project := &types.Project{
+		Name: "myproject",
+		Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+			"app": {Name: "app", Scale: intPtr(1), DependsOn: types.DependsOnConfig{
+				"db": {Condition: types.ServiceConditionHealthy, Required: true},
+			}},
+		},
+	}
+	observed := &ObservedState{
+		ProjectName: "myproject",
+		Containers:  map[string][]ObservedContainer{},
+		Networks:    map[string][]ObservedNetwork{},
+		Volumes:     map[string][]ObservedVolume{},
+	}
+
+	options := defaultReconcileOptions()
+	options.PlanStart = true
+	plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+	assert.NilError(t, err)
+	assert.Equal(t, plan.String(), strings.TrimSpace(`
+[] -> #1 service:db:1, CreateContainer, no existing container
+[1] -> #2 service:db:1, StartContainer, service start
+[2] -> #3 service:app:1, CreateContainer, no existing container
+[2] -> #4 wait:app:db, WaitCondition, app depends on db (service_healthy)
+[2,3,4] -> #5 service:app:1, StartContainer, service start
+`)+"\n")
+}
+
+func TestReconcilePlanStartOptionalDependency(t *testing.T) {
+	project := &types.Project{
+		Name: "myproject",
+		Services: types.Services{
+			"db": {Name: "db", Scale: intPtr(1)},
+			"app": {Name: "app", Scale: intPtr(1), DependsOn: types.DependsOnConfig{
+				"db": {Condition: types.ServiceConditionHealthy, Required: false},
+			}},
+		},
+	}
+	observed := &ObservedState{
+		ProjectName: "myproject",
+		Containers:  map[string][]ObservedContainer{},
+		Networks:    map[string][]ObservedNetwork{},
+		Volumes:     map[string][]ObservedVolume{},
+	}
+
+	options := defaultReconcileOptions()
+	options.PlanStart = true
+	plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+	assert.NilError(t, err)
+	for _, node := range plan.Nodes {
+		if node.Operation.Type == OpWaitCondition {
+			assert.Assert(t, node.Operation.Optional, "a required:false wait must be Optional")
+			return
+		}
+	}
+	t.Fatal("expected a WaitCondition node in the plan")
+}
+
+func TestReconcilePlanStartPreStart(t *testing.T) {
+	project := &types.Project{
+		Name: "myproject",
+		Services: types.Services{
+			"app": {Name: "app", Scale: intPtr(2), PreStart: []types.ServiceHook{
+				{Command: []string{"echo", "init"}},
+			}},
+		},
+	}
+
+	t.Run("hook planned once when no replica is running", func(t *testing.T) {
+		observed := &ObservedState{
+			ProjectName: "myproject",
+			Containers:  map[string][]ObservedContainer{},
+			Networks:    map[string][]ObservedNetwork{},
+			Volumes:     map[string][]ObservedVolume{},
+		}
+		options := defaultReconcileOptions()
+		options.PlanStart = true
+		plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+		assert.NilError(t, err)
+		count := 0
+		for _, node := range plan.Nodes {
+			if node.Operation.Type == OpRunPreStart {
+				count++
+				// every start of the service must wait for the hook
+				for _, other := range plan.Nodes {
+					if other.Operation.Type == OpStartContainer {
+						assert.Assert(t, slices.Contains(other.DependsOn, node),
+							"start %s must depend on the pre_start node", other.Operation.ResourceID)
+					}
+				}
+			}
+		}
+		assert.Equal(t, count, 1, "pre_start must be planned exactly once per service")
+	})
+
+	t.Run("hook not planned while a replica is already running", func(t *testing.T) {
+		hash, err := serviceHashWithResolvedRefs(project.Services["app"], map[string]Containers{})
+		assert.NilError(t, err)
+		observed := &ObservedState{
+			ProjectName: "myproject",
+			Containers: map[string][]ObservedContainer{
+				"app": {{
+					ID: "app1", Name: "myproject-app-1", Number: 1,
+					State: container.StateRunning, ConfigHash: hash,
+				}},
+			},
+			Networks: map[string][]ObservedNetwork{},
+			Volumes:  map[string][]ObservedVolume{},
+		}
+		options := defaultReconcileOptions()
+		options.PlanStart = true
+		plan, err := reconcile(t.Context(), project, observed, options, declinePrompt)
+		assert.NilError(t, err)
+		for _, node := range plan.Nodes {
+			assert.Assert(t, node.Operation.Type != OpRunPreStart,
+				"scale-up beside a running replica must not re-run pre_start")
+		}
+	})
 }

--- a/pkg/compose/scale.go
+++ b/pkg/compose/scale.go
@@ -26,10 +26,9 @@ import (
 
 func (s *composeService) Scale(ctx context.Context, project *types.Project, options api.ScaleOptions) error {
 	return Run(ctx, tracing.SpanWrapFunc("project/scale", tracing.ProjectOptions(ctx, project), func(ctx context.Context) error {
-		err := s.create(ctx, project, api.CreateOptions{Services: options.Services})
-		if err != nil {
-			return err
-		}
-		return s.start(ctx, project.Name, api.StartOptions{Project: project, Services: options.Services}, nil)
+		// Prototype of the start-in-plan convergence (see the tracking epic):
+		// a single plan carries creation AND the start phase, instead of
+		// chaining s.create with the separate s.start engine.
+		return s.converge(ctx, project, api.CreateOptions{Services: options.Services}, true)
 	}), "scale", s.events)
 }

--- a/pkg/compose/scale.go
+++ b/pkg/compose/scale.go
@@ -26,9 +26,9 @@ import (
 
 func (s *composeService) Scale(ctx context.Context, project *types.Project, options api.ScaleOptions) error {
 	return Run(ctx, tracing.SpanWrapFunc("project/scale", tracing.ProjectOptions(ctx, project), func(ctx context.Context) error {
-		// Prototype of the start-in-plan convergence (see the tracking epic):
-		// a single plan carries creation AND the start phase, instead of
-		// chaining s.create with the separate s.start engine.
-		return s.converge(ctx, project, api.CreateOptions{Services: options.Services}, true)
+		// Start-in-plan convergence (see the tracking epic): a single plan
+		// carries creation AND the start phase, instead of chaining s.create
+		// with the separate s.start engine.
+		return s.converge(ctx, project, api.CreateOptions{Services: options.Services}, &startPhaseOptions{})
 	}), "scale", s.events)
 }

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/moby/moby/client"
@@ -49,6 +50,14 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 		}
 	}
 
+	if listener == nil {
+		// Start-only plan profile (see the start-in-plan convergence epic):
+		// existing containers are started as they are, no resource touched.
+		// The listener-driven path below remains for the interactive up,
+		// until the session moves to executor hooks (phase 2).
+		return s.startWithPlan(ctx, project, options)
+	}
+
 	res, err := s.apiClient().ContainerList(ctx, client.ContainerListOptions{
 		Filters: projectFilter(project.Name).Add("label", oneOffFilter(false)),
 		All:     true,
@@ -71,28 +80,88 @@ func (s *composeService) start(ctx context.Context, projectName string, options 
 	}
 
 	if options.Wait {
-		depends := types.DependsOnConfig{}
-		for _, s := range project.Services {
-			depends[s.Name] = types.ServiceDependency{
-				Condition: getDependencyCondition(s, project),
-				Required:  true,
-			}
-		}
-		if options.WaitTimeout > 0 {
-			withTimeout, cancel := context.WithTimeout(ctx, options.WaitTimeout)
-			ctx = withTimeout
-			defer cancel()
-		}
-
-		err = s.waitDependencies(ctx, project, project.Name, depends, containers, 0)
-		if err != nil {
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return fmt.Errorf("application not healthy after %s", options.WaitTimeout)
-			}
-			return err
-		}
+		return s.waitStarted(ctx, project, options.WaitTimeout)
 	}
 
+	return nil
+}
+
+// startWithPlan runs `compose start` through the plan engine: a start-only
+// plan (dependency-condition waits, pre_start hooks, container starts) over
+// the containers as they exist — never creating, recreating or removing
+// anything.
+func (s *composeService) startWithPlan(ctx context.Context, project *types.Project, options api.StartOptions) error {
+	observed, err := s.collectObservedState(ctx, project)
+	if err != nil {
+		return err
+	}
+
+	empty := true
+	for _, ocs := range observed.Containers {
+		if len(ocs) > 0 {
+			empty = false
+			break
+		}
+	}
+	if empty {
+		for _, name := range sortedKeys(project.Services) {
+			svc := project.Services[name]
+			if svc.GetScale() > 0 {
+				return fmt.Errorf("service %q has no container to start", name)
+			}
+		}
+		return nil
+	}
+
+	plan, err := reconcile(ctx, project, observed, ReconcileOptions{
+		Start: &startPhaseOptions{Only: true, WaitTimeout: options.WaitTimeout},
+	}, s.prompt)
+	if err != nil {
+		return err
+	}
+	if err := s.executePlan(ctx, project, observed, plan); err != nil {
+		return err
+	}
+
+	if options.Wait {
+		return s.waitStarted(ctx, project, options.WaitTimeout)
+	}
+	return nil
+}
+
+// waitStarted blocks until every service of the project is running (or
+// healthy, or completed for one-shot services), implementing the --wait
+// barrier of `up` and `start`.
+func (s *composeService) waitStarted(ctx context.Context, project *types.Project, timeout time.Duration) error {
+	res, err := s.apiClient().ContainerList(ctx, client.ContainerListOptions{
+		Filters: projectFilter(project.Name).Add("label", oneOffFilter(false)),
+		All:     true,
+	})
+	if err != nil {
+		return err
+	}
+	containers := Containers(res.Items)
+
+	depends := types.DependsOnConfig{}
+	for _, svc := range project.Services {
+		depends[svc.Name] = types.ServiceDependency{
+			Condition: getDependencyCondition(svc, project),
+			Required:  true,
+		}
+	}
+	if timeout > 0 {
+		withTimeout, cancel := context.WithTimeout(ctx, timeout)
+		ctx = withTimeout
+		defer cancel()
+	}
+
+	err = s.waitDependencies(ctx, project, project.Name, depends, containers, 0)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("application not healthy after %s", timeout)
+		}
+		return err
+	}
 	return nil
 }
 

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -43,14 +43,22 @@ import (
 
 func (s *composeService) Up(ctx context.Context, project *types.Project, options api.UpOptions) error { //nolint:gocyclo
 	err := Run(ctx, tracing.SpanWrapFunc("project/up", tracing.ProjectOptions(ctx, project), func(ctx context.Context) error {
-		err := s.create(ctx, project, options.Create)
-		if err != nil {
-			return err
-		}
 		if options.Start.Attach == nil {
-			return s.start(ctx, project.Name, options.Start, nil)
+			// Detached up: one plan carries creation and the start phase
+			// (see the start-in-plan convergence epic). The --wait barrier
+			// stays a post-plan verification.
+			err := s.converge(ctx, project, options.Create, &startPhaseOptions{
+				WaitTimeout: options.Start.WaitTimeout,
+			})
+			if err != nil {
+				return err
+			}
+			if options.Start.Wait {
+				return s.waitStarted(ctx, project, options.Start.WaitTimeout)
+			}
+			return nil
 		}
-		return nil
+		return s.create(ctx, project, options.Create)
 	}), "up", s.events)
 	if err != nil {
 		return err

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -668,28 +668,22 @@ func (s *composeService) rebuild(ctx context.Context, project *types.Project, se
 
 	options.LogTo.Log(api.WatchLogger, fmt.Sprintf("service(s) %q successfully built", services))
 
-	err = s.create(ctx, project, api.CreateOptions{
-		Services:      services,
-		Inherit:       true,
-		Recreate:      api.RecreateForce,
-		SkipProviders: true,
-	})
-	if err != nil {
-		options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Failed to recreate services after update. Error: %v", err))
-		return err
-	}
-
 	p, err := project.WithSelectedServices(services, types.IncludeDependents)
 	if err != nil {
 		return err
 	}
-	err = s.start(ctx, project.Name, api.StartOptions{
-		Project:  p,
-		Services: services,
-		AttachTo: services,
-	}, nil)
+	// One plan recreates the rebuilt services and starts them (and their
+	// dependents) — see the start-in-plan convergence epic. The start phase
+	// is scoped so services outside the rebuilt subset are left alone.
+	err = s.converge(ctx, project, api.CreateOptions{
+		Services:      services,
+		Inherit:       true,
+		Recreate:      api.RecreateForce,
+		SkipProviders: true,
+	}, &startPhaseOptions{Services: p.ServiceNames()})
 	if err != nil {
-		options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Application failed to start after update. Error: %v", err))
+		options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Failed to recreate services after update. Error: %v", err))
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Phase 1 of #14081, stacked on #14082 — the four detached consumers of the second lifecycle engine now converge through a single create+start plan. Nine commits, in three groups:

**Prototype on `scale`** (CI-validated): start-phase planning behind `startPhaseOptions` (WaitCondition nodes, once-per-service RunPreStart, enriched StartContainer with secret/config injection and post_start hooks), executor support, wiring. Collecting start candidates surfaced a dangling case: containers the plan stops to recreate a diverged network were never restarted by the plan itself.

**Validated design decisions** (docker/compose#14081 (comment)): plan-time start-candidates with a runtime guard on `pre_start`; waits as nodes (walker stays decision-free, plans stay inspectable); the event contract written on `api.EventProcessor` and enforced by a recorder test; per-container Skipped/Error granularity on wait failures.

**Extension to `up -d`, `watch`, `start`**:
- start-phase **scope** (`watch` only restarts rebuilt services and their dependents — pinned by `TestWatchRebuildIgnoresDependencies`);
- **wait-node dedup** by (dependency, condition, required);
- the **start-only profile** for `compose start`: no resource reconciliation, no creation/recreation/removal, diverged containers started as they are — its long-standing semantics, now stated by a plan-shape test;
- detached `up` converges in one plan, `--wait` stays a post-plan barrier (shared `waitStarted` helper);
- the listener-driven `s.start` path remains solely for the interactive `up` (phase 2 will move the session to executor hooks and retire it).

**Validation**: plan-shape + event-contract unit tests (`-race` clean); locally the wide e2e sweep (scale, hooks, start/stop, restart, networks, up families — the bulk of the suite runs `up -d`) plus the watch rebuild e2e trio, all green (the only local failure, `TestWatch/debian`, reproduces identically on the base branch: daemon 'restricted host mount', environmental).

Part of #14081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)