### PR TITLE
fix(tty): render child task lines so per-layer pull progress is visible

### DIFF
--- a/AI_AGENT_DISCLOSURE.md
+++ b/AI_AGENT_DISCLOSURE.md
@@ -1,0 +1,3 @@
+*"This contribution was prepared by an AI agent acting on a human's behalf. The human submitter may not have independently reviewed or tested the change."*
+
+2026-09-06

--- a/cmd/display/tty.go
+++ b/cmd/display/tty.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"iter"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -309,6 +308,7 @@ func (w *ttyWriter) childrenTasks(parent string) iter.Seq[*task] {
 type lineData struct {
 	spinner           string // rendered spinner with color
 	prefix            string // dry-run prefix if any
+	indent            string // indentation for child task lines
 	taskID            string // possibly abbreviated
 	progress          string // progress bar and (optionally) size info appended
 	progressSizeBytes int    // byte length of the trailing size suffix in progress, 0 if none
@@ -357,48 +357,82 @@ func (w *ttyWriter) printWithDimensions(terminalWidth, terminalHeight int) {
 	firstLine := fmt.Sprintf("[+] %s %d/%d", w.operation, numDone(w.tasks), len(w.tasks))
 	_, _ = fmt.Fprintln(w.out, firstLine)
 
-	// Collect parent tasks in original order
-	allTasks := slices.Collect(w.parentTasks())
+	// Collect parent tasks with their children in original order, so that
+	// per-layer pull progress (child tasks) is rendered under its parent.
+	// See https://github.com/docker/compose/issues/13757
+	type taskEntry struct {
+		t      *task
+		indent string
+	}
+	var entries []taskEntry
+	for t := range w.parentTasks() {
+		entries = append(entries, taskEntry{t, ""})
+		for child := range w.childrenTasks(t.ID) {
+			entries = append(entries, taskEntry{child, "  "})
+		}
+	}
 
 	// Available lines: terminal height - 2 (header line + potential "more" line)
 	maxLines := max(terminalHeight-2, 1)
 
-	showMore := len(allTasks) > maxLines
-	tasksToShow := allTasks
+	showMore := len(entries) > maxLines
+	entriesToShow := entries
 	if showMore {
-		tasksToShow = allTasks[:maxLines-1] // Reserve one line for "more" message
+		entriesToShow = entries[:maxLines-1] // Reserve one line for "more" message
 	}
 
-	// collect line data and compute timerLen
-	lines := make([]lineData, len(tasksToShow))
-	var timerLen int
-	for i, t := range tasksToShow {
-		lines[i] = w.prepareLineData(t)
-		if len(lines[i].timer) > timerLen {
-			timerLen = len(lines[i].timer)
+	// layoutLines prepares, truncates and pads lines for the given entries.
+	layoutLines := func(entries []taskEntry) []lineData {
+		// collect line data and compute timerLen
+		lines := make([]lineData, len(entries))
+		var timerLen int
+		for i, e := range entries {
+			lines[i] = w.prepareLineData(e.t)
+			lines[i].indent = e.indent
+			if len(lines[i].timer) > timerLen {
+				timerLen = len(lines[i].timer)
+			}
 		}
+
+		// pad timers so they all have the same visible width
+		for i := range lines {
+			l := &lines[i]
+			if l.timer == "" {
+				continue
+			}
+			timerWidth := utf8.RuneCountInString(l.timer)
+			if timerWidth < timerLen {
+				// Left-pad so the timer's right edge stays aligned on the terminal.
+				// This also prevents stale suffix characters from visually “sticking”
+				// when a previously-rendered timer was wider (e.g. "10.6s" -> "0.0s").
+				l.timer = strings.Repeat(" ", timerLen-timerWidth) + l.timer
+			}
+		}
+
+		// shorten details/taskID to fit terminal width
+		w.adjustLineWidth(lines, timerLen, terminalWidth)
+
+		// compute padding
+		w.applyPadding(lines, terminalWidth, timerLen)
+		return lines
 	}
 
-	// pad timers so they all have the same visible width
-	for i := range lines {
-		l := &lines[i]
-		if l.timer == "" {
-			continue
+	lines := layoutLines(entriesToShow)
+
+	// Child task lines carry indentation and longer status labels, so when
+	// lines still overflow the terminal width after truncation, drop the
+	// expendable child lines and re-layout parents only.
+	if linesOverflow(lines, terminalWidth) {
+		var parents []taskEntry
+		for _, e := range entriesToShow {
+			if e.indent == "" {
+				parents = append(parents, e)
+			}
 		}
-		timerWidth := utf8.RuneCountInString(l.timer)
-		if timerWidth < timerLen {
-			// Left-pad so the timer's right edge stays aligned on the terminal.
-			// This also prevents stale suffix characters from visually “sticking”
-			// when a previously-rendered timer was wider (e.g. "10.6s" -> "0.0s").
-			l.timer = strings.Repeat(" ", timerLen-timerWidth) + l.timer
+		if len(parents) < len(entriesToShow) {
+			lines = layoutLines(parents)
 		}
 	}
-
-	// shorten details/taskID to fit terminal width
-	w.adjustLineWidth(lines, timerLen, terminalWidth)
-
-	// compute padding
-	w.applyPadding(lines, terminalWidth, timerLen)
 
 	// Render lines
 	numLines := 0
@@ -408,7 +442,7 @@ func (w *ttyWriter) printWithDimensions(terminalWidth, terminalHeight int) {
 	}
 
 	if showMore {
-		moreCount := len(allTasks) - len(tasksToShow)
+		moreCount := len(entries) - len(entriesToShow)
 		moreText := fmt.Sprintf(" ... %d more", moreCount)
 		pad := max(terminalWidth-len(moreText), 0)
 		_, _ = fmt.Fprintf(w.out, "%s%s\n", moreText, strings.Repeat(" ", pad))
@@ -427,16 +461,16 @@ func (w *ttyWriter) applyPadding(lines []lineData, terminalWidth int, timerLen i
 	var maxBeforeStatus int
 	for i := range lines {
 		l := &lines[i]
-		// Width before statusPad: space(1) + spinner(1) + prefix + space(1) + taskID + progress
-		beforeStatus := 3 + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
+		// Width before statusPad: space(1) + indent + spinner(1) + prefix + space(1) + taskID + progress
+		beforeStatus := 3 + utf8.RuneCountInString(l.indent) + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
 		if beforeStatus > maxBeforeStatus {
 			maxBeforeStatus = beforeStatus
 		}
 	}
 
 	for i, l := range lines {
-		// Position before statusPad: space(1) + spinner(1) + prefix + space(1) + taskID + progress
-		beforeStatus := 3 + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
+		// Position before statusPad: space(1) + indent + spinner(1) + prefix + space(1) + taskID + progress
+		beforeStatus := 3 + utf8.RuneCountInString(l.indent) + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
 		// statusPad aligns status; lineText adds 1 more space after statusPad
 		l.statusPad = maxBeforeStatus - beforeStatus
 
@@ -483,12 +517,12 @@ func maxStatusLength(lines []lineData) int {
 }
 
 // maxBeforeStatusWidth computes the maximum width before statusPad across all lines.
-// This is: space(1) + spinner(1) + prefix + space(1) + taskID + progress
+// This is: space(1) + indent + spinner(1) + prefix + space(1) + taskID + progress
 func maxBeforeStatusWidth(lines []lineData) int {
 	var maxWidth int
 	for i := range lines {
 		l := &lines[i]
-		width := 3 + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
+		width := 3 + utf8.RuneCountInString(l.indent) + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
 		if width > maxWidth {
 			maxWidth = width
 		}
@@ -516,6 +550,17 @@ func computeOverflow(lines []lineData, maxBeforeStatus, maxStatusLen, timerLen, 
 	return maxOverflow
 }
 
+// linesOverflow reports whether any rendered line exceeds the terminal width.
+func linesOverflow(lines []lineData, terminalWidth int) bool {
+	for i := range lines {
+		// lineText appends a trailing newline, don't count it as visible width
+		if lenAnsi(strings.TrimSuffix(lineText(lines[i]), "\n")) > terminalWidth {
+			return true
+		}
+	}
+	return false
+}
+
 // truncateProgressSize drops the trailing "X.XMB / Y.YMB" size info from the
 // line currently driving maxBeforeStatusWidth — only that line's shrink can
 // reduce overflow. Returns true if any line was modified.
@@ -527,7 +572,7 @@ func truncateProgressSize(lines []lineData) bool {
 		if l.progressSizeBytes == 0 {
 			continue
 		}
-		w := lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
+		w := utf8.RuneCountInString(l.indent) + lenAnsi(l.prefix) + utf8.RuneCountInString(l.taskID) + lenAnsi(l.progress)
 		if maxIdx < 0 || w > maxWidth {
 			maxWidth = w
 			maxIdx = i
@@ -652,6 +697,7 @@ func (w *ttyWriter) prepareLineData(t *task) lineData {
 func lineText(l lineData) string {
 	var sb strings.Builder
 	sb.WriteString(" ")
+	sb.WriteString(l.indent)
 	sb.WriteString(l.spinner)
 	sb.WriteString(l.prefix)
 	sb.WriteString(" ")

--- a/cmd/display/tty_test.go
+++ b/cmd/display/tty_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -763,4 +764,66 @@ func TestPrintWithDimensions_MultipleRendersFit(t *testing.T) {
 				tick, i, lenAnsi(line), terminalWidth, line)
 		}
 	}
+}
+
+var ansiSequencePattern = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// stripAnsiSequences removes ANSI escape sequences so tests can assert on
+// the visible text (indentation, task IDs) of rendered lines.
+func stripAnsiSequences(s string) string {
+	return ansiSequencePattern.ReplaceAllString(s, "")
+}
+
+// TestPrintWithDimensions_ShowsChildTasks is a regression test for
+// docker/compose#13757: per-layer pull progress lines (child tasks) must be
+// rendered indented under their parent task instead of being dropped.
+func TestPrintWithDimensions_ShowsChildTasks(t *testing.T) {
+	w, buf := newTestWriter()
+	addParentWithDownloadingChildren(w, "Image foo/bar", 3, 3_000_000)
+
+	w.printWithDimensions(100, 24)
+
+	plainLines := strings.Split(stripAnsiSequences(buf.String()), "\n")
+	assert.Assert(t, len(plainLines) > 0)
+	assert.Assert(t, strings.Contains(plainLines[1], "Image foo/bar"),
+		"parent task line missing: %q", plainLines)
+	for i := range 3 {
+		id := fmt.Sprintf("Image foo/bar/layer%d", i)
+		found := false
+		for _, line := range plainLines {
+			if strings.Contains(line, id) {
+				found = true
+				assert.Assert(t, strings.HasPrefix(line, "   "),
+					"child task line %q is not indented", line)
+			}
+		}
+		assert.Assert(t, found, "child task line %q missing in:\n%s", id, plainLines)
+	}
+	for i, line := range plainLines {
+		if lenAnsi(line) == 0 {
+			continue
+		}
+		assert.Assert(t, lenAnsi(line) <= 100,
+			"line %d has length %d which exceeds terminal width 100: %q",
+			i, lenAnsi(line), line)
+	}
+}
+
+// TestPrintWithDimensions_ChildrenCountAgainstLineBudget verifies child task
+// lines share the terminal height budget with parent lines: with a single
+// parent and three children on a 5-line terminal, only the parent and the
+// first child fit before the "more" indicator.
+func TestPrintWithDimensions_ChildrenCountAgainstLineBudget(t *testing.T) {
+	w, buf := newTestWriter()
+	addParentWithDownloadingChildren(w, "Image foo/bar", 3, 3_000_000)
+
+	w.printWithDimensions(100, 5)
+
+	plain := stripAnsiSequences(buf.String())
+	assert.Assert(t, strings.Contains(plain, "Image foo/bar"))
+	assert.Assert(t, strings.Contains(plain, "Image foo/bar/layer0"))
+	assert.Assert(t, strings.Contains(plain, "more"),
+		"expected a \"more\" indicator, got:\n%s", plain)
+	assert.Assert(t, !strings.Contains(plain, "Image foo/bar/layer2"),
+		"child task beyond the line budget should be hidden, got:\n%s", plain)
 }


### PR DESCRIPTION
Fixes #13757

**Problem**
Since v5.0.2 (commit c8d6875, terminal-width adaptation rewrite), `docker compose pull` no longer shows per-layer progress lines. The rewrite renders only parent tasks; the `childrenTasks` loop that printed each layer (e.g. `6e7932d5cb55 Downloading [===>] 25.33MB`) under its `Image …` parent was dropped. Only the aggregated braille strip on the parent line remains.

**Change** (`cmd/display/tty.go`)
- Collect parent tasks together with their children (indented two spaces, as before the rewrite) and count both against the terminal-height budget behind the existing "... N more" indicator.
- Carry the indent through `lineData` into rendering and all width math (padding, truncation, overflow), so the fit-to-width guarantees still hold.
- If lines still overflow after truncation, fall back to parents-only (child detail is expendable), preserving the narrow-terminal behavior the width tests pin down.
- Regression tests: child lines render indented under the parent; children share the line budget with the "more" indicator.

Also adds the repo-required `AI_AGENT_DISCLOSURE.md`.

**Verification**
- New tests fail on the pre-fix code and pass with the fix; full `go test ./cmd/...` passes; `golangci-lint run ./cmd/display/` reports 0 issues.
- End-to-end with a locally built binary against a real daemon (pty): pulling `alpine:3.22` now prints per-layer lines (`738128faa30f Downloading 2.097MB`, `Download complete`, …) under the parent, matching the v5.0.1 output quoted in the issue; the released v5.4.0 binary on the same pull prints zero layer lines.