### PR TITLE
fix: hold startMx on the start path actually exercised

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -349,7 +349,11 @@ func (s *composeService) createContainer(ctx context.Context, project *types.Pro
 	return ctr, nil
 }
 
-// force sequential calls to ContainerStart to prevent race condition in engine assigning ports from ranges
+// startMx serializes ContainerStart calls across the whole process: the
+// engine allocates published ports from ranges non-atomically, and two
+// concurrent starts can be assigned the same port. Every code path calling
+// ContainerStart on a service container must hold it (the plan executor's
+// execStartContainer and the imperative startServiceContainer both do).
 var startMx sync.Mutex
 
 func (s *composeService) createMobyContainer(ctx context.Context, project *types.Project, service types.ServiceConfig,
@@ -598,7 +602,10 @@ func (s *composeService) startServiceContainer(ctx context.Context, project *typ
 
 	eventName := getContainerProgressName(ctr)
 	s.events.On(newEvent(eventName, api.Working, api.StatusStarting))
-	if _, err := s.apiClient().ContainerStart(ctx, ctr.ID, client.ContainerStartOptions{}); err != nil {
+	startMx.Lock()
+	_, err := s.apiClient().ContainerStart(ctx, ctr.ID, client.ContainerStartOptions{})
+	startMx.Unlock()
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`startMx` exists to serialize `ContainerStart` because the engine assigns published ports from ranges non-atomically — but it is only held by the plan executor's `execStartContainer`, a nearly dead path (plans emit `OpStartContainer` only for paused/dead containers). `startServiceContainer`, the path every `up`/`start` actually runs, never takes it: the protection is inoperative today.

This takes the mutex around the real `ContainerStart` call and documents the contract. Trade-off worth an explicit maintainer call (also raised in #14081): this serializes the start API call across services (replicas were already sequential). The alternative is deleting `startMx` entirely — happy to flip this PR that way instead. Engine-side references to inform that call: `startMx` was introduced by #12851 as a workaround for #12846 (duplicate host ports on random-port mappings); there is no dedicated moby issue, but moby/moby#50054 (merged, ships in Engine 28.3.0) explicitly fixes docker/compose#12846 — a daemon port-allocator flaw (`SO_REUSEADDR` hid `0.0.0.0` vs specific-address clashes from `bind()`), introduced by the 28.0 port-mapping refactor (moby/moby#48567/#48132). Notably @robmry assessed on #12846 that the original problem was not a race between container starts, so the mutex likely never protected against that case; engines 28.0–28.2 remain exposed to it either way.

Part of #14074 (section C) — lot 0 of #14081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

