### PR TITLE
fix: dependency wait timeout surfaced only by luck

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -198,6 +198,11 @@ func (s *composeService) waitDependency(ctx context.Context, dep string, config 
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
+			// An expired deadline is precisely the failure this wait is meant
+			// to detect; only a plain cancellation (Ctrl-C) stays silent.
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return ctx.Err()
+			}
 			return nil
 		}
 		var (

--- a/pkg/compose/convergence_test.go
+++ b/pkg/compose/convergence_test.go
@@ -22,6 +22,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/config/configfile"
@@ -729,4 +730,44 @@ func TestRuntimeAPIVersionRetriesOnTransientError(t *testing.T) {
 	version, err = tested.RuntimeAPIVersion(t.Context())
 	assert.NilError(t, err)
 	assert.Equal(t, version, "1.44")
+}
+
+// TestWaitDependencyDeadline locks the timeout semantics of the dependency
+// wait: an expired deadline surfaces as "timeout waiting for dependencies",
+// while a plain user cancellation is not a wait failure.
+func TestWaitDependencyDeadline(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	apiClient := mocks.NewMockAPIClient(mockCtrl)
+	cli := mocks.NewMockCli(mockCtrl)
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+	cli.EXPECT().Client().Return(apiClient).AnyTimes()
+
+	project := types.Project{Name: strings.ToLower(testProject), Services: types.Services{
+		"db": {Name: "db", Scale: intPtr(1)},
+	}}
+	dependencies := types.DependsOnConfig{
+		"db": {Condition: types.ServiceConditionHealthy, Required: true},
+	}
+	containers := Containers{{
+		ID:     "db-ctr",
+		Names:  []string{"/db-ctr"},
+		Labels: map[string]string{api.ServiceLabel: "db"},
+	}}
+
+	t.Run("expired deadline is an error", func(t *testing.T) {
+		// Timeout shorter than the first 500ms poll tick: the deadline fires
+		// before any condition check, and must not be swallowed.
+		err := tested.(*composeService).waitDependencies(t.Context(), &project, "app", dependencies, containers, 50*time.Millisecond)
+		assert.Error(t, err, "timeout waiting for dependencies")
+	})
+
+	t.Run("user cancellation is not a wait failure", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		err := tested.(*composeService).waitDependencies(ctx, &project, "app", dependencies, containers, 0)
+		assert.NilError(t, err)
+	})
 }

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -31,6 +31,15 @@ func TestUpWait(t *testing.T) {
 		ServiceState("oneshot", "exited"))
 }
 
+func TestUpWaitTimeout(t *testing.T) {
+	s := NewScenario(t, "up --wait --wait-timeout must fail once the timeout expires instead of silently succeeding")
+	s.Step("up --wait fails after the timeout with the service still starting",
+		ComposeCmd("up", "--wait", "--wait-timeout", "3", "-d").MayFail().Within(60*time.Second),
+		ExitCode(1),
+		OutputContains("application not healthy after 3s"),
+		ServiceState("app", "running"))
+}
+
 func TestUpExitCodeFrom(t *testing.T) {
 	NewScenario(t, "up --exit-code-from must return the selected service's exit code").
 		Step("up returns the failing service's code once it exits",

--- a/pkg/e2e/testdata/TestUpWaitTimeout/compose.yaml
+++ b/pkg/e2e/testdata/TestUpWaitTimeout/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  app:
+    image: alpine
+    init: true
+    command: sleep infinity
+    healthcheck:
+      # Keeps failing during a long start_period, so health stays "starting"
+      # and --wait can only end by hitting its timeout.
+      test: ["CMD", "false"]
+      interval: 1s
+      retries: 3
+      start_period: 120s


### PR DESCRIPTION
`waitDependency` returned `nil` whenever its context ended, so an expired wait deadline surfaced only when the 500ms poll ticker won the select race and the condition check then failed on the expired context — whether `up --wait --wait-timeout` failed or silently succeeded after the timeout was effectively a coin toss.

The deadline now returns its error deterministically; a plain user cancellation (Ctrl-C) is still not reported as a dependency failure. Unit test pins both sides (a deadline shorter than the first tick used to be swallowed with certainty); a new e2e scenario documents the user-visible contract (`application not healthy after 3s`, non-zero exit, container left running).

Part of #14074 (section C) — lot 0 of #14081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
