### PR TITLE
fix(watch): sync into a symlinked directory instead of failing

### DIFF
--- a/internal/sync/tar.go
+++ b/internal/sync/tar.go
@@ -96,7 +96,7 @@ func (t *Tar) Sync(ctx context.Context, service string, paths []*PathMapping) er
 	eg.SetLimit(16) // arbitrary limit, adjust to taste :D
 	for i := range containers {
 		containerID := containers[i].ID
-		tarReader := tarArchive(pathsToCopy)
+		tarReader := tarArchive(pathsToCopy, keepImpliedDirectories)
 
 		eg.Go(func() error {
 			if len(deleteCmd) != 0 {
@@ -108,9 +108,24 @@ func (t *Tar) Sync(ctx context.Context, service string, paths []*PathMapping) er
 			}
 
 			if err := t.client.Untar(ctx, containerID, tarReader); err != nil {
-				errMu.Lock()
-				errs = append(errs, fmt.Errorf("copying files to %s: %w", containerID, err))
-				errMu.Unlock()
+				// The engine answers with a plain 500, so the message is the only discriminator.
+				if !strings.Contains(err.Error(), "cannot overwrite non-directory") {
+					errMu.Lock()
+					errs = append(errs, fmt.Errorf("copying files to %s: %w", containerID, err))
+					errMu.Unlock()
+					return nil
+				}
+
+				// A directory header for a path the container resolves through a symlink makes
+				// the engine reject the whole copy, so retry without the headers the archive's
+				// own entries already imply. That archive is a strict subset of the one that
+				// just failed, so sending it again is safe.
+				retry := tarArchive(pathsToCopy, dropImpliedDirectories)
+				if retryErr := t.client.Untar(ctx, containerID, retry); retryErr != nil {
+					errMu.Lock()
+					errs = append(errs, fmt.Errorf("copying files to %s: %w", containerID, errors.Join(err, retryErr)))
+					errMu.Unlock()
+				}
 			}
 			return nil // don't fail-fast; collect all errors
 		})
@@ -139,7 +154,7 @@ func (a *ArchiveBuilder) Close() error {
 }
 
 // ArchivePathsIfExist creates a tar archive of all local files in `paths`. It quietly skips any paths that don't exist.
-func (a *ArchiveBuilder) ArchivePathsIfExist(paths []PathMapping) error {
+func (a *ArchiveBuilder) ArchivePathsIfExist(paths []PathMapping, dropImpliedDirs bool) error {
 	// In order to handle overlapping syncs, we
 	// 1) collect all the entries,
 	// 2) de-dupe them, with last-one-wins semantics
@@ -161,6 +176,9 @@ func (a *ArchiveBuilder) ArchivePathsIfExist(paths []PathMapping) error {
 	}
 
 	entries = dedupeEntries(entries)
+	if dropImpliedDirs {
+		entries = withoutImpliedDirectories(entries)
+	}
 	for _, entry := range entries {
 		err := a.writeEntry(entry)
 		if err != nil {
@@ -318,11 +336,17 @@ func (a *ArchiveBuilder) entriesForPath(localPath, containerPath string) ([]arch
 	return result, nil
 }
 
-func tarArchive(ops []PathMapping) io.ReadCloser {
+// Whether tarArchive keeps the header of a directory the archive itself fills with entries.
+const (
+	keepImpliedDirectories = false
+	dropImpliedDirectories = true
+)
+
+func tarArchive(ops []PathMapping, dropImpliedDirs bool) io.ReadCloser {
 	pr, pw := io.Pipe()
 	go func() {
 		ab := NewArchiveBuilder(pw)
-		err := ab.ArchivePathsIfExist(ops)
+		err := ab.ArchivePathsIfExist(ops, dropImpliedDirs)
 		if err != nil {
 			_ = pw.CloseWithError(fmt.Errorf("adding files to tar: %w", err))
 		} else {
@@ -336,6 +360,28 @@ func tarArchive(ops []PathMapping) io.ReadCloser {
 		}
 	}()
 	return pr
+}
+
+// withoutImpliedDirectories removes the header of every directory the archive already fills with
+// entries: the engine creates those while extracting, while an explicit header makes it reject the
+// whole copy when the container resolves that path through a symlink. A directory nothing else
+// would create - an empty one - keeps its header.
+//
+// The engine creates them with ImpliedDirectoryMode and its own root uid/gid rather than the host's,
+// so this is a fallback for a copy that already failed, never the first attempt.
+func withoutImpliedDirectories(entries []archiveEntry) []archiveEntry {
+	holdsEntries := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		holdsEntries[path.Dir(path.Clean(entry.header.Name))] = true
+	}
+	result := make([]archiveEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.header.Typeflag == tar.TypeDir && holdsEntries[path.Clean(entry.header.Name)] {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
 }
 
 // Dedupe the entries with last-entry-wins semantics.

--- a/internal/sync/tar_test.go
+++ b/internal/sync/tar_test.go
@@ -15,7 +15,9 @@
 package sync
 
 import (
+	"archive/tar"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,6 +34,10 @@ type fakeLowLevelClient struct {
 	containers []container.Summary
 	execCmds   [][]string
 	untarCount int
+	// untarErrs[i] is what the i-th Untar call returns
+	untarErrs []error
+	// untarHeaders[i] holds the headers the i-th Untar call received, by entry name
+	untarHeaders []map[string]tar.Header
 }
 
 func (f *fakeLowLevelClient) ContainersForService(_ context.Context, _ string, _ string) ([]container.Summary, error) {
@@ -43,8 +49,25 @@ func (f *fakeLowLevelClient) Exec(_ context.Context, _ string, cmd []string, _ i
 	return nil
 }
 
-func (f *fakeLowLevelClient) Untar(_ context.Context, _ string, _ io.ReadCloser) error {
+func (f *fakeLowLevelClient) Untar(_ context.Context, _ string, reader io.ReadCloser) error {
+	headers := map[string]tar.Header{}
+	tr := tar.NewReader(reader)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		headers[header.Name] = *header
+	}
+	f.untarHeaders = append(f.untarHeaders, headers)
+
 	f.untarCount++
+	if f.untarCount <= len(f.untarErrs) {
+		return f.untarErrs[f.untarCount-1]
+	}
 	return nil
 }
 
@@ -56,9 +79,9 @@ func TestSync_ExistingPath(t *testing.T) {
 	client := &fakeLowLevelClient{
 		containers: []container.Summary{{ID: "ctr1"}},
 	}
-	tar := NewTar("proj", client)
+	syncer := NewTar("proj", client)
 
-	err := tar.Sync(t.Context(), "svc", []*PathMapping{
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
 		{HostPath: existingFile, ContainerPath: "/app/exists.txt"},
 	})
 
@@ -71,9 +94,9 @@ func TestSync_NonExistentPath(t *testing.T) {
 	client := &fakeLowLevelClient{
 		containers: []container.Summary{{ID: "ctr1"}},
 	}
-	tar := NewTar("proj", client)
+	syncer := NewTar("proj", client)
 
-	err := tar.Sync(t.Context(), "svc", []*PathMapping{
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
 		{HostPath: "/no/such/file", ContainerPath: "/app/gone.txt"},
 	})
 
@@ -105,9 +128,9 @@ func TestSync_StatPermissionError(t *testing.T) {
 	client := &fakeLowLevelClient{
 		containers: []container.Summary{{ID: "ctr1"}},
 	}
-	tar := NewTar("proj", client)
+	syncer := NewTar("proj", client)
 
-	err := tar.Sync(t.Context(), "svc", []*PathMapping{
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
 		{HostPath: targetFile, ContainerPath: "/app/secret.txt"},
 	})
 
@@ -125,9 +148,9 @@ func TestSync_MixedPaths(t *testing.T) {
 	client := &fakeLowLevelClient{
 		containers: []container.Summary{{ID: "ctr1"}},
 	}
-	tar := NewTar("proj", client)
+	syncer := NewTar("proj", client)
 
-	err := tar.Sync(t.Context(), "svc", []*PathMapping{
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
 		{HostPath: existingFile, ContainerPath: "/app/keep.txt"},
 		{HostPath: "/no/such/path", ContainerPath: "/app/removed.txt"},
 	})
@@ -136,4 +159,106 @@ func TestSync_MixedPaths(t *testing.T) {
 	assert.Equal(t, client.untarCount, 1, "existing path should be copied")
 	assert.Equal(t, len(client.execCmds), 1)
 	assert.Check(t, cmp.Contains(client.execCmds[0][len(client.execCmds[0])-1], "removed.txt"))
+}
+
+// A directory that arrives already populated keeps its own header: left implied, the engine
+// creates it with ImpliedDirectoryMode and its own root uid/gid, and a non-root service can no
+// longer write into what it synced.
+func TestSync_PopulatedDirectoryKeepsItsHeader(t *testing.T) {
+	tmpDir := populatedSyncDir(t)
+
+	client := &fakeLowLevelClient{
+		containers: []container.Summary{{ID: "ctr1"}},
+	}
+	syncer := NewTar("proj", client)
+
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
+		{HostPath: filepath.Join(tmpDir, "sub"), ContainerPath: "/app/sub"},
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, client.untarCount, 1)
+
+	sent := client.untarHeaders[0]
+	dir, sentDirHeader := sent["app/sub/"]
+	assert.Assert(t, sentDirHeader, "the synced directory needs its own header: %v", sent)
+	hostDir, err := os.Stat(filepath.Join(tmpDir, "sub"))
+	assert.NilError(t, err)
+	assert.Equal(t, dir.FileInfo().Mode().Perm(), hostDir.Mode().Perm(), "the header carries the host mode, not the engine's")
+	assert.Equal(t, sent["app/sub/data.txt"].Typeflag, byte(tar.TypeReg))
+}
+
+// A directory header for a path the container resolves through a symlink makes the engine reject
+// the whole copy (docker/compose#13795). The retry leaves those directories implied, so the files
+// land through the symlink.
+func TestSync_RetriesWithoutImpliedDirectoriesWhenCopyFails(t *testing.T) {
+	tmpDir := populatedSyncDir(t)
+
+	client := &fakeLowLevelClient{
+		containers: []container.Summary{{ID: "ctr1"}},
+		untarErrs:  []error{errors.New(`cannot overwrite non-directory "/app/sub" with directory "/"`)},
+	}
+	syncer := NewTar("proj", client)
+
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
+		{HostPath: filepath.Join(tmpDir, "sub"), ContainerPath: "/app/sub"},
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, client.untarCount, 2)
+
+	retried := client.untarHeaders[1]
+	_, sentDirHeader := retried["app/sub/"]
+	assert.Check(t, !sentDirHeader, "no header expected for the directory holding the synced files: %v", retried)
+	assert.Equal(t, retried["app/sub/data.txt"].Typeflag, byte(tar.TypeReg))
+	assert.Equal(t, retried["app/sub/nested/"].Typeflag, byte(tar.TypeDir), "an empty directory still needs its own header")
+}
+
+func TestSync_ReportsTheCopyErrorWhenTheRetryFailsToo(t *testing.T) {
+	tmpDir := populatedSyncDir(t)
+
+	client := &fakeLowLevelClient{
+		containers: []container.Summary{{ID: "ctr1"}},
+		untarErrs: []error{
+			errors.New(`cannot overwrite non-directory "/app/sub" with directory "/"`),
+			errors.New("no such container"),
+		},
+	}
+	syncer := NewTar("proj", client)
+
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
+		{HostPath: filepath.Join(tmpDir, "sub"), ContainerPath: "/app/sub"},
+	})
+
+	assert.ErrorContains(t, err, "cannot overwrite non-directory")
+	assert.ErrorContains(t, err, "no such container")
+	assert.Equal(t, client.untarCount, 2)
+}
+
+// Retrying drops the directory headers, so only the failure they cause may be retried.
+func TestSync_DoesNotRetryACopyThatFailedForAnotherReason(t *testing.T) {
+	tmpDir := populatedSyncDir(t)
+
+	client := &fakeLowLevelClient{
+		containers: []container.Summary{{ID: "ctr1"}},
+		untarErrs:  []error{errors.New("no such container")},
+	}
+	syncer := NewTar("proj", client)
+
+	err := syncer.Sync(t.Context(), "svc", []*PathMapping{
+		{HostPath: filepath.Join(tmpDir, "sub"), ContainerPath: "/app/sub"},
+	})
+
+	assert.ErrorContains(t, err, "no such container")
+	assert.Equal(t, client.untarCount, 1)
+	assert.Equal(t, client.untarHeaders[0]["app/sub/"].Typeflag, byte(tar.TypeDir), "the archive sent must be the unreduced one")
+}
+
+// sub/ holds a file and an empty directory, the shapes the archive treats differently.
+func populatedSyncDir(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(tmpDir, "sub", "nested"), 0o700))
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpDir, "sub", "data.txt"), []byte("data"), 0o644))
+	return tmpDir
 }

--- a/pkg/e2e/fixtures/watch/symlink.yaml
+++ b/pkg/e2e/fixtures/watch/symlink.yaml
@@ -1,0 +1,11 @@
+services:
+  app:
+    image: alpine
+    init: true
+    # /app/data/sub is a symlink, so synced files have to land in /var/sub through it
+    command: sh -c 'mkdir -p /app/data /var/sub && ln -s /var/sub /app/data/sub && sleep infinity'
+    develop:
+      watch:
+        - action: sync
+          path: ./data
+          target: /app/data

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -447,6 +447,64 @@ func TestWatchRebuildIgnoresDependencies(t *testing.T) {
 	c.RunDockerComposeCmdNoCheck(t, "-p", projectName, "kill", "-s", "9")
 }
 
+// Reproduces docker/compose#13795: syncing a directory onto a path the image exposes as a
+// symlink failed with `cannot overwrite non-directory "/app/data/sub" with directory "/"`.
+func TestWatchSyncIntoSymlinkedDirectory(t *testing.T) {
+	c := NewCLI(t)
+	const projectName = "test_watch_symlink"
+
+	defer c.cleanupWithDown(t, projectName)
+
+	tmpdir := t.TempDir()
+	composeFilePath := filepath.Join(tmpdir, "compose.yaml")
+	CopyFile(t, filepath.Join("fixtures", "watch", "symlink.yaml"), composeFilePath)
+	dataDir := filepath.Join(tmpdir, "data")
+	assert.NilError(t, os.Mkdir(dataDir, 0o700))
+
+	// Fill the directory outside the watched tree and move it in, so a single change carries
+	// the directory together with its content, the way a branch switch does.
+	staged := filepath.Join(tmpdir, "staged")
+	assert.NilError(t, os.Mkdir(staged, 0o700))
+	assert.NilError(t, os.WriteFile(filepath.Join(staged, "hello.txt"), []byte("hello symlink\n"), 0o600))
+
+	cmd := c.NewDockerComposeCmd(t, "-p", projectName, "-f", composeFilePath, "up", "--watch")
+	buffer := bytes.NewBuffer(nil)
+	cmd.Stdout = buffer
+	cmd.Stderr = buffer
+	watch := icmd.StartCmd(cmd)
+	assert.NilError(t, watch.Error)
+	t.Cleanup(func() {
+		if watch.Cmd.Process != nil {
+			_ = watch.Cmd.Process.Kill()
+		}
+	})
+
+	poll.WaitOn(t, func(l poll.LogT) poll.Result {
+		if strings.Contains(buffer.String(), "Watch enabled") {
+			return poll.Success()
+		}
+		return poll.Continue("waiting for watch to start: %v", buffer.String())
+	}, poll.WithTimeout(120*time.Second))
+
+	assert.NilError(t, os.Rename(staged, filepath.Join(dataDir, "sub")))
+
+	poll.WaitOn(t, func(l poll.LogT) poll.Result {
+		// The image resolves /app/data/sub to /var/sub, where the synced file has to show up.
+		cat := c.RunDockerComposeCmdNoCheck(t, "-p", projectName, "exec", "app", "cat", "/var/sub/hello.txt")
+		if strings.Contains(cat.Stdout(), "hello symlink") {
+			return poll.Success()
+		}
+		return poll.Continue("%v\n%v", cat.Combined(), buffer.String())
+	}, poll.WithTimeout(60*time.Second), poll.WithDelay(time.Second))
+
+	// the sync must go through the symlink, not replace it
+	c.RunDockerComposeCmd(t, "-p", projectName, "exec", "app", "test", "-L", "/app/data/sub")
+	assert.Assert(t, !strings.Contains(buffer.String(), "cannot overwrite non-directory"),
+		"sync failed on the symlinked path:\n%s", buffer.String())
+
+	c.RunDockerComposeCmdNoCheck(t, "-p", projectName, "kill", "-s", "9")
+}
+
 func TestWatchIncludes(t *testing.T) {
 	c := NewCLI(t)
 	const projectName = "test_watch_includes"


### PR DESCRIPTION
**What I did**

`compose watch` aborted the whole sync batch when a synced directory maps onto a path the
image exposes as a symlink:

```
Error handling changed files: copying files to <id>: Error response from daemon:
cannot overwrite non-directory "/app/data/sub" with directory "/"
```

The archive built for a sync carries a header for every directory it walks, and extraction
runs with `noOverwriteDirNonDir`, so a directory header for a path the container resolves
through a symlink makes the engine reject the entire copy — not a single file of that batch
lands.

A sync sends the archive unchanged, exactly as it does today. Only when the engine rejects the
copy does compose rebuild it without the headers the archive's own entries already imply — the
engine creates those directories while extracting (`createImpliedDirectories`), so the file
entries resolve through the symlink, which is what a `sync` action is expected to do. A
directory nothing else would create — an empty one — keeps its header. The retried archive is a
strict subset of the one that just failed, so replaying it is safe, and it costs an extra round
trip only in the case that was already broken.

Reproducer:

```yaml
services:
  app:
    image: alpine
    command: sh -c 'mkdir -p /app/data /var/sub && ln -s /var/sub /app/data/sub && sleep infinity'
    develop:
      watch:
        - action: sync
          path: ./data
          target: /app/data
```

`docker compose up --watch`, then create `./data/sub/hello.txt` on the host. On main the sync
fails with the error above; with this change the file lands in `/var/sub/hello.txt` and
`/app/data/sub` is still a symlink.

Two things worth flagging:

- Because the retry only fires on a copy that already failed, an ordinary sync keeps sending
  the directory headers and the host's mode and ownership with them. In the fallback the
  engine creates those directories with `ImpliedDirectoryMode` (0755) and its own root
  uid/gid; empty directories still carry their own header either way.
- Creating an *empty* directory right on top of a symlinked path still fails. There the
  header is the only thing that would create the directory, and the client has no way to know
  the container resolves that path through a symlink.

**Tests**

- `internal/sync`, all three reading back the archives handed to `Untar`:
  `TestSync_PopulatedDirectoryKeepsItsHeader` asserts a directory that arrives already
  populated still carries its own header, with the host's mode;
  `TestSync_RetriesWithoutImpliedDirectoriesWhenCopyFails` asserts the retried archive drops
  that header while an empty nested directory keeps its own; and
  `TestSync_ReportsTheCopyErrorWhenTheRetryFailsToo` asserts the engine's original error is
  what surfaces when the fallback fails too.
- `pkg/e2e`: `TestWatchSyncIntoSymlinkedDirectory` moves an already populated directory into
  the watched tree, the way a branch switch does, and checks the file shows up in the symlink
  target with the symlink intact. It fails on main with the exact error from the issue.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes #13795

<img width="300"  alt="2150649137" src="https://github.com/user-attachments/assets/f8384b55-aa1c-42c0-a591-a8d295c6b042" />