### PR TITLE
feat(hooks): capture and surface lifecycle hook output

### DIFF
--- a/docs/reference/compose_down.md
+++ b/docs/reference/compose_down.md
@@ -15,6 +15,18 @@ Anonymous volumes are not removed by default. However, as they don’t have a st
 mounted by a subsequent `up`. For data that needs to persist between updates, use explicit paths as bind mounts or
 named volumes.
 
+### Pre-start hook containers
+
+When a `pre_start` lifecycle hook fails, Compose retains its container for post-mortem inspection instead of removing
+it immediately. `compose down` automatically removes these retained hook containers as part of teardown, so they do
+not accumulate over time.
+
+To list retained hook containers before running `down`:
+
+```console
+$ docker ps -a --filter label=com.docker.compose.hook=pre_start
+```
+
 ### Options
 
 | Name               | Type     | Default | Description                                                                                                             |
@@ -43,3 +55,15 @@ Networks and volumes defined as external are never removed.
 Anonymous volumes are not removed by default. However, as they don’t have a stable name, they are not automatically
 mounted by a subsequent `up`. For data that needs to persist between updates, use explicit paths as bind mounts or
 named volumes.
+
+### Pre-start hook containers
+
+When a `pre_start` lifecycle hook fails, Compose retains its container for post-mortem inspection instead of removing
+it immediately. `compose down` automatically removes these retained hook containers as part of teardown, so they do
+not accumulate over time.
+
+To list retained hook containers before running `down`:
+
+```console
+$ docker ps -a --filter label=com.docker.compose.hook=pre_start
+```

--- a/docs/reference/compose_up.md
+++ b/docs/reference/compose_up.md
@@ -21,6 +21,19 @@ If you want to force Compose to stop and recreate all containers, use the `--for
 If the process encounters an error, the exit code for this command is `1`.
 If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the containers are stopped, and the exit code is `0`.
 
+### Pre-start hook failures
+
+When a `pre_start` lifecycle hook exits with a non-zero code, Compose stops the service startup and retains the
+hook’s container so you can inspect what went wrong:
+
+```console
+$ docker ps -a --filter label=com.docker.compose.hook=pre_start
+$ docker logs <container-id>
+```
+
+On the next `compose up`, any retained hook containers for the same service are cleaned up automatically before the
+hook runs again. Running `compose down` also removes them.
+
 ### Options
 
 | Name                           | Type          | Default  | Description                                                                                                                                         |
@@ -80,3 +93,16 @@ If you want to force Compose to stop and recreate all containers, use the `--for
 
 If the process encounters an error, the exit code for this command is `1`.
 If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the containers are stopped, and the exit code is `0`.
+
+### Pre-start hook failures
+
+When a `pre_start` lifecycle hook exits with a non-zero code, Compose stops the service startup and retains the
+hook’s container so you can inspect what went wrong:
+
+```console
+$ docker ps -a --filter label=com.docker.compose.hook=pre_start
+$ docker logs <container-id>
+```
+
+On the next `compose up`, any retained hook containers for the same service are cleaned up automatically before the
+hook runs again. Running `compose down` also removes them.

--- a/docs/reference/docker_compose_down.yaml
+++ b/docs/reference/docker_compose_down.yaml
@@ -14,6 +14,18 @@ long: |-
     Anonymous volumes are not removed by default. However, as they don’t have a stable name, they are not automatically
     mounted by a subsequent `up`. For data that needs to persist between updates, use explicit paths as bind mounts or
     named volumes.
+
+    ### Pre-start hook containers
+
+    When a `pre_start` lifecycle hook fails, Compose retains its container for post-mortem inspection instead of removing
+    it immediately. `compose down` automatically removes these retained hook containers as part of teardown, so they do
+    not accumulate over time.
+
+    To list retained hook containers before running `down`:
+
+    ```console
+    $ docker ps -a --filter label=com.docker.compose.hook=pre_start
+    ```
 usage: docker compose down [OPTIONS] [SERVICES]
 pname: docker compose
 plink: docker_compose.yaml

--- a/docs/reference/docker_compose_up.yaml
+++ b/docs/reference/docker_compose_up.yaml
@@ -20,6 +20,19 @@ long: |-
 
     If the process encounters an error, the exit code for this command is `1`.
     If the process is interrupted using `SIGINT` (ctrl + C) or `SIGTERM`, the containers are stopped, and the exit code is `0`.
+
+    ### Pre-start hook failures
+
+    When a `pre_start` lifecycle hook exits with a non-zero code, Compose stops the service startup and retains the
+    hook’s container so you can inspect what went wrong:
+
+    ```console
+    $ docker ps -a --filter label=com.docker.compose.hook=pre_start
+    $ docker logs <container-id>
+    ```
+
+    On the next `compose up`, any retained hook containers for the same service are cleaned up automatically before the
+    hook runs again. Running `compose down` also removes them.
 usage: docker compose up [OPTIONS] [SERVICE...]
 pname: docker compose
 plink: docker_compose.yaml

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -62,6 +62,11 @@ const (
 	ContainerReplaceLabel = "com.docker.compose.replace"
 	// ContainerEngineLabel stores the name of the engine that runs the container
 	ContainerEngineLabel = "com.docker.compose.engine"
+	// HookLabel identifies an ephemeral lifecycle-hook container and stores the
+	// hook type, e.g. "pre_start". It is applied to every container created by
+	// runPreStartHook so orphan hook containers from a previous failed run can
+	// be found and removed by project+service+hook label filters.
+	HookLabel = "com.docker.compose.hook"
 )
 
 // ComposeVersion is the compose tool version as declared by label VersionLabel

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -107,6 +107,10 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 		}
 	}
 
+	if err := s.removePreStartHookContainers(ctx, projectName, options.Services); err != nil {
+		return err
+	}
+
 	ops := s.ensureNetworksDown(ctx, project)
 
 	if options.Images != "" {
@@ -384,4 +388,44 @@ func (s *composeService) getProjectWithResources(ctx context.Context, containers
 	project.Networks = networks
 
 	return project, nil
+}
+
+// removePreStartHookContainers force-removes any pre_start hook containers that
+// were retained after a failed hook run. These containers are created without a
+// ConfigHashLabel, so getContainers and the normal teardown path never see them;
+// without this step they would survive compose down. When services is non-empty
+// the cleanup is scoped to those services; otherwise the whole project is swept.
+// Individual removal failures are logged at warn level and do not abort teardown.
+func (s *composeService) removePreStartHookContainers(ctx context.Context, projectName string, services []string) error {
+	var filters []client.Filters
+	if len(services) == 0 {
+		f := projectFilter(projectName)
+		f.Add("label", hookFilter(preStartHookType))
+		filters = []client.Filters{f}
+	} else {
+		for _, service := range services {
+			f := projectFilter(projectName)
+			f.Add("label", serviceFilter(service))
+			f.Add("label", hookFilter(preStartHookType))
+			filters = append(filters, f)
+		}
+	}
+	for _, f := range filters {
+		res, err := s.apiClient().ContainerList(ctx, client.ContainerListOptions{
+			All:     true,
+			Filters: f,
+		})
+		if err != nil {
+			return err
+		}
+		for _, ctr := range res.Items {
+			if _, removeErr := s.apiClient().ContainerRemove(ctx, ctr.ID, client.ContainerRemoveOptions{
+				Force:         true,
+				RemoveVolumes: true,
+			}); removeErr != nil {
+				logrus.Warnf("failed to remove retained pre_start hook container %s: %v", ctr.ID, removeErr)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -91,6 +91,8 @@ func TestDown(t *testing.T) {
 	api.EXPECT().NetworkRemove(gomock.Any(), "abc123", gomock.Any()).Return(client.NetworkRemoveResult{}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "def456", gomock.Any()).Return(client.NetworkRemoveResult{}, nil)
 
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).Return(client.ContainerListResult{}, nil)
+
 	err = tested.Down(t.Context(), strings.ToLower(testProject), compose.DownOptions{})
 	assert.NilError(t, err)
 }
@@ -137,6 +139,8 @@ func TestDownWithGivenServices(t *testing.T) {
 	}}, nil)
 	api.EXPECT().NetworkInspect(gomock.Any(), "abc123", gomock.Any()).Return(client.NetworkInspectResult{Network: network.Inspect{Network: network.Network{ID: "abc123"}}}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "abc123", gomock.Any()).Return(client.NetworkRemoveResult{}, nil)
+
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt("service1")).Return(client.ContainerListResult{}, nil)
 
 	err = tested.Down(t.Context(), strings.ToLower(testProject), compose.DownOptions{
 		Services: []string{"service1", "not-running-service"},
@@ -232,6 +236,8 @@ func TestDownRemoveOrphans(t *testing.T) {
 	}, nil)
 	api.EXPECT().NetworkRemove(gomock.Any(), "abc123", gomock.Any()).Return(client.NetworkRemoveResult{}, nil)
 
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).Return(client.ContainerListResult{}, nil)
+
 	err = tested.Down(t.Context(), strings.ToLower(testProject), compose.DownOptions{RemoveOrphans: true})
 	assert.NilError(t, err)
 }
@@ -266,6 +272,8 @@ func TestDownRemoveVolumes(t *testing.T) {
 
 	api.EXPECT().VolumeRemove(gomock.Any(), "myProject_volume", client.VolumeRemoveOptions{Force: true}).Return(client.VolumeRemoveResult{}, nil)
 
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).Return(client.ContainerListResult{}, nil)
+
 	err = tested.Down(t.Context(), strings.ToLower(testProject), compose.DownOptions{Volumes: true})
 	assert.NilError(t, err)
 }
@@ -299,6 +307,8 @@ func TestDownRemoveImages(t *testing.T) {
 			},
 		}, nil).
 		AnyTimes()
