### PR TITLE
fix(formatter): handle nil JSON values

### DIFF
--- a/cmd/formatter/formatter.go
+++ b/cmd/formatter/formatter.go
@@ -31,7 +31,7 @@ func Print(toJSON any, format string, outWriter io.Writer, writerFn func(w io.Wr
 	case TABLE, PRETTY, "":
 		return PrintPrettySection(outWriter, writerFn, headers...)
 	case TemplateLegacyJSON:
-		switch reflect.TypeOf(toJSON).Kind() {
+		switch reflect.ValueOf(toJSON).Kind() {
 		case reflect.Slice:
 			s := reflect.ValueOf(toJSON)
 			for i := 0; i < s.Len(); i++ {
@@ -50,7 +50,7 @@ func Print(toJSON any, format string, outWriter io.Writer, writerFn func(w io.Wr
 			_, _ = fmt.Fprintln(outWriter, outJSON)
 		}
 	case JSON:
-		switch reflect.TypeOf(toJSON).Kind() {
+		switch reflect.ValueOf(toJSON).Kind() {
 		case reflect.Slice:
 			outJSON, err := ToJSON(toJSON, "", "")
 			if err != nil {

--- a/cmd/formatter/formatter_test.go
+++ b/cmd/formatter/formatter_test.go
@@ -73,6 +73,16 @@ func TestPrint(t *testing.T) {
 `)
 }
 
+func TestPrintNilAsJSON(t *testing.T) {
+	for _, format := range []string{JSON, TemplateLegacyJSON} {
+		t.Run(format, func(t *testing.T) {
+			var output bytes.Buffer
+			assert.NilError(t, Print(nil, format, &output, func(io.Writer) {}))
+			assert.Equal(t, output.String(), "null\n")
+		})
+	}
+}
+
 func TestColorsGoroutinesLeak(t *testing.T) {
 	goleak.VerifyNone(t)
 }


### PR DESCRIPTION
**What I did**

Prevent `formatter.Print` from panicking when JSON output receives an untyped nil value. `reflect.TypeOf(nil)` returns nil, so calling `Kind()` on it panics; `reflect.ValueOf(nil).Kind()` safely returns `Invalid` and lets the existing standard JSON path emit `null`.

Added regression coverage for both `json` and legacy `{{json .}}` formatting. Both should produce `null\n`.

**Related issue**

No issue; this is a small, self-contained nil-input fix.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**

<img width="1920" height="2560" alt="0502d80a9e7cd8cff98f188e59b65b13" src="https://github.com/user-attachments/assets/81ccf4a1-64ea-4f8f-9df4-0149f1a59b1c" />
