### PR TITLE
fix(compose): reject unknown subcommands under bridge/transformations

### DIFF
--- a/cmd/compose/bridge.go
+++ b/cmd/compose/bridge.go
@@ -39,12 +39,27 @@ func bridgeCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
 		Use:              "bridge CMD [OPTIONS]",
 		Short:            "Convert compose files into another model",
 		TraverseChildren: true,
+		RunE:             rejectUnknownSubcommand,
 	}
 	cmd.AddCommand(
 		convertCommand(p, dockerCli),
 		transformersCommand(dockerCli),
 	)
 	return cmd
+}
+
+// rejectUnknownSubcommand is the RunE for a parent command that only groups
+// subcommands: by default (no Run/RunE), cobra shows help for an unknown
+// subcommand but exits 0.
+func rejectUnknownSubcommand(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmd.Help()
+	}
+	_ = cmd.Help()
+	return cli.StatusError{
+		StatusCode: 1,
+		Status:     fmt.Sprintf("unknown docker command: %q", cmd.CommandPath()+" "+args[0]),
+	}
 }
 
 func convertCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
@@ -81,6 +96,7 @@ func transformersCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "transformations CMD [OPTIONS]",
 		Short: "Manage transformation images",
+		RunE:  rejectUnknownSubcommand,
 	}
 	cmd.AddCommand(
 		listTransformersCommand(dockerCli),

--- a/cmd/compose/bridge_test.go
+++ b/cmd/compose/bridge_test.go
@@ -55,6 +55,28 @@ func TestBridgeCommandsArgsValidation(t *testing.T) {
 			args:    []string{"extra"},
 			wantErr: "unknown command",
 		},
+		{
+			name:    "bridge rejects an unknown subcommand",
+			cmd:     bridgeCommand(&ProjectOptions{}, nil),
+			args:    []string{"zzz"},
+			wantErr: "unknown docker command",
+		},
+		{
+			name: "bridge with no subcommand shows help",
+			cmd:  bridgeCommand(&ProjectOptions{}, nil),
+			args: []string{},
+		},
+		{
+			name:    "transformations rejects an unknown subcommand",
+			cmd:     bridgeCommand(&ProjectOptions{}, nil),
+			args:    []string{"transformations", "zzz"},
+			wantErr: "unknown docker command",
+		},
+		{
+			name: "transformations with no subcommand shows help",
+			cmd:  transformersCommand(nil),
+			args: []string{},
+		},
 	}
 
 	for _, test := range tests {
@@ -63,7 +85,11 @@ func TestBridgeCommandsArgsValidation(t *testing.T) {
 			test.cmd.SetOut(io.Discard)
 			test.cmd.SetErr(io.Discard)
 			err := test.cmd.Execute()
-			assert.ErrorContains(t, err, test.wantErr)
+			if test.wantErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, test.wantErr)
+			}
 		})
 	}
 }

--- a/docs/reference/docker_compose_bridge.yaml
+++ b/docs/reference/docker_compose_bridge.yaml
@@ -1,6 +1,7 @@
 command: docker compose bridge
 short: Convert compose files into another model
 long: Convert compose files into another model
+usage: docker compose bridge CMD [OPTIONS]
 pname: docker compose
 plink: docker_compose.yaml
 cname:

--- a/docs/reference/docker_compose_bridge_transformations.yaml
+++ b/docs/reference/docker_compose_bridge_transformations.yaml
@@ -1,6 +1,7 @@
 command: docker compose bridge transformations
 short: Manage transformation images
 long: Manage transformation images
+usage: docker compose bridge transformations CMD [OPTIONS]
 pname: docker compose bridge
 plink: docker_compose_bridge.yaml
 cname:


### PR DESCRIPTION
**What I did**
`bridgeCommand` and `transformersCommand` had no `RunE`, so an unknown subcommand (e.g. "bridge zzz") fell through cobra's default non-Runnable path: help printed, exit 0. Scripts couldn't distinguish a typo from success. Mirrors the same fix already shipped on the compose root command.

**Related issue**
https://docker.atlassian.net/browse/DDB-666

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="3000" height="2000" alt="image" src="https://github.com/user-attachments/assets/0bcf92df-6ab0-4337-bcce-74f2da3a0bf8" />
