### PR TITLE
test(e2e): bump compose-bridge images to v0.0.7

### DIFF
--- a/pkg/e2e/bridge_test.go
+++ b/pkg/e2e/bridge_test.go
@@ -28,7 +28,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-const bridgeImageVersion = "v0.0.3"
+const bridgeImageVersion = "v0.0.7"
 
 func TestConvertAndTransformList(t *testing.T) {
 	c := NewParallelCLI(t)

--- a/pkg/e2e/fixtures/bridge/expected-helm/templates/private-network-network-policy.yaml
+++ b/pkg/e2e/fixtures/bridge/expected-helm/templates/private-network-network-policy.yaml
@@ -11,14 +11,8 @@ spec:
             com.docker.compose.network.private-network: "true"
     policyTypes:
         - Ingress
-        - Egress
     ingress:
         - from:
-            - podSelector:
-                matchLabels:
-                    com.docker.compose.network.private-network: "true"
-    egress:
-        - to:
             - podSelector:
                 matchLabels:
                     com.docker.compose.network.private-network: "true"

--- a/pkg/e2e/fixtures/bridge/expected-helm/templates/public-network-network-policy.yaml
+++ b/pkg/e2e/fixtures/bridge/expected-helm/templates/public-network-network-policy.yaml
@@ -11,14 +11,8 @@ spec:
             com.docker.compose.network.public-network: "true"
     policyTypes:
         - Ingress
-        - Egress
     ingress:
         - from:
-            - podSelector:
-                matchLabels:
-                    com.docker.compose.network.public-network: "true"
-    egress:
-        - to:
             - podSelector:
                 matchLabels:
                     com.docker.compose.network.public-network: "true"

--- a/pkg/e2e/fixtures/bridge/expected-kubernetes/base/private-network-network-policy.yaml
+++ b/pkg/e2e/fixtures/bridge/expected-kubernetes/base/private-network-network-policy.yaml
@@ -11,14 +11,8 @@ spec:
             com.docker.compose.network.private-network: "true"
     policyTypes:
         - Ingress
-        - Egress
     ingress:
         - from:
-            - podSelector:
-                matchLabels:
-                    com.docker.compose.network.private-network: "true"
-    egress:
-        - to:
             - podSelector:
                 matchLabels:
                     com.docker.compose.network.private-network: "true"

--- a/pkg/e2e/fixtures/bridge/expected-kubernetes/base/public-network-network-policy.yaml
+++ b/pkg/e2e/fixtures/bridge/expected-kubernetes/base/public-network-network-policy.yaml
@@ -11,14 +11,8 @@ spec:
             com.docker.compose.network.public-network: "true"
     policyTypes:
         - Ingress
-        - Egress
     ingress:
         - from:
-            - podSelector:
-                matchLabels:
-                    com.docker.compose.network.public-network: "true"
-    egress:
-        - to:
             - podSelector:
                 matchLabels:
                     com.docker.compose.network.public-network: "true"


### PR DESCRIPTION
**What I did**

v0.0.3 had a mis-published multi-arch manifest, causing exec format errors on non-amd64 architectures.

Fixed upstream in docker/compose-bridge-transformer@665f67e.

Otherwise test fails on openQA: https://openqa.opensuse.org/tests/6193496#external

```
# Test messages # TestConvertBuildOnlyService
# failure: 

Failed
=== RUN   TestConvertBuildOnlyService
=== PAUSE TestConvertBuildOnlyService
=== CONT  TestConvertBuildOnlyService
    framework.go:170: WARNING: docker-model cli-plugin not found
    bridge_test.go:66: Running command: docker compose version
    bridge_test.go:69: Running command: docker compose -f ./fixtures/bridge-build-only/compose.yaml --project-name bridge-build-only bridge convert --output /tmp/TestConvertBuildOnlyService2914424688/003 --transformation docker/compose-bridge-kubernetes:v0.0.3
v0.0.3: Pulling from docker/compose-bridge-kubernetes
    bridge_test.go:69: assertion failed: 
        Command:  docker compose -f ./fixtures/bridge-build-only/compose.yaml --project-name bridge-build-only bridge convert --output /tmp/TestConvertBuildOnlyService2914424688/003 --transformation docker/compose-bridge-kubernetes:v0.0.3
        ExitCode: 255
        Error:    exit status 255
        Stdout:   v0.0.3: Pulling from docker/compose-bridge-kubernetes
        b1b15940657b: Pulling fs layer
        4e3b1e361818: Pulling fs layer
        6bd31a75b555: Download complete
        13d5fb902dea: Download complete
        b1b15940657b: Download complete
        4e3b1e361818: Download complete
        b1b15940657b: Pull complete
        4e3b1e361818: Pull complete
        Digest: sha256:4ffd3f23f377b1fdd9d0195732980e7534a8975c8a210a12681dc803c002f761
        Status: Downloaded newer image for docker/compose-bridge-kubernetes:v0.0.3
        
        Stderr:   time="2026-08-30T08:13:55-04:00" level=warning msg="image bridge-build-only-app for service app not found locally; Dockerfile-exposed ports will not be included — run `docker compose build` first to include them"
        exec /transform: exec format error
        
        
        
        Failures:
        ExitCode was 255 expected 0
        Expected no error
    framework.go:143: Contents of config dir:
    framework.go:145:   - /tmp/TestConvertBuildOnlyService2914424688/001
    framework.go:145:   - /tmp/TestConvertBuildOnlyService2914424688/001/cli-plugins
    framework.go:145:   - /tmp/TestConvertBuildOnlyService2914424688/001/cli-plugins/docker-buildx
    framework.go:145:   - /tmp/TestConvertBuildOnlyService2914424688/001/cli-plugins/docker-compose
    framework.go:145:   - /tmp/TestConvertBuildOnlyService2914424688/001/cli-plugins/docker-scan
--- FAIL: TestConvertBuildOnlyService (2.95s)
```

**Related issue**

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
