### PR TITLE
fix(build): don't fail bake progress when stdout is not a console

### DIFF
--- a/pkg/compose/build_bake.go
+++ b/pkg/compose/build_bake.go
@@ -140,7 +140,7 @@ func (s *composeService) doBuildBake(ctx context.Context, project *types.Project
 	if out == nil {
 		out = s.stdout()
 	}
-	display, err := progressui.NewDisplay(makeConsole(out), displayMode)
+	display, err := newBakeDisplay(out, displayMode)
 	if err != nil {
 		return nil, err
 	}
@@ -509,12 +509,25 @@ func (s *composeService) getBuildxPlugin() (*manager.Plugin, error) {
 // matters, and falls back to plain elsewhere.
 func makeConsole(out io.Writer) io.Writer {
 	if s, ok := out.(*streams.Out); ok {
-		if f, ok := s.File(); ok {
+		if f, ok := s.File(); ok && s.IsTerminal() {
 			return f
 		}
-		return &_console{s}
+		if s.IsTerminal() {
+			return &_console{s}
+		}
+		return s
 	}
 	return out
+}
+
+// newBakeDisplay falls back to plain when TTY mode is requested but out is not a console
+// (e.g. `docker compose build >/dev/null`, #14182).
+func newBakeDisplay(out io.Writer, mode progressui.DisplayMode) (progressui.Display, error) {
+	d, err := progressui.NewDisplay(makeConsole(out), mode)
+	if err != nil && mode != progressui.PlainMode && mode != progressui.QuietMode {
+		d, err = progressui.NewDisplay(out, progressui.PlainMode)
+	}
+	return d, err
 }
 
 var _ console.File = &_console{}

--- a/pkg/compose/build_bake_test.go
+++ b/pkg/compose/build_bake_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/streams"
+	"github.com/moby/buildkit/util/progress/progressui"
 	"gotest.tools/v3/assert"
 )
 
@@ -105,19 +106,52 @@ func TestToBakeAttest(t *testing.T) {
 // os.Stdin/Stdout/Stderr values, so a wrapper would disable the TTY progress
 // rendering entirely (#14086).
 func TestMakeConsole(t *testing.T) {
-	t.Run("stream wrapping a real file yields the file itself", func(t *testing.T) {
-		out := makeConsole(streams.NewOut(os.Stdout))
-		assert.Equal(t, out, os.Stdout)
+	t.Run("terminal stdout yields the real file", func(t *testing.T) {
+		s := streams.NewOut(os.Stdout)
+		out := makeConsole(s)
+		if s.IsTerminal() {
+			assert.Equal(t, out, os.Stdout)
+			return
+		}
+		assert.Check(t, out != os.Stdout, "non-console stdout must not be passed to ConsoleFromFile")
+	})
+
+	t.Run("redirected file is not treated as a console", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = r.Close()
+			_ = w.Close()
+		})
+		s := streams.NewOut(w)
+		out := makeConsole(s)
+		assert.Check(t, out != w, "pipe fd must not be handed to ConsoleFromFile")
 	})
 
 	t.Run("file-less stream keeps the console.File wrapper", func(t *testing.T) {
-		out := makeConsole(streams.NewOut(&bytes.Buffer{}))
-		_, ok := out.(*_console)
-		assert.Check(t, ok, "expected a *_console, got %T", out)
+		s := streams.NewOut(&bytes.Buffer{})
+		out := makeConsole(s)
+		if s.IsTerminal() {
+			_, ok := out.(*_console)
+			assert.Check(t, ok, "expected a *_console, got %T", out)
+			return
+		}
+		assert.Equal(t, out, io.Writer(s))
 	})
 
 	t.Run("plain writer is left untouched", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		assert.Equal(t, makeConsole(buf), io.Writer(buf))
 	})
+}
+
+func TestNewBakeDisplayFallsBackWhenNotConsole(t *testing.T) {
+	r, w, err := os.Pipe()
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+	_, err = newBakeDisplay(streams.NewOut(w), progressui.TtyMode)
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
#14090 unwraps the real stdout file so Windows TTY progress works. that also feeds a redirected stdout (`compose build >/dev/null`) into ConsoleFromFile, which then dies with `provided file is not a console`.

only unwrap when stdout actually is a terminal, and fall back to plain progress otherwise.

Fixes #14182