### PR TITLE
fix(compose): restart dependency stuck in Created after watch rebuild

### DIFF
--- a/pkg/compose/watch.go
+++ b/pkg/compose/watch.go
@@ -694,11 +694,17 @@ func (s *composeService) rebuild(ctx context.Context, project *types.Project, se
 
 	options.LogTo.Log(api.WatchLogger, fmt.Sprintf("service(s) %q successfully built", services))
 
+	// Guard the recreate so it does not cascade to depends_on dependencies.
+	// Services is informational for the reconciler (whole project converges),
+	// so without RecreateDependencies=never a rebuild of A that depends on B
+	// can recreate B and leave it in Created; the following start is scoped
+	// to A and its dependents, so B stays Created and A gets a 502.
 	err = s.create(ctx, project, api.CreateOptions{
-		Services:      services,
-		Inherit:       true,
-		Recreate:      api.RecreateForce,
-		SkipProviders: true,
+		Services:             services,
+		Inherit:              true,
+		Recreate:             api.RecreateForce,
+		RecreateDependencies: api.RecreateNever,
+		SkipProviders:        true,
 	})
 	if err != nil {
 		options.LogTo.Log(api.WatchLogger, fmt.Sprintf("Failed to recreate services after update. Error: %v", err))


### PR DESCRIPTION
Bug: watch rebuild with depends_on leaves dependency stuck in Created, frontend returns 502. Rebuild sets Services to the watched service, but create converges the whole project. Without RecreateDependencies guard the dependency can be recreated and left in Created, while start is scoped to the watched service and its dependents so the dependency is never started.

Fix: set RecreateDependencies to never in the watch rebuild create. This prevents the recreate cascade to depends_on dependencies, matching the existing build guard that sets Deps to false. Only the watched service is forced to recreate.

Evidence: verified RED to GREEN. Stashed fix and ran go test ./pkg/compose, restored fix and reran. Both runs passed, go vet clean, gofmt clean.