### PR TITLE
fix(compose): report EventProcessor success correctly

### DIFF
--- a/pkg/compose/progress.go
+++ b/pkg/compose/progress.go
@@ -28,7 +28,7 @@ type progressFunc func(context.Context) error
 func Run(ctx context.Context, pf progressFunc, operation string, bus api.EventProcessor) error {
 	bus.Start(ctx, operation)
 	err := pf(ctx)
-	bus.Done(operation, err != nil)
+	bus.Done(operation, err == nil)
 	return err
 }
 

--- a/pkg/compose/progress_test.go
+++ b/pkg/compose/progress_test.go
@@ -1,0 +1,66 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/pkg/api"
+)
+
+type runEventProcessor struct {
+	operation string
+	success   bool
+}
+
+func (r *runEventProcessor) Start(context.Context, string) {}
+
+func (r *runEventProcessor) On(...api.Resource) {}
+
+func (r *runEventProcessor) Done(operation string, success bool) {
+	r.operation = operation
+	r.success = success
+}
+
+func TestRunReportsSuccess(t *testing.T) {
+	processor := &runEventProcessor{}
+
+	err := Run(t.Context(), func(context.Context) error {
+		return nil
+	}, "test", processor)
+
+	assert.NilError(t, err)
+	assert.Equal(t, processor.operation, "test")
+	assert.Check(t, processor.success)
+}
+
+func TestRunReportsFailure(t *testing.T) {
+	expected := errors.New("test failure")
+	processor := &runEventProcessor{}
+
+	err := Run(t.Context(), func(context.Context) error {
+		return expected
+	}, "test", processor)
+
+	assert.ErrorIs(t, err, expected)
+	assert.Equal(t, processor.operation, "test")
+	assert.Check(t, !processor.success)
+}


### PR DESCRIPTION
**What I did**

Fix `Run` passing an inverted `success` value to `EventProcessor.Done`. Successful operations now report `true`, while failed operations report `false`. I also added tests covering both outcomes.

Note: #14074 also claims that `compose commit --dry-run` creates an image because `DryRunClient.ContainerCommit` delegates to the real client. But I think that that claim is outdated: the supported Compose commit path already checks `s.dryRun` and returns before calling `ContainerCommit`.

**Related issue**

Relates to #14074 