### PR TITLE
fix(network): pass IPAM options when creating networks

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -1424,7 +1424,7 @@ func buildBindOption(bind *types.ServiceVolumeBind) *mount.BindOptions {
 // name-matched networks is decided by the reconciler from the observed state.
 func (s *composeService) createNetwork(ctx context.Context, n *types.NetworkConfig) error {
 	var ipam *network.IPAM
-	if n.Ipam.Config != nil {
+	if n.Ipam.Driver != "" || len(n.Ipam.Config) > 0 || len(n.Ipam.Options) > 0 {
 		var config []network.IPAMConfig
 		for _, pool := range n.Ipam.Config {
 			c, err := parseIPAMPool(pool)
@@ -1434,8 +1434,9 @@ func (s *composeService) createNetwork(ctx context.Context, n *types.NetworkConf
 			config = append(config, c)
 		}
 		ipam = &network.IPAM{
-			Driver: n.Ipam.Driver,
-			Config: config,
+			Driver:  n.Ipam.Driver,
+			Config:  config,
+			Options: n.Ipam.Options,
 		}
 	}
 	hash, err := NetworkHash(n)
@@ -1452,22 +1453,6 @@ func (s *composeService) createNetwork(ctx context.Context, n *types.NetworkConf
 		IPAM:       ipam,
 		EnableIPv6: n.EnableIPv6,
 		EnableIPv4: n.EnableIPv4,
-	}
-
-	if n.Ipam.Driver != "" || len(n.Ipam.Config) > 0 {
-		networkCreateOptions.IPAM = &network.IPAM{}
-	}
-
-	if n.Ipam.Driver != "" {
-		networkCreateOptions.IPAM.Driver = n.Ipam.Driver
-	}
-
-	for _, ipamConfig := range n.Ipam.Config {
-		c, err := parseIPAMPool(ipamConfig)
-		if err != nil {
-			return err
-		}
-		networkCreateOptions.IPAM.Config = append(networkCreateOptions.IPAM.Config, c)
 	}
 
 	networkEventName := fmt.Sprintf("Network %s", n.Name)

--- a/pkg/compose/executor_test.go
+++ b/pkg/compose/executor_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
@@ -70,6 +71,41 @@ func TestExecutePlanCreateNetwork(t *testing.T) {
 	// made by the reconciler from the observed state, not here).
 	apiClient.EXPECT().NetworkCreate(gomock.Any(), "test_default", gomock.Any()).
 		Return(client.NetworkCreateResult{ID: "net1"}, nil)
+
+	plan := &Plan{}
+	plan.addNode(Operation{
+		Type:       OpCreateNetwork,
+		ResourceID: "network:default",
+		Cause:      "not found",
+		Name:       nw.Name,
+		Network:    &nw,
+	}, "")
+
+	err := svc.executePlan(t.Context(), project, emptyObservedState("test"), plan)
+	assert.NilError(t, err)
+}
+
+func TestExecutePlanCreateNetworkWithIPAMOptions(t *testing.T) {
+	svc, apiClient := newTestService(t)
+
+	nw := types.NetworkConfig{
+		Name: "test_default",
+		Ipam: types.IPAMConfig{
+			Options: types.Options{"ipam-option": "enabled"},
+		},
+	}
+	project := &types.Project{
+		Name:     "test",
+		Networks: types.Networks{"default": nw},
+	}
+
+	apiClient.EXPECT().NetworkCreate(gomock.Any(), "test_default", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, opts client.NetworkCreateOptions) (client.NetworkCreateResult, error) {
+			assert.DeepEqual(t, opts.IPAM, &network.IPAM{
+				Options: map[string]string{"ipam-option": "enabled"},
+			})
+			return client.NetworkCreateResult{ID: "net1"}, nil
+		})
 
 	plan := &Plan{}
 	plan.addNode(Operation{


### PR DESCRIPTION
**What I did**
`createNetwork` built the IPAM object in two separate blocks; the second silently overwrote `createOpts.IPAM` with a fresh empty struct and never forwarded `n.Ipam.Options` to the daemon. 
Consolidate into a single block covering driver, config pool, and options.

**Related issue**
Fixes #13785
Supersedes #13936

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="3840" height="2710" alt="image" src="https://github.com/user-attachments/assets/6f26527e-781e-48f8-ae9b-5190c3b3a15c" />
