### PR TITLE
fix(watch): stop swallowing SetRecursive errors via nolint

### DIFF
--- a/pkg/watch/watcher_naive.go
+++ b/pkg/watch/watcher_naive.go
@@ -309,11 +309,10 @@ func newWatcher(paths []string) (Notify, error) {
 	}
 	MaybeIncreaseBufferSize(fsw)
 
-	// SetRecursive only succeeds on Windows; every other platform returns
-	// "Not supported" and the non-recursive fallback below is taken. On a
-	// single GOOS staticcheck proves the comparison constant (SA4023).
-	err = fsw.SetRecursive()         //nolint:staticcheck
-	isWatcherRecursive := err == nil //nolint:staticcheck
+	isWatcherRecursive, err := setRecursive(fsw)
+	if err != nil {
+		return nil, err
+	}
 
 	wrappedEvents := make(chan FileEvent)
 	notifyList := make(map[string]bool, len(paths))

--- a/pkg/watch/watcher_nonwin.go
+++ b/pkg/watch/watcher_nonwin.go
@@ -23,3 +23,8 @@ import "github.com/tilt-dev/fsnotify"
 func MaybeIncreaseBufferSize(w *fsnotify.Watcher) {
 	// Not needed on non-windows
 }
+
+func setRecursive(_ *fsnotify.Watcher) (bool, error) {
+	// SetRecursive is only supported on Windows.
+	return false, nil
+}

--- a/pkg/watch/watcher_windows.go
+++ b/pkg/watch/watcher_windows.go
@@ -33,3 +33,10 @@ import (
 func MaybeIncreaseBufferSize(w *fsnotify.Watcher) {
 	w.SetBufferSize(DesiredWindowsBufferSize())
 }
+
+func setRecursive(w *fsnotify.Watcher) (bool, error) {
+	if err := w.SetRecursive(); err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
**What I did**
Split SetRecursive into the existing per-GOOS watcher files instead of a runtime check + nolint: the non-Windows stub never calls the always-failing SetRecursive, and Windows failures now propagate as a real error instead of silently downgrading to non-recursive.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Addresses review from thaJeztah on #14164.

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