+
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).Return(client.ContainerListResult{}, nil).AnyTimes()
 
 	api.EXPECT().ImageList(gomock.Any(), client.ImageListOptions{
 		Filters: projectFilter(strings.ToLower(testProject)).Add("dangling", "false"),
@@ -409,8 +419,28 @@ func TestDownRemoveImages_NoLabel(t *testing.T) {
 
 	api.EXPECT().ImageRemove(gomock.Any(), "testproject-service1:latest", client.ImageRemoveOptions{}).Return(client.ImageRemoveResult{}, nil)
 
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).Return(client.ContainerListResult{}, nil)
+
 	err = tested.Down(t.Context(), strings.ToLower(testProject), compose.DownOptions{Images: "local"})
 	assert.NilError(t, err)
+}
+
+// hookFilterListOpt returns the ContainerListOptions used by removePreStartHookContainers.
+// When services are provided the filter is scoped per service; otherwise it matches the
+// whole project. The argument order must match the production code: project → service → hook.
+func hookFilterListOpt(services ...string) client.ContainerListOptions {
+	if len(services) == 0 {
+		f := projectFilter(strings.ToLower(testProject))
+		f.Add("label", hookFilter(preStartHookType))
+		return client.ContainerListOptions{Filters: f, All: true}
+	}
+	// For service-scoped calls there is one list per service; callers should pass a single service.
+	f := projectFilter(strings.ToLower(testProject))
+	for _, svc := range services {
+		f.Add("label", serviceFilter(svc))
+	}
+	f.Add("label", hookFilter(preStartHookType))
+	return client.ContainerListOptions{Filters: f, All: true}
 }
 
 func prepareMocks(mockCtrl *gomock.Controller) (*mocks.MockAPIClient, *mocks.MockCli) {
@@ -420,4 +450,89 @@ func prepareMocks(mockCtrl *gomock.Controller) (*mocks.MockAPIClient, *mocks.Moc
 	cli.EXPECT().Err().Return(streams.NewOut(os.Stderr)).AnyTimes()
 	cli.EXPECT().Out().Return(streams.NewOut(os.Stdout)).AnyTimes()
 	return api, cli
+}
+
+// TestDownRemovesRetainedPreStartHookContainers verifies that compose down finds and
+// removes pre_start hook containers that were retained after a failed hook run.
+// These containers lack ConfigHashLabel so the normal getContainers path never sees them.
+func TestDownRemovesRetainedPreStartHookContainers(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	api, cli := prepareMocks(mockCtrl)
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+
+	// No regular service containers running.
+	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt(false)).
+		Return(client.ContainerListResult{}, nil)
+	api.EXPECT().VolumeList(gomock.Any(), client.VolumeListOptions{
+		Filters: projectFilter(strings.ToLower(testProject)),
+	}).Return(client.VolumeListResult{}, nil)
+	api.EXPECT().NetworkList(gomock.Any(), client.NetworkListOptions{
+		Filters: projectFilter(strings.ToLower(testProject)),
+	}).Return(client.NetworkListResult{}, nil)
+
+	// Hook container scan finds one retained pre_start container.
+	hookCtr := container.Summary{
+		ID:    "hook-1",
+		Names: []string{"/hook-1"},
+		Labels: map[string]string{
+			compose.ProjectLabel: strings.ToLower(testProject),
+			compose.ServiceLabel: "service1",
+			compose.HookLabel:    preStartHookType,
+		},
+	}
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).
+		Return(client.ContainerListResult{Items: []container.Summary{hookCtr}}, nil)
+
+	// The hook container must be force-removed with volumes.
+	api.EXPECT().ContainerRemove(gomock.Any(), "hook-1",
+		client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, nil)
+
+	err = tested.Down(t.Context(), strings.ToLower(testProject), compose.DownOptions{})
+	assert.NilError(t, err)
+}
+
+// TestDownHookContainerRemovalFailureIsNonFatal verifies that a failure to remove a
+// retained hook container is logged as a warning but does not abort compose down.
+func TestDownHookContainerRemovalFailureIsNonFatal(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	api, cli := prepareMocks(mockCtrl)
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+
+	// No regular service containers running.
+	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt(false)).
+		Return(client.ContainerListResult{}, nil)
+	api.EXPECT().VolumeList(gomock.Any(), client.VolumeListOptions{
+		Filters: projectFilter(strings.ToLower(testProject)),
+	}).Return(client.VolumeListResult{}, nil)
+	api.EXPECT().NetworkList(gomock.Any(), client.NetworkListOptions{
+		Filters: projectFilter(strings.ToLower(testProject)),
+	}).Return(client.NetworkListResult{}, nil)
+
+	// Hook scan finds one container.
+	hookCtr := container.Summary{
+		ID:    "hook-2",
+		Names: []string{"/hook-2"},
+		Labels: map[string]string{
+			compose.ProjectLabel: strings.ToLower(testProject),
+			compose.ServiceLabel: "service1",
+			compose.HookLabel:    preStartHookType,
+		},
+	}
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).
+		Return(client.ContainerListResult{Items: []container.Summary{hookCtr}}, nil)
+
+	// Removal fails — Down must still return nil.
+	api.EXPECT().ContainerRemove(gomock.Any(), "hook-2",
+		client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, fmt.Errorf("daemon busy"))
+
+	err = tested.Down(t.Context(), strings.ToLower(testProject), compose.DownOptions{})
+	assert.NilError(t, err)
 }

--- a/pkg/compose/filters.go
+++ b/pkg/compose/filters.go
@@ -54,6 +54,11 @@ func containerNumberFilter(index int) string {
 	return labelFilter(api.ContainerNumberLabel, strconv.Itoa(index))
 }
 
+// hookFilter returns a label filter that matches containers by hook type
+// (stored in api.HookLabel). hookType is parametric for future hook types
+// (e.g. post_start); today all callers pass preStartHookType.
+//
+//nolint:unparam
 func hookFilter(hookType string) string {
 	return labelFilter(api.HookLabel, hookType)
 }

