### PR TITLE
warn about deploy attributes ignored in standalone mode

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -356,6 +356,9 @@ func (o *ProjectOptions) ToProject(ctx context.Context, dockerCli command.Cli, b
 		return nil, metrics, err
 	}
 
+	// Warn about deploy attributes that are ignored in standalone mode
+	warnIgnoredDeployAttributes(project)
+
 	return project, metrics, nil
 }
 

--- a/cmd/compose/warnings.go
+++ b/cmd/compose/warnings.go
@@ -1,0 +1,74 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/sirupsen/logrus"
+)
+
+// warnIgnoredDeployAttributes emits a warning for deploy attributes that are
+// ignored by Compose when running in standalone (non-Swarm) mode, so users
+// don't silently rely on configuration that has no effect.
+// See https://github.com/docker/compose/issues/13150
+func warnIgnoredDeployAttributes(project *types.Project) {
+	for _, svc := range project.Services {
+		ignored := collectIgnoredDeployAttributes(svc.Deploy)
+		if len(ignored) == 0 {
+			continue
+		}
+		sort.Strings(ignored)
+		logrus.Warnf(
+			"Service %q uses deploy attributes that are ignored by Compose in standalone mode: %s",
+			svc.Name,
+			strings.Join(ignored, ", "),
+		)
+	}
+}
+
+// collectIgnoredDeployAttributes returns the deploy sub-attributes that are
+// consistently ignored in standalone mode. Attributes that are still honored
+// (replicas, device reservations, restart_policy fallback) are intentionally
+// excluded to avoid noisy or misleading warnings.
+func collectIgnoredDeployAttributes(deploy *types.DeployConfig) []string {
+	if deploy == nil {
+		return nil
+	}
+	var ignored []string
+	if len(deploy.Placement.Constraints) > 0 {
+		ignored = append(ignored, "placement.constraints")
+	}
+	if len(deploy.Placement.Preferences) > 0 {
+		ignored = append(ignored, "placement.preferences")
+	}
+	if deploy.UpdateConfig != nil {
+		ignored = append(ignored, "update_config")
+	}
+	if deploy.RollbackConfig != nil {
+		ignored = append(ignored, "rollback_config")
+	}
+	if deploy.EndpointMode != "" {
+		ignored = append(ignored, "endpoint_mode")
+	}
+	if deploy.Mode != "" {
+		ignored = append(ignored, "mode")
+	}
+	return ignored
+}

--- a/cmd/compose/warnings_test.go
+++ b/cmd/compose/warnings_test.go
@@ -1,0 +1,61 @@
+/*
+   Copyright 2026 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestCollectIgnoredDeployAttributes(t *testing.T) {
+	updateConfig := &types.UpdateConfig{}
+	t.Run("nil deploy", func(t *testing.T) {
+		assert.DeepEqual(t, collectIgnoredDeployAttributes(nil), []string(nil))
+	})
+	t.Run("no deploy attributes", func(t *testing.T) {
+		assert.DeepEqual(t, collectIgnoredDeployAttributes(&types.DeployConfig{}), []string(nil))
+	})
+	t.Run("supported attributes only", func(t *testing.T) {
+		replicas := 2
+		deploy := &types.DeployConfig{
+			Replicas: &replicas,
+		}
+		assert.DeepEqual(t, collectIgnoredDeployAttributes(deploy), []string(nil))
+	})
+	t.Run("ignored attributes", func(t *testing.T) {
+		deploy := &types.DeployConfig{
+			Mode:           "replicated",
+			EndpointMode:   "vip",
+			UpdateConfig:   updateConfig,
+			RollbackConfig: updateConfig,
+			Placement: types.Placement{
+				Constraints: []string{"node.role==manager"},
+				Preferences: []types.PlacementPreferences{{Spread: "node.labels.zone"}},
+			},
+		}
+		assert.DeepEqual(t, collectIgnoredDeployAttributes(deploy), []string{
+			"placement.constraints",
+			"placement.preferences",
+			"update_config",
+			"rollback_config",
+			"endpoint_mode",
+			"mode",
+		})
+	})
+}


### PR DESCRIPTION
Fixes #13150

Compose silently ignores several `deploy` sub-attributes outside Swarm mode (e.g. a service with `deploy.update_config` behaves as if it wasn't set). Per the Compose spec the runtime should warn about unsupported attributes.

**Change**
- New `cmd/compose/warnings.go`: after the project model loads (`ProjectOptions.ToProject`), emit one warning per service listing the ignored deploy attributes it sets: `placement.constraints`, `placement.preferences`, `update_config`, `rollback_config`, `endpoint_mode`, `mode`. Attributes that are still honored (`replicas`, device reservations, `restart_policy` fallback) are deliberately excluded.
- Unit tests for the collector (nil/empty/supported-only/ignored).

**Verification**
- `go test ./cmd/compose/` passes (incl. new tests); `golangci-lint` 0 issues; gofmt clean.
- End-to-end with a locally built binary: a service with `update_config` + `placement.constraints` prints `Service "web" uses deploy attributes that are ignored by Compose in standalone mode: placement.constraints, update_config` on stderr; a replicas-only service stays silent.