### PR TITLE
fix: skip unreadable default .env instead of failing

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -399,7 +399,7 @@ func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 
 	opts = append(opts,
 		// Load PWD/.env if present and no explicit --env-file has been set
-		cli.WithEnvFiles(o.EnvFiles...),
+		utils.WithEnvFiles(o.EnvFiles...),
 		// read dot env file to populate project environment
 		cli.WithDotEnv,
 		// get compose file path set by COMPOSE_FILE
@@ -407,7 +407,7 @@ func (o *ProjectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 		// if none was selected, get default compose.yaml file from current dir or parent folder
 		cli.WithDefaultConfigPath,
 		// .. and then, a project directory != PWD maybe has been set so let's load .env file
-		cli.WithEnvFiles(o.EnvFiles...), //nolint:gocritic // intentionally applying cli.WithEnvFiles twice.
+		utils.WithEnvFiles(o.EnvFiles...), //nolint:gocritic // intentionally applying cli.WithEnvFiles twice.
 		cli.WithDotEnv,                  //nolint:gocritic // intentionally applying cli.WithDotEnv twice.
 		// eventually COMPOSE_PROFILES should have been set
 		cli.WithDefaultProfiles(o.Profiles...),
@@ -746,7 +746,7 @@ func setEnvWithDotEnv(opts ProjectOptions, dockerCli command.Cli) error {
 	options, err := cli.NewProjectOptions(opts.ConfigPaths,
 		cli.WithWorkingDirectory(opts.ProjectDir),
 		cli.WithOsEnv,
-		cli.WithEnvFiles(opts.EnvFiles...),
+		utils.WithEnvFiles(opts.EnvFiles...),
 		cli.WithDotEnv,
 	)
 	if err != nil {

--- a/pkg/compose/loader.go
+++ b/pkg/compose/loader.go
@@ -98,7 +98,7 @@ func (s *composeService) buildProjectOptions(options api.ProjectLoadOptions, rem
 
 	projectOptionsFns = append(projectOptionsFns,
 		// Load PWD/.env if present and no explicit --env-file has been set
-		cli.WithEnvFiles(options.EnvFiles...),
+		utils.WithEnvFiles(options.EnvFiles...),
 		// read dot env file to populate project environment
 		cli.WithDotEnv,
 		// get compose file path set by COMPOSE_FILE
@@ -106,7 +106,7 @@ func (s *composeService) buildProjectOptions(options api.ProjectLoadOptions, rem
 		// if none was selected, get default compose.yaml file from current dir or parent folder
 		cli.WithDefaultConfigPath,
 		// .. and then, a project directory != PWD maybe has been set so let's load .env file
-		cli.WithEnvFiles(options.EnvFiles...), //nolint:gocritic // intentionally applying cli.WithEnvFiles twice.
+		utils.WithEnvFiles(options.EnvFiles...), //nolint:gocritic // intentionally applying cli.WithEnvFiles twice.
 		cli.WithDotEnv,                        //nolint:gocritic // intentionally applying cli.WithDotEnv twice.
 		// eventually COMPOSE_PROFILES should have been set
 		cli.WithDefaultProfiles(options.Profiles...),

--- a/pkg/utils/envfiles.go
+++ b/pkg/utils/envfiles.go
@@ -1,0 +1,42 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+
+	"github.com/compose-spec/compose-go/v2/cli"
+	"github.com/sirupsen/logrus"
+)
+
+// WithEnvFiles wraps cli.WithEnvFiles so a default .env that exists but
+// cannot be stat'd (typically permission denied on the working directory)
+// is skipped instead of failing the command. Explicit --env-file paths
+// still error if they are unreadable.
+func WithEnvFiles(files ...string) cli.ProjectOptionsFn {
+	return func(o *cli.ProjectOptions) error {
+		err := cli.WithEnvFiles(files...)(o)
+		if err == nil || len(files) > 0 {
+			return err
+		}
+		if os.IsPermission(err) {
+			logrus.Warnf("ignoring unreadable default .env file: %v", err)
+			return nil
+		}
+		return err
+	}
+}

--- a/pkg/utils/envfiles_test.go
+++ b/pkg/utils/envfiles_test.go
@@ -1,0 +1,63 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/cli"
+	"gotest.tools/v3/assert"
+)
+
+func TestWithEnvFilesSkipsUnreadableDefault(t *testing.T) {
+	root := t.TempDir()
+	blocked := filepath.Join(root, "blocked")
+	assert.NilError(t, os.Mkdir(blocked, 0o700))
+	assert.NilError(t, os.WriteFile(filepath.Join(blocked, ".env"), []byte("FOO=1\n"), 0o600))
+	assert.NilError(t, os.Chmod(blocked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o700) })
+
+	if _, err := os.Stat(filepath.Join(blocked, ".env")); err == nil {
+		t.Skip("process can still stat the file (running as root?)")
+	}
+
+	opts, err := cli.NewProjectOptions(nil,
+		cli.WithWorkingDirectory(blocked),
+		WithEnvFiles(),
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, len(opts.EnvFiles), 0)
+}
+
+func TestWithEnvFilesKeepsExplicitPath(t *testing.T) {
+	opts, err := cli.NewProjectOptions(nil, WithEnvFiles("/no/such/.env"))
+	assert.NilError(t, err)
+	assert.DeepEqual(t, opts.EnvFiles, []string{"/no/such/.env"})
+}
+
+func TestWithEnvFilesLoadsReadableDefault(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("FOO=1\n"), 0o600))
+	opts, err := cli.NewProjectOptions(nil,
+		cli.WithWorkingDirectory(dir),
+		WithEnvFiles(),
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, len(opts.EnvFiles), 1)
+}


### PR DESCRIPTION
`docker compose` currently dies if it can't `stat` the default `.env` in the working directory, even when that file isn't required.

that shows up as `stat /root/.env: permission denied` when you `sudo -u otheruser docker compose ...` from a directory the target user can't read (the file doesn't even have to exist).

skip the default `.env` in that case and keep going. explicit `--env-file` is unchanged.

Fixes #14166