--- a/pkg/compose/filters.go
+++ b/pkg/compose/filters.go
@@ -53,3 +53,7 @@ func oneOffFilter(b bool) string {
 func containerNumberFilter(index int) string {
 	return labelFilter(api.ContainerNumberLabel, strconv.Itoa(index))
 }
+
+func hookFilter(hookType string) string {
+	return labelFilter(api.HookLabel, hookType)
+}

--- a/pkg/compose/hook.go
+++ b/pkg/compose/hook.go
@@ -216,7 +216,7 @@ func (t *outputTail) pushLine(line string) {
 
 // String returns the kept output, newest content last, trimmed to maxBytes.
 func (t *outputTail) String() string {
-	lines := t.lines
+	lines := append([]string(nil), t.lines...)
 	if partial := strings.TrimSpace(strings.ToValidUTF8(t.partial.String(), "")); partial != "" {
 		lines = append(lines, partial)
 	}

--- a/pkg/compose/hook.go
+++ b/pkg/compose/hook.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -39,27 +40,33 @@ const (
 )
 
 func (s *composeService) runHook(ctx context.Context, ctr container.Summary, service types.ServiceConfig, hook types.ServiceHook, listener api.ContainerEventListener) error {
-	// The output of a hook is the only explanation of why it failed, so keep the
-	// tail of it even when no listener is attached: the exec used to run
-	// unattached in that case, the daemon discarded both streams, and the caller
-	// was left with a bare exit code. Only surfaced on failure, and bounded.
-	tail := newOutputTail(hookOutputTailLines, hookOutputTailBytes)
+	// Keep stdout and stderr in separate tails so the error message can prefer
+	// stderr (which usually holds the real error) over stdout progress noise.
+	tailOut := newOutputTail(hookOutputTailLines, hookOutputTailBytes)
+	tailErr := newOutputTail(hookOutputTailLines, hookOutputTailBytes)
 
-	var out io.Writer = tail
+	// wOut/wErr receive the demultiplexed stdout/stderr from StdCopy. When a
+	// listener is attached they also forward each line to it.
+	var wOut, wErr io.Writer
+	wOut = tailOut
+	wErr = tailErr
 
 	if listener != nil {
-		wOut := utils.GetWriter(func(line string) {
+		source := getContainerNameWithoutProject(ctr) + " ->"
+		// stdout and stderr share one listener writer: ContainerEvent has no stream
+		// field, so both appear identically in the live display.
+		lw := utils.GetWriter(func(line string) {
 			listener(api.ContainerEvent{
 				Type:    api.HookEventLog,
-				Source:  getContainerNameWithoutProject(ctr) + " ->",
+				Source:  source,
 				ID:      ctr.ID,
 				Service: service.Name,
 				Line:    line,
 			})
 		})
-		defer wOut.Close() //nolint:errcheck
-
-		out = io.MultiWriter(wOut, tail)
+		defer lw.Close() //nolint:errcheck
+		wOut = io.MultiWriter(lw, tailOut)
+		wErr = io.MultiWriter(lw, tailErr)
 	}
 
 	exec, err := s.apiClient().ExecCreate(ctx, ctr.ID, client.ExecCreateOptions{
@@ -92,13 +99,31 @@ func (s *composeService) runHook(ctx context.Context, ctr container.Summary, ser
 	}
 	defer attach.Close()
 
-	if service.Tty {
-		_, err = io.Copy(out, attach.Reader)
-	} else {
-		_, err = stdcopy.StdCopy(out, out, attach.Reader)
-	}
-	if err != nil {
-		return err
+	// Run the copy in a goroutine so that a context cancellation (Ctrl+C) can
+	// interrupt it. Without this the blocked Read inside StdCopy/io.Copy would
+	// prevent the first Ctrl+C from taking effect.
+	copyDone := make(chan error, 1)
+	go func() {
+		var cErr error
+		if service.Tty {
+			_, cErr = io.Copy(wOut, attach.Reader)
+		} else {
+			_, cErr = stdcopy.StdCopy(wOut, wErr, attach.Reader)
+		}
+		copyDone <- cErr
+	}()
+
+	select {
+	case err = <-copyDone:
+		if err != nil {
+			return err
+		}
+	case <-ctx.Done():
+		// Close the connection to unblock the blocked Read in the copy goroutine,
+		// then wait for it to exit before returning so there is no goroutine leak.
+		attach.Close()
+		<-copyDone
+		return ctx.Err()
 	}
 
 	inspected, err := s.apiClient().ExecInspect(ctx, exec.ID, client.ExecInspectOptions{})
@@ -106,13 +131,23 @@ func (s *composeService) runHook(ctx context.Context, ctr container.Summary, ser
 		return err
 	}
 	if inspected.ExitCode != 0 {
-		if output := tail.String(); output != "" {
-			return fmt.Errorf("%s hook exited with status %d: %s", service.Name, inspected.ExitCode, output)
-		}
-
-		return fmt.Errorf("%s hook exited with status %d", service.Name, inspected.ExitCode)
+		return hookExitError(service.Name, inspected.ExitCode, tailOut, tailErr)
 	}
 	return nil
+}
+
+// hookExitError builds a hook failure error. Stderr content is preferred over
+// stdout because it usually holds the real failure reason rather than progress
+// noise. Falls back to stdout when stderr is empty.
+func hookExitError(serviceName string, code int, tailOut, tailErr *outputTail) error {
+	output := tailErr.String()
+	if output == "" {
+		output = tailOut.String()
+	}
+	if output == "" {
+		return fmt.Errorf("%s hook exited with status %d", serviceName, code)
+	}
+	return fmt.Errorf("%s hook exited with status %d: %s", serviceName, code, output)
 }
 
 // outputTail keeps the last lines written to it, bounded by a line and a byte
@@ -131,27 +166,44 @@ func newOutputTail(maxLines, maxBytes int) *outputTail {
 }
 
 func (t *outputTail) Write(p []byte) (int, error) {
-	for _, b := range p {
-		if b != '\n' {
-			// Cap the line being assembled, so a hook printing megabytes without
-			// a newline cannot grow this buffer without bound.
-			if t.partial.Len() < t.maxBytes {
-				t.partial.WriteByte(b)
-			}
-
-			continue
+	n := len(p)
+	for len(p) > 0 {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			t.appendToPartial(p)
+			break
 		}
-
-		t.pushLine(t.partial.String())
+		t.appendToPartial(p[:i])
+		// ToValidUTF8 ensures a byte-truncated multi-byte rune does not corrupt
+		// the error message.
+		t.pushLine(strings.ToValidUTF8(t.partial.String(), ""))
 		t.partial.Reset()
+		p = p[i+1:]
 	}
+	return n, nil
+}
 
-	return len(p), nil
+// appendToPartial appends b to the in-progress partial line, capped at maxBytes
+// so a hook printing megabytes without a newline cannot grow the buffer unbounded.
+func (t *outputTail) appendToPartial(b []byte) {
+	if remaining := t.maxBytes - t.partial.Len(); remaining > 0 {
+		if len(b) > remaining {
+			b = b[:remaining]
+		}
+		_, _ = t.partial.Write(b)
+	}
 }
 
 // pushLine appends a line and drops the oldest one when the limit is reached.
 func (t *outputTail) pushLine(line string) {
+	// Strip trailing \r (from \r\n sequences). For progress-bar output that uses
+	// bare \r to rewind the cursor (curl, apt, pip), keep only the last segment
+	// after the final \r so the visible content is preserved rather than the
+	// intermediate states.
 	line = strings.TrimRight(line, "\r")
+	if idx := strings.LastIndex(line, "\r"); idx >= 0 {
+		line = line[idx+1:]
+	}
 	if strings.TrimSpace(line) == "" {
 		return
 	}
@@ -165,13 +217,15 @@ func (t *outputTail) pushLine(line string) {
 // String returns the kept output, newest content last, trimmed to maxBytes.
 func (t *outputTail) String() string {
 	lines := t.lines
-	if partial := strings.TrimSpace(t.partial.String()); partial != "" {
-		lines = append(append([]string{}, lines...), partial)
+	if partial := strings.TrimSpace(strings.ToValidUTF8(t.partial.String(), "")); partial != "" {
+		lines = append(lines, partial)
 	}
 
 	output := strings.TrimSpace(strings.Join(lines, "\n"))
 	if len(output) > t.maxBytes {
-		output = output[len(output)-t.maxBytes:]
+		// Byte-slicing may split a multi-byte rune; ToValidUTF8 drops the broken
+		// leading sequence rather than emitting a replacement character.
+		output = strings.ToValidUTF8(output[len(output)-t.maxBytes:], "")
 	}
 
 	return output

--- a/pkg/compose/hook_test.go
+++ b/pkg/compose/hook_test.go
@@ -19,8 +19,10 @@
 package compose
 
 import (
+	"bufio"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -433,4 +435,165 @@ func TestRunHook_ContextCancellation(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("runHook did not return within 5 s after ctx cancellation")
 	}
+}
+
+// TestRunHook_CopyError covers the branch in runHook where the copy goroutine
+// itself returns an error (e.g. a mid-stream I/O failure on the exec reader).
+// The error must be propagated immediately without blocking.
+func TestRunHook_CopyError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAPI := mocks.NewMockAPIClient(mockCtrl)
+	mockCli := mocks.NewMockCli(mockCtrl)
+	mockCli.EXPECT().Client().Return(mockAPI).AnyTimes()
+	mockCli.EXPECT().Err().Return(streams.NewOut(os.Stderr)).AnyTimes()
+	mockCli.EXPECT().Out().Return(streams.NewOut(os.Stdout)).AnyTimes()
+
+	ctr := container.Summary{ID: "ctr-1"}
+	service := types.ServiceConfig{Name: "svc", Tty: false}
+	hook := types.ServiceHook{Command: types.ShellCommand{"true"}}
+
+	mockAPI.EXPECT().
+		ExecCreate(gomock.Any(), "ctr-1", gomock.Any()).
+		Return(client.ExecCreateResult{ID: "exec-1"}, nil)
+
+	// Build a pipe whose read side immediately returns a hard error, simulating
+	// an I/O failure mid-stream rather than a clean EOF.
+	pr, pw := io.Pipe()
+	_ = pw.CloseWithError(fmt.Errorf("simulated I/O failure"))
+
+	// Use net.Pipe() only for the Conn field (Close); reads come from pr.
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close() //nolint:errcheck
+	defer clientConn.Close() //nolint:errcheck
+
+	mockAPI.EXPECT().
+		ExecAttach(gomock.Any(), "exec-1", gomock.Any()).
+		Return(client.ExecAttachResult{
+			HijackedResponse: client.HijackedResponse{
+				Conn:   clientConn,
+				Reader: bufio.NewReader(pr),
+			},
+		}, nil)
+	// ExecInspect must NOT be called: runHook must return the copy error first.
+
+	s, err := NewComposeService(mockCli)
+	assert.NilError(t, err)
+
+	err = s.(*composeService).runHook(t.Context(), ctr, service, hook, nil)
+	assert.ErrorContains(t, err, "simulated I/O failure")
+}
+
+// TestHookExitError_NoOutput covers the branch in hookExitError where both
+// stdout and stderr tails are empty — the error must not include an output suffix.
+func TestHookExitError_NoOutput(t *testing.T) {
+	empty1 := newOutputTail(10, 512)
+	empty2 := newOutputTail(10, 512)
+	err := hookExitError("mysvc", 127, empty1, empty2)
+	assert.ErrorContains(t, err, "mysvc")
+	assert.ErrorContains(t, err, "127")
+	// No colon separator: the no-output format has no ': <output>' suffix.
+	assert.Assert(t, !strings.Contains(err.Error(), ": "), "unexpected output suffix in: %q", err.Error())
+}
+
+// TestHookExitError_StdoutFallback covers the branch in hookExitError where
+// stderr is empty but stdout has content: stdout is used as the fallback output.
+func TestHookExitError_StdoutFallback(t *testing.T) {
+	stdoutTail := newOutputTail(10, 512)
+	_, _ = stdoutTail.Write([]byte("stdout only line\n"))
+	stderrTail := newOutputTail(10, 512) // empty
+
+	err := hookExitError("mysvc", 1, stdoutTail, stderrTail)
+	assert.ErrorContains(t, err, "stdout only line")
+}
+
+// TestRunHook_ExecCreateError covers the branch where ExecCreate returns an
+// error — runHook must propagate it immediately.
+func TestRunHook_ExecCreateError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAPI := mocks.NewMockAPIClient(mockCtrl)
+	mockCli := mocks.NewMockCli(mockCtrl)
+	mockCli.EXPECT().Client().Return(mockAPI).AnyTimes()
+	mockCli.EXPECT().Err().Return(streams.NewOut(os.Stderr)).AnyTimes()
+	mockCli.EXPECT().Out().Return(streams.NewOut(os.Stdout)).AnyTimes()
+
+	ctr := container.Summary{ID: "ctr-1"}
+	service := types.ServiceConfig{Name: "svc"}
+	hook := types.ServiceHook{Command: types.ShellCommand{"true"}}
+
+	mockAPI.EXPECT().
+		ExecCreate(gomock.Any(), "ctr-1", gomock.Any()).
+		Return(client.ExecCreateResult{}, fmt.Errorf("exec create failed"))
+
+	s, err := NewComposeService(mockCli)
+	assert.NilError(t, err)
+	err = s.(*composeService).runHook(t.Context(), ctr, service, hook, nil)
+	assert.ErrorContains(t, err, "exec create failed")
+}
+
+// TestRunHook_ExecAttachError covers the branch where ExecAttach returns an
+// error — runHook must propagate it immediately.
+func TestRunHook_ExecAttachError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAPI := mocks.NewMockAPIClient(mockCtrl)
+	mockCli := mocks.NewMockCli(mockCtrl)
+	mockCli.EXPECT().Client().Return(mockAPI).AnyTimes()
+	mockCli.EXPECT().Err().Return(streams.NewOut(os.Stderr)).AnyTimes()
+	mockCli.EXPECT().Out().Return(streams.NewOut(os.Stdout)).AnyTimes()
+
+	ctr := container.Summary{ID: "ctr-1"}
+	service := types.ServiceConfig{Name: "svc"}
+	hook := types.ServiceHook{Command: types.ShellCommand{"true"}}
+
+	mockAPI.EXPECT().
+		ExecCreate(gomock.Any(), "ctr-1", gomock.Any()).
+		Return(client.ExecCreateResult{ID: "exec-1"}, nil)
+	mockAPI.EXPECT().
+		ExecAttach(gomock.Any(), "exec-1", gomock.Any()).
+		Return(client.ExecAttachResult{}, fmt.Errorf("exec attach failed"))
+
+	s, err := NewComposeService(mockCli)
+	assert.NilError(t, err)
+	err = s.(*composeService).runHook(t.Context(), ctr, service, hook, nil)
+	assert.ErrorContains(t, err, "exec attach failed")
+}
+
+// TestRunHook_ExecInspectError covers the branch where ExecInspect returns an
+// error — runHook must propagate it (copy finished successfully beforehand).
+func TestRunHook_ExecInspectError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAPI := mocks.NewMockAPIClient(mockCtrl)
+	mockCli := mocks.NewMockCli(mockCtrl)
+	mockCli.EXPECT().Client().Return(mockAPI).AnyTimes()
+	mockCli.EXPECT().Err().Return(streams.NewOut(os.Stderr)).AnyTimes()
+	mockCli.EXPECT().Out().Return(streams.NewOut(os.Stdout)).AnyTimes()
+
+	ctr := container.Summary{ID: "ctr-1"}
+	service := types.ServiceConfig{Name: "svc", Tty: false}
+	hook := types.ServiceHook{Command: types.ShellCommand{"true"}}
+
+	mockAPI.EXPECT().
+		ExecCreate(gomock.Any(), "ctr-1", gomock.Any()).
+		Return(client.ExecCreateResult{ID: "exec-1"}, nil)
+
+	// Pipe that closes immediately (EOF) so StdCopy returns with no error.
+	serverConn, clientConn := net.Pipe()
+	serverConn.Close() //nolint:errcheck
+	mockAPI.EXPECT().
+		ExecAttach(gomock.Any(), "exec-1", gomock.Any()).
+		Return(client.ExecAttachResult{
+			HijackedResponse: client.NewHijackedResponse(clientConn, ""),
+		}, nil)
+
+	mockAPI.EXPECT().
+		ExecInspect(gomock.Any(), "exec-1", gomock.Any()).
+		Return(client.ExecInspectResult{}, fmt.Errorf("inspect failed"))
+
+	s, err := NewComposeService(mockCli)
+	assert.NilError(t, err)
+	err = s.(*composeService).runHook(t.Context(), ctr, service, hook, nil)
+	assert.ErrorContains(t, err, "inspect failed")
 }

--- a/pkg/compose/hook_test.go
+++ b/pkg/compose/hook_test.go
@@ -24,8 +24,10 @@ import (
 	"io"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/creack/pty"
@@ -141,11 +143,11 @@ func writeStdcopyFrame(w io.Writer, stream byte, payload string) error {
 // daemon, leaving no way to find out at all.
 func TestRunHook_FailureIncludesOutput(t *testing.T) {
 	tests := []struct {
-		name     string
-		listener api.ContainerEventListener
+		name         string
+		withListener bool
 	}{
-		{name: "with listener", listener: func(api.ContainerEvent) {}},
-		{name: "without listener", listener: nil},
+		{name: "with listener", withListener: true},
+		{name: "without listener", withListener: false},
 	}
 
 	for _, tc := range tests {
@@ -194,9 +196,23 @@ func TestRunHook_FailureIncludesOutput(t *testing.T) {
 			s, err := NewComposeService(mockCli)
 			assert.NilError(t, err)
 
-			err = s.(*composeService).runHook(t.Context(), ctr, service, hook, tc.listener)
+			var got []string
+			var listener api.ContainerEventListener
+			if tc.withListener {
+				listener = func(event api.ContainerEvent) {
+					got = append(got, event.Line)
+				}
+			}
+
+			err = s.(*composeService).runHook(t.Context(), ctr, service, hook, listener)
 			assert.ErrorContains(t, err, "db hook exited with status 1")
 			assert.ErrorContains(t, err, "SQLSTATE[42S02]: table not found")
+			if tc.withListener {
+				assert.Check(t, slices.Contains(got, "migrating"),
+					"listener must receive stdout lines on failure; got: %v", got)
+				assert.Check(t, slices.Contains(got, "SQLSTATE[42S02]: table not found"),
+					"listener must receive stderr lines on failure; got: %v", got)
+			}
 		})
 	}
 }
@@ -284,4 +300,137 @@ func TestOutputTail(t *testing.T) {
 		assert.Check(t, len(tail.String()) <= 16, "output must stay within the byte limit")
 		assert.Check(t, strings.HasSuffix(tail.String(), "last line"), "the newest output must survive")
 	})
+
+	t.Run("strips trailing CR (CRLF lines)", func(t *testing.T) {
+		tail := newOutputTail(5, 1024)
+		_, err := tail.Write([]byte("line one\r\nline two\r\n"))
+		assert.NilError(t, err)
+		assert.Equal(t, tail.String(), "line one\nline two")
+	})
+
+	t.Run("progress bar: keeps last segment after mid-line CR", func(t *testing.T) {
+		tail := newOutputTail(5, 1024)
+		_, err := tail.Write([]byte("10%\r20%\r30%\n"))
+		assert.NilError(t, err)
+		assert.Equal(t, tail.String(), "30%")
+	})
+
+	t.Run("byte-truncation in String is UTF-8 safe", func(t *testing.T) {
+		// maxBytes=5: joining two € lines gives "€\n€" (7 bytes); the last-5-byte
+		// slice cuts inside the first €, leaving a broken leading byte. ToValidUTF8
+		// must strip it so the result is valid UTF-8.
+		tail := newOutputTail(10, 5)
+		_, err := tail.Write([]byte("€\n€\n"))
+		assert.NilError(t, err)
+		out := tail.String()
+		assert.Check(t, out != "", "truncated string must not be empty")
+		assert.Check(t, strings.ToValidUTF8(out, "\uFFFD") == out,
+			"String() must return valid UTF-8 after byte truncation; got %q", out)
+	})
+}
+
+// TestRunHook_StderrBias verifies that when a failing hook produces output on
+// both stdout and stderr, the error message preferentially shows stderr content.
+// Stderr is where hooks write their actual error; stdout is progress noise.
+func TestRunHook_StderrBias(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockAPI := mocks.NewMockAPIClient(mockCtrl)
+	mockCli := mocks.NewMockCli(mockCtrl)
+	mockCli.EXPECT().Client().Return(mockAPI).AnyTimes()
+	mockCli.EXPECT().Err().Return(streams.NewOut(os.Stderr)).AnyTimes()
+	mockCli.EXPECT().Out().Return(streams.NewOut(os.Stdout)).AnyTimes()
+
+	serverConn, clientConn := net.Pipe()
+
+	go func() {
+		// stdout: progress noise that should NOT dominate the error message
+		assert.NilError(t, writeStdcopyFrame(serverConn, 1, "running migration…\n"))
+		// stderr: the actual error that SHOULD appear in the error message
+		assert.NilError(t, writeStdcopyFrame(serverConn, 2, "Table 'service.sites' doesn't exist\n"))
+		serverConn.Close() //nolint:errcheck
+	}()
+
+	mockAPI.EXPECT().ExecCreate(gomock.Any(), "ctr-a1b2c3d4e5f6", gomock.Any()).
+		Return(client.ExecCreateResult{ID: "exec-x"}, nil)
+	mockAPI.EXPECT().ExecAttach(gomock.Any(), "exec-x", gomock.Any()).
+		Return(client.ExecAttachResult{
+			HijackedResponse: client.NewHijackedResponse(clientConn, ""),
+		}, nil)
+	mockAPI.EXPECT().ExecInspect(gomock.Any(), "exec-x", gomock.Any()).
+		Return(client.ExecInspectResult{ExitCode: 1}, nil)
+
+	s, err := NewComposeService(mockCli)
+	assert.NilError(t, err)
+
+	var got []string
+	listener := func(event api.ContainerEvent) {
+		got = append(got, event.Line)
+	}
+
+	runErr := s.(*composeService).runHook(t.Context(),
+		container.Summary{ID: "ctr-a1b2c3d4e5f6"},
+		types.ServiceConfig{Name: "db"},
+		types.ServiceHook{Command: []string{"migrate"}},
+		listener)
+
+	assert.ErrorContains(t, runErr, "doesn't exist", "stderr content must appear in the error")
+	assert.Assert(t, !strings.Contains(runErr.Error(), "running migration"),
+		"stdout progress noise must not dominate when stderr has content; got: %s", runErr.Error())
+	// The listener receives all lines from both streams regardless of stderr bias.
+	assert.Check(t, slices.Contains(got, "running migration\u2026"),
+		"listener must receive stdout lines; got: %v", got)
+	assert.Check(t, slices.Contains(got, "Table 'service.sites' doesn't exist"),
+		"listener must receive stderr lines; got: %v", got)
+}
+
+// TestRunHook_ContextCancellation verifies that cancelling the context unblocks
+// a hook that is waiting for output (e.g. a hung or slow container) and causes
+// runHook to return promptly with context.Canceled. Without the goroutine/select
+// fix the first Ctrl+C had no effect because StdCopy blocked on the attach reader.
+func TestRunHook_ContextCancellation(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockAPI := mocks.NewMockAPIClient(mockCtrl)
+	mockCli := mocks.NewMockCli(mockCtrl)
+	mockCli.EXPECT().Client().Return(mockAPI).AnyTimes()
+	mockCli.EXPECT().Err().Return(streams.NewOut(os.Stderr)).AnyTimes()
+	mockCli.EXPECT().Out().Return(streams.NewOut(os.Stdout)).AnyTimes()
+
+	// serverConn is held open and never writes data: StdCopy will block on Read.
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close() //nolint:errcheck
+
+	mockAPI.EXPECT().ExecCreate(gomock.Any(), "ctr-hang", gomock.Any()).
+		Return(client.ExecCreateResult{ID: "exec-hang"}, nil)
+	mockAPI.EXPECT().ExecAttach(gomock.Any(), "exec-hang", gomock.Any()).
+		Return(client.ExecAttachResult{
+			HijackedResponse: client.NewHijackedResponse(clientConn, ""),
+		}, nil)
+	// ExecInspect must NOT be called: runHook must return before reaching it.
+
+	ctx, cancel := context.WithCancel(t.Context())
+	s, err := NewComposeService(mockCli)
+	assert.NilError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.(*composeService).runHook(ctx,
+			container.Summary{ID: "ctr-hang"},
+			types.ServiceConfig{Name: "svc"},
+			types.ServiceHook{Command: []string{"sleep", "infinity"}},
+			nil)
+	}()
+
+	cancel()
+
+	select {
+	case runErr := <-errCh:
+		assert.ErrorIs(t, runErr, context.Canceled,
+			"runHook must return context.Canceled after ctx cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("runHook did not return within 5 s after ctx cancellation")
+	}
 }

--- a/pkg/compose/pre_start.go
+++ b/pkg/compose/pre_start.go
@@ -33,6 +33,11 @@ import (
 	"github.com/docker/compose/v5/pkg/utils"
 )
 
+// preStartHookType is stored in the HookLabel on every pre_start hook container
+// so orphan containers from a previous failed run can be identified and removed
+// by a project+service+hook label filter.
+const preStartHookType = "pre_start"
+
 // lowestNumberedContainer returns the container with the lowest
 // com.docker.compose.container-number label, so pre_start always targets the
 // same replica regardless of the order the daemon returned them in.
@@ -65,6 +70,14 @@ func (s *composeService) runPreStart(ctx context.Context, project *types.Project
 			return fmt.Errorf("service %q pre_start[%d]: per_replica is not yet supported; remove per_replica or set it to false", service.Name, i)
 		}
 	}
+	// Remove any hook containers left behind by a previous failed run so they do
+	// not accumulate. Only one orphan can exist per service (failure gates the
+	// remaining hooks), but we clean the whole set in case the service definition
+	// changed between runs. Removal failures are non-fatal: they are logged so
+	// the operator can identify the stale container.
+	if err := s.removeOrphanPreStartContainers(ctx, project.Name, service.Name); err != nil {
+		logrus.Warnf("service %q: failed to remove stale pre_start hook containers: %v", service.Name, err)
+	}
 	for i, hook := range service.PreStart {
 		if err := s.runPreStartHook(ctx, project, service, ctr, i, hook, listener); err != nil {
 			return err
@@ -89,20 +102,18 @@ func (s *composeService) runPreStartHook(
 		Condition: container.WaitConditionNextExit,
 	})
 
-	// Open the log stream before ContainerStart so AutoRemove cannot race us
-	// to a 404 on a fast-exiting hook. The dedicated logCtx lets us force the
-	// follow stream closed once the hook has exited, so a daemon that keeps
-	// the connection open cannot deadlock `<-logsDone`.
+	// Open the log stream before ContainerStart so a fast-exiting hook cannot
+	// race us to a 404. The dedicated logCtx lets us force the follow stream
+	// closed once the hook has exited, so a daemon that keeps the connection
+	// open cannot deadlock `<-logsDone`.
 	logCtx, cancelLogs := context.WithCancel(ctx)
 	defer cancelLogs()
 	logsDone, getTail := s.streamPreStartLogs(logCtx, created.ID, service, index, listener)
 
 	if _, err := s.apiClient().ContainerStart(ctx, created.ID, client.ContainerStartOptions{}); err != nil {
-		// AutoRemove only fires after a successful start, so the never-started
-		// container has to be dropped explicitly. A failed removal is logged
-		// at warn level — without that hint the orphan is only discoverable
-		// via the project/service labels.
-		if _, removeErr := s.apiClient().ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{Force: true}); removeErr != nil {
+		// AutoRemove is false, so we must remove the never-started container
+		// explicitly. A failed removal is logged so the orphan is visible.
+		if _, removeErr := s.apiClient().ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}); removeErr != nil {
 			logrus.Warnf("service %q pre_start[%d]: failed to remove orphan hook container %s: %v", service.Name, index, created.ID, removeErr)
 		}
 		// Drain waitRes so the client's wait goroutine exits without having to
@@ -121,11 +132,34 @@ func (s *composeService) runPreStartHook(
 	cancelLogs()
 	<-logsDone
 	if waitErr != nil {
-		if tail := getTail(); tail != "" {
-			return fmt.Errorf("%w: %s", waitErr, tail)
+		// Ctrl-C is a user cancellation, not a hook failure: remove the container
+		// and return the raw context error without decorating it with the tail or
+		// retaining the container for post-mortem inspection.
+		if ctx.Err() != nil {
+			if _, removeErr := s.apiClient().ContainerRemove(context.Background(), created.ID, client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}); removeErr != nil {
+				logrus.Warnf("service %q pre_start[%d]: failed to remove hook container %s after cancellation: %v", service.Name, index, created.ID, removeErr)
+			}
+			return waitErr
 		}
+		// Genuine hook failure: retain the container so the operator can run
+		// `docker logs <id>` and `docker inspect <id>` to diagnose the failure.
+		// Include the short container ID in the error to make it actionable.
+		shortID := created.ID
+		if len(shortID) > 12 {
+			shortID = shortID[:12]
+		}
+		if tail := getTail(); tail != "" {
+			return fmt.Errorf("%w: %s (hook container %s retained for inspection)", waitErr, tail, shortID)
+		}
+		return fmt.Errorf("%w (hook container %s retained for inspection)", waitErr, shortID)
 	}
-	return waitErr
+	// Success: remove the hook container, mirroring the old AutoRemove behaviour
+	// (including its anonymous volumes). A removal failure is logged but does not
+	// gate service start — the hook already succeeded.
+	if _, removeErr := s.apiClient().ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{RemoveVolumes: true}); removeErr != nil {
+		logrus.Warnf("service %q pre_start[%d]: failed to remove hook container %s: %v", service.Name, index, created.ID, removeErr)
+	}
+	return nil
 }
 
 func (s *composeService) createPreStartContainer(
@@ -144,16 +178,21 @@ func (s *composeService) createPreStartContainer(
 		WorkingDir: hook.WorkingDir,
 		Env:        append(ToMobyEnv(service.Environment), ToMobyEnv(hook.Environment)...),
 		// Tag the ephemeral hook container with the project/service it belongs
-		// to so a failed AutoRemove leaves something that `compose down` (and
-		// other label-scoped tooling) can still find.
+		// to so it can be found by `compose down` and label-scoped tooling.
+		// HookLabel also distinguishes hook containers from the real service
+		// container (which shares ProjectLabel and ServiceLabel).
 		Labels: map[string]string{
 			api.ProjectLabel: project.Name,
 			api.ServiceLabel: service.Name,
 			api.VersionLabel: api.ComposeVersion,
+			api.HookLabel:    preStartHookType,
 		},
 	}
 	hostCfg := &container.HostConfig{
-		AutoRemove:  true,
+		// AutoRemove is intentionally false: a failed hook container is retained
+		// so the operator can inspect its logs. On success runPreStartHook
+		// removes the container explicitly (see the success path below).
+		AutoRemove:  false,
 		Privileged:  hook.Privileged,
 		VolumesFrom: []string{ctr.ID},
 	}
@@ -180,10 +219,9 @@ func (s *composeService) createPreStartContainer(
 
 	if versions.LessThan(apiVersion, apiVersion144) {
 		if err := s.connectPreStartExtraNetworks(ctx, project, service, created.ID, networkMode); err != nil {
-			// Same reason as the ContainerStart-failure cleanup: AutoRemove never
-			// fires on a container that was created but not started. Surface
-			// any cleanup failure so the orphan is at least visible in logs.
-			if _, removeErr := s.apiClient().ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{Force: true}); removeErr != nil {
+			// AutoRemove is false; remove the container explicitly since it was
+			// never started. Log failures so the orphan is at least visible.
+			if _, removeErr := s.apiClient().ContainerRemove(ctx, created.ID, client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}); removeErr != nil {
 				logrus.Warnf("service %q pre_start: failed to remove orphan hook container %s: %v", service.Name, created.ID, removeErr)
 			}
 			return client.ContainerCreateResult{}, err
@@ -210,6 +248,32 @@ func (s *composeService) connectPreStartExtraNetworks(ctx context.Context, proje
 			EndpointConfig: eps,
 		}); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// removeOrphanPreStartContainers finds and force-removes any hook containers
+// left behind by a previous failed run of this service's pre_start hooks.
+// Containers are identified by project + service + HookLabel=pre_start.
+// Removal failures are logged at warn level and do not abort the run.
+func (s *composeService) removeOrphanPreStartContainers(ctx context.Context, projectName, serviceName string) error {
+	f := projectFilter(projectName)
+	f.Add("label", serviceFilter(serviceName))
+	f.Add("label", hookFilter(preStartHookType))
+	res, err := s.apiClient().ContainerList(ctx, client.ContainerListOptions{
+		All:     true,
+		Filters: f,
+	})
+	if err != nil {
+		return err
+	}
+	for _, ctr := range res.Items {
+		if _, removeErr := s.apiClient().ContainerRemove(ctx, ctr.ID, client.ContainerRemoveOptions{
+			Force:         true,
+			RemoveVolumes: true,
+		}); removeErr != nil {
+			logrus.Warnf("failed to remove stale pre_start hook container %s: %v", ctr.ID, removeErr)
 		}
 	}
 	return nil
@@ -262,9 +326,6 @@ func preStartResultErr(serviceName string, index int, res container.WaitResponse
 	return nil
 }
 
-// streamPreStartLogs returns a channel that is closed once the hook log stream
-// has been fully drained (or never opened). Callers must wait on it before
-// returning so the goroutine cannot outlive the hook.
 // streamPreStartLogs opens the hook container's log stream in a background
 // goroutine, tees output into the listener (when non-nil) and into per-stream
 // tail buffers. It returns:

--- a/pkg/compose/pre_start.go
+++ b/pkg/compose/pre_start.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -94,7 +95,7 @@ func (s *composeService) runPreStartHook(
 	// the connection open cannot deadlock `<-logsDone`.
 	logCtx, cancelLogs := context.WithCancel(ctx)
 	defer cancelLogs()
-	logsDone := s.streamPreStartLogs(logCtx, created.ID, service, index, listener)
+	logsDone, getTail := s.streamPreStartLogs(logCtx, created.ID, service, index, listener)
 
 	if _, err := s.apiClient().ContainerStart(ctx, created.ID, client.ContainerStartOptions{}); err != nil {
 		// AutoRemove only fires after a successful start, so the never-started
@@ -119,6 +120,11 @@ func (s *composeService) runPreStartHook(
 	waitErr := waitPreStart(ctx, service.Name, index, waitRes)
 	cancelLogs()
 	<-logsDone
+	if waitErr != nil {
+		if tail := getTail(); tail != "" {
+			return fmt.Errorf("%w: %s", waitErr, tail)
+		}
+	}
 	return waitErr
 }
 
@@ -259,12 +265,32 @@ func preStartResultErr(serviceName string, index int, res container.WaitResponse
 // streamPreStartLogs returns a channel that is closed once the hook log stream
 // has been fully drained (or never opened). Callers must wait on it before
 // returning so the goroutine cannot outlive the hook.
-func (s *composeService) streamPreStartLogs(ctx context.Context, containerID string, service types.ServiceConfig, index int, listener api.ContainerEventListener) <-chan struct{} {
+// streamPreStartLogs opens the hook container's log stream in a background
+// goroutine, tees output into the listener (when non-nil) and into per-stream
+// tail buffers. It returns:
+//   - done: closed when the goroutine exits; callers must wait on it
+//   - getTail: returns the stderr-biased tail (stderr preferred, stdout fallback);
+//     safe to call only after done is closed
+//
+// The log stream is always opened even when listener is nil, so the tail is
+// populated in detached mode and can appear in error messages.
+func (s *composeService) streamPreStartLogs(
+	ctx context.Context,
+	containerID string,
+	service types.ServiceConfig,
+	index int,
+	listener api.ContainerEventListener,
+) (<-chan struct{}, func() string) {
 	done := make(chan struct{})
-	if listener == nil {
-		close(done)
-		return done
+	tailOut := newOutputTail(hookOutputTailLines, hookOutputTailBytes)
+	tailErr := newOutputTail(hookOutputTailLines, hookOutputTailBytes)
+	getTail := func() string {
+		if s := tailErr.String(); s != "" {
+			return s
+		}
+		return tailOut.String()
 	}
+
 	source := fmt.Sprintf("%s pre_start[%d] ->", service.Name, index)
 	logs, err := s.apiClient().ContainerLogs(ctx, containerID, client.ContainerLogsOptions{
 		ShowStdout: true,
@@ -272,30 +298,44 @@ func (s *composeService) streamPreStartLogs(ctx context.Context, containerID str
 		Follow:     true,
 	})
 	if err != nil {
-		listener(api.ContainerEvent{
-			Type:    api.HookEventLog,
-			Source:  source,
-			ID:      containerID,
-			Service: service.Name,
-			Line:    fmt.Sprintf("warning: could not attach pre_start log stream: %s", err),
-		})
-		close(done)
-		return done
-	}
-	go func() {
-		defer close(done)
-		defer logs.Close() //nolint:errcheck
-		w := utils.GetWriter(func(line string) {
+		if listener != nil {
 			listener(api.ContainerEvent{
 				Type:    api.HookEventLog,
 				Source:  source,
 				ID:      containerID,
 				Service: service.Name,
-				Line:    line,
+				Line:    fmt.Sprintf("warning: could not attach pre_start log stream: %s", err),
 			})
-		})
-		defer w.Close() //nolint:errcheck
-		_, _ = stdcopy.StdCopy(w, w, logs)
+		}
+		close(done)
+		return done, getTail
+	}
+	go func() {
+		defer close(done)
+		defer logs.Close() //nolint:errcheck
+
+		var wOut, wErr io.Writer
+		wOut = tailOut
+		wErr = tailErr
+
+		if listener != nil {
+			// stdout and stderr share one listener writer: ContainerEvent has no stream
+			// field, so both appear identically in the live display.
+			lw := utils.GetWriter(func(line string) {
+				listener(api.ContainerEvent{
+					Type:    api.HookEventLog,
+					Source:  source,
+					ID:      containerID,
+					Service: service.Name,
+					Line:    line,
+				})
+			})
+			defer lw.Close() //nolint:errcheck
+			wOut = io.MultiWriter(lw, tailOut)
+			wErr = io.MultiWriter(lw, tailErr)
+		}
+
+		_, _ = stdcopy.StdCopy(wOut, wErr, logs)
 	}()
-	return done
+	return done, getTail
 }

--- a/pkg/compose/pre_start_test.go
+++ b/pkg/compose/pre_start_test.go
@@ -18,8 +18,10 @@ package compose
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -34,11 +36,11 @@ import (
 )
 
 func newPreStartTestService(t *testing.T) (*composeService, *mocks.MockAPIClient) {
+	return newPreStartTestServiceWithVersion(t, "1.44")
+}
+
+func newPreStartTestServiceWithVersion(t *testing.T, apiVersion string) (*composeService, *mocks.MockAPIClient) {
 	t.Helper()
-	// Register the goroutine-leak check first so it runs last (t.Cleanup is
-	// LIFO), after gomock's own cleanup has drained any internal goroutines.
-	// Any goroutine spawned by the code under test that outlives the test will
-	// fail this assertion.
 	ignoreExisting := goleak.IgnoreCurrent()
 	t.Cleanup(func() {
 		goleak.VerifyNone(t, ignoreExisting)
@@ -49,8 +51,8 @@ func newPreStartTestService(t *testing.T) (*composeService, *mocks.MockAPIClient
 	cli := mocks.NewMockCli(mockCtrl)
 	cli.EXPECT().Client().Return(apiClient).AnyTimes()
 	apiClient.EXPECT().Ping(gomock.Any(), client.PingOptions{NegotiateAPIVersion: true}).
-		Return(client.PingResult{APIVersion: "1.44"}, nil).AnyTimes()
-	apiClient.EXPECT().ClientVersion().Return("1.44").AnyTimes()
+		Return(client.PingResult{APIVersion: apiVersion}, nil).AnyTimes()
+	apiClient.EXPECT().ClientVersion().Return(apiVersion).AnyTimes()
 	tested, err := NewComposeService(cli)
 	assert.NilError(t, err)
 	return tested.(*composeService), apiClient
@@ -67,6 +69,23 @@ func emptyLogs() client.ContainerLogsResult {
 	return io.NopCloser(bytes.NewReader(nil))
 }
 
+// expectEmptyOrphanScan sets up the ContainerList expectation for the orphan
+// pre_start cleanup that happens once at the start of every runPreStart call
+// (after the per_replica validation loop). It returns the empty list.
+func expectEmptyOrphanScan(apiClient *mocks.MockAPIClient) *gomock.Call {
+	return apiClient.EXPECT().
+		ContainerList(gomock.Any(), gomock.Any()).
+		Return(client.ContainerListResult{}, nil)
+}
+
+// expectSuccessRemove sets up the ContainerRemove call that runPreStartHook
+// makes after a successful hook run (mirrors old AutoRemove behaviour).
+func expectSuccessRemove(apiClient *mocks.MockAPIClient, hookID string) *gomock.Call {
+	return apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), hookID, client.ContainerRemoveOptions{RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, nil)
+}
+
 func TestPreStart_SuccessTwoHooksInOrder(t *testing.T) {
 	tested, apiClient := newPreStartTestService(t)
 
@@ -81,25 +100,30 @@ func TestPreStart_SuccessTwoHooksInOrder(t *testing.T) {
 	}
 	ctr := container.Summary{ID: "service-ctr-id"}
 
-	// Hook 1: create → wait (subscribe) → logs (subscribe) → start.
+	// Orphan cleanup runs once before the first hook.
+	scan := expectEmptyOrphanScan(apiClient)
+
+	// Hook 1: create → wait (subscribe) → logs (subscribe) → start → remove.
 	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
 	wait1 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(0)).After(create1)
 	logs1 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
 		Return(emptyLogs(), nil).After(wait1)
 	start1 := apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil).After(logs1)
+	remove1 := expectSuccessRemove(apiClient, "hook-1").After(start1)
 
-	// Hook 2 is only created after hook 1 has been started (and waited on).
+	// Hook 2 is only created after hook 1 has been removed.
 	create2 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{ID: "hook-2"}, nil).After(start1)
+		Return(client.ContainerCreateResult{ID: "hook-2"}, nil).After(remove1)
 	wait2 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-2", gomock.Any()).
 		Return(waitResultExit(0)).After(create2)
 	logs2 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-2", gomock.Any()).
 		Return(emptyLogs(), nil).After(wait2)
-	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-2", gomock.Any()).
+	start2 := apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-2", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil).After(logs2)
+	expectSuccessRemove(apiClient, "hook-2").After(start2)
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
 	assert.NilError(t, err)
@@ -119,14 +143,16 @@ func TestPreStart_FirstHookFailsStopsExecution(t *testing.T) {
 	}
 	ctr := container.Summary{ID: "service-ctr-id"}
 
+	scan := expectEmptyOrphanScan(apiClient)
 	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
 	wait1 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(42)).After(create1)
 	logs1 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
 		Return(emptyLogs(), nil).After(wait1)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil).After(logs1)
+	// Hook container is retained on failure — no ContainerRemove expected.
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
 	assert.ErrorContains(t, err, `service "web" pre_start[0]`)
@@ -165,17 +191,19 @@ func TestPreStart_ImageFallsBackToBuiltImage(t *testing.T) {
 	ctr := container.Summary{ID: "service-ctr-id"}
 
 	var gotImage string
+	scan := expectEmptyOrphanScan(apiClient)
 	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ any, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 			gotImage = opts.Config.Image
 			return client.ContainerCreateResult{ID: "hook-1"}, nil
-		})
+		}).After(scan)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil)
 	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
 		Return(emptyLogs(), nil)
 	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(0))
+	expectSuccessRemove(apiClient, "hook-1")
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
 	assert.NilError(t, err)
@@ -196,17 +224,19 @@ func TestPreStart_ExplicitHookImageUsed(t *testing.T) {
 	ctr := container.Summary{ID: "service-ctr-id"}
 
 	var gotImage string
+	scan := expectEmptyOrphanScan(apiClient)
 	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ any, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 			gotImage = opts.Config.Image
 			return client.ContainerCreateResult{ID: "hook-1"}, nil
-		})
+		}).After(scan)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil)
 	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
 		Return(emptyLogs(), nil)
 	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(0))
+	expectSuccessRemove(apiClient, "hook-1")
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
 	assert.NilError(t, err)
@@ -228,23 +258,31 @@ func TestPreStart_VolumesFromServiceContainer(t *testing.T) {
 
 	var gotVolumesFrom []string
 	var gotAutoRemove bool
+	var gotLabels map[string]string
+	scan := expectEmptyOrphanScan(apiClient)
 	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ any, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 			gotVolumesFrom = opts.HostConfig.VolumesFrom
 			gotAutoRemove = opts.HostConfig.AutoRemove
+			gotLabels = opts.Config.Labels
 			return client.ContainerCreateResult{ID: "hook-1"}, nil
-		})
+		}).After(scan)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil)
 	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
 		Return(emptyLogs(), nil)
 	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(0))
