### PR TITLE
fix(build): hand unresolved 'auto' progress mode to bake

### DIFF
--- a/cmd/compose/build.go
+++ b/cmd/compose/build.go
@@ -68,8 +68,17 @@ func (opts buildOptions) toAPIBuildOptions(services []string) (api.BuildOptions,
 	}
 
 	uiMode := display.Mode
-	if uiMode == display.ModeJSON {
+	switch {
+	case uiMode == display.ModeJSON:
 		uiMode = "rawjson"
+	case uiMode == display.ModeTTY && opts.Progress != display.ModeTTY:
+		// display.Mode resolves "auto" against stderr, the stream Compose's
+		// own progress renders to. Bake renders on stdout: hand the
+		// unresolved "auto" back so buildkit's progressui probes the actual
+		// output stream and degrades to plain when stdout is redirected
+		// (#14182). An explicit --progress=tty is passed through and fails
+		// loudly on a non-terminal, as `buildx bake` does.
+		uiMode = display.ModeAuto
 	}
 
 	return api.BuildOptions{

--- a/cmd/compose/build_test.go
+++ b/cmd/compose/build_test.go
@@ -1,0 +1,57 @@
+/*
+   Copyright 2026 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose/v5/cmd/display"
+)
+
+// display.Mode resolves "auto" against stderr — the stream Compose's own
+// progress renders to — while bake renders on stdout. toAPIBuildOptions must
+// therefore hand the unresolved "auto" back to bake unless the user explicitly
+// asked for tty, so buildkit probes the actual output stream and degrades to
+// plain when stdout is redirected (#14182).
+func TestToAPIBuildOptionsProgress(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string // display.Mode as resolved by selectEventProcessor
+		progress string // raw --progress flag value
+		want     string
+	}{
+		{name: "auto resolved to tty is handed back as auto", mode: display.ModeTTY, progress: "", want: display.ModeAuto},
+		{name: "explicit tty is passed through", mode: display.ModeTTY, progress: display.ModeTTY, want: display.ModeTTY},
+		{name: "plain is passed through", mode: display.ModePlain, progress: "", want: display.ModePlain},
+		{name: "quiet is passed through", mode: display.ModeQuiet, progress: "", want: display.ModeQuiet},
+		{name: "json maps to rawjson", mode: display.ModeJSON, progress: display.ModeJSON, want: "rawjson"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode := display.Mode
+			t.Cleanup(func() { display.Mode = mode })
+			display.Mode = tt.mode
+
+			opts := buildOptions{ProjectOptions: &ProjectOptions{Progress: tt.progress}}
+			bo, err := opts.toAPIBuildOptions(nil)
+			assert.NilError(t, err)
+			assert.Equal(t, bo.Progress, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
display.Mode resolves `auto` against **stderr** — the stream Compose's own progress renders to — so `compose build >/dev/null` in an interactive terminal resolves to `tty`. Bake reuses that mode for a display writing to **stdout**, and buildkit's progressui hard-fails in tty mode when the stream is not a console.

Pass the unresolved `auto` to bake unless the user explicitly asked for tty: progressui then probes the actual output stream and degrades to plain by itself when stdout is redirected. An explicit `--progress=tty` keeps failing loudly on a non-terminal, matching `buildx bake`. This also revives the `BUILDKIT_PROGRESS` override in `doBuildBake`, which only applies to auto mode and could no longer trigger.

Alternative to #14184, addressing the root cause upstream of `build_bake`.

Fixes #14182

🤖 Generated with [Claude Code](https://claude.com/claude-code)