### PR TITLE
chore: remove github.com/buger/goterm dependency

### DIFF
--- a/cmd/display/tty.go
+++ b/cmd/display/tty.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"time"
 
-	"github.com/buger/goterm"
+	"golang.org/x/term"
 
 	"github.com/docker/compose/v5/pkg/api"
 )
@@ -82,12 +83,9 @@ type termWriter struct {
 }
 
 func termSize() (int, int) {
-	width, height := goterm.Width(), goterm.Height()
-	if width <= 0 {
-		width = 80
-	}
-	if height <= 0 {
-		height = 24
+	width, height, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || width <= 0 || height <= 0 {
+		width, height = 80, 24
 	}
 	return width, height
 }

--- a/cmd/formatter/logs.go
+++ b/cmd/formatter/logs.go
@@ -25,8 +25,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buger/goterm"
 	"github.com/moby/moby/client/pkg/jsonmessage"
+	"github.com/morikuni/aec"
 
 	"github.com/docker/compose/v5/pkg/api"
 )
@@ -131,7 +131,7 @@ func (l *logConsumer) write(w io.Writer, container, message string) {
 
 func (l *logConsumer) Status(container, msg string) {
 	p := l.getPresenter(container)
-	s := p.colors(fmt.Sprintf("%s%s %s\n", goterm.RESET_LINE, container, msg))
+	s := p.colors(fmt.Sprintf("\r%s%s %s\n", aec.EraseLine(aec.EraseModes.Tail), container, msg))
 	l.stdout.Write([]byte(s)) //nolint:errcheck
 }
 

--- a/cmd/formatter/shortcut.go
+++ b/cmd/formatter/shortcut.go
@@ -26,10 +26,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/buger/goterm"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/eiannone/keyboard"
 	"github.com/skratchdot/open-golang/open"
+	"golang.org/x/term"
 
 	"github.com/docker/compose/v5/internal/desktop"
 	"github.com/docker/compose/v5/internal/tracing"
@@ -149,12 +149,12 @@ func (lk *LogKeyboard) printNavigationMenu() {
 	lk.createBuffer(offset)
 
 	if lk.logLevel == INFO {
-		height := goterm.Height()
 		menu := lk.navigationMenu()
 
 		carriageReturn()
 		saveCursor()
 
+		_, height := termSize()
 		lk.kError.printError(height, menu)
 
 		moveCursor(height-extraLines(menu), 0)
@@ -191,11 +191,11 @@ func (lk *LogKeyboard) navigationMenu() string {
 }
 
 func (lk *LogKeyboard) clearNavigationMenu() {
-	height := goterm.Height()
 	carriageReturn()
 	saveCursor()
 
 	// clearLine()
+	_, height := termSize()
 	for range height {
 		moveCursorDown(1)
 		clearLine()
@@ -376,7 +376,8 @@ func allocateSpace(lines int) {
 }
 
 func extraLines(s string) int {
-	return int(math.Floor(float64(lenAnsi(s)) / float64(goterm.Width())))
+	width, _ := termSize()
+	return int(math.Floor(float64(lenAnsi(s)) / float64(width)))
 }
 
 func shortcutKeyColor(key string) string {
@@ -389,4 +390,12 @@ func shortcutKeyColor(key string) string {
 
 func navColor(key string) string {
 	return ansiColor(FAINT, key)
+}
+
+func termSize() (width, height int) {
+	width, height, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || width <= 0 || height <= 0 {
+		return 80, 24
+	}
+	return width, height
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/DefangLabs/secret-detector v0.0.0-20250403165618-22662109213e
 	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
-	github.com/buger/goterm v1.0.4
 	github.com/compose-spec/compose-go/v2 v2.15.1-0.20260908103050-cda18529aca7
 	github.com/containerd/console v1.0.5
 	github.com/containerd/containerd/v2 v2.3.5
@@ -53,6 +52,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/sync v0.23.0
 	golang.org/x/sys v0.48.0
+	golang.org/x/term v0.45.0
 	google.golang.org/grpc v1.83.2
 	gotest.tools/v3 v3.5.2
 	tags.cncf.io/container-device-interface v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9
 github.com/anchore/go-struct-converter v0.1.0/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
-github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -312,7 +310,6 @@ golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
 golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sync v0.23.0 h1:KameEIfc1IkluZyXWLn39Wd4tURc6GbCiISGiZm2bQk=
 golang.org/x/sync v0.23.0/go.mod h1:sUUOizhqBxiL6pEWpqNLUiaJn1ShEbZ6BBqskPbjZm0=
-golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Replace goterm's terminal size detection with golang.org/x/term, which provides the same functionality and is already an indirect dependency.

Use the existing github.com/morikuni/aec dependency for clearing the current terminal line.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
