### PR TITLE
fix(watch): exclude Dockerfile and compose files from initial sync

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -784,11 +784,19 @@ func (s *composeService) initialSync(ctx context.Context, service types.ServiceC
 	if err != nil {
 		return err
 	}
-	// FIXME .dockerignore
+
+	// the Dockerfile and compose files drive the build/orchestration, not the
+	// application: never copy them into the container on initial sync
+	dockerFileIgnore, err := watch.NewDockerPatternMatcher("/", []string{"Dockerfile", "*compose*.y*ml"})
+	if err != nil {
+		return err
+	}
+
 	ignoreInitialSync := watch.NewCompositeMatcher(
 		dockerIgnores,
 		watch.EphemeralPathMatcher(),
 		dotGitIgnore,
+		dockerFileIgnore,
 		triggerIgnore)
 
 	pathsToCopy, err := s.initialSyncFiles(service, trigger, ignoreInitialSync)

--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -29,6 +29,7 @@ import (
 	gsync "sync"
 	"time"
 
+	"github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/compose-spec/compose-go/v2/utils"
 	ccli "github.com/docker/cli/cli/command/container"
@@ -785,9 +786,14 @@ func (s *composeService) initialSync(ctx context.Context, service types.ServiceC
 		return err
 	}
 
-	// the Dockerfile and compose files drive the build/orchestration, not the
-	// application: never copy them into the container on initial sync
-	dockerFileIgnore, err := watch.NewDockerPatternMatcher("/", []string{"Dockerfile", "*compose*.y*ml"})
+	// also exclude override compose files and any custom-named Dockerfile
+	dockerFilePatterns := append([]string{"Dockerfile"}, cli.DefaultFileNames...)
+	dockerFilePatterns = append(dockerFilePatterns, cli.DefaultOverrideFileNames...)
+	if service.Build != nil && service.Build.Dockerfile != "" {
+		dockerFilePatterns = append(dockerFilePatterns, filepath.Base(service.Build.Dockerfile))
+	}
+
+	dockerFileIgnore, err := watch.NewDockerPatternMatcher("/", dockerFilePatterns)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/watch_test.go
+++ b/pkg/compose/watch_test.go
@@ -247,7 +247,7 @@ func TestInitialSyncFilesRegularFile(t *testing.T) {
 // matcher nor EphemeralPathMatcher cover this.
 func TestInitialSync_ExcludesDockerfileAndComposeFiles(t *testing.T) {
 	hostDir := t.TempDir()
-	for _, name := range []string{"Dockerfile", "compose.yaml", "compose.override.yml", "app.go"} {
+	for _, name := range []string{"Dockerfile", "compose.yaml", "docker-compose.yml", "compose.override.yml", "app.go"} {
 		assert.NilError(t, os.WriteFile(filepath.Join(hostDir, name), []byte("content"), 0o600))
 	}
 
@@ -255,6 +255,61 @@ func TestInitialSync_ExcludesDockerfileAndComposeFiles(t *testing.T) {
 	err := (&composeService{}).initialSync(t.Context(), types.ServiceConfig{
 		Name:  "svc",
 		Build: &types.BuildConfig{Context: hostDir},
+	}, types.Trigger{
+		Path:   hostDir,
+		Target: "/app",
+	}, syncer)
+	assert.NilError(t, err)
+
+	paths := <-syncer.synced
+	assert.DeepEqual(t, paths, []*sync.PathMapping{{
+		HostPath:      filepath.Join(hostDir, "app.go"),
+		ContainerPath: "/app/app.go",
+	}})
+}
+
+// TestInitialSync_ExcludesCustomNamedDockerfile verifies that a service using
+// a non-default Dockerfile name (build.dockerfile) still has it excluded from
+// the initial sync, not just the literal "Dockerfile".
+func TestInitialSync_ExcludesCustomNamedDockerfile(t *testing.T) {
+	hostDir := t.TempDir()
+	for _, name := range []string{"Dockerfile.prod", "app.go"} {
+		assert.NilError(t, os.WriteFile(filepath.Join(hostDir, name), []byte("content"), 0o600))
+	}
+
+	syncer := &fakeSyncer{synced: make(chan []*sync.PathMapping, 1)}
+	err := (&composeService{}).initialSync(t.Context(), types.ServiceConfig{
+		Name:  "svc",
+		Build: &types.BuildConfig{Context: hostDir, Dockerfile: "Dockerfile.prod"},
+	}, types.Trigger{
+		Path:   hostDir,
+		Target: "/app",
+	}, syncer)
+	assert.NilError(t, err)
+
+	paths := <-syncer.synced
+	assert.DeepEqual(t, paths, []*sync.PathMapping{{
+		HostPath:      filepath.Join(hostDir, "app.go"),
+		ContainerPath: "/app/app.go",
+	}})
+}
+
+// TestInitialSync_ExcludesNestedCustomNamedDockerfile verifies that a
+// build.dockerfile living in a subdirectory of the build context (e.g.
+// "docker/Dockerfile.prod") is still excluded by its basename: the ignore
+// matcher only ever receives filepath.Base(path), so appending the raw
+// service.Build.Dockerfile value (which may include the subdirectory) would
+// never match.
+func TestInitialSync_ExcludesNestedCustomNamedDockerfile(t *testing.T) {
+	hostDir := t.TempDir()
+	assert.NilError(t, os.MkdirAll(filepath.Join(hostDir, "docker"), 0o755))
+	assert.NilError(t, os.WriteFile(filepath.Join(hostDir, "docker", "Dockerfile.prod"), []byte("content"), 0o600))
+	assert.NilError(t, os.WriteFile(filepath.Join(hostDir, "app.go"), []byte("content"), 0o600))
+
+	syncer := &fakeSyncer{synced: make(chan []*sync.PathMapping, 1)}
+	err := (&composeService{}).initialSync(t.Context(), types.ServiceConfig{
+		Name:  "svc",
+		Build: &types.BuildConfig{Context: hostDir, Dockerfile: "docker/Dockerfile.prod"},
 	}, types.Trigger{
 		Path:   hostDir,
 		Target: "/app",

--- a/pkg/compose/watch_test.go
+++ b/pkg/compose/watch_test.go
@@ -241,6 +241,33 @@ func TestInitialSyncFilesRegularFile(t *testing.T) {
 	}})
 }
 
+// initialSync's doc comment promises the Dockerfile and compose files are
+// never copied into the container, but a refactor (ed10804e0) dropped the
+// matcher enforcing it without replacement — neither the .dockerignore-derived
+// matcher nor EphemeralPathMatcher cover this.
+func TestInitialSync_ExcludesDockerfileAndComposeFiles(t *testing.T) {
+	hostDir := t.TempDir()
+	for _, name := range []string{"Dockerfile", "compose.yaml", "compose.override.yml", "app.go"} {
+		assert.NilError(t, os.WriteFile(filepath.Join(hostDir, name), []byte("content"), 0o600))
+	}
+
+	syncer := &fakeSyncer{synced: make(chan []*sync.PathMapping, 1)}
+	err := (&composeService{}).initialSync(t.Context(), types.ServiceConfig{
+		Name:  "svc",
+		Build: &types.BuildConfig{Context: hostDir},
+	}, types.Trigger{
+		Path:   hostDir,
+		Target: "/app",
+	}, syncer)
+	assert.NilError(t, err)
+
+	paths := <-syncer.synced
+	assert.DeepEqual(t, paths, []*sync.PathMapping{{
+		HostPath:      filepath.Join(hostDir, "app.go"),
+		ContainerPath: "/app/app.go",
+	}})
+}
+
 // TestPruneDanglingImagesOnRebuild verifies the post-rebuild prune only
 // removes superseded dangling images: a dangling image whose ID matches one
 // of the freshly built images must be spared. The lookup used to probe the


### PR DESCRIPTION
**What I did**

`initialSync`'s doc comment promises that the Dockerfile and compose files are never copied into the container during `docker compose watch`'s initial sync — but the matcher enforcing that was dropped without replacement in a January 2025 refactor ([#12469](https://github.com/docker/compose/pull/12469)), leaving only a `// FIXME .dockerignore` comment where it used to sit. Neither `.dockerignore`-derived ignores nor `EphemeralPathMatcher()` (editor swap/temp files) cover this, so a `develop.watch` trigger whose path includes the project root would copy `Dockerfile`/`compose.yaml` into the running container on initial sync.

Reintroduced a dedicated `dockerFileIgnore` matcher (`Dockerfile`, `*compose*.y*ml`) inside `initialSync`, matching the pre-refactor behavior.

Scoped to `initialSync` only: the continuous watch loop's ignore (`getWatchRules`) never carried this exclusion, and — because it matches against full paths rather than basenames — would need a differently-anchored matcher to work there; that's a separate change if wanted.

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**