### PR TITLE
[PoC] hook logs through the engine: compose logs --hooks

### DIFF
--- a/cmd/compose/logs.go
+++ b/cmd/compose/logs.go
@@ -40,6 +40,7 @@ type logsOptions struct {
 	noColor    bool
 	noPrefix   bool
 	timestamps bool
+	hooks      bool
 }
 
 func logsCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *BackendOptions) *cobra.Command {
@@ -71,6 +72,7 @@ func logsCommand(p *ProjectOptions, dockerCli command.Cli, backendOptions *Backe
 	flags.BoolVar(&opts.noColor, "no-color", false, "Produce monochrome output")
 	flags.BoolVar(&opts.noPrefix, "no-log-prefix", false, "Don't print prefix in logs")
 	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps")
+	flags.BoolVar(&opts.hooks, "hooks", false, "Include the output of lifecycle hooks (PoC, requires engine API v1.56)")
 	flags.SetAnnotation("timestamps", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#timestamps"}) //nolint:errcheck
 	flags.StringVarP(&opts.tail, "tail", "n", "all", "Number of lines to show from the end of the logs for each container")
 	flags.SetAnnotation("tail", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/container/logs/#tail"}) //nolint:errcheck
@@ -106,6 +108,7 @@ func runLogs(ctx context.Context, dockerCli command.Cli, backendOptions *Backend
 		Since:      opts.since,
 		Until:      opts.until,
 		Timestamps: opts.timestamps,
+		Hooks:      opts.hooks,
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -219,3 +219,7 @@ exclude (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 )
+
+replace github.com/moby/moby/api => github.com/ndeloof/docker/api v0.0.0-20260819110214-21c8742baa27
+
+replace github.com/moby/moby/client => github.com/ndeloof/docker/client v0.0.0-20260819110214-21c8742baa27

--- a/go.sum
+++ b/go.sum
@@ -411,10 +411,6 @@ github.com/moby/go-archive v0.3.3 h1:OxxR9paxsluYi+zDUEXTTaIxtkK3viymW+Ka7vRhhME
 github.com/moby/go-archive v0.3.3/go.mod h1:Npdv43fFqlhZW7Xo8fbm3ZMYFvAGNviUPqX21VERbcE=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/moby/api v1.55.0 h1:2/sexvQyqIWS8pRSCFddBfpW2qE7vR7FCL+vN8pxwMc=
-github.com/moby/moby/api v1.55.0/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
-github.com/moby/moby/client v0.5.1 h1:tYNaJno4c0HXz12y5BiqEDy0rVTYkWzI26lGvnTMiJw=
-github.com/moby/moby/client v0.5.1/go.mod h1:odLstlZ6uSnfvAgVxMpvgmb8SUdd+siH2T0GBuxVAlM=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/policy-helpers v0.0.0-20260722051018-856be88baec4 h1:3uAZ4pSEOHW0dCkXOxb50ux0YE69lNCwr5MnT2Vf0O8=
@@ -445,6 +441,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
+github.com/ndeloof/docker/api v0.0.0-20260819110214-21c8742baa27 h1:FA5+p99g7vUHo7UZLJlgr3KX0OA38WBVVxmqW4UqIJs=
+github.com/ndeloof/docker/api v0.0.0-20260819110214-21c8742baa27/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
+github.com/ndeloof/docker/client v0.0.0-20260819110214-21c8742baa27 h1:YRuLUDDKi0ZvhSpoNPfqR6IvnLvrd3IotHrJxRv/NP8=
+github.com/ndeloof/docker/client v0.0.0-20260819110214-21c8742baa27/go.mod h1:odLstlZ6uSnfvAgVxMpvgmb8SUdd+siH2T0GBuxVAlM=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/open-policy-agent/opa v1.14.1 h1:MhurLB9mSbXmojYFCmGbiC1Uagu1+aFAV4XVotDA86M=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -630,6 +630,9 @@ type LogOptions struct {
 	Until      string
 	Follow     bool
 	Timestamps bool
+	// Hooks includes the captured output of lifecycle hooks (PoC), labeled
+	// with the hook type.
+	Hooks bool
 }
 
 // PauseOptions group options of the Pause API

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -27,6 +27,9 @@ const (
 	ProjectLabel = "com.docker.compose.project"
 	// ServiceLabel allow to track resource related to a compose service
 	ServiceLabel = "com.docker.compose.service"
+	// HookLabel is set on lifecycle-hook execs (and stamped on their captured
+	// log messages) with the hook type: "post_start" or "pre_stop". PoC.
+	HookLabel = "com.docker.compose.hook"
 	// ConfigHashLabel stores configuration hash for a compose service
 	ConfigHashLabel = "com.docker.compose.config-hash"
 	// ContainerNumberLabel stores the container index of a replicated service

--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -603,7 +603,7 @@ func (s *composeService) startServiceContainer(ctx context.Context, project *typ
 	}
 
 	for _, hook := range service.PostStart {
-		if err := s.runHook(ctx, ctr, service, hook, listener); err != nil {
+		if err := s.runHook(ctx, ctr, service, hook, "post_start", listener); err != nil {
 			return err
 		}
 	}

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -287,7 +287,7 @@ func (s *composeService) stopContainer(ctx context.Context, service *types.Servi
 
 	if service != nil {
 		for _, hook := range service.PreStop {
-			err := s.runHook(ctx, ctr, *service, hook, listener)
+			err := s.runHook(ctx, ctr, *service, hook, "pre_stop", listener)
 			if err != nil {
 				// Ignore errors indicating that some containers were already stopped or removed.
 				if errdefs.IsNotFound(err) || errdefs.IsConflict(err) {

--- a/pkg/compose/hook.go
+++ b/pkg/compose/hook.go
@@ -31,7 +31,7 @@ import (
 	"github.com/docker/compose/v5/pkg/utils"
 )
 
-func (s *composeService) runHook(ctx context.Context, ctr container.Summary, service types.ServiceConfig, hook types.ServiceHook, listener api.ContainerEventListener) error {
+func (s *composeService) runHook(ctx context.Context, ctr container.Summary, service types.ServiceConfig, hook types.ServiceHook, hookType string, listener api.ContainerEventListener) error {
 	wOut := utils.GetWriter(func(line string) {
 		listener(api.ContainerEvent{
 			Type:    api.HookEventLog,
@@ -52,6 +52,16 @@ func (s *composeService) runHook(ctx context.Context, ctr container.Summary, ser
 		Cmd:          hook.Command,
 		AttachStdout: !detached,
 		AttachStderr: !detached,
+		// PoC: tee the hook output into the container's logging driver,
+		// stamped with the hook's identity, so `compose logs --hooks` can
+		// surface it later without any client-side state. Daemons whose API
+		// predates CaptureLogs simply ignore both fields.
+		CaptureLogs: true,
+		Labels: map[string]string{
+			api.ProjectLabel: ctr.Labels[api.ProjectLabel],
+			api.ServiceLabel: service.Name,
+			api.HookLabel:    hookType,
+		},
 	})
 	if err != nil {
 		return err

--- a/pkg/compose/hook_logs.go
+++ b/pkg/compose/hook_logs.go
@@ -1,0 +1,63 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/docker/compose/v5/pkg/api"
+)
+
+// hookLogLine is a details-decorated log line split into its parts. The
+// engine formats such lines as "k=v,k2=v2 payload" — attributes sorted,
+// url-encoded, comma-joined, then a single space and the payload; the
+// attribute block is empty for messages carrying no attributes.
+type hookLogLine struct {
+	// Hook is the hook type stamped by compose on captured hook execs
+	// (post_start, pre_stop); empty for regular container output.
+	Hook    string
+	Payload string
+}
+
+// parseDetailsLine splits a details-decorated log line and extracts the
+// compose hook identity, if any. timestamps indicates the line starts with
+// an RFC3339 timestamp (the engine puts it before the attribute block);
+// it is re-attached to the payload so display is unchanged.
+func parseDetailsLine(line string, timestamps bool) hookLogLine {
+	ts := ""
+	if timestamps {
+		if i := strings.IndexByte(line, ' '); i >= 0 {
+			ts, line = line[:i+1], line[i+1:]
+		}
+	}
+	attrs, payload, ok := strings.Cut(line, " ")
+	if !ok {
+		return hookLogLine{Payload: ts + line}
+	}
+	l := hookLogLine{Payload: ts + payload}
+	for _, kv := range strings.Split(attrs, ",") {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k != api.HookLabel {
+			continue
+		}
+		if hook, err := url.QueryUnescape(v); err == nil {
+			l.Hook = hook
+		}
+	}
+	return l
+}

--- a/pkg/compose/hook_logs_test.go
+++ b/pkg/compose/hook_logs_test.go
@@ -1,0 +1,54 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseDetailsLine(t *testing.T) {
+	t.Run("hook line", func(t *testing.T) {
+		l := parseDetailsLine("com.docker.compose.hook=post_start,com.docker.compose.service=db,exec_id=abc123 SQL ready", false)
+		assert.Equal(t, l.Hook, "post_start")
+		assert.Equal(t, l.Payload, "SQL ready")
+	})
+
+	t.Run("plain container line carries an empty attribute block", func(t *testing.T) {
+		l := parseDetailsLine(" hello world", false)
+		assert.Equal(t, l.Hook, "")
+		assert.Equal(t, l.Payload, "hello world")
+	})
+
+	t.Run("line with non-hook attributes", func(t *testing.T) {
+		l := parseDetailsLine("env=prod hello", false)
+		assert.Equal(t, l.Hook, "")
+		assert.Equal(t, l.Payload, "hello")
+	})
+
+	t.Run("timestamps precede the attribute block and stay on the payload", func(t *testing.T) {
+		l := parseDetailsLine("2026-08-19T10:00:00.000000000Z com.docker.compose.hook=pre_stop bye", true)
+		assert.Equal(t, l.Hook, "pre_stop")
+		assert.Equal(t, l.Payload, "2026-08-19T10:00:00.000000000Z bye")
+	})
+
+	t.Run("url-encoded value", func(t *testing.T) {
+		l := parseDetailsLine("com.docker.compose.hook=post%5Fstart go", false)
+		assert.Equal(t, l.Hook, "post_start")
+	})
+}

--- a/pkg/compose/hook_test.go
+++ b/pkg/compose/hook_test.go
@@ -109,7 +109,7 @@ func TestRunHook_ConsoleSize(t *testing.T) {
 			assert.NilError(t, err)
 
 			noopListener := func(api.ContainerEvent) {}
-			err = s.(*composeService).runHook(t.Context(), ctr, service, hook, noopListener)
+			err = s.(*composeService).runHook(t.Context(), ctr, service, hook, "post_start", noopListener)
 			assert.NilError(t, err)
 		})
 	}

--- a/pkg/compose/logs.go
+++ b/pkg/compose/logs.go
@@ -145,15 +145,29 @@ func (s *composeService) doLogContainer(ctx context.Context, consumer api.LogCon
 		Until:      options.Until,
 		Tail:       options.Tail,
 		Timestamps: options.Timestamps,
+		// PoC: details expose the per-message attributes hook execs are
+		// stamped with, letting hook output be told apart and labeled
+		Details: options.Hooks,
 	})
 	if err != nil {
 		return err
 	}
 	defer r.Close() //nolint:errcheck
 
-	w := utils.GetWriter(func(line string) {
+	sink := func(line string) {
 		consumer.Log(name, line)
-	})
+	}
+	if options.Hooks {
+		sink = func(line string) {
+			parsed := parseDetailsLine(line, options.Timestamps)
+			if parsed.Hook != "" {
+				consumer.Log(name+" ["+parsed.Hook+"]", parsed.Payload)
+				return
+			}
+			consumer.Log(name, parsed.Payload)
+		}
+	}
+	w := utils.GetWriter(sink)
 	if ctr.Config.Tty {
 		_, err = io.Copy(w, r)
 	} else {

--- a/pkg/compose/restart.go
+++ b/pkg/compose/restart.go
@@ -108,7 +108,7 @@ func (s *composeService) prepareRestartProject(ctx context.Context, containers C
 // hooks around the restart
 func (s *composeService) restartContainer(ctx context.Context, def types.ServiceConfig, ctr container.Summary, options api.RestartOptions) error {
 	for _, hook := range def.PreStop {
-		err := s.runHook(ctx, ctr, def, hook, nil)
+		err := s.runHook(ctx, ctr, def, hook, "post_start", nil)
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func (s *composeService) restartContainer(ctx context.Context, def types.Service
 	}
 	s.events.On(newEvent(eventName, api.Done, api.StatusStarted))
 	for _, hook := range def.PostStart {
-		err := s.runHook(ctx, ctr, def, hook, nil)
+		err := s.runHook(ctx, ctr, def, hook, "post_start", nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -112,7 +112,7 @@ func (s *composeService) runPostStartHooksOnEvent(ctx context.Context, container
 	}
 
 	for _, hook := range service.PostStart {
-		if err := s.runHook(ctx, ctr, service, hook, nil); err != nil {
+		if err := s.runHook(ctx, ctr, service, hook, "post_start", nil); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
PoC consuming moby/moby#53407 (opt-in capture of exec output through the container's logging driver, moby/moby#53406): lifecycle hooks get durable, attributable logs — with zero client-side state.

- hook execs are created with `CaptureLogs: true` and the compose identity labels (project, service, and a new `com.docker.compose.hook` label carrying `post_start`/`pre_stop`); the engine stamps every captured line with them
- `docker compose logs --hooks` requests the log details and labels hook lines with their hook type:

```
test-1 [post_start]  | post_start hook - warming cache for 6d190474fcf2
test-1 [post_start]  | post_start hook - cache warmed (stderr)
test-1 [pre_stop]    | pre_stop hook - flushing state before shutdown
```

Verified end to end against a daemon built from the moby branch (API v1.56): hook output is retrievable **after the exec is long gone** — including `pre_stop` output after `compose stop` — from any client, since the attribution travels in the engine's own log stream. This is the stateless alternative to the client-side store explored in #14091.

Graceful degradation both ways: daemons whose API predates `CaptureLogs` ignore the capture fields (hooks behave exactly as today), and without `--hooks` the logs output is unchanged.

`go.mod` pins `github.com/moby/moby/{api,client}` to the fork carrying moby/moby#53407; to be dropped for the released modules once it lands. Not mergeable before that.

Related to #14088 / #14091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
