### PR TITLE
Support per-replica volumes for scaled services (x-per-replica)

### DIFF
--- a/AI_AGENT_DISCLOSURE.md
+++ b/AI_AGENT_DISCLOSURE.md
@@ -1,0 +1,4 @@
+> *"This contribution was prepared by an AI agent acting on a human's behalf.
+> The human submitter may not have independently reviewed or tested the change."*
+
+2026-09-05

--- a/docs/per-replica-volumes.md
+++ b/docs/per-replica-volumes.md
@@ -1,0 +1,62 @@
+# Per-replica volumes
+
+## Problem
+
+When a service is scaled to several replicas (`deploy.replicas` or `--scale`), every replica shares the exact
+same named volume:
+
+```yaml
+services:
+  configsvr:
+    image: mongo
+    command: mongod --configsvr --replSet configsvr
+    deploy:
+      replicas: 3
+    volumes:
+      - configsvr-data:/data/db
+
+volumes:
+  configsvr-data:
+```
+
+All three `configsvr` replicas above mount the very same `configsvr-data` volume, which corrupts any service
+that expects each replica to keep its own independent state (e.g. members of a database replica set). The only
+workaround has been to hand-declare one service per replica, each with its own named volume — defeating the
+purpose of `replicas`.
+
+## `x-per-replica`
+
+Setting `x-per-replica: true` on a long-syntax volume entry gives every replica of that service its own,
+distinct volume instead of sharing the one declared under the top-level `volumes:` key:
+
+```yaml
+services:
+  configsvr:
+    image: mongo
+    command: mongod --configsvr --replSet configsvr
+    deploy:
+      replicas: 3
+    volumes:
+      - type: volume
+        source: configsvr-data
+        target: /data/db
+        x-per-replica: true
+
+volumes:
+  configsvr-data:
+```
+
+Replica `N` of `configsvr` gets a volume named `<project>_configsvr-data-N` (`myproject_configsvr-data-1`,
+`myproject_configsvr-data-2`, `myproject_configsvr-data-3`), created on demand with the same driver, driver
+options and labels as the declared `configsvr-data` volume. Replicas keep the same volume across restarts and
+recreation, exactly like a normal named volume; only the sharing across replicas is removed.
+
+`docker compose down --volumes` removes every per-replica volume actually backing the project's containers,
+alongside the (in this mode, never populated) base volume name.
+
+`x-per-replica` requires a named volume (`type: volume` with a `source`) and cannot be combined with
+`external: true` — Compose only mints new volume names for volumes it owns.
+
+`x-per-replica` is a Compose-specific extension: it is not (yet) part of the
+[Compose Specification](https://github.com/compose-spec/compose-spec), so other tools that consume Compose
+files won't recognize it.

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -193,6 +193,64 @@ func warnUnmanagedNetworks(project *types.Project, observed *ObservedState) {
 	}
 }
 
