### PR TITLE
fix(build): TTY progress on Windows — hand the real stdout to buildkit

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -494,11 +494,23 @@ func (s *composeService) getBuildxPlugin() (*manager.Plugin, error) {
 	return buildx, nil
 }
 
-// makeConsole wraps the provided writer to match [containerd.File] interface if it is of type *streams.Out.
-// buildkit's NewDisplay doesn't actually require a [io.Reader], it only uses the [containerd.Console] type to
-// benefits from ANSI capabilities, but only does writes.
+// makeConsole adapts the provided writer for buildkit's NewDisplay, which
+// requires a [console.File] to enable the TTY rendering (it only ever writes,
+// but goes through [console.ConsoleFromFile] for the ANSI capabilities).
+//
+// When the stream was constructed from a real file — the interactive case,
+// where it wraps os.Stdout — the genuine [*os.File] is handed over: on
+// Windows, containerd/console only accepts the exact os.Stdin/Stdout/Stderr
+// values (identity check in newMaster), so any wrapper fails with "creating a
+// console from a file is not supported on windows" and the TTY progress can
+// never engage (#14086). For file-less streams the [console.File] wrapper is
+// kept: the TTY rendering then works on Unix, where only the descriptor
+// matters, and falls back to plain elsewhere.
 func makeConsole(out io.Writer) io.Writer {
 	if s, ok := out.(*streams.Out); ok {
+		if f, ok := s.File(); ok {
+			return f
+		}
 		return &_console{s}
 	}
 	return out

--- a/pkg/compose/build_bake_test.go
+++ b/pkg/compose/build_bake_test.go
@@ -17,9 +17,13 @@
 package compose
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/cli/cli/streams"
 	"gotest.tools/v3/assert"
 )
 
@@ -44,5 +48,27 @@ func TestBakeTargetNames(t *testing.T) {
 		"a_b":   "a_b_",
 		"a.b.c": "a_b_c",
 		"a_b.c": "a_b_c_",
+	})
+}
+
+// makeConsole must hand the genuine *os.File over when the stream wraps one:
+// on Windows, containerd/console rejects anything but the exact
+// os.Stdin/Stdout/Stderr values, so a wrapper would disable the TTY progress
+// rendering entirely (#14086).
+func TestMakeConsole(t *testing.T) {
+	t.Run("stream wrapping a real file yields the file itself", func(t *testing.T) {
+		out := makeConsole(streams.NewOut(os.Stdout))
+		assert.Equal(t, out, os.Stdout)
+	})
+
+	t.Run("file-less stream keeps the console.File wrapper", func(t *testing.T) {
+		out := makeConsole(streams.NewOut(&bytes.Buffer{}))
+		_, ok := out.(*_console)
+		assert.Check(t, ok, "expected a *_console, got %T", out)
+	})
+
+	t.Run("plain writer is left untouched", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		assert.Equal(t, makeConsole(buf), io.Writer(buf))
 	})
 }


### PR DESCRIPTION
Fixes #14086: TTY/colorized build progress was structurally broken on Windows.

The bake display goes through containerd/console, whose Windows `newMaster` only accepts the exact `os.Stdin/Stdout/Stderr` values — a pointer-identity check, not a capability probe. The `_console` wrapper added to satisfy buildkit's `console.File` type-assert could therefore never pass it: `--progress=auto` silently fell back to plain, and `--progress=tty` / `--ansi always` failed with `failed to get console: creating a console from a file is not supported on windows`.

The fix hands the genuine `*os.File` (via `streams.Out.File()`) to `progressui.NewDisplay` when the CLI stream wraps a real file, which is the interactive case. File-less streams keep the wrapper, unchanged: TTY rendering still works on Unix there, where only the descriptor matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