+	expectSuccessRemove(apiClient, "hook-1")
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, gotVolumesFrom, []string{"service-ctr-id"})
-	assert.Assert(t, gotAutoRemove)
+	// AutoRemove must be false: the hook container is retained on failure for
+	// post-mortem and explicitly removed on success by runPreStartHook.
+	assert.Assert(t, !gotAutoRemove, "AutoRemove must be false")
+	// HookLabel must be set so orphan cleanup can identify the container.
+	assert.Equal(t, gotLabels[api.HookLabel], preStartHookType)
 }
 
 func TestPreStart_ContainerCreateFailurePropagates(t *testing.T) {
@@ -261,8 +299,9 @@ func TestPreStart_ContainerCreateFailurePropagates(t *testing.T) {
 	}
 	ctr := container.Summary{ID: "service-ctr-id"}
 
+	scan := expectEmptyOrphanScan(apiClient)
 	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{}, fmt.Errorf("no such image: missing:latest"))
+		Return(client.ContainerCreateResult{}, fmt.Errorf("no such image: missing:latest")).After(scan)
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
 	assert.ErrorContains(t, err, "no such image")
@@ -281,8 +320,9 @@ func TestPreStart_ContainerStartFailurePropagates(t *testing.T) {
 	}
 	ctr := container.Summary{ID: "service-ctr-id"}
 