+// PerReplicaVolumeExtension opts a named volume mount into a distinct
+// underlying Docker volume per service replica, instead of every replica
+// sharing the single volume declared under the top-level `volumes:` key.
+// Set it on the long-syntax service volume entry:
+//
+//	volumes:
+//	  - type: volume
+//	    source: data
+//	    target: /data
+//	    x-per-replica: true
+//
+// https://github.com/docker/compose/issues/9026
+const PerReplicaVolumeExtension = "x-per-replica"
+
+func isPerReplicaVolume(v types.ServiceVolumeConfig) bool {
+	enabled, _ := v.Extensions[PerReplicaVolumeExtension].(bool)
+	return enabled
+}
+
+// perReplicaVolumeName derives the distinct volume name backing a given
+// replica of a service opted into PerReplicaVolumeExtension.
+func perReplicaVolumeName(base types.VolumeConfig, number int) string {
+	return fmt.Sprintf("%s-%d", base.Name, number)
+}
+
+// ensurePerReplicaVolumes provisions the distinct volumes declared via
+// PerReplicaVolumeExtension ahead of container creation. Unlike the
+// project-wide volumes the plan creates once (planCreateVolume), a
+// per-replica volume has no single OpCreateVolume node to own it: every
+// replica needs its own, keyed off a replica number only known once
+// container creation begins.
+func (s *composeService) ensurePerReplicaVolumes(ctx context.Context, p types.Project, service types.ServiceConfig, number int) error {
+	if number <= 0 {
+		return nil
+	}
+	for _, v := range service.Volumes {
+		if !isPerReplicaVolume(v) {
+			continue
+		}
+		if v.Type != types.VolumeTypeVolume || v.Source == "" {
+			return fmt.Errorf("service %q: %s requires a named volume source", service.Name, PerReplicaVolumeExtension)
+		}
+		base, ok := p.Volumes[v.Source]
+		if !ok {
+			return fmt.Errorf("service %q: volume %q is not declared", service.Name, v.Source)
+		}
+		if base.External {
+			return fmt.Errorf("service %q: %s cannot be combined with external volume %q", service.Name, PerReplicaVolumeExtension, v.Source)
+		}
+		replica := base
+		replica.Name = perReplicaVolumeName(base, number)
+		if err := s.createVolume(ctx, replica); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // prepareVolumes injects the compose-managed labels onto every project volume so
 // that createVolume (executed later as a plan operation) persists them and the
 // volume can be matched back to the project on the next run. It mirrors
@@ -341,7 +399,10 @@ func (s *composeService) getCreateConfigs(ctx context.Context,
 		k, v, _ := strings.Cut(t, ":")
 		tmpfs[k] = v
 	}
-	binds, mounts, err := s.buildContainerVolumes(ctx, *p, service, inherit)
+	if err := s.ensurePerReplicaVolumes(ctx, *p, service, number); err != nil {
+		return createConfigs{}, err
+	}
+	binds, mounts, err := s.buildContainerVolumes(ctx, *p, service, number, inherit)
 	if err != nil {
 		return createConfigs{}, err
 	}
@@ -960,12 +1021,13 @@ func (s *composeService) buildContainerVolumes(
 	ctx context.Context,
 	p types.Project,
 	service types.ServiceConfig,
+	number int,
 	inherit *container.Summary,
 ) ([]string, []mount.Mount, error) {
 	var mounts []mount.Mount
 	var binds []string
 
-	mountOptions, err := s.buildContainerMountOptions(ctx, p, service, inherit)
+	mountOptions, err := s.buildContainerMountOptions(ctx, p, service, number, inherit)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1110,7 +1172,7 @@ func volumeRequiresMountAPI(vol *types.ServiceVolumeVolume) bool {
 	}
 }
 
-func (s *composeService) buildContainerMountOptions(ctx context.Context, p types.Project, service types.ServiceConfig, inherit *container.Summary) ([]mount.Mount, error) {
+func (s *composeService) buildContainerMountOptions(ctx context.Context, p types.Project, service types.ServiceConfig, number int, inherit *container.Summary) ([]mount.Mount, error) {
 	mounts := map[string]mount.Mount{}
 	if inherit != nil {
 		for _, m := range inherit.Mounts {
@@ -1156,7 +1218,7 @@ func (s *composeService) buildContainerMountOptions(ctx context.Context, p types
 		}
 	}
 
-	mounts, err := fillBindMounts(p, service, mounts)
+	mounts, err := fillBindMounts(p, service, number, mounts)
 	if err != nil {
 		return nil, err
 	}
@@ -1168,9 +1230,9 @@ func (s *composeService) buildContainerMountOptions(ctx context.Context, p types
 	return values, nil
 }
 
-func fillBindMounts(project types.Project, service types.ServiceConfig, mounts map[string]mount.Mount) (map[string]mount.Mount, error) {
+func fillBindMounts(project types.Project, service types.ServiceConfig, number int, mounts map[string]mount.Mount) (map[string]mount.Mount, error) {
 	for _, volume := range service.Volumes {
-		bindMount, err := buildMount(project, volume)
+		bindMount, err := buildMount(project, volume, number)
 		if err != nil {
 			return nil, err
 		}
@@ -1238,7 +1300,7 @@ func buildContainerConfigMounts(p types.Project, s types.ServiceConfig) ([]mount
 			Source:   definedConfig.File,
 			Target:   target,
 			ReadOnly: true,
-		})
+		}, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -1295,7 +1357,7 @@ func buildContainerSecretMounts(p types.Project, s types.ServiceConfig) ([]mount
 			Bind: &types.ServiceVolumeBind{
 				CreateHostPath: false,
 			},
-		})
+		}, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -1320,7 +1382,7 @@ func isWindowsAbs(p string) bool {
 	return paths.IsWindowsAbs(p)
 }
 
-func buildMount(project types.Project, volume types.ServiceVolumeConfig) (mount.Mount, error) {
+func buildMount(project types.Project, volume types.ServiceVolumeConfig, number int) (mount.Mount, error) {
 	source := volume.Source
 	switch volume.Type {
 	case types.VolumeTypeBind:
@@ -1337,6 +1399,9 @@ func buildMount(project types.Project, volume types.ServiceVolumeConfig) (mount.
 			pVolume, ok := project.Volumes[volume.Source]
 			if ok {
 				source = pVolume.Name
+				if number > 0 && isPerReplicaVolume(volume) {
+					source = perReplicaVolumeName(pVolume, number)
+				}
 			}
 		}
 	}

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"context"
 	"net"
 	"net/netip"
 	"os"
@@ -45,7 +46,7 @@ func TestBuildBindMount(t *testing.T) {
 		Source: "",
 		Target: "/data",
 	}
-	mount, err := buildMount(project, volume)
+	mount, err := buildMount(project, volume, 0)
 	assert.NilError(t, err)
 	assert.Assert(t, filepath.IsAbs(mount.Source))
 	_, err = os.Stat(mount.Source)
@@ -60,7 +61,7 @@ func TestBuildNamedPipeMount(t *testing.T) {
 		Source: "\\\\.\\pipe\\docker_engine_windows",
 		Target: "\\\\.\\pipe\\docker_engine",
 	}
-	mount, err := buildMount(project, volume)
+	mount, err := buildMount(project, volume, 0)
 	assert.NilError(t, err)
 	assert.Equal(t, mount.Type, mountTypes.TypeNamedPipe)
 }
@@ -79,10 +80,124 @@ func TestBuildVolumeMount(t *testing.T) {
 		Source: "myVolume",
 		Target: "/data",
 	}
-	mount, err := buildMount(project, volume)
+	mount, err := buildMount(project, volume, 0)
 	assert.NilError(t, err)
 	assert.Equal(t, mount.Source, "myProject_myVolume")
 	assert.Equal(t, mount.Type, mountTypes.TypeVolume)
+}
+
+// https://github.com/docker/compose/issues/9026
+// PerReplicaVolumeExtension must give each replica its own volume instead of
+// every replica of a scaled service sharing the single declared volume.
+func TestBuildVolumeMount_PerReplica(t *testing.T) {
+	project := composetypes.Project{
+		Name: "myProject",
+		Volumes: composetypes.Volumes(map[string]composetypes.VolumeConfig{
+			"myVolume": {Name: "myProject_myVolume"},
+		}),
+	}
+	volume := composetypes.ServiceVolumeConfig{
+		Type:       composetypes.VolumeTypeVolume,
+		Source:     "myVolume",
+		Target:     "/data",
+		Extensions: composetypes.Extensions{PerReplicaVolumeExtension: true},
+	}
+
+	mount, err := buildMount(project, volume, 2)
+	assert.NilError(t, err)
+	assert.Equal(t, mount.Source, "myProject_myVolume-2")
+
+	// number == 0 (a one-off container) keeps the shared, unsuffixed volume
+	mount, err = buildMount(project, volume, 0)
+	assert.NilError(t, err)
+	assert.Equal(t, mount.Source, "myProject_myVolume")
+
+	// without the extension, replicas keep sharing the one declared volume
+	plain := composetypes.ServiceVolumeConfig{Type: composetypes.VolumeTypeVolume, Source: "myVolume", Target: "/data"}
+	mount, err = buildMount(project, plain, 2)
+	assert.NilError(t, err)
+	assert.Equal(t, mount.Source, "myProject_myVolume")
+}
+
+func TestEnsurePerReplicaVolumes(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mock, cli := prepareMocks(mockCtrl)
+	s := composeService{dockerCli: cli, events: &ignore{}}
+
+	project := composetypes.Project{
+		Name: "myProject",
+		Volumes: composetypes.Volumes(map[string]composetypes.VolumeConfig{
+			"myVolume": {Name: "myProject_myVolume", Driver: "local"},
+		}),
+	}
+	service := composetypes.ServiceConfig{
+		Name: "web",
+		Volumes: []composetypes.ServiceVolumeConfig{
+			{
+				Type:       composetypes.VolumeTypeVolume,
+				Source:     "myVolume",
+				Target:     "/data",
+				Extensions: composetypes.Extensions{PerReplicaVolumeExtension: true},
+			},
+		},
+	}
+
+	mock.EXPECT().VolumeCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, opts client.VolumeCreateOptions) (client.VolumeCreateResult, error) {
+			assert.Equal(t, opts.Name, "myProject_myVolume-3")
+			assert.Equal(t, opts.Driver, "local")
+			return client.VolumeCreateResult{}, nil
+		})
+
+	err := s.ensurePerReplicaVolumes(t.Context(), project, service, 3)
+	assert.NilError(t, err)
+
+	// number == 0 means a one-off container: no per-replica volume to create
+	err = s.ensurePerReplicaVolumes(t.Context(), project, service, 0)
+	assert.NilError(t, err)
+}
+
+func TestEnsurePerReplicaVolumes_RejectsExternalVolume(t *testing.T) {
+	s := composeService{}
+	project := composetypes.Project{
+		Volumes: composetypes.Volumes(map[string]composetypes.VolumeConfig{
+			"myVolume": {Name: "myProject_myVolume", External: true},
+		}),
+	}
+	service := composetypes.ServiceConfig{
+		Name: "web",
+		Volumes: []composetypes.ServiceVolumeConfig{
+			{
+				Type:       composetypes.VolumeTypeVolume,
+				Source:     "myVolume",
+				Target:     "/data",
+				Extensions: composetypes.Extensions{PerReplicaVolumeExtension: true},
+			},
+		},
+	}
+
+	err := s.ensurePerReplicaVolumes(t.Context(), project, service, 1)
+	assert.ErrorContains(t, err, "external volume")
+}
+
+func TestEnsurePerReplicaVolumes_RejectsBindMount(t *testing.T) {
+	s := composeService{}
+	service := composetypes.ServiceConfig{
+		Name: "web",
+		Volumes: []composetypes.ServiceVolumeConfig{
+			{
+				Type:       composetypes.VolumeTypeBind,
+				Source:     "/host/path",
+				Target:     "/data",
+				Extensions: composetypes.Extensions{PerReplicaVolumeExtension: true},
+			},
+		},
+	}
+
+	err := s.ensurePerReplicaVolumes(t.Context(), composetypes.Project{}, service, 1)
+	assert.ErrorContains(t, err, "requires a named volume source")
 }
 
 func TestServiceImageName(t *testing.T) {
@@ -166,7 +281,7 @@ func TestBuildContainerMountOptions(t *testing.T) {
 	}
 	mock.EXPECT().ImageInspect(gomock.Any(), "myProject-myService").AnyTimes().Return(client.ImageInspectResult{}, nil)
 
-	mounts, err := s.buildContainerMountOptions(t.Context(), project, project.Services["myService"], inherit)
+	mounts, err := s.buildContainerMountOptions(t.Context(), project, project.Services["myService"], 0, inherit)
 	sort.Slice(mounts, func(i, j int) bool {
 		return mounts[i].Target < mounts[j].Target
 	})
@@ -178,7 +293,7 @@ func TestBuildContainerMountOptions(t *testing.T) {
 	assert.Equal(t, mounts[2].VolumeOptions.Subpath, "etc")
 	assert.Equal(t, mounts[3].Target, "\\\\.\\pipe\\docker_engine")
 
-	mounts, err = s.buildContainerMountOptions(t.Context(), project, project.Services["myService"], inherit)
+	mounts, err = s.buildContainerMountOptions(t.Context(), project, project.Services["myService"], 0, inherit)
 	sort.Slice(mounts, func(i, j int) bool {
 		return mounts[i].Target < mounts[j].Target
 	})
@@ -477,7 +592,7 @@ volumes:
 			})
 			assert.NilError(t, err)
 			s := &composeService{}
-			binds, mounts, err := s.buildContainerVolumes(t.Context(), *p, p.Services["test"], nil)
+			binds, mounts, err := s.buildContainerVolumes(t.Context(), *p, p.Services["test"], 0, nil)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, tt.binds, binds)
 			assert.DeepEqual(t, tt.mounts, mounts)

--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -131,7 +132,7 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 	}
 
 	if options.Volumes {
-		ops = append(ops, s.ensureVolumesDown(ctx, project)...)
+		ops = append(ops, s.ensureVolumesDown(ctx, project, containers)...)
 	}
 
 	if !resourceToRemove && len(ops) == 0 {
@@ -145,9 +146,9 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 	return eg.Wait()
 }
 
