### PR TITLE
build: error messages name the real remedy, not a removed builder

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -64,7 +64,8 @@ func buildWithBake(dockerCli command.Cli) (bool, error) {
 	_, err = manager.GetPlugin("buildx", dockerCli, &cobra.Command{})
 	if err != nil {
 		if errdefs.IsNotFound(err) {
-			logrus.Warnf("Docker Compose requires buildx plugin to be installed")
+			logrus.Warnf("buildx Docker CLI plugin not found: falling back to the classic builder. " +
+				"BuildKit-only build features (multi-arch, secrets, ssh, additional contexts, ...) will not be available")
 			return false, nil
 		}
 		return false, err

--- a/pkg/compose/build_classic.go
+++ b/pkg/compose/build_classic.go
@@ -232,19 +232,19 @@ func (s *composeService) doBuildImage(ctx context.Context, project *types.Projec
 // doesn't implement
 func checkClassicBuilderSupported(service types.ServiceConfig) error {
 	if len(service.Build.Platforms) > 1 {
-		return fmt.Errorf("the classic builder doesn't support multi-arch build, set DOCKER_BUILDKIT=1 to use BuildKit")
+		return fmt.Errorf("the classic builder doesn't support multi-arch build; building with BuildKit requires the buildx Docker CLI plugin, and DOCKER_BUILDKIT must not be set to 0")
 	}
 	if service.Build.Privileged {
-		return fmt.Errorf("the classic builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use BuildKit")
+		return fmt.Errorf("the classic builder doesn't support privileged mode; building with BuildKit requires the buildx Docker CLI plugin, and DOCKER_BUILDKIT must not be set to 0")
 	}
 	if len(service.Build.AdditionalContexts) > 0 {
-		return fmt.Errorf("the classic builder doesn't support additional contexts, set DOCKER_BUILDKIT=1 to use BuildKit")
+		return fmt.Errorf("the classic builder doesn't support additional contexts; building with BuildKit requires the buildx Docker CLI plugin, and DOCKER_BUILDKIT must not be set to 0")
 	}
 	if len(service.Build.SSH) > 0 {
-		return fmt.Errorf("the classic builder doesn't support SSH keys, set DOCKER_BUILDKIT=1 to use BuildKit")
+		return fmt.Errorf("the classic builder doesn't support SSH keys; building with BuildKit requires the buildx Docker CLI plugin, and DOCKER_BUILDKIT must not be set to 0")
 	}
 	if len(service.Build.Secrets) > 0 {
-		return fmt.Errorf("the classic builder doesn't support secrets, set DOCKER_BUILDKIT=1 to use BuildKit")
+		return fmt.Errorf("the classic builder doesn't support secrets; building with BuildKit requires the buildx Docker CLI plugin, and DOCKER_BUILDKIT must not be set to 0")
 	}
 	return nil
 }

--- a/pkg/e2e/build_test.go
+++ b/pkg/e2e/build_test.go
@@ -402,7 +402,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 		})
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      "the classic builder doesn't support multi-arch build, set DOCKER_BUILDKIT=1 to use BuildKit",
+			Err:      "the classic builder doesn't support multi-arch build; building with BuildKit requires the buildx Docker CLI plugin, and DOCKER_BUILDKIT must not be set to 0",
 		})
 	})
 
@@ -470,7 +470,7 @@ func TestBuildPlatformsStandardErrors(t *testing.T) {
 		})
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      "the classic builder doesn't support privileged mode, set DOCKER_BUILDKIT=1 to use BuildKit",
+			Err:      "the classic builder doesn't support privileged mode; building with BuildKit requires the buildx Docker CLI plugin, and DOCKER_BUILDKIT must not be set to 0",
 		})
 	})
 }


### PR DESCRIPTION
Five classic-builder rejections advertised `DOCKER_BUILDKIT=1`, a remedy tied to the internal BuildKit builder removed long ago. They now name the actual requirement (buildx plugin installed, `DOCKER_BUILDKIT` not forced to 0), and the silent buildx-missing fallback warning states its consequences. Only user-visible wording changes (e2e assertions updated).

Epic #14074, section A — split out of #14075 for focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)