+	scan := expectEmptyOrphanScan(apiClient)
 	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
 	wait1 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(0)).After(create1)
 	logs1 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
@@ -290,8 +330,9 @@ func TestPreStart_ContainerStartFailurePropagates(t *testing.T) {
 	start1 := apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, fmt.Errorf("daemon: container start failed")).After(logs1)
 	// AutoRemove never fires when start fails, so the hook must drop the ghost
-	// container explicitly.
-	apiClient.EXPECT().ContainerRemove(gomock.Any(), "hook-1", gomock.Any()).
+	// container explicitly. This is distinct from the success-path removal
+	// (RemoveVolumes:true) — the never-started container has no logs to preserve.
+	apiClient.EXPECT().ContainerRemove(gomock.Any(), "hook-1", client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
 		Return(client.ContainerRemoveResult{}, nil).After(start1)
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
@@ -324,14 +365,16 @@ func TestPreStart_WaitResultPreferredOverNilError(t *testing.T) {
 	resultC <- container.WaitResponse{StatusCode: 0}
 	errC <- nil
 
+	scan := expectEmptyOrphanScan(apiClient)
 	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
 	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerWaitResult{Result: resultC, Error: errC})
 	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
 		Return(emptyLogs(), nil)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil)
+	expectSuccessRemove(apiClient, "hook-1")
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, func(api.ContainerEvent) {})
 	assert.NilError(t, err)
@@ -399,8 +442,9 @@ func TestPreStart_DetachedModeAttachesLogs(t *testing.T) {
 	}
 	ctr := container.Summary{ID: "service-ctr-id"}
 
+	scan := expectEmptyOrphanScan(apiClient)
 	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
 	wait1 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(0)).After(create1)
 	// ContainerLogs MUST be called even with a nil listener.
@@ -408,6 +452,7 @@ func TestPreStart_DetachedModeAttachesLogs(t *testing.T) {
 		Return(emptyLogs(), nil).After(wait1)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil).After(logs1)
+	expectSuccessRemove(apiClient, "hook-1")
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
 	assert.NilError(t, err)
@@ -435,18 +480,702 @@ func TestPreStart_FailureIncludesTail(t *testing.T) {
 		stdcopyFrame(2, "table 'sites' doesn't exist\n")..., // stderr error
 	)
 
+	scan := expectEmptyOrphanScan(apiClient)
 	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
-		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
 	wait1 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(1)).After(create1)
 	logs1 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
 		Return(io.NopCloser(bytes.NewReader(logContent)), nil).After(wait1)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
 		Return(client.ContainerStartResult{}, nil).After(logs1)
+	// Hook container is retained on failure — no ContainerRemove expected.
 
 	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
 	assert.Assert(t, err != nil)
 	assert.ErrorContains(t, err, "pre_start[0]")
 	// Stderr content must be in the error (stderr bias).
 	assert.ErrorContains(t, err, "doesn't exist")
+}
+
+// ---------------------------------------------------------------------------
+// Feature tests: pre_start container retention on failure
+// ---------------------------------------------------------------------------
+
+// TestPreStart_SuccessRemovesContainer verifies that a successful pre_start hook
+// triggers an explicit ContainerRemove (with RemoveVolumes: true to mirror the
+// old AutoRemove behaviour) and that AutoRemove is false at create time.
+func TestPreStart_SuccessRemovesContainer(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	var gotAutoRemove bool
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
+			gotAutoRemove = opts.HostConfig.AutoRemove
+			return client.ContainerCreateResult{ID: "hook-1"}, nil
+		}).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	// Success path: explicit remove with RemoveVolumes: true.
+	apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "hook-1", client.ContainerRemoveOptions{RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, nil)
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+	assert.Assert(t, !gotAutoRemove, "AutoRemove must be false; retention is managed explicitly")
+}
+
+// TestPreStart_FailureRetainsContainer verifies that a pre_start hook that exits
+// with a non-zero code does NOT trigger ContainerRemove — the container is kept
+// for post-mortem inspection.
+func TestPreStart_FailureRetainsContainer(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"migrate"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	logContent := stdcopyFrame(2, "migration failed: table missing\n")
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(1))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(io.NopCloser(bytes.NewReader(logContent)), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	// No ContainerRemove expectation: gomock fails on unexpected calls.
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.ErrorContains(t, err, "pre_start[0]")
+	assert.ErrorContains(t, err, "table missing")
+	// Short container ID must appear in the error so the operator can run
+	// `docker logs hook-1` immediately.
+	assert.ErrorContains(t, err, "hook-1")
+}
+
+// TestPreStart_CancellationRemovesContainer verifies that when the context is
+// cancelled while a hook is running the container is removed (not retained) and
+// the error is exactly ctx.Err() with no tail decoration.
+func TestPreStart_CancellationRemovesContainer(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"long-running-op"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-cancel-123"}, nil).After(scan)
+	// ContainerWait channel: cancel the context before delivering any result so
+	// waitPreStart returns ctx.Err().
+	resultC := make(chan container.WaitResponse)
+	errC := make(chan error)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-cancel-123", gomock.Any()).
+		Return(client.ContainerWaitResult{Result: resultC, Error: errC})
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-cancel-123", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-cancel-123", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	// On cancellation the container must be removed, not retained.
+	apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "hook-cancel-123", client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- tested.runPreStart(ctx, project, service, ctr, nil)
+	}()
+	// Cancel after the hook container has started.
+	cancel()
+
+	err := <-errCh
+	assert.ErrorIs(t, err, context.Canceled, "must return ctx.Err() on cancellation")
+	// The error must NOT include "retained" — it should be the raw context error.
+	assert.Assert(t, !strings.Contains(err.Error(), "retained"), "cancelled hook must not be retained; got: %s", err)
+}
+
+// TestPreStart_RemovesOrphanBeforeRun verifies that a hook container left behind
+// by a previous failed run is force-removed before the new container is created.
+func TestPreStart_RemovesOrphanBeforeRun(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"migrate"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	// ContainerList returns the stale orphan from a previous run.
+	orphan := container.Summary{ID: "orphan-hook-123", State: "exited"}
+	scan := apiClient.EXPECT().ContainerList(gomock.Any(), gomock.Any()).
+		Return(client.ContainerListResult{Items: []container.Summary{orphan}}, nil)
+	// Orphan must be removed before the new hook container is created.
+	removeOrphan := apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "orphan-hook-123", client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, nil).After(scan)
+	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(removeOrphan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0)).After(create1)
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	expectSuccessRemove(apiClient, "hook-1")
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+}
+
+// TestPreStart_SuccessRemoveFailureIsNonFatal verifies that a ContainerRemove
+// failure on the success path is logged but does not fail runPreStart.
+func TestPreStart_SuccessRemoveFailureIsNonFatal(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	// Simulate a removal failure.
+	apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "hook-1", client.ContainerRemoveOptions{RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, fmt.Errorf("already removed"))
+
+	// The hook succeeded; the service must start even if removal failed.
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Coverage-gap tests: previously uncovered branches
+// ---------------------------------------------------------------------------
+
+// TestLowestNumberedContainer verifies that lowestNumberedContainer always
+// picks the replica with the smallest ContainerNumberLabel value.
+func TestLowestNumberedContainer(t *testing.T) {
+	makeCtr := func(id, num string) container.Summary {
+		return container.Summary{ID: id, Labels: map[string]string{
+			api.ContainerNumberLabel: num,
+		}}
+	}
+	tests := []struct {
+		name       string
+		containers Containers
+		wantID     string
+	}{
+		{"single", Containers{makeCtr("a", "1")}, "a"},
+		{"ascending", Containers{makeCtr("a", "1"), makeCtr("b", "2"), makeCtr("c", "3")}, "a"},
+		{"descending", Containers{makeCtr("a", "3"), makeCtr("b", "2"), makeCtr("c", "1")}, "c"},
+		{"unordered", Containers{makeCtr("a", "5"), makeCtr("b", "1"), makeCtr("c", "3")}, "b"},
+		{"missing_label", Containers{makeCtr("x", ""), makeCtr("y", "1")}, "x"}, // strconv.Atoi("") = 0 = lowest
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lowestNumberedContainer(tc.containers)
+			assert.Equal(t, got.ID, tc.wantID)
+		})
+	}
+}
+
+// TestPreStart_WaitCancelled covers the ctx.Done() branch in waitPreStart:
+// when the context is already canceled the function must return ctx.Err()
+// without blocking on the result or error channels.
+func TestPreStart_WaitCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // already canceled
+
+	resultC := make(chan container.WaitResponse) // never sends
+	errC := make(chan error)                     // never sends
+	waitRes := client.ContainerWaitResult{Result: resultC, Error: errC}
+
+	err := waitPreStart(ctx, "web", 0, waitRes)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestPreStart_ResultErrWaitError covers the preStartResultErr branch where
+// the WaitResponse carries a daemon-reported error message.
+func TestPreStart_ResultErrWaitError(t *testing.T) {
+	res := container.WaitResponse{
+		Error: &container.WaitExitError{Message: "oom killed"},
+	}
+	err := preStartResultErr("web", 0, res)
+	assert.ErrorContains(t, err, "wait error")
+	assert.ErrorContains(t, err, "oom killed")
+}
+
+// TestPreStart_StreamLogsError_NilListener covers the ContainerLogs-failure
+// branch in streamPreStartLogs when the caller passes no listener.
+// The hook must still start and succeed; the missing log stream is non-fatal.
+func TestPreStart_StreamLogsError_NilListener(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+	// ContainerLogs fails; nil listener → no warning event, done closed immediately.
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(nil, fmt.Errorf("logs: connection refused"))
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	expectSuccessRemove(apiClient, "hook-1")
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+}
+
+// TestPreStart_StreamLogsError_WithListener covers the ContainerLogs-failure
+// branch in streamPreStartLogs when a listener IS present: a warning event
+// must be emitted on the listener.
+func TestPreStart_StreamLogsError_WithListener(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(nil, fmt.Errorf("logs: daemon unavailable"))
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	expectSuccessRemove(apiClient, "hook-1")
+
+	var gotWarning string
+	listener := func(ev api.ContainerEvent) {
+		gotWarning = ev.Line
+	}
+	err := tested.runPreStart(t.Context(), project, service, ctr, listener)
+	assert.NilError(t, err)
+	assert.Assert(t, gotWarning != "", "listener must receive a warning when ContainerLogs fails")
+	assert.Assert(t, bytes.Contains([]byte(gotWarning), []byte("warning")), "expected 'warning' in: %q", gotWarning)
+}
+
+// TestPreStart_OldAPIVersion covers the versions.LessThan(apiVersion, "1.44")
+// branch in createPreStartContainer: on a pre-1.44 daemon the extra-networks
+// path runs via connectPreStartExtraNetworks. With only one (primary) network
+// no NetworkConnect call is issued and the hook succeeds normally.
+func TestPreStart_OldAPIVersion(t *testing.T) {
+	tested, apiClient := newPreStartTestServiceWithVersion(t, "1.43")
+
+	project := &types.Project{
+		Name: "proj",
+		Networks: types.Networks{
+			"default": {Name: "proj_default"},
+		},
+	}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		Networks: map[string]*types.ServiceNetworkConfig{
+			"default": nil,
+		},
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	// Single network = primary only; no NetworkConnect expected.
+	expectSuccessRemove(apiClient, "hook-1")
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+}
+
+// TestPreStart_ConnectExtraNetworksSuccess covers connectPreStartExtraNetworks
+// when a secondary network is present: NetworkConnect must be called for it.
+func TestPreStart_ConnectExtraNetworksSuccess(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{
+		Name: "proj",
+		Networks: types.Networks{
+			"default": {Name: "proj_default"},
+			"extra":   {Name: "proj_extra"},
+		},
+	}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		Networks: map[string]*types.ServiceNetworkConfig{
+			"default": nil,
+			"extra":   nil,
+		},
+	}
+
+	apiClient.EXPECT().
+		NetworkConnect(gomock.Any(), "proj_extra", gomock.Any()).
+		Return(client.NetworkConnectResult{}, nil)
+
+	err := tested.connectPreStartExtraNetworks(t.Context(), project, service, "ctr-id", "proj_default")
+	assert.NilError(t, err)
+}
+
+// TestPreStart_ConnectExtraNetworksFails covers the NetworkConnect error branch
+// in connectPreStartExtraNetworks.
+func TestPreStart_ConnectExtraNetworksFails(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{
+		Name: "proj",
+		Networks: types.Networks{
+			"default": {Name: "proj_default"},
+			"extra":   {Name: "proj_extra"},
+		},
+	}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		Networks: map[string]*types.ServiceNetworkConfig{
+			"default": nil,
+			"extra":   nil,
+		},
+	}
+
+	apiClient.EXPECT().
+		NetworkConnect(gomock.Any(), "proj_extra", gomock.Any()).
+		Return(client.NetworkConnectResult{}, fmt.Errorf("network not found"))
+
+	err := tested.connectPreStartExtraNetworks(t.Context(), project, service, "ctr-id", "proj_default")
+	assert.ErrorContains(t, err, "network not found")
+}
+
+// TestPreStart_ContainerStartFailureAndRemoveFails covers the Warnf path in
+// runPreStartHook when ContainerStart fails AND the subsequent ContainerRemove
+// also fails (the orphan is unremovable but the caller still gets the start error).
+func TestPreStart_ContainerStartFailureAndRemoveFails(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0)).After(create1)
+	logs1 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	start1 := apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, fmt.Errorf("start failed")).After(logs1)
+	// Both the start AND the cleanup removal fail.
+	apiClient.EXPECT().ContainerRemove(gomock.Any(), "hook-1", client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, fmt.Errorf("removal failed")).After(start1)
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	// The original start error must be returned, not the removal error.
+	assert.ErrorContains(t, err, "start failed")
+}
+
+// TestPreStart_OrphanScanFails verifies that when ContainerList fails during
+// orphan cleanup the Warnf path in runPreStart is hit, but execution continues
+// and the hook runs successfully.
+func TestPreStart_OrphanScanFails(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	// ContainerList fails → Warnf in runPreStart; hook still proceeds.
+	apiClient.EXPECT().ContainerList(gomock.Any(), gomock.Any()).
+		Return(client.ContainerListResult{}, fmt.Errorf("daemon unavailable"))
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	expectSuccessRemove(apiClient, "hook-1")
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+}
+
+// TestPreStart_OrphanRemovalFails verifies the Warnf path in
+// removeOrphanPreStartContainers when an individual stale container cannot be
+// removed. The hook must still proceed normally.
+func TestPreStart_OrphanRemovalFails(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	orphan := container.Summary{ID: "orphan-123"}
+	// ContainerList finds the orphan; its removal fails → Warnf then continue.
+	apiClient.EXPECT().ContainerList(gomock.Any(), gomock.Any()).
+		Return(client.ContainerListResult{Items: []container.Summary{orphan}}, nil)
+	apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "orphan-123", client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, fmt.Errorf("permission denied"))
+	// Hook still runs and succeeds.
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+	expectSuccessRemove(apiClient, "hook-1")
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+}
+
+// TestPreStart_OldAPINetworkConnectFails covers the createPreStartContainer path
+// for API < 1.44 with a secondary network: when NetworkConnect fails the function
+// must clean up the created-but-never-started container and return the error.
+func TestPreStart_OldAPINetworkConnectFails(t *testing.T) {
+	tested, apiClient := newPreStartTestServiceWithVersion(t, "1.43")
+
+	project := &types.Project{
+		Name: "proj",
+		Networks: types.Networks{
+			"default": {Name: "proj_default"},
+			"extra":   {Name: "proj_extra"},
+		},
+	}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		Networks: map[string]*types.ServiceNetworkConfig{
+			"default": nil,
+			"extra":   nil,
+		},
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	// NetworkConnect for the secondary network fails.
+	apiClient.EXPECT().NetworkConnect(gomock.Any(), "proj_extra", gomock.Any()).
+		Return(client.NetworkConnectResult{}, fmt.Errorf("network not found"))
+	// The never-started container is cleaned up (Force:true).
+	apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "hook-1", client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, nil)
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.ErrorContains(t, err, "network not found")
+}
+
+// TestPreStart_OldAPINetworkConnectAndRemoveFails covers the Warnf path inside
+// createPreStartContainer when both NetworkConnect and the cleanup ContainerRemove fail.
+func TestPreStart_OldAPINetworkConnectAndRemoveFails(t *testing.T) {
+	tested, apiClient := newPreStartTestServiceWithVersion(t, "1.43")
+
+	project := &types.Project{
+		Name: "proj",
+		Networks: types.Networks{
+			"default": {Name: "proj_default"},
+			"extra":   {Name: "proj_extra"},
+		},
+	}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		Networks: map[string]*types.ServiceNetworkConfig{
+			"default": nil,
+			"extra":   nil,
+		},
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().NetworkConnect(gomock.Any(), "proj_extra", gomock.Any()).
+		Return(client.NetworkConnectResult{}, fmt.Errorf("network not found"))
+	// Cleanup removal also fails → Warnf; original error is still returned.
+	apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "hook-1", client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, fmt.Errorf("removal also failed"))
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.ErrorContains(t, err, "network not found")
+}
+
+// TestPreStart_RuntimeAPIVersionError covers the early-return in
+// createPreStartContainer when RuntimeAPIVersion fails (Ping returns an error).
+func TestPreStart_RuntimeAPIVersionError(t *testing.T) {
+	ignoreExisting := goleak.IgnoreCurrent()
+	t.Cleanup(func() { goleak.VerifyNone(t, ignoreExisting) })
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+	apiClient := mocks.NewMockAPIClient(mockCtrl)
+	cli := mocks.NewMockCli(mockCtrl)
+	cli.EXPECT().Client().Return(apiClient).AnyTimes()
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+	s := tested.(*composeService)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	// Orphan scan succeeds (ContainerList does not need Ping).
+	apiClient.EXPECT().ContainerList(gomock.Any(), gomock.Any()).
+		Return(client.ContainerListResult{}, nil)
+	// createPreStartContainer calls RuntimeAPIVersion → Ping fails.
+	apiClient.EXPECT().
+		Ping(gomock.Any(), client.PingOptions{NegotiateAPIVersion: true}).
+		Return(client.PingResult{}, fmt.Errorf("daemon unreachable"))
+
+	err = s.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.ErrorContains(t, err, "daemon unreachable")
+}
+
+// TestPreStart_FailureStdoutOnlyTail covers the stdout-fallback branch in the
+// getTail closure inside streamPreStartLogs: when stderr is empty but stdout has
+// content, getTail must return the stdout content.
+func TestPreStart_FailureStdoutOnlyTail(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "proj"}
+	service := types.ServiceConfig{
+		Name:  "db",
+		Image: "postgres",
+		PreStart: []types.ServiceHook{
+			{Image: "postgres", Command: types.ShellCommand{"migrate"}},
+		},
+	}
+	ctr := container.Summary{ID: "svc-ctr"}
+
+	// stdout-only content: stderr frame absent so getTail falls back to stdout.
+	logContent := stdcopyFrame(1, "migration failed: schema mismatch\n")
+
+	scan := expectEmptyOrphanScan(apiClient)
+	apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil).After(scan)
+	apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(1))
+	apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(io.NopCloser(bytes.NewReader(logContent)), nil)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil)
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.ErrorContains(t, err, "pre_start[0]")
+	// Stdout fallback: no stderr → stdout content appears in the error.
+	assert.ErrorContains(t, err, "schema mismatch")
 }

