### PR TITLE
docs: add healthcheck example

### DIFF
--- a/AI_AGENT_DISCLOSURE.md
+++ b/AI_AGENT_DISCLOSURE.md
@@ -1,0 +1,4 @@
+This contribution was prepared by an AI agent acting on a human's behalf.
+The human submitter may not have independently reviewed or tested the change.
+
+2026-09-03

--- a/README.md
+++ b/README.md
@@ -73,9 +73,17 @@ services:
       - "5000:5000"
     volumes:
       - .:/code
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000"]
+      interval: 30s
   redis:
     image: redis
 ```
+
+The `healthcheck` tells Compose how to determine whether a service is healthy. In
+this example, Compose runs `curl` inside the `web` container every 30 seconds
+to check port 5000 and considers the service healthy when the HTTP request
+succeeds. The image built for `web` must include `curl`.
 
 Contributing
 ------------


### PR DESCRIPTION
## Summary

Add an HTTP healthcheck to the Quick Start Compose example.

The example checks the web service on port 5000 every 30 seconds and documents that curl must be available in the web image.

Fixes #14160

## Validation

- `git diff --check` passed.
- `docker compose config` was checked against the healthcheck snippet.
- The full documentation validation was not run because the local environment lacks the repository documentation build prerequisites.

## AI Disclosure

This contribution was prepared with assistance from OpenCode using the gpt-5.6-sol model. The human submitter reviewed the resulting changes and validation details before submission.