### PR TITLE
fix(bridge): confirm before wiping non-empty convert output dir

### DIFF
--- a/cmd/compose/bridge.go
+++ b/cmd/compose/bridge.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose/v5/cmd/formatter"
+	"github.com/docker/compose/v5/cmd/prompt"
 	"github.com/docker/compose/v5/pkg/bridge"
 	"github.com/docker/compose/v5/pkg/compose"
 )
@@ -64,11 +65,17 @@ func rejectUnknownSubcommand(cmd *cobra.Command, args []string) error {
 
 func convertCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
 	convertOpts := bridge.ConvertOptions{}
+	var assumeYes bool
 	cmd := &cobra.Command{
 		Use:   "convert",
 		Short: "Convert compose files to Kubernetes manifests, Helm charts, or another model",
 		Args:  cobra.NoArgs,
 		RunE: Adapt(func(ctx context.Context, args []string) error {
+			if assumeYes {
+				convertOpts.Confirm = func(string, bool) (bool, error) { return true, nil }
+			} else {
+				convertOpts.Confirm = prompt.NewPrompt(dockerCli.In(), dockerCli.Out()).Confirm
+			}
 			return runConvert(ctx, dockerCli, p, convertOpts)
 		}),
 	}
@@ -76,6 +83,8 @@ func convertCommand(p *ProjectOptions, dockerCli command.Cli) *cobra.Command {
 	flags.StringVarP(&convertOpts.Output, "output", "o", "out", "The output directory for the Kubernetes resources")
 	flags.StringArrayVarP(&convertOpts.Transformations, "transformation", "t", nil, "Transformation to apply to compose model (default: docker/compose-bridge-kubernetes)")
 	flags.StringVar(&convertOpts.Templates, "templates", "", "Directory containing transformation templates")
+	flags.BoolVarP(&assumeYes, "yes", "y", false,
+		"Assume \"yes\" to the output directory overwrite prompt. For scripts/CI, where no interactive confirmation is possible")
 	return cmd
 }
 

--- a/docs/reference/compose_bridge_convert.md
+++ b/docs/reference/compose_bridge_convert.md
@@ -5,12 +5,13 @@ Convert compose files to Kubernetes manifests, Helm charts, or another model
 
 ### Options
 
-| Name                     | Type          | Default | Description                                                                          |
-|:-------------------------|:--------------|:--------|:-------------------------------------------------------------------------------------|
-| `--dry-run`              | `bool`        |         | Execute command in dry run mode                                                      |
-| `-o`, `--output`         | `string`      | `out`   | The output directory for the Kubernetes resources                                    |
-| `--templates`            | `string`      |         | Directory containing transformation templates                                        |
-| `-t`, `--transformation` | `stringArray` |         | Transformation to apply to compose model (default: docker/compose-bridge-kubernetes) |
+| Name                     | Type          | Default | Description                                                                                                          |
+|:-------------------------|:--------------|:--------|:---------------------------------------------------------------------------------------------------------------------|
+| `--dry-run`              | `bool`        |         | Execute command in dry run mode                                                                                      |
+| `-o`, `--output`         | `string`      | `out`   | The output directory for the Kubernetes resources                                                                    |
+| `--templates`            | `string`      |         | Directory containing transformation templates                                                                        |
+| `-t`, `--transformation` | `stringArray` |         | Transformation to apply to compose model (default: docker/compose-bridge-kubernetes)                                 |
+| `-y`, `--yes`            | `bool`        |         | Assume "yes" to the output directory overwrite prompt. For scripts/CI, where no interactive confirmation is possible |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/docker_compose_bridge_convert.yaml
+++ b/docs/reference/docker_compose_bridge_convert.yaml
@@ -39,6 +39,18 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
+    - option: "yes"
+      shorthand: "y"
+      value_type: bool
+      default_value: "false"
+      description: |
+        Assume "yes" to the output directory overwrite prompt. For scripts/CI, where no interactive confirmation is possible
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
 inherited_options:
     - option: dry-run
       value_type: bool

--- a/pkg/bridge/convert.go
+++ b/pkg/bridge/convert.go
@@ -42,10 +42,17 @@ import (
 	"github.com/docker/compose/v5/pkg/utils"
 )
 
+// Confirm asks the user to confirm a destructive action described by
+// message, returning defaultValue when no explicit answer can be read.
+type Confirm func(message string, defaultValue bool) (bool, error)
+
 type ConvertOptions struct {
 	Output          string
 	Templates       string
 	Transformations []string
+	// Confirm is asked before deleting a non-empty output directory. If nil,
+	// deletion is refused whenever the directory is not empty.
+	Confirm Confirm
 }
 
 func Convert(ctx context.Context, dockerCli command.Cli, project *types.Project, opts ConvertOptions) error {
@@ -70,14 +77,56 @@ func Convert(ctx context.Context, dockerCli command.Cli, project *types.Project,
 	}
 
 	if opts.Output != "" {
-		_ = os.RemoveAll(opts.Output)
-		err := os.MkdirAll(opts.Output, 0o744)
-		if err != nil && !os.IsExist(err) {
-			return fmt.Errorf("cannot create output folder: %w", err)
+		if err := prepareOutputDir(opts); err != nil {
+			return err
 		}
 	}
 	// Run Transformers images
 	return convert(ctx, dockerCli, model, opts)
+}
+
+// prepareOutputDir makes sure output exists and is empty. If it already
+// contains files, it asks for confirmation before deleting them, so a typo
+// or misuse (e.g. -o . or -o $HOME) doesn't silently destroy user data.
+func prepareOutputDir(opts ConvertOptions) error {
+	empty, err := isEmptyOrMissingDir(opts.Output)
+	if err != nil {
+		return err
+	}
+	if empty {
+		return os.MkdirAll(opts.Output, 0o744)
+	}
+
+	confirmed := false
+	if opts.Confirm != nil {
+		confirmed, err = opts.Confirm(
+			fmt.Sprintf("Output directory '%s' is not empty, all its content will be permanently deleted. Continue?", opts.Output),
+			false)
+		if err != nil {
+			return err
+		}
+	}
+	if !confirmed {
+		return fmt.Errorf("deletion of output directory '%s' was not confirmed", opts.Output)
+	}
+	if err := os.RemoveAll(opts.Output); err != nil {
+		return fmt.Errorf("cannot remove existing output folder: %w", err)
+	}
+	if err := os.MkdirAll(opts.Output, 0o744); err != nil {
+		return fmt.Errorf("output directory '%s' was deleted but could not be recreated: %w", opts.Output, err)
+	}
+	return nil
+}
+
+func isEmptyOrMissingDir(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("cannot read output folder: %w", err)
+	}
+	return len(entries) == 0, nil
 }
 
 func convert(ctx context.Context, dockerCli command.Cli, model map[string]any, opts ConvertOptions) error {

--- a/pkg/bridge/convert_test.go
+++ b/pkg/bridge/convert_test.go
@@ -17,6 +17,8 @@
 package bridge
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -51,4 +53,79 @@ func TestLoadAdditionalResources_BuildOnlySkipsPull(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, actual.Services["api"].Image, "test-api")
 	assert.DeepEqual(t, actual.Services["api"].Expose, types.StringOrNumberList{"8080"})
+}
+
+func TestIsEmptyOrMissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist-yet")
+	empty, err := isEmptyOrMissingDir(missing)
+	assert.NilError(t, err)
+	assert.Equal(t, empty, true)
+
+	emptyDir := t.TempDir()
+	empty, err = isEmptyOrMissingDir(emptyDir)
+	assert.NilError(t, err)
+	assert.Equal(t, empty, true)
+
+	nonEmptyDir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(nonEmptyDir, "README.md"), []byte("do not delete me"), 0o600))
+	empty, err = isEmptyOrMissingDir(nonEmptyDir)
+	assert.NilError(t, err)
+	assert.Equal(t, empty, false)
+}
+
+func failIfCalled(t *testing.T) Confirm {
+	t.Helper()
+	return func(string, bool) (bool, error) {
+		t.Fatal("Confirm should not be called")
+		return false, nil
+	}
+}
+
+func TestPrepareOutputDir_EmptyOrMissingDirNeedsNoConfirmation(t *testing.T) {
+	for name, dir := range map[string]string{
+		"missing": filepath.Join(t.TempDir(), "does-not-exist-yet"),
+		"empty":   t.TempDir(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NilError(t, prepareOutputDir(ConvertOptions{Output: dir, Confirm: failIfCalled(t)}))
+
+			info, err := os.Stat(dir)
+			assert.NilError(t, err)
+			assert.Assert(t, info.IsDir())
+		})
+	}
+}
+
+func TestPrepareOutputDir_NilConfirmRefusesNonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("do not delete me"), 0o600))
+
+	err := prepareOutputDir(ConvertOptions{Output: dir})
+	assert.ErrorContains(t, err, "not confirmed")
+
+	_, statErr := os.Stat(filepath.Join(dir, "README.md"))
+	assert.NilError(t, statErr, "user file must not be deleted")
+}
+
+func TestPrepareOutputDir_ConfirmedWipesNonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "stale.yaml"), []byte("stale"), 0o600))
+	confirm := func(string, bool) (bool, error) { return true, nil }
+
+	assert.NilError(t, prepareOutputDir(ConvertOptions{Output: dir, Confirm: confirm}))
+
+	_, err := os.Stat(filepath.Join(dir, "stale.yaml"))
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+func TestPrepareOutputDir_DeclinedPreservesFiles(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("do not delete me"), 0o600))
+	confirm := func(string, bool) (bool, error) { return false, nil }
+
+	err := prepareOutputDir(ConvertOptions{Output: dir, Confirm: confirm})
+	assert.ErrorContains(t, err, "not confirmed")
+
+	_, statErr := os.Stat(filepath.Join(dir, "README.md"))
+	assert.NilError(t, statErr, "user file must not be deleted")
 }

--- a/pkg/e2e/bridge_convert_output_test.go
+++ b/pkg/e2e/bridge_convert_output_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+
+/*
+   Copyright 2026 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// Regression tests for a captain-reported P1: `bridge convert -o <dir>` used
+// to os.RemoveAll the output directory unconditionally, discarding the
+// error, so pointing -o at a non-empty directory (e.g. -o . or -o $PWD)
+// silently destroyed its content.
+
+// setupNonEmptyOutputDir creates dir/out pre-populated with a guard file, so
+// bridge convert sees it as a non-empty output directory.
+func setupNonEmptyOutputDir(t *testing.T, s *Scenario, filename, content string) (outDir, guardFile string) {
+	t.Helper()
+	outDir = filepath.Join(s.Dir(), "out")
+	assert.NilError(t, os.MkdirAll(outDir, 0o755))
+	guardFile = filepath.Join(outDir, filename)
+	assert.NilError(t, os.WriteFile(guardFile, []byte(content), 0o600))
+	return outDir, guardFile
+}
+
+func TestBridgeConvertOutputNotEmptyDeclined(t *testing.T) {
+	s := NewScenario(t, "bridge convert must not touch a non-empty output directory unless the user confirms")
+	outDir, guardFile := setupNonEmptyOutputDir(t, s, "README.md", "do not delete me")
+
+	s.Step("convert without confirmation leaves the non-empty output directory untouched",
+		ComposeCmd("bridge", "convert", "--output", outDir,
+			"--transformation", fmt.Sprintf("docker/compose-bridge-kubernetes:%s", bridgeImageVersion)).MayFail(),
+		ExitCode(1),
+		FileContains(guardFile, "do not delete me"))
+}
+
+func TestBridgeConvertOutputNotEmptyConfirmed(t *testing.T) {
+	s := NewScenario(t, "bridge convert must overwrite a non-empty output directory once the user confirms")
+	outDir, guardFile := setupNonEmptyOutputDir(t, s, "stale.txt", "stale content")
+
+	s.Step("convert --yes wipes the stale content and regenerates the output",
+		ComposeCmd("bridge", "convert", "--output", outDir, "--yes",
+			"--transformation", fmt.Sprintf("docker/compose-bridge-kubernetes:%s", bridgeImageVersion)),
+		FileAbsent(guardFile),
+		FileExists(filepath.Join(outDir, "base", "0-"+s.Project()+"-namespace.yaml")))
+}

--- a/pkg/e2e/checks.go
+++ b/pkg/e2e/checks.go
@@ -489,6 +489,22 @@ func FileContains(path, sub string) Check {
 	}
 }
 
+// FileAbsent expects no file or directory to exist at the given host path,
+// e.g. content a previous step wiped.
+func FileAbsent(path string) Check {
+	return Check{
+		name: fmt.Sprintf("file %q is absent", path),
+		fn: func(ctx *CheckContext) error {
+			if _, err := os.Stat(path); err == nil {
+				return fmt.Errorf("file still exists")
+			} else if !os.IsNotExist(err) {
+				return err
+			}
+			return nil
+		},
+	}
+}
+
 // LabelSet expects every container of the service to carry a non-empty label.
 func LabelSet(service, key string) Check {
 	return Check{

--- a/pkg/e2e/testdata/TestBridgeConvertOutputNotEmptyConfirmed/compose.yaml
+++ b/pkg/e2e/testdata/TestBridgeConvertOutputNotEmptyConfirmed/compose.yaml
@@ -1,0 +1,3 @@
+services:
+  app:
+    image: alpine

--- a/pkg/e2e/testdata/TestBridgeConvertOutputNotEmptyDeclined/compose.yaml
+++ b/pkg/e2e/testdata/TestBridgeConvertOutputNotEmptyDeclined/compose.yaml
@@ -1,0 +1,3 @@
+services:
+  app:
+    image: alpine


### PR DESCRIPTION
**What I did**
`bridge convert -o <dir>` unconditionally ran `os.RemoveAll` on the output directory and discarded any error, so a typo (`-o .`, `-o $PWD`, `-o ~`) silently destroyed unrelated user data.

An empty or missing output directory is still created silently, but a non-empty one now requires explicit confirmation (prompted interactively, or via the new `--yes` flag for scripts/CI) before being wiped.

**Related issue**
https://docker.atlassian.net/browse/DDB-683

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="1572" height="1257" alt="image" src="https://github.com/user-attachments/assets/8816a389-0620-4015-b3d4-13247c9f88a5" />
