### PR TITLE
test(e2e): gate the e2e suite behind the build tag the docs already promise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,11 @@
 
 - Build: `make build`
 - Test all: `make test`
-- Test unit: `go test ./pkg/...`
+- Test unit: `go test ./pkg/...` — needs no Docker daemon; the e2e suite is
+  gated behind the `e2e` build tag and is not picked up
 - Test single: `go test ./pkg/compose/ -run TestFunctionName`
-- E2E tests: `go test -tags e2e ./pkg/e2e/ -run TestName`
+- E2E tests: `go test -tags e2e ./pkg/e2e/ -run TestName` — requires a Docker
+  daemon and the locally built binary (`make build`)
 
 ## E2E tests
 

--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,11 @@ install: binary
 
 .PHONY: e2e-compose
 e2e-compose: example-provider ## Run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test
-	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- -v $(TEST_FLAGS) -count=1 -parallel=$(E2E_PARALLEL_PLUGIN) -timeout 20m ./pkg/e2e
+	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- -v $(TEST_FLAGS) -count=1 -parallel=$(E2E_PARALLEL_PLUGIN) -timeout 20m -tags e2e ./pkg/e2e
 
 .PHONY: e2e-compose-standalone
 e2e-compose-standalone: ## Run End to end local tests in standalone mode. Set E2E_TEST=TestName to run a single test
-	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- $(TEST_FLAGS) -v -count=1 -parallel=$(E2E_STANDALONE_PARALLEL) -timeout 20m --tags=standalone ./pkg/e2e
+	go run gotest.tools/gotestsum@latest --format testname --junitfile "/tmp/report/report.xml" -- $(TEST_FLAGS) -v -count=1 -parallel=$(E2E_STANDALONE_PARALLEL) -timeout 20m --tags=e2e,standalone ./pkg/e2e
 
 .PHONY: build-and-e2e-compose
 build-and-e2e-compose: build e2e-compose ## Compile the compose cli-plugin and run end to end local tests in plugin mode. Set E2E_TEST=TestName to run a single test

--- a/pkg/e2e/bridge_test.go
+++ b/pkg/e2e/bridge_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/cancel_test.go
+++ b/pkg/e2e/cancel_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build e2e && !windows
 
 /*
    Copyright 2020 Docker Compose CLI authors

--- a/pkg/e2e/cascade_test.go
+++ b/pkg/e2e/cascade_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build e2e && !windows
 
 /*
    Copyright 2022 Docker Compose CLI authors

--- a/pkg/e2e/commit_test.go
+++ b/pkg/e2e/commit_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2023 Docker Compose CLI authors
 

--- a/pkg/e2e/compose_environment_test.go
+++ b/pkg/e2e/compose_environment_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/compose_exec_test.go
+++ b/pkg/e2e/compose_exec_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/compose_run_build_once_test.go
+++ b/pkg/e2e/compose_run_build_once_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/compose_up_test.go
+++ b/pkg/e2e/compose_up_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/config_test.go
+++ b/pkg/e2e/config_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/configs_test.go
+++ b/pkg/e2e/configs_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/container_name_test.go
+++ b/pkg/e2e/container_name_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build e2e && !windows
 
 /*
    Copyright 2022 Docker Compose CLI authors

--- a/pkg/e2e/cp_test.go
+++ b/pkg/e2e/cp_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/env_file_test.go
+++ b/pkg/e2e/env_file_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/events_test.go
+++ b/pkg/e2e/events_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/exec_test.go
+++ b/pkg/e2e/exec_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2023 Docker Compose CLI authors
 

--- a/pkg/e2e/export_test.go
+++ b/pkg/e2e/export_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2023 Docker Compose CLI authors
 

--- a/pkg/e2e/expose_test.go
+++ b/pkg/e2e/expose_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build e2e && !windows
 
 /*
    Copyright 2020 Docker Compose CLI authors

--- a/pkg/e2e/healthcheck_test.go
+++ b/pkg/e2e/healthcheck_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2023 Docker Compose CLI authors
 

--- a/pkg/e2e/hooks_test.go
+++ b/pkg/e2e/hooks_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2023 Docker Compose CLI authors
 

--- a/pkg/e2e/image_identity_corner_test.go
+++ b/pkg/e2e/image_identity_corner_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2026 Docker Compose CLI authors
 

--- a/pkg/e2e/image_identity_test.go
+++ b/pkg/e2e/image_identity_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/images_test.go
+++ b/pkg/e2e/images_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2026 Docker Compose CLI authors
 

--- a/pkg/e2e/ipc_test.go
+++ b/pkg/e2e/ipc_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/logs_test.go
+++ b/pkg/e2e/logs_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/main_test.go
+++ b/pkg/e2e/main_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/model_test.go
+++ b/pkg/e2e/model_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/multiplatform_test.go
+++ b/pkg/e2e/multiplatform_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2026 Docker Compose CLI authors
 

--- a/pkg/e2e/networks_test.go
+++ b/pkg/e2e/networks_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/noDeps_test.go
+++ b/pkg/e2e/noDeps_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build e2e && !windows
 
 /*
    Copyright 2022 Docker Compose CLI authors

--- a/pkg/e2e/orphans_test.go
+++ b/pkg/e2e/orphans_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/pause_test.go
+++ b/pkg/e2e/pause_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/profiles_test.go
+++ b/pkg/e2e/profiles_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/providers_test.go
+++ b/pkg/e2e/providers_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/ps_test.go
+++ b/pkg/e2e/ps_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/publish_test.go
+++ b/pkg/e2e/publish_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/pull_test.go
+++ b/pkg/e2e/pull_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/recreate_no_deps_test.go
+++ b/pkg/e2e/recreate_no_deps_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2022 Docker Compose CLI authors
 

--- a/pkg/e2e/restart_test.go
+++ b/pkg/e2e/restart_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/scale_test.go
+++ b/pkg/e2e/scale_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/secrets_test.go
+++ b/pkg/e2e/secrets_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/start_stop_test.go
+++ b/pkg/e2e/start_stop_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/testdata_test.go
+++ b/pkg/e2e/testdata_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/up_test.go
+++ b/pkg/e2e/up_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build e2e && !windows
 
 /*
    Copyright 2022 Docker Compose CLI authors

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/wait_test.go
+++ b/pkg/e2e/wait_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/pkg/e2e/watch_test.go
+++ b/pkg/e2e/watch_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
    Copyright 2023 Docker Compose CLI authors
 


### PR DESCRIPTION
`go test ./pkg/...` used to launch the whole e2e suite (requiring a daemon and a built binary for up to 20 minutes) because no file in `pkg/e2e` carried the `e2e` build tag AGENTS.md documents — `-tags e2e` was a no-op. Every test file is now gated; non-test helpers stay untagged so the package always compiles. Makefile targets pass the tag; CI behavior is unchanged.

Epic #14074, section A — split out of #14075 for focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)