-func (s *composeService) ensureVolumesDown(ctx context.Context, project *types.Project) []downOp {
+func (s *composeService) ensureVolumesDown(ctx context.Context, project *types.Project, containers Containers) []downOp {
 	var ops []downOp
-	for _, vol := range project.Volumes {
+	for key, vol := range project.Volumes {
 		if vol.External {
 			continue
 		}
@@ -155,9 +156,43 @@ func (s *composeService) ensureVolumesDown(ctx context.Context, project *types.P
 		ops = append(ops, func() error {
 			return s.removeVolume(ctx, volumeName)
 		})
+		for _, name := range perReplicaVolumeNamesInUse(project, key, vol, containers) {
+			ops = append(ops, func() error {
+				return s.removeVolume(ctx, name)
+			})
+		}
 	}
 
 	return ops
+}
+
+// perReplicaVolumeNamesInUse returns the distinct per-replica volume names
+// (PerReplicaVolumeExtension) actually backing the given volume's observed
+// containers. The base volume name (vol.Name) never exists on disk for a
+// volume used exclusively in per-replica mode, so it must be found this way
+// rather than guessed from the service's current scale.
+func perReplicaVolumeNamesInUse(project *types.Project, key string, vol types.VolumeConfig, containers Containers) []string {
+	var names []string
+	for _, service := range project.Services {
+		usesPerReplica := false
+		for _, v := range service.Volumes {
+			if v.Source == key && isPerReplicaVolume(v) {
+				usesPerReplica = true
+				break
+			}
+		}
+		if !usesPerReplica {
+			continue
+		}
+		for _, ctr := range containers.filter(isService(service.Name)) {
+			number, err := strconv.Atoi(ctr.Labels[api.ContainerNumberLabel])
+			if err != nil {
+				continue
+			}
+			names = append(names, perReplicaVolumeName(vol, number))
+		}
+	}
+	return names
 }
 
 func (s *composeService) ensureImagesDown(ctx context.Context, project *types.Project, options api.DownOptions) ([]downOp, error) {

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -285,6 +285,71 @@ func TestDownRemoveVolumes(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+// https://github.com/docker/compose/issues/9026
+// down --volumes must remove every per-replica volume actually backing a
+// scaled service's containers, not just the (never-created) base volume
+// name, since PerReplicaVolumeExtension gives each replica its own volume.
+func TestDownRemovesPerReplicaVolumes(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	api, cli := prepareMocks(mockCtrl)
+	tested, err := NewComposeService(cli)
+	assert.NilError(t, err)
+
+	projectName := strings.ToLower(testProject)
+	project := &types.Project{
+		Name: projectName,
+		Volumes: types.Volumes{
+			"data": types.VolumeConfig{Name: projectName + "_data"},
+		},
+		Services: types.Services{
+			"web": {
+				Name: "web",
+				Volumes: []types.ServiceVolumeConfig{
+					{
+						Type:       types.VolumeTypeVolume,
+						Source:     "data",
+						Target:     "/data",
+						Extensions: types.Extensions{PerReplicaVolumeExtension: true},
+					},
+				},
+			},
+		},
+	}
+
+	replicaLabels := func(number string) map[string]string {
+		return map[string]string{
+			compose.ServiceLabel:         "web",
+			compose.ProjectLabel:         projectName,
+			compose.ContainerNumberLabel: number,
+		}
+	}
+	containers := []container.Summary{
+		{ID: "c1", Names: []string{"/c1"}, Labels: replicaLabels("1"), State: container.StateExited},
+		{ID: "c2", Names: []string{"/c2"}, Labels: replicaLabels("2"), State: container.StateExited},
+	}
+
+	api.EXPECT().ContainerList(gomock.Any(), projectFilterListOpt(false)).Return(
+		client.ContainerListResult{Items: containers}, nil)
+
+	for _, id := range []string{"c1", "c2"} {
+		api.EXPECT().ContainerStop(gomock.Any(), id, client.ContainerStopOptions{}).Return(client.ContainerStopResult{}, nil)
+		api.EXPECT().ContainerRemove(gomock.Any(), id, client.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).
+			Return(client.ContainerRemoveResult{}, nil)
+	}
+
+	for _, name := range []string{projectName + "_data", projectName + "_data-1", projectName + "_data-2"} {
+		api.EXPECT().VolumeInspect(gomock.Any(), name, gomock.Any()).Return(client.VolumeInspectResult{}, nil)
+		api.EXPECT().VolumeRemove(gomock.Any(), name, client.VolumeRemoveOptions{Force: true}).Return(client.VolumeRemoveResult{}, nil)
+	}
+
+	api.EXPECT().ContainerList(gomock.Any(), hookFilterListOpt()).Return(client.ContainerListResult{}, nil)
+
+	err = tested.Down(t.Context(), projectName, compose.DownOptions{Volumes: true, Project: project})
+	assert.NilError(t, err)
+}
+
 func TestDownRemoveImages(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/e2e/testdata/TestPerReplicaVolumes/compose.yaml
+++ b/pkg/e2e/testdata/TestPerReplicaVolumes/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  test:
+    image: alpine
+    init: true
+    command: sh -c "wc -l < /data/log 2>/dev/null || echo 0; echo seed >> /data/log; sleep infinity"
+    volumes:
+      - type: volume
+        source: data
+        target: /data
+        x-per-replica: true
+    deploy:
+      replicas: 2
+
+volumes:
+  data:

--- a/pkg/e2e/volumes_test.go
+++ b/pkg/e2e/volumes_test.go
@@ -169,6 +169,25 @@ func TestUpRecreateVolumesIgnoreBinds(t *testing.T) {
 			NotRecreated("app"))
 }
 
+// https://github.com/docker/compose/issues/9026
+// x-per-replica must give each replica of a scaled service its own volume
+// instead of every replica sharing the single volume declared in `volumes:`.
+func TestPerReplicaVolumes(t *testing.T) {
+	s := NewScenario(t, "x-per-replica must give each replica of a scaled service its own volume")
+	s.Step("up creates two replicas, each seeding its own volume",
+		ComposeCmd("up", "-d"),
+		ServiceScale("test", 2)).
+		Step("the first replica's own volume exists",
+			DockerCmd("volume", "inspect", s.Project()+"_data-1")).
+		Step("the second replica's own volume exists",
+			DockerCmd("volume", "inspect", s.Project()+"_data-2")).
+		Step("recreating both replicas shows neither ever saw the other's write",
+			ComposeCmd("up", "-d", "--force-recreate"),
+			Recreated("test"),
+			StdoutContains("test-1  | 1"),
+			StdoutContains("test-2  | 1"))
+}
+
 func TestImageVolume(t *testing.T) {
 	NewScenario(t, "an image volume must mount the source image's content at the requested subpath").
 		Requires(EngineVersionAtLeast(28)).


### PR DESCRIPTION
## Summary
- Today, when a service is scaled to several replicas, every replica shares the exact same named volume — which corrupts any service that expects each replica to keep its own independent state (e.g. members of a database replica set, the original use case in the issue). The only workaround has been to hand-declare one service per replica, each with its own named volume, defeating the purpose of `replicas`/`--scale`.
- Adds an opt-in `x-per-replica: true` extension on a long-syntax service volume entry: when set, replica `N` of the service gets its own distinct volume (`<project>_<volume>-N`) instead of sharing the one declared under the top-level `volumes:` key, created on demand with the same driver, driver options and labels as the declared volume.
- `down --volumes` removes every per-replica volume actually backing the project's observed containers (derived from each container's replica-number label), in addition to the base volume name.
- This is intentionally opt-in via an `x-` extension rather than a compose-spec change or automatic behavior: changing the default for scaled named volumes would be a breaking change for anyone currently relying on replicas sharing state through one volume.
- New doc page: `docs/per-replica-volumes.md`.

## Test plan
- [x] `go test ./pkg/compose/...` — new unit tests for `buildMount`'s per-replica naming, `ensurePerReplicaVolumes` (including external-volume and bind-mount rejection), and `down --volumes` cleanup (`TestDownRemovesPerReplicaVolumes`)
- [x] `golangci-lint run --build-tags e2e ./...` — 0 issues
- [ ] New e2e scenario (`TestPerReplicaVolumes`) added but not run in this environment — no Docker daemon available. Please run `go test -tags e2e ./pkg/e2e/ -run TestPerReplicaVolumes` before merging.

Closes #9026

🤖 Generated with [Claude Code](https://claude.com/claude-code)