--- a/pkg/compose/pre_start_test.go
+++ b/pkg/compose/pre_start_test.go
@@ -367,3 +367,86 @@ func TestWaitPreStart_RaceRealErrorAndResult(t *testing.T) {
 		assert.ErrorContains(t, err, "connection lost")
 	}
 }
+
+// stdcopyFrame encodes a single stdcopy-multiplexed frame.
+// stream: 1=stdout, 2=stderr. Returns the encoded bytes.
+// This helper is kept local (not using writeStdcopyFrame from hook_test.go)
+// because hook_test.go carries a //go:build !windows constraint.
+func stdcopyFrame(stream byte, data string) []byte {
+	payload := []byte(data)
+	header := [8]byte{stream, 0, 0, 0}
+	header[4] = byte(len(payload) >> 24)
+	header[5] = byte(len(payload) >> 16)
+	header[6] = byte(len(payload) >> 8)
+	header[7] = byte(len(payload))
+	return append(header[:], payload...)
+}
+
+// TestPreStart_DetachedModeAttachesLogs verifies that ContainerLogs is opened
+// even when listener is nil (detached / compose up -d). Previously
+// streamPreStartLogs short-circuited and returned immediately, leaving the tail
+// buffer empty and any failure error without output context.
+func TestPreStart_DetachedModeAttachesLogs(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "demo"}
+	service := types.ServiceConfig{
+		Name:  "web",
+		Image: "alpine",
+		PreStart: []types.ServiceHook{
+			{Image: "alpine", Command: types.ShellCommand{"true"}},
+		},
+	}
+	ctr := container.Summary{ID: "service-ctr-id"}
+
+	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+	wait1 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(0)).After(create1)
+	// ContainerLogs MUST be called even with a nil listener.
+	logs1 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil).After(wait1)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil).After(logs1)
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.NilError(t, err)
+}
+
+// TestPreStart_FailureIncludesTail verifies that when a pre_start hook exits
+// with a non-zero code the error message includes the captured stderr output,
+// giving operators the context they need to diagnose the failure.
+func TestPreStart_FailureIncludesTail(t *testing.T) {
+	tested, apiClient := newPreStartTestService(t)
+
+	project := &types.Project{Name: "demo"}
+	service := types.ServiceConfig{
+		Name:  "db",
+		Image: "postgres",
+		PreStart: []types.ServiceHook{
+			{Image: "postgres", Command: types.ShellCommand{"migrate"}},
+		},
+	}
+	ctr := container.Summary{ID: "service-ctr-id"}
+
+	// Build a stdcopy-multiplexed log stream with a stderr error line.
+	logContent := append(
+		stdcopyFrame(1, "starting migration\n"),             // stdout noise
+		stdcopyFrame(2, "table 'sites' doesn't exist\n")..., // stderr error
+	)
+
+	create1 := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		Return(client.ContainerCreateResult{ID: "hook-1"}, nil)
+	wait1 := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
+		Return(waitResultExit(1)).After(create1)
+	logs1 := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(io.NopCloser(bytes.NewReader(logContent)), nil).After(wait1)
+	apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
+		Return(client.ContainerStartResult{}, nil).After(logs1)
+
+	err := tested.runPreStart(t.Context(), project, service, ctr, nil)
+	assert.Assert(t, err != nil)
+	assert.ErrorContains(t, err, "pre_start[0]")
+	// Stderr content must be in the error (stderr bias).
+	assert.ErrorContains(t, err, "doesn't exist")
+}

--- a/pkg/compose/start_test.go
+++ b/pkg/compose/start_test.go
@@ -203,20 +203,35 @@ func TestStartService_PreStartOnLowestReplica(t *testing.T) {
 	replica1 := serviceContainer("web", 1, container.StateExited)
 	containers := Containers{replica2, replica1}
 
+	// runPreStart sweeps orphan hook containers from any previous failed run
+	// before creating the new one.
+	orphanScan := apiClient.EXPECT().
+		ContainerList(gomock.Any(), gomock.Any()).
+		Return(client.ContainerListResult{}, nil)
+
 	// The hook container shares the volumes of the lowest-numbered replica.
 	hookCreate := apiClient.EXPECT().ContainerCreate(gomock.Any(), gomock.Any()).
+		After(orphanScan).
 		DoAndReturn(func(_ context.Context, opts client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 			assert.DeepEqual(t, opts.HostConfig.VolumesFrom, []string{replica1.ID})
 			return client.ContainerCreateResult{ID: "hook-1"}, nil
 		})
 	hookWait := apiClient.EXPECT().ContainerWait(gomock.Any(), "hook-1", gomock.Any()).
 		Return(waitResultExit(0)).After(hookCreate)
+	// streamPreStartLogs always opens ContainerLogs (even with nil listener) so
+	// the tail is available for failure error messages.
+	hookLogs := apiClient.EXPECT().ContainerLogs(gomock.Any(), "hook-1", gomock.Any()).
+		Return(emptyLogs(), nil).After(hookWait)
 	hookStart := apiClient.EXPECT().ContainerStart(gomock.Any(), "hook-1", gomock.Any()).
-		Return(client.ContainerStartResult{}, nil).After(hookWait)
+		Return(client.ContainerStartResult{}, nil).After(hookLogs)
+	// On success the hook container is removed explicitly (AutoRemove is false).
+	hookRemove := apiClient.EXPECT().
+		ContainerRemove(gomock.Any(), "hook-1", client.ContainerRemoveOptions{RemoveVolumes: true}).
+		Return(client.ContainerRemoveResult{}, nil).After(hookStart)
 
 	// Replicas are then started sequentially, in list order, after the hook.
 	start2 := apiClient.EXPECT().ContainerStart(gomock.Any(), replica2.ID, gomock.Any()).
-		Return(client.ContainerStartResult{}, nil).After(hookStart)
+		Return(client.ContainerStartResult{}, nil).After(hookRemove)
 	apiClient.EXPECT().ContainerStart(gomock.Any(), replica1.ID, gomock.Any()).
 		Return(client.ContainerStartResult{}, nil).After(start2)
 


### PR DESCRIPTION
## What this PR delivers

Builds on #14088 (merged), which added the hook output tail and error reporting foundation.

**Context cancellation fix:** `runHook` previously blocked indefinitely on the exec-attach reader. The copy goroutine held the connection open, so the first Ctrl+C had no effect — only the OS kill on the second signal interrupted the process, skipping cleanup. Fix: run the copy in a background goroutine and `select` on `ctx.Done()` vs completion; on cancellation, close the connection to unblock the goroutine and return `ctx.Err()` directly (no `ExecInspect` on the cancel path). Restores the behaviour of the old `runWaitExec`.

**outputTail robustness:**
- `Write()` rewritten to block-scan with `bytes.IndexByte` (O(n) vs O(n²) byte-by-byte loop); partial line byte-capped via `appendToPartial`.
- `strings.ToValidUTF8` applied at both truncation sites so a cut multi-byte rune does not corrupt the error message.
- `pushLine` handles mid-line `\r` (progress bars from curl/apt/pip): strip trailing `\r`, then keep the segment after the last bare `\r`.

**pre_start parity (from #14088 base):** log stream always opened even without a listener so the tail is populated in detached mode; stderr-biased error reporting.

## What was intentionally excluded

The client-side NDJSON hook-log store and `compose logs --hooks` flag were prototyped in an earlier revision of this branch but have been dropped. Persisting hook output belongs in the engine (see moby/moby#32047, moby/moby#9527), not as a client-side workaround. That work is deferred until an engine-native solution exists.

## Testing

- `TestRunHook_ContextCancellation`: net.Pipe that never writes; asserts `context.Canceled` within 5 s of `cancel()`.
- `TestRunHook_FailureIncludesOutput/with_listener`: asserts listener receives all output lines on failure.
- `TestRunHook_StderrBias`: uses a capturing listener; asserts both stream lines are delivered.
- `TestOutputTail`: CRLF stripping, progress-bar `\r`, UTF-8-safe byte truncation.