### PR TITLE
refactor(compatibility): hoist flag/command lists to package vars

### DIFF
--- a/cmd/compatibility/convert.go
+++ b/cmd/compatibility/convert.go
@@ -25,31 +25,25 @@ import (
 	"github.com/docker/compose/v5/cmd/compose"
 )
 
-func getCompletionCommands() []string {
-	return []string{
-		"__complete",
-		"__completeNoDesc",
-	}
+var completionCommands = []string{
+	"__complete",
+	"__completeNoDesc",
 }
 
-func getBoolFlags() []string {
-	return []string{
-		"--debug", "-D",
-		"--verbose",
-		"--tls",
-		"--tlsverify",
-	}
+var boolFlags = []string{
+	"--debug", "-D",
+	"--verbose",
+	"--tls",
+	"--tlsverify",
 }
 
-func getStringFlags() []string {
-	return []string{
-		"--tlscacert",
-		"--tlscert",
-		"--tlskey",
-		"--host", "-H",
-		"--context",
-		"--log-level",
-	}
+var stringFlags = []string{
+	"--tlscacert",
+	"--tlscert",
+	"--tlskey",
+	"--host", "-H",
+	"--context",
+	"--log-level",
 }
 
 // Convert transforms standalone docker-compose args into CLI plugin compliant ones
@@ -60,7 +54,7 @@ func Convert(args []string) []string {
 ARGS:
 	for i := 0; i < l; i++ {
 		arg := args[i]
-		if slices.Contains(getCompletionCommands(), arg) {
+		if slices.Contains(completionCommands, arg) {
 			command = append([]string{arg}, command...)
 			continue
 		}
@@ -80,11 +74,11 @@ ARGS:
 			arg = "version"
 		}
 
-		if slices.Contains(getBoolFlags(), arg) {
+		if slices.Contains(boolFlags, arg) {
 			rootFlags = append(rootFlags, arg)
 			continue
 		}
-		for _, flag := range getStringFlags() {
+		for _, flag := range stringFlags {
 			if arg == flag {
 				i++
 				if i >= l {


### PR DESCRIPTION
**What I did**

`getCompletionCommands()` / `getBoolFlags()` / `getStringFlags()` in
`cmd/compatibility/convert.go` rebuilt their slice literals on every
call, and `Convert` calls them once per parsed argument in its main
loop. This moves the three lists to package-level `var`s so they are
allocated once instead of repeatedly. No behavior change: call sites
now reference the vars directly with `slices.Contains`/range instead
of calling the getter functions.

**Related issue**


**(not mandatory) A picture of a cute animal, if possible in relation to what you did**
<img width="334" height="262" alt="image" src="https://github.com/user-attachments/assets/d16f8b18-89a9-48a6-a667-7190998cd